### PR TITLE
fix(tcgc): temporary work-around of `@format("date")`

### DIFF
--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -116,6 +116,7 @@ export type SdkBuiltInKinds =
   | "boolean"
   | "date"
   | "time"
+  | "utcDatetime"
   | "any"
   | "int32"
   | "int64"

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -141,6 +141,10 @@ export function addFormatInfo<TServiceOperation extends SdkServiceOperation>(
       case "azurelocation":
         propertyType.kind = "azureLocation";
         break;
+      // TODO: we need to handle how to process @format("date-time") and utcDateTime
+      // We have a separate SdkDateTimeType, but for @format("date-time") the SDKType is SDKBuiltInType
+      // I cannot use `datetime` here, because it will conflict with SdkDateTimeType
+      // We need to re-think how we want to `addFormatInfo`, maybe not carry the format info in `propertyType.kind`
       case "date":
         propertyType.kind = "date";
         break;
@@ -216,12 +220,6 @@ function getScalarKind(scalar: Scalar): SdkBuiltInKinds {
       return "date";
     case "plainTime":
       return "time";
-    // TODO: we need to handle how to process @format("date-time") and utcDateTime
-    // We have a separate SdkDateTimeType, but for @format("date-time") the SDKType is SDKBuiltInType
-    // I cannot use `datetime` here, because it will conflict with SdkDateTimeType
-    // We need to re-think how we want to `addFormatInfo`, maybe not carry the format info in `propertyType.kind`
-    case "utcDateTime":
-      return "utcDatetime";
     case "float":
       return "float32";
     case "decimal128":

--- a/packages/typespec-client-generator-core/test/types.test.ts
+++ b/packages/typespec-client-generator-core/test/types.test.ts
@@ -184,6 +184,8 @@ describe("typespec-client-generator-core: types", () => {
           azureLocationProperty: string;
           @format("etag")
           etagProperty: string;
+          @format("date")
+          dateProperty: string;
         }
       `
       );
@@ -340,6 +342,19 @@ describe("typespec-client-generator-core: types", () => {
       strictEqual(sdkType.kind, "datetime");
       strictEqual(sdkType.wireType.kind, "string");
       strictEqual(sdkType.encode, "rfc3339");
+    });
+    it("used as parameter", async function () {
+      await runner.compileWithBuiltInService(
+        `
+        op addTimeHeader(
+          @header("Repeatability-First-Sent") repeatabilityFirstSent?: utcDateTime 
+        ): void;
+      `
+      );
+      const m = runner.context.sdkPackage.clients[0].methods[0].parameters[0];
+      strictEqual(m.type.kind, "datetime");
+      strictEqual(m.type.wireType.kind, "string");
+      strictEqual(m.type.encode, "rfc7231");
     });
     it("rfc3339", async function () {
       await runner.compileWithBuiltInService(


### PR DESCRIPTION
- add new `SDKBuiltIntType`: `utcDatetime`
  - we cannot use `datetime` because it's occupied by SDKDateTimeType
- change `addFormatInfo()` to add suuport of format `date` and `date-time`
- add test case

resolve #64