### PR TITLE
Fix `missing-x-ms-identifiers` rule triggering for every `enum`

### DIFF
--- a/.chronus/changes/fix-missing-x-ms-id-rule-2024-1-23-17-39-50.md
+++ b/.chronus/changes/fix-missing-x-ms-id-rule-2024-1-23-17-39-50.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Fix `missing-x-ms-identifiers` rule triggering for every `enum`

--- a/packages/typespec-azure-resource-manager/src/rules/missing-x-ms-identifiers.ts
+++ b/packages/typespec-azure-resource-manager/src/rules/missing-x-ms-identifiers.ts
@@ -1,6 +1,5 @@
 import {
   ArrayModelType,
-  Enum,
   ModelProperty,
   Program,
   createRule,
@@ -23,13 +22,6 @@ export const missingXmsIdentifiersRule = createRule({
   },
   create(context) {
     return {
-      enum: (en: Enum) => {
-        context.reportDiagnostic({
-          format: { enumName: en.name },
-          target: en,
-        });
-      },
-
       modelProperty: (property: ModelProperty) => {
         const type = property.type;
         if (type.kind === "Model" && isArrayModelType(context.program, type)) {


### PR DESCRIPTION
Issue was I wrote this rule by copying `no-enum` rule but forgot to remove the diagnostic report on every enum.