### PR TITLE
[tcgc] change response structure to mapping with key number, status code range, or *

### DIFF
--- a/.chronus/changes/response_structure-2024-2-25-17-16-10.md
+++ b/.chronus/changes/response_structure-2024-2-25-17-16-10.md
@@ -1,0 +1,7 @@
+---
+changeKind: breaking
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+change responses from a record to a mapping of status code, range, or default

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -14,6 +14,7 @@ import {
   HttpAuth,
   HttpOperation,
   HttpOperationResponse,
+  HttpStatusCodeRange,
   HttpVerb,
   Visibility,
 } from "@typespec/http";
@@ -440,8 +441,8 @@ export interface SdkHttpOperation extends SdkServiceOperationBase {
   verb: HttpVerb;
   parameters: (SdkPathParameter | SdkQueryParameter | SdkHeaderParameter)[];
   bodyParams: SdkBodyParameter[]; // array for cases like urlencoded / multipart
-  responses: Record<number | string, SdkHttpResponse>; // we will use string to represent status code range
-  exceptions: Record<number | string, SdkHttpResponse>; // we will use string to represent status code range
+  responses: Map<HttpStatusCodeRange | number, SdkHttpResponse>;
+  exceptions: Map<HttpStatusCodeRange | number | "*", SdkHttpResponse>;
 }
 
 /**

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -14,7 +14,7 @@ import {
   ignoreDiagnostics,
   isNullType,
 } from "@typespec/compiler";
-import { HttpOperation } from "@typespec/http";
+import { HttpOperation, HttpStatusCodeRange } from "@typespec/http";
 import { getAddedOnVersions, getRemovedOnVersions, getVersions } from "@typespec/versioning";
 import {
   SdkBuiltInKinds,
@@ -258,13 +258,15 @@ export function getNonNullOptions(type: Union): Type[] {
   return [...type.variants.values()].map((x) => x.type).filter((t) => !isNullType(t));
 }
 
-function getAllResponseBodiesAndNonBodyExists(responses: Record<number, SdkHttpResponse>): {
+function getAllResponseBodiesAndNonBodyExists(
+  responses: Map<HttpStatusCodeRange | number | "*", SdkHttpResponse>
+): {
   allResponseBodies: SdkType[];
   nonBodyExists: boolean;
 } {
   const allResponseBodies: SdkType[] = [];
   let nonBodyExists = false;
-  for (const response of Object.values(responses)) {
+  for (const response of responses.values()) {
     if (response.type) {
       if (response.nullable) {
         nonBodyExists = true;
@@ -277,7 +279,9 @@ function getAllResponseBodiesAndNonBodyExists(responses: Record<number, SdkHttpR
   return { allResponseBodies, nonBodyExists };
 }
 
-export function getAllResponseBodies(responses: Record<number, SdkHttpResponse>): SdkType[] {
+export function getAllResponseBodies(
+  responses: Map<HttpStatusCodeRange | number | "*", SdkHttpResponse>
+): SdkType[] {
   return getAllResponseBodiesAndNonBodyExists(responses).allResponseBodies;
 }
 

--- a/packages/typespec-client-generator-core/test/package.test.ts
+++ b/packages/typespec-client-generator-core/test/package.test.ts
@@ -941,7 +941,7 @@ describe("typespec-client-generator-core: package", () => {
 
       const serviceOperation = method.operation;
       strictEqual(serviceOperation.bodyParams.length, 0);
-      strictEqual(serviceOperation.exceptions["*"], undefined);
+      strictEqual(serviceOperation.exceptions.get("*"), undefined);
 
       strictEqual(serviceOperation.parameters.length, 1);
       const pathParam = serviceOperation.parameters[0];
@@ -1010,7 +1010,7 @@ describe("typespec-client-generator-core: package", () => {
 
       const serviceOperation = method.operation;
       strictEqual(serviceOperation.bodyParams.length, 0);
-      strictEqual(serviceOperation.exceptions["*"], undefined);
+      strictEqual(serviceOperation.exceptions.get("*"), undefined);
 
       strictEqual(serviceOperation.parameters.length, 1);
       const headerParam = serviceOperation.parameters[0];
@@ -1094,7 +1094,7 @@ describe("typespec-client-generator-core: package", () => {
 
       const serviceOperation = method.operation;
       strictEqual(serviceOperation.bodyParams.length, 0);
-      strictEqual(serviceOperation.exceptions["*"], undefined);
+      strictEqual(serviceOperation.exceptions.get("*"), undefined);
 
       strictEqual(serviceOperation.parameters.length, 1);
       const queryParam = serviceOperation.parameters[0];
@@ -1651,8 +1651,9 @@ describe("typespec-client-generator-core: package", () => {
       strictEqual(serviceContentTypeParam.type.value, "application/json");
       strictEqual(serviceContentTypeParam.type.valueType.kind, "string");
 
-      strictEqual(Object.keys(serviceOperation.responses).length, 1);
-      const response = serviceOperation.responses[200];
+      strictEqual(serviceOperation.responses.size, 1);
+      const response = serviceOperation.responses.get(200);
+      ok(response);
       strictEqual(response.kind, "http");
       strictEqual(response.type, sdkPackage.models[0]);
       strictEqual(response.contentTypes?.length, 1);
@@ -1694,8 +1695,9 @@ describe("typespec-client-generator-core: package", () => {
       strictEqual(serviceContentTypeParam.type.value, "image/png");
       strictEqual(serviceContentTypeParam.type.valueType.kind, "string");
 
-      strictEqual(Object.keys(serviceOperation.responses).length, 1);
-      const response = serviceOperation.responses[200];
+      strictEqual(serviceOperation.responses.size, 1);
+      const response = serviceOperation.responses.get(200);
+      ok(response);
       strictEqual(response.kind, "http");
       strictEqual(sdkPackage.models.length, 0);
       strictEqual(response.contentTypes?.length, 1);
@@ -1724,14 +1726,16 @@ describe("typespec-client-generator-core: package", () => {
       strictEqual(sdkPackage.models.length, 1);
       strictEqual(method.name, "delete");
       const serviceResponses = method.operation.responses;
-      strictEqual(Object.keys(serviceResponses).length, 1);
+      strictEqual(serviceResponses.size, 1);
 
-      const voidResponse = serviceResponses[204];
+      const voidResponse = serviceResponses.get(204);
+      ok(voidResponse);
       strictEqual(voidResponse.kind, "http");
       strictEqual(voidResponse.type, undefined);
       strictEqual(voidResponse.headers.length, 0);
 
-      const errorResponse = method.operation.exceptions["*"];
+      const errorResponse = method.operation.exceptions.get("*");
+      ok(errorResponse);
       strictEqual(errorResponse.kind, "http");
       ok(errorResponse.type);
       strictEqual(errorResponse.type.kind, "model");
@@ -1765,9 +1769,10 @@ describe("typespec-client-generator-core: package", () => {
       strictEqual(sdkPackage.models.length, 2);
       strictEqual(method.name, "create");
       const serviceResponses = method.operation.responses;
-      strictEqual(Object.keys(serviceResponses).length, 1);
+      strictEqual(serviceResponses.size, 1);
 
-      const createResponse = serviceResponses[200];
+      const createResponse = serviceResponses.get(200);
+      ok(createResponse);
       strictEqual(createResponse.kind, "http");
       strictEqual(
         createResponse.type,
@@ -1775,7 +1780,8 @@ describe("typespec-client-generator-core: package", () => {
       );
       strictEqual(createResponse.headers.length, 0);
 
-      const errorResponse = method.operation.exceptions["*"];
+      const errorResponse = method.operation.exceptions.get("*");
+      ok(errorResponse);
       strictEqual(errorResponse.kind, "http");
       ok(errorResponse.type);
       strictEqual(errorResponse.type.kind, "model");
@@ -1806,11 +1812,12 @@ describe("typespec-client-generator-core: package", () => {
       strictEqual(sdkPackage.models.length, 1);
       strictEqual(method.name, "operation");
       const serviceResponses = method.operation.responses;
-      strictEqual(Object.keys(serviceResponses).length, 1);
+      strictEqual(serviceResponses.size, 1);
 
       strictEqual(method.parameters.length, 1);
 
-      const createResponse = serviceResponses[200];
+      const createResponse = serviceResponses.get(200);
+      ok(createResponse);
       strictEqual(createResponse.kind, "http");
       strictEqual(
         createResponse.type,
@@ -1852,7 +1859,8 @@ describe("typespec-client-generator-core: package", () => {
       const method = getServiceMethodOfClient(sdkPackage);
       const serviceResponses = method.operation.responses;
 
-      const createResponse = serviceResponses[200];
+      const createResponse = serviceResponses.get(200);
+      ok(createResponse);
       strictEqual(createResponse.headers[0].nullable, true);
       strictEqual(createResponse.nullable, true);
 
@@ -1873,10 +1881,12 @@ describe("typespec-client-generator-core: package", () => {
       const method = getServiceMethodOfClient(sdkPackage);
       const serviceResponses = method.operation.responses;
 
-      const okResponse = serviceResponses[200];
+      const okResponse = serviceResponses.get(200);
+      ok(okResponse);
       strictEqual(okResponse.nullable, false);
 
-      const noContentResponse = serviceResponses[204];
+      const noContentResponse = serviceResponses.get(204);
+      ok(noContentResponse);
       strictEqual(noContentResponse.nullable, true);
 
       strictEqual(method.response.nullable, true);
@@ -1894,9 +1904,10 @@ describe("typespec-client-generator-core: package", () => {
       strictEqual(method.name, "delete");
       strictEqual(method.response.nullable, true);
       const serviceResponses = method.operation.responses;
-      strictEqual(Object.keys(serviceResponses).length, 1);
+      strictEqual(serviceResponses.size, 1);
 
-      const voidResponse = serviceResponses[204];
+      const voidResponse = serviceResponses.get(204);
+      ok(voidResponse);
       strictEqual(voidResponse.kind, "http");
       strictEqual(voidResponse.type, undefined);
       strictEqual(voidResponse.headers.length, 0);
@@ -2640,28 +2651,31 @@ describe("typespec-client-generator-core: package", () => {
       strictEqual(serviceOperation.bodyParams[0].name, "resource");
       strictEqual(serviceOperation.bodyParams[0].type, widgetModel);
 
-      strictEqual(Object.keys(serviceOperation.responses).length, 2);
+      strictEqual(serviceOperation.responses.size, 2);
       const responseHeaders = [
         "Repeatability-Result",
         "ETag",
         "x-ms-client-request-id",
         "Operation-Location",
       ];
-      const response200 = serviceOperation.responses[200];
+      const response200 = serviceOperation.responses.get(200);
+      ok(response200);
       deepStrictEqual(
         response200.headers.map((x) => x.serializedName),
         responseHeaders
       );
       strictEqual(response200.type, widgetModel);
 
-      const response201 = serviceOperation.responses[201];
+      const response201 = serviceOperation.responses.get(201);
+      ok(response201);
       deepStrictEqual(
         response201.headers.map((x) => x.serializedName),
         responseHeaders
       );
       strictEqual(response201.type, widgetModel);
 
-      const exception = serviceOperation.exceptions["*"];
+      const exception = serviceOperation.exceptions.get("*");
+      ok(exception);
       strictEqual(exception.kind, "http");
       ok(exception.type);
       strictEqual(exception.type.kind, "model");
@@ -2744,8 +2758,9 @@ describe("typespec-client-generator-core: package", () => {
         listManufacturers.parameters[1]
       );
 
-      strictEqual(Object.keys(operation.responses).length, 1);
-      const response200 = operation.responses[200];
+      strictEqual(operation.responses.size, 1);
+      const response200 = operation.responses.get(200);
+      ok(response200);
       strictEqual(response200.kind, "http");
       const pagingModel = response200.type;
       ok(pagingModel);


### PR DESCRIPTION
The `HttpOperationResponse` that `@typespec/http` returns to us has property `.statusCodes` on each of them. The type of this is `HttpStatusCodeRange | number | "*"`. On the tcgc side, we're creating a map to more easily map status codes to the expected responses. We used to map this as a `Record` of `number | string` (we would do some processing magic for status codes). However, we've decided to switch to a `Map` since it can handle complex key inputs, and made the key inputs the same as the `.statusCodes` type from `tsp` for fidelity.

All instances of passing the responses to `Object.keys(responses)` / `Object.values(responses)` / `Object.items(responses)` should be changed, and you can directly access the native `.keys(responses)` etc