### PR TITLE
Add read-only to ARM status enums

### DIFF
--- a/eng/feeds/arm/tspconfig.yaml
+++ b/eng/feeds/arm/tspconfig.yaml
@@ -2,6 +2,7 @@ emit:
   - '@azure-tools/typespec-autorest'
 options:
   '@azure-tools/typespec-autorest':
+    use-read-only-status-schema: true
     emitter-output-dir: "{project-root}/.."
     azure-resource-provider-folder: "resource-manager"
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json"


### PR DESCRIPTION
It looks like this was not successfully backmerged from the release branch