### PR TITLE
Adjust generated discriminator property sequence to prevent potential breaking change

### DIFF
--- a/.chronus/changes/discriminator_sequence-2024-2-20-15-38-34.md
+++ b/.chronus/changes/discriminator_sequence-2024-2-20-15-38-34.md
@@ -1,0 +1,7 @@
+---
+changeKind: breaking
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+adjust generated discriminator property sequence to prevent potential breaking change

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -470,7 +470,7 @@ function addDiscriminatorToModelType(
       };
     }
     const name = discriminator.propertyName;
-    model.properties.push({
+    model.properties.splice(0, 0, {
       kind: "property",
       optional: false,
       discriminator: true,
@@ -484,7 +484,7 @@ function addDiscriminatorToModelType(
       isMultipartFileInput: false, // discriminator property cannot be a file
       flatten: false, // discriminator properties can not be flattened
     });
-    model.discriminatorProperty = model.properties[model.properties.length - 1];
+    model.discriminatorProperty = model.properties[0];
   }
   return diagnostics.wrap(undefined);
 }

--- a/packages/typespec-client-generator-core/test/types.test.ts
+++ b/packages/typespec-client-generator-core/test/types.test.ts
@@ -1557,7 +1557,6 @@ describe("typespec-client-generator-core: types", () => {
       @discriminator("sharktype")
       model Shark extends Fish {
         kind: "shark";
-        sharktype: string;
       }
 
       model Salmon extends Fish {
@@ -1582,8 +1581,9 @@ describe("typespec-client-generator-core: types", () => {
       strictEqual(models.length, 5);
       const fish = models.find((x) => x.name === "Fish");
       ok(fish);
-      const kindProperty = fish.properties.find((x) => x.name === "kind");
+      const kindProperty = fish.properties[0];
       ok(kindProperty);
+      strictEqual(kindProperty.name, "kind");
       strictEqual(kindProperty.kind, "property");
       strictEqual(kindProperty.discriminator, true);
       strictEqual(kindProperty.type.kind, "string");
@@ -1592,8 +1592,9 @@ describe("typespec-client-generator-core: types", () => {
       const shark = models.find((x) => x.name === "Shark");
       ok(shark);
       strictEqual(shark.properties.length, 2);
-      const sharktypeProperty = shark.properties.find((x) => x.name === "sharktype");
+      const sharktypeProperty = shark.properties[0];
       ok(sharktypeProperty);
+      strictEqual(sharktypeProperty.name, "sharktype");
       strictEqual(sharktypeProperty.kind, "property");
       strictEqual(sharktypeProperty.discriminator, true);
       strictEqual(sharktypeProperty.type.kind, "string");
@@ -1614,8 +1615,9 @@ describe("typespec-client-generator-core: types", () => {
       strictEqual(models.length, 1);
       const fish = models.find((x) => x.name === "Fish");
       ok(fish);
-      const kindProperty = fish.properties.find((x) => x.name === "kind");
+      const kindProperty = fish.properties[0];
       ok(kindProperty);
+      strictEqual(kindProperty.name, "kind");
       strictEqual(kindProperty.kind, "property");
       strictEqual(kindProperty.discriminator, true);
       strictEqual(kindProperty.type.kind, "string");
@@ -1801,9 +1803,7 @@ describe("typespec-client-generator-core: types", () => {
       strictEqual(runner.context.experimental_sdkPackage.enums.length, 1);
       const dogKind = runner.context.experimental_sdkPackage.enums[0];
 
-      const dogKindProperty = dog.properties.find(
-        (x) => x.kind === "property" && x.serializedName === "kind"
-      );
+      const dogKindProperty = dog.properties[0];
       ok(dogKindProperty);
       strictEqual(dogKindProperty.type, dogKind);
     });


### PR DESCRIPTION
```
@discriminator("kind")
model Foo {
  name: string
}
```
Previous behavior: properties as ["name", "kind"].
Change to: properties as ["kind", "name"]. 