### PR TITLE
[tcgc] Use own usage flags

### DIFF
--- a/.chronus/changes/use_own_usage_flags-2024-2-8-16-57-50.md
+++ b/.chronus/changes/use_own_usage_flags-2024-2-8-16-57-50.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+switch internal usage of UsageFlags from the one in compiler to our own. This way we can add values to it over time.

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -14,7 +14,6 @@ import {
   SyntaxKind,
   Type,
   Union,
-  UsageFlags,
   getNamespaceFullName,
   getProjectedName,
   isService,
@@ -33,6 +32,7 @@ import {
   SdkHttpOperation,
   SdkOperationGroup,
   SdkServiceOperation,
+  UsageFlags,
 } from "./interfaces.js";
 import { TCGCContext, parseEmitterName } from "./internal-utils.js";
 import { createStateSymbol, reportDiagnostic } from "./lib.js";

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -505,6 +505,9 @@ export type SdkHttpPackage = SdkPackage<SdkHttpOperation>;
 
 export type LanguageScopes = "dotnet" | "java" | "python" | "javascript" | "go" | string;
 
+/**
+ * This enum represents the different ways a model can be used in a method.
+ */
 export enum UsageFlags {
   None = 0,
   Input = 1 << 1,

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -9,7 +9,6 @@ import {
   Namespace,
   Operation,
   Type,
-  UsageFlags,
 } from "@typespec/compiler";
 import {
   HttpAuth,
@@ -505,3 +504,9 @@ export interface SdkPackage<TServiceOperation extends SdkServiceOperation> {
 export type SdkHttpPackage = SdkPackage<SdkHttpOperation>;
 
 export type LanguageScopes = "dotnet" | "java" | "python" | "javascript" | "go" | string;
+
+export enum UsageFlags {
+  None = 0,
+  Input = 1 << 1,
+  Output = 1 << 2,
+}

--- a/packages/typespec-client-generator-core/src/package.ts
+++ b/packages/typespec-client-generator-core/src/package.ts
@@ -3,7 +3,6 @@ import {
   Diagnostic,
   Operation,
   Type,
-  UsageFlags,
   createDiagnosticCollector,
   getNamespaceFullName,
   getService,
@@ -52,6 +51,7 @@ import {
   SdkServiceParameter,
   SdkServiceResponseHeader,
   SdkType,
+  UsageFlags,
 } from "./interfaces.js";
 import {
   getAvailableApiVersions,

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -23,7 +23,6 @@ import {
   Type,
   Union,
   UnionVariant,
-  UsageFlags,
   createDiagnosticCollector,
   getDiscriminator,
   getEncode,
@@ -85,6 +84,7 @@ import {
   SdkTupleType,
   SdkType,
   SdkUnionType,
+  UsageFlags,
   getKnownScalars,
   isSdkBuiltInKind,
 } from "./interfaces.js";

--- a/packages/typespec-client-generator-core/test/types.test.ts
+++ b/packages/typespec-client-generator-core/test/types.test.ts
@@ -1,5 +1,5 @@
 import { AzureCoreTestLibrary } from "@azure-tools/typespec-azure-core/testing";
-import { Enum, Union, UsageFlags } from "@typespec/compiler";
+import { Enum, Union } from "@typespec/compiler";
 import { expectDiagnostics } from "@typespec/compiler/testing";
 import { deepEqual, deepStrictEqual, strictEqual } from "assert";
 import { beforeEach, describe, it } from "vitest";
@@ -11,6 +11,7 @@ import {
   SdkModelType,
   SdkType,
   SdkUnionType,
+  UsageFlags,
 } from "../src/interfaces.js";
 import { isErrorOrChildOfError } from "../src/public-utils.js";
 import {


### PR DESCRIPTION
I've verified that this code still works, so language emitters currently relying on `typespec/compiler`'s `UsageFlags` won't be broken

```typescript
import { UsageFlags } from "@typespec/compiler";
import { getAllModels } from "@azure-tools/typespec-client-generator-core";


const models = getAllModels(sdkContext).filter(x => x.usage === UsageFlags.Input);
```