### PR TITLE
[tcgc] rename lroMethod.initialOperation -> lroMethod.operation

### DIFF
--- a/.chronus/changes/rename_initial_operation-2024-2-27-14-56-44.md
+++ b/.chronus/changes/rename_initial_operation-2024-2-27-14-56-44.md
@@ -1,0 +1,7 @@
+---
+changeKind: breaking
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+git status

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -492,7 +492,6 @@ export interface SdkPagingServiceMethod<TServiceOperation extends SdkServiceOper
 
 interface SdkLroServiceMethodOptions {
   __raw_lro_metadata: LroMetadata;
-  initialOperation: SdkServiceOperation;
 }
 
 export interface SdkLroServiceMethod<TServiceOperation extends SdkServiceOperation>

--- a/packages/typespec-client-generator-core/src/package.ts
+++ b/packages/typespec-client-generator-core/src/package.ts
@@ -363,7 +363,7 @@ function getSdkLroServiceMethod<
     ...basicServiceMethod,
     kind: "lro",
     __raw_lro_metadata: metadata,
-    initialOperation: diagnostics.pipe(
+    operation: diagnostics.pipe(
       getSdkServiceOperation<TOptions, TServiceOperation>(
         context,
         metadata.operation,


### PR DESCRIPTION
This avoids duplicate `.operation` and `.initialOperation` on `SdkLroMethod`