### PR TITLE
Specify the fully qualified name of `@OpenAPI.extension` decorator in `missing-x-ms-identifiers` linter warning

### DIFF
--- a/.chronus/changes/604-2024-3-5-16-44-59.md
+++ b/.chronus/changes/604-2024-3-5-16-44-59.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Specify the fully qualified name of `@OpenAPI.extension` decorator in `missing-x-ms-identifiers` linter warning.

--- a/docs/libraries/azure-resource-manager/rules/missing-x-ms-identifiers.md
+++ b/docs/libraries/azure-resource-manager/rules/missing-x-ms-identifiers.md
@@ -11,13 +11,13 @@ Check that array properties have `x-ms-identifiers` specified with `@OpenAPI.ext
 #### ❌ Incorrect
 
 ```tsp
-model Address [] {
+model Address {
   city: string;
   street: string;
 }
 
 model ResourceProperties {
-  array: Address[]
+  array: Address[];
 }
 ```
 

--- a/packages/typespec-azure-resource-manager/src/rules/missing-x-ms-identifiers.ts
+++ b/packages/typespec-azure-resource-manager/src/rules/missing-x-ms-identifiers.ts
@@ -16,8 +16,8 @@ export const missingXmsIdentifiersRule = createRule({
   severity: "warning",
   url: "https://azure.github.io/typespec-azure/docs/libraries/azure-resource-manager/rules/missing-x-ms-identifiers",
   messages: {
-    default: `Missing identifying properties of objects in the array item, please add @extension("x-ms-identifiers", [<prop>]) to specify it. If there are no appropriate identifying properties, please add @extension("x-ms-identifiers",[]).`,
-    notArray: paramMessage`Value passed to @extension("x-ms-identifiers",...) was a "${"valueType"}". Pass an array of property name.`,
+    default: `Missing identifying properties of objects in the array item, please add @OpenAPI.extension("x-ms-identifiers", [<prop>]) to specify it. If there are no appropriate identifying properties, please add @OpenAPI.extension("x-ms-identifiers",[]).`,
+    notArray: paramMessage`Value passed to @OpenAPI.extension("x-ms-identifiers",...) was a "${"valueType"}". Pass an array of property name.`,
     missingProperty: paramMessage`Property "${"propertyName"}" is not found in "${"targetModelName"}". Make sure value of x-ms-identifiers extension are valid property name of the array element.`,
   },
   create(context) {

--- a/packages/typespec-azure-resource-manager/test/rules/missing-x-ms-identifiers.test.ts
+++ b/packages/typespec-azure-resource-manager/test/rules/missing-x-ms-identifiers.test.ts
@@ -23,7 +23,7 @@ describe("typespec-azure-core: no-enum rule", () => {
   it("emit warning for array of model without x-ms-identifiers", async () => {
     await tester
       .expect(
-        `        
+        `
         model Foo {
           bar: Bar[];
         }
@@ -35,14 +35,14 @@ describe("typespec-azure-core: no-enum rule", () => {
       )
       .toEmitDiagnostics({
         code: "@azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers",
-        message: `Missing identifying properties of objects in the array item, please add @extension("x-ms-identifiers", [<prop>]) to specify it. If there are no appropriate identifying properties, please add @extension("x-ms-identifiers",[]).`,
+        message: `Missing identifying properties of objects in the array item, please add @OpenAPI.extension("x-ms-identifiers", [<prop>]) to specify it. If there are no appropriate identifying properties, please add @OpenAPI.extension("x-ms-identifiers",[]).`,
       });
   });
 
   it("emit warning if value is not a tuple", async () => {
     await tester
       .expect(
-        `        
+        `
         model Foo {
           @OpenAPI.extension("x-ms-identifiers", "customName")
           bar: Bar[];
@@ -55,14 +55,14 @@ describe("typespec-azure-core: no-enum rule", () => {
       )
       .toEmitDiagnostics({
         code: "@azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers",
-        message: `Value passed to @extension("x-ms-identifiers",...) was a "string". Pass an array of property name.`,
+        message: `Value passed to @OpenAPI.extension("x-ms-identifiers",...) was a "string". Pass an array of property name.`,
       });
   });
 
   it("emit diagnostic when x-ms-identifiers property names are not found in the target type", async () => {
     await tester
       .expect(
-        `        
+        `
         model Foo {
           @OpenAPI.extension("x-ms-identifiers", ["not-a-prop"])
           bar: Bar[];
@@ -82,7 +82,7 @@ describe("typespec-azure-core: no-enum rule", () => {
   it(`doesn't emit diagnostic if @extension("x-ms-identifiers",...) is specified`, async () => {
     await tester
       .expect(
-        `        
+        `
         model Foo {
           @OpenAPI.extension("x-ms-identifiers", ["customName"])
           bar: Bar[];
@@ -98,7 +98,7 @@ describe("typespec-azure-core: no-enum rule", () => {
   it(`doesn't emit diagnostic if element is a primitive type`, async () => {
     await tester
       .expect(
-        `        
+        `
         model Foo {
           bar: Bar[];
         }

--- a/packages/website/versioned_docs/version-latest/libraries/azure-resource-manager/rules/missing-x-ms-identifiers.md
+++ b/packages/website/versioned_docs/version-latest/libraries/azure-resource-manager/rules/missing-x-ms-identifiers.md
@@ -11,13 +11,13 @@ Check that array properties have `x-ms-identifiers` specified with `@OpenAPI.ext
 #### ❌ Incorrect
 
 ```tsp
-model Address [] {
+model Address {
   city: string;
   street: string;
 }
 
 model ResourceProperties {
-  array: Address[]
+  array: Address[];
 }
 ```
 


### PR DESCRIPTION
Fixes #604 and also resolves a syntax error in the documentation for `missing-x-ms-identifiers`.