### PR TITLE
HotFix: Autorest emitter should generated format: decimal

### DIFF
--- a/common/changes/@azure-tools/typespec-autorest/fix-autorest-decimal128_2024-01-29-21-10.json
+++ b/common/changes/@azure-tools/typespec-autorest/fix-autorest-decimal128_2024-01-29-21-10.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@azure-tools/typespec-autorest",
+      "comment": "Fix: Autorest emitter should generated format: decimal",
+      "type": "none"
+    }
+  ],
+  "packageName": "@azure-tools/typespec-autorest"
+}

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -2111,7 +2111,7 @@ function createOAPIEmitter(program: Program, options: ResolvedAutorestEmitterOpt
       case "decimal":
         return { type: "number", format: "decimal" };
       case "decimal128":
-        return { type: "number", format: "decimal128" };
+        return { type: "number", format: "decimal" };
       case "string":
         return { type: "string" };
       case "boolean":

--- a/packages/typespec-autorest/test/primitive-types.test.ts
+++ b/packages/typespec-autorest/test/primitive-types.test.ts
@@ -28,7 +28,7 @@ describe("typespec-autorest: primitives", () => {
       ["duration", { type: "string", format: "duration" }],
       ["bytes", { type: "string", format: "byte" }],
       ["decimal", { type: "number", format: "decimal" }],
-      ["decimal128", { type: "number", format: "decimal128" }],
+      ["decimal128", { type: "number", format: "decimal" }],
     ];
 
     for (const test of cases) {


### PR DESCRIPTION
`decimal128` might be the correct format as established in the registry but autorest doesn't support it today and treats `decimal` as a 128bit decimal