### PR TITLE
Fix website build due to missing dependency on new autorest-canonical package

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -38,6 +38,8 @@
     "@azure-tools/typespec-azure-portal-core": "workspace:~",
     "@azure-tools/typespec-azure-resource-manager": "workspace:~",
     "@azure-tools/typespec-client-generator-core": "workspace:~",
+    "@azure-tools/typespec-autorest-canonical": "workspace:~",
+    "@azure-tools/typespec-autorest": "workspace:~",
     "@azure-tools/typespec-service-csharp": "workspace:~",
     "@docusaurus/module-type-aliases": "^3.1.1",
     "@docusaurus/tsconfig": "^3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2216,6 +2216,12 @@ importers:
         specifier: ~18.2.0
         version: 18.2.0(react@18.2.0)
     devDependencies:
+      '@azure-tools/typespec-autorest':
+        specifier: workspace:~
+        version: link:../typespec-autorest
+      '@azure-tools/typespec-autorest-canonical':
+        specifier: workspace:~
+        version: link:../typespec-autorest-canonical
       '@azure-tools/typespec-azure-core':
         specifier: workspace:~
         version: link:../typespec-azure-core


### PR DESCRIPTION
Gets into a race condition and website tries to gen the docs for the package before it is build