### PR TITLE
block @browse.argQuery usage for ProxyResource and adding more validations

### DIFF
--- a/.chronus/changes/yejeelee-proxyFix-2024-2-7-15-0-25.md
+++ b/.chronus/changes/yejeelee-proxyFix-2024-2-7-15-0-25.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-azure-portal-core"
+---
+
+put more validation and remove browse.argQuery from proxyResource usage

--- a/packages/typespec-azure-portal-core/src/decorators.ts
+++ b/packages/typespec-azure-portal-core/src/decorators.ts
@@ -158,18 +158,29 @@ export function checkIsArmResource(
   target: Model,
   decoratorName: "browse" | "about" | "marketplaceOffer" | "promotion"
 ) {
-  if (
-    getArmResourceKind(target) !== ("Tracked" as ArmResourceKind) &&
-    getArmResourceKind(target) !== ("Proxy" as ArmResourceKind)
-  ) {
-    reportDiagnostic(program, {
-      code: "not-a-resource",
-      format: {
-        decoratorName: decoratorName,
-      },
-      target,
-    });
-    return false;
+  if (decoratorName === "browse") {
+    if (getArmResourceKind(target) !== ("Tracked" as ArmResourceKind)) {
+      reportDiagnostic(program, {
+        code: "not-a-resource",
+        messageId: "browse",
+        target,
+      });
+      return false;
+    }
+  } else {
+    if (
+      getArmResourceKind(target) !== ("Tracked" as ArmResourceKind) &&
+      getArmResourceKind(target) !== ("Proxy" as ArmResourceKind)
+    ) {
+      reportDiagnostic(program, {
+        code: "not-a-resource",
+        format: {
+          decoratorName: decoratorName,
+        },
+        target,
+      });
+      return false;
+    }
   }
   return true;
 }

--- a/packages/typespec-azure-portal-core/src/lib.ts
+++ b/packages/typespec-azure-portal-core/src/lib.ts
@@ -9,9 +9,18 @@ export const $lib = createTypeSpecLibrary({
         default: paramMessage`cannot find @${"decoratorName"} file ${"propertyName"} from path ${"filePath"}`,
       },
     },
+    "invalid-type": {
+      severity: "error",
+      messages: {
+        iconSvg: paramMessage`@about.icon.filePath only allows svg file, current file: ${"filePath"}`,
+        argQueryFile: paramMessage`@browse.argQuery.filePath only allows kql or kml file, current file: ${"filePath"}`,
+        argQueryString: paramMessage`@browse.argQuery only allows literal string query value, current query: ${"query"}`,
+      },
+    },
     "not-a-resource": {
       severity: "error",
       messages: {
+        browse: `@browse can only be applied to TrackedResource models`,
         default: paramMessage`@${"decoratorName"} can only be applied to TrackedResource and ProxyResource models`,
       },
     },


### PR DESCRIPTION
* @browse.argQuery should only be used in TrackedResource
* @browse.argQuery should not take file name
* @browse.argQuery.filePath should only allow .kql or .kml files
* @about.icon.filePath should only allow .svg