### PR TITLE
Set failTaskOnFailedTests=false in CI pipeline

### DIFF
--- a/eng/pipelines/jobs/build-and-test.yml
+++ b/eng/pipelines/jobs/build-and-test.yml
@@ -61,7 +61,7 @@ steps:
       searchFolder: "$(System.DefaultWorkingDirectory)/core/packages"
       testResultsFiles: "*/test-results.xml"
       mergeTestResults: true
-      failTaskOnFailedTests: true
+      failTaskOnFailedTests: false
       testRunTitle: "[CORE] Test os: ${{ parameters.poolName }}, node: ${{ parameters.nodeVersion }}"
     displayName: Publish core test results
     condition: always()
@@ -72,7 +72,7 @@ steps:
       searchFolder: "$(System.DefaultWorkingDirectory)/packages"
       testResultsFiles: "*/test-results.xml"
       mergeTestResults: true
-      failTaskOnFailedTests: true
+      failTaskOnFailedTests: false
       testRunTitle: "[NON-CORE] Test os: ${{ parameters.poolName }}, node: ${{ parameters.nodeVersion }}"
     displayName: Publish non-core test results
     condition: always()


### PR DESCRIPTION
The task running tests already fails if tests have failed:

![image](https://github.com/Azure/typespec-azure/assets/351644/179f7f33-1e77-46cc-b49a-f7705d839e88)

So the task publishing the test results failing makes a wrong impression that it failed to upload the test results, what's not the case.