### PR TITLE
[tcgc] recursively check error models

### DIFF
--- a/.chronus/changes/error_models-2024-1-27-16-15-52.md
+++ b/.chronus/changes/error_models-2024-1-27-16-15-52.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+adds function and property to recursively check if a model is an error model

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -201,6 +201,7 @@ export interface SdkModelType extends SdkTypeBase {
   properties: SdkModelPropertyType[];
   name: string;
   isFormDataType: boolean;
+  isError: boolean;
   generatedName?: string;
   description?: string;
   details?: string;

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -534,7 +534,7 @@ function buildNameFromContextPaths(context: TCGCContext, contextPath: ContextNod
   return createName;
 }
 
-export function tcgcIsErrorModel(context: TCGCContext, model: Model): boolean {
+export function recursivelyCheckIsErrorModel(context: TCGCContext, model: Model): boolean {
   const errorDecorator = isErrorModel(context.program, model);
   if (errorDecorator) return true;
   let baseModel = model.baseModel;

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -8,6 +8,7 @@ import {
   getSummary,
   ignoreDiagnostics,
   Interface,
+  isErrorModel,
   listServices,
   Model,
   ModelProperty,
@@ -531,4 +532,15 @@ function buildNameFromContextPaths(context: TCGCContext, contextPath: ContextNod
     context.generatedNames = new Set<string>([createName]);
   }
   return createName;
+}
+
+export function tcgcIsErrorModel(context: TCGCContext, model: Model): boolean {
+  const errorDecorator = isErrorModel(context.program, model);
+  if (errorDecorator) return true;
+  let baseModel = model.baseModel;
+  while (baseModel) {
+    if (isErrorModel(context.program, baseModel)) return true;
+    baseModel = baseModel.baseModel;
+  }
+  return false;
 }

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -534,7 +534,7 @@ function buildNameFromContextPaths(context: TCGCContext, contextPath: ContextNod
   return createName;
 }
 
-export function recursivelyCheckIsErrorModel(context: TCGCContext, model: Model): boolean {
+export function isErrorOrChildOfError(context: TCGCContext, model: Model): boolean {
   const errorDecorator = isErrorModel(context.program, model);
   if (errorDecorator) return true;
   let baseModel = model.baseModel;

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -82,6 +82,7 @@ import {
   getSdkTypeBaseHelper,
   intOrFloat,
   isAzureCoreModel,
+  tcgcIsErrorModel,
 } from "./public-utils.js";
 
 import { TCGCContext } from "./internal-utils.js";
@@ -501,6 +502,7 @@ export function getSdkModel(
       usage: UsageFlags.None, // dummy value since we need to update models map before we can set this
       crossLanguageDefinitionId: getCrossLanguageDefinitionId(type),
       isFormDataType,
+      isError: tcgcIsErrorModel(context, type),
     };
 
     updateModelsMap(context, type, sdkType, operation);

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -82,7 +82,7 @@ import {
   getSdkTypeBaseHelper,
   intOrFloat,
   isAzureCoreModel,
-  tcgcIsErrorModel,
+  recursivelyCheckIsErrorModel,
 } from "./public-utils.js";
 
 import { TCGCContext } from "./internal-utils.js";
@@ -502,7 +502,7 @@ export function getSdkModel(
       usage: UsageFlags.None, // dummy value since we need to update models map before we can set this
       crossLanguageDefinitionId: getCrossLanguageDefinitionId(type),
       isFormDataType,
-      isError: tcgcIsErrorModel(context, type),
+      isError: recursivelyCheckIsErrorModel(context, type),
     };
 
     updateModelsMap(context, type, sdkType, operation);

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -82,7 +82,7 @@ import {
   getSdkTypeBaseHelper,
   intOrFloat,
   isAzureCoreModel,
-  recursivelyCheckIsErrorModel,
+  isErrorOrChildOfError,
 } from "./public-utils.js";
 
 import { TCGCContext } from "./internal-utils.js";
@@ -502,7 +502,7 @@ export function getSdkModel(
       usage: UsageFlags.None, // dummy value since we need to update models map before we can set this
       crossLanguageDefinitionId: getCrossLanguageDefinitionId(type),
       isFormDataType,
-      isError: recursivelyCheckIsErrorModel(context, type),
+      isError: isErrorOrChildOfError(context, type),
     };
 
     updateModelsMap(context, type, sdkType, operation);

--- a/packages/typespec-client-generator-core/test/types.test.ts
+++ b/packages/typespec-client-generator-core/test/types.test.ts
@@ -12,7 +12,7 @@ import {
   SdkType,
   SdkUnionType,
 } from "../src/interfaces.js";
-import { recursivelyCheckIsErrorModel } from "../src/public-utils.js";
+import { isErrorOrChildOfError } from "../src/public-utils.js";
 import { getAllModels, getAllModelsWithDiagnostics, getSdkEnum, isReadOnly } from "../src/types.js";
 import { SdkTestRunner, createSdkTestRunner, createTcgcTestRunnerForEmitter } from "./test-host.js";
 
@@ -2067,7 +2067,7 @@ describe("typespec-client-generator-core: types", () => {
       strictEqual(models[0].isError, true);
       const rawModel = models[0].__raw!;
       strictEqual(rawModel.kind, "Model");
-      strictEqual(recursivelyCheckIsErrorModel(runner.context, rawModel), true);
+      strictEqual(isErrorOrChildOfError(runner.context, rawModel), true);
     });
 
     it("error model inheritance", async () => {

--- a/packages/typespec-client-generator-core/test/types.test.ts
+++ b/packages/typespec-client-generator-core/test/types.test.ts
@@ -12,6 +12,7 @@ import {
   SdkType,
   SdkUnionType,
 } from "../src/interfaces.js";
+import { tcgcIsErrorModel } from "../src/public-utils.js";
 import { getAllModels, getAllModelsWithDiagnostics, getSdkEnum, isReadOnly } from "../src/types.js";
 import { SdkTestRunner, createSdkTestRunner, createTcgcTestRunnerForEmitter } from "./test-host.js";
 
@@ -2050,6 +2051,56 @@ describe("typespec-client-generator-core: types", () => {
       `);
       const models = getAllModels(runner.context);
       strictEqual(models.length, 2);
+    });
+    it("error model", async () => {
+      await runner.compileWithBuiltInService(`
+        @error
+        model ApiError {
+          code: string;
+        }
+
+        op test(): ApiError;
+      `);
+      const models = getAllModels(runner.context);
+      strictEqual(models.length, 1);
+      strictEqual(models[0].kind, "model");
+      strictEqual(models[0].isError, true);
+      const rawModel = models[0].__raw!;
+      strictEqual(rawModel.kind, "Model");
+      strictEqual(tcgcIsErrorModel(runner.context, rawModel), true);
+    });
+
+    it("error model inheritance", async () => {
+      await runner.compileWithBuiltInService(`
+        model ValidResponse {
+          prop: string;
+        };
+
+        @error
+        model ApiError {
+          code: string
+        };
+
+        model FourHundredError extends ApiError {};
+        model FourZeroFourError extends FourHundredError {};
+        model FiveHundredError extends ApiError {};
+
+        op test(): ValidResponse | FourZeroFourError | FiveHundredError;
+      `);
+      const models = getAllModels(runner.context);
+      strictEqual(models.length, 5);
+      const errorModels = models.filter((x) => x.kind === "model" && x.isError);
+      deepStrictEqual(errorModels.map((x) => x.name).sort(), [
+        "ApiError",
+        "FiveHundredError",
+        "FourHundredError",
+        "FourZeroFourError",
+      ]);
+      const validModel = models.filter((x) => x.kind === "model" && !x.isError);
+      deepStrictEqual(
+        validModel.map((x) => x.name),
+        ["ValidResponse"]
+      );
     });
   });
   describe("SdkMultipartFormType", () => {

--- a/packages/typespec-client-generator-core/test/types.test.ts
+++ b/packages/typespec-client-generator-core/test/types.test.ts
@@ -12,7 +12,7 @@ import {
   SdkType,
   SdkUnionType,
 } from "../src/interfaces.js";
-import { tcgcIsErrorModel } from "../src/public-utils.js";
+import { recursivelyCheckIsErrorModel } from "../src/public-utils.js";
 import { getAllModels, getAllModelsWithDiagnostics, getSdkEnum, isReadOnly } from "../src/types.js";
 import { SdkTestRunner, createSdkTestRunner, createTcgcTestRunnerForEmitter } from "./test-host.js";
 
@@ -2067,7 +2067,7 @@ describe("typespec-client-generator-core: types", () => {
       strictEqual(models[0].isError, true);
       const rawModel = models[0].__raw!;
       strictEqual(rawModel.kind, "Model");
-      strictEqual(tcgcIsErrorModel(runner.context, rawModel), true);
+      strictEqual(recursivelyCheckIsErrorModel(runner.context, rawModel), true);
     });
 
     it("error model inheritance", async () => {


### PR DESCRIPTION
Recursively check if a model is an error model bc [questions](https://github.com/microsoft/typespec/issues/2957) about whether typespec's `isErrorModel` should recursively check needs to have a design review