### PR TITLE
fix wrong propagation for nullable properties

### DIFF
--- a/.chronus/changes/fix_access-2024-3-10-18-31-10.md
+++ b/.chronus/changes/fix_access-2024-3-10-18-31-10.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+fix wrong propagation for nullable properties

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -402,16 +402,14 @@ export function getSdkConstant(
 function addDiscriminatorToModelType(
   context: TCGCContext,
   type: Model,
-  model: SdkModelType,
+  model: SdkModelType
 ): [undefined, readonly Diagnostic[]] {
   const discriminator = getDiscriminator(context.program, type);
   const diagnostics = createDiagnosticCollector();
   if (discriminator) {
     let discriminatorProperty;
     for (const childModel of type.derivedModels) {
-      const childModelSdkType = diagnostics.pipe(
-        getSdkModelWithDiagnostics(context, childModel)
-      );
+      const childModelSdkType = diagnostics.pipe(getSdkModelWithDiagnostics(context, childModel));
       for (const property of childModelSdkType.properties) {
         if (property.kind === "property") {
           if (property.__raw?.name === discriminator?.propertyName) {
@@ -1443,7 +1441,9 @@ export function getAllModelsWithDiagnostics(
     filter += UsageFlags.Output;
   }
   diagnostics.pipe(modelChecks(context));
-  return diagnostics.wrap([...new Set(context.modelsMap.values())].filter((t) => (t.usage & filter) > 0));
+  return diagnostics.wrap(
+    [...new Set(context.modelsMap.values())].filter((t) => (t.usage & filter) > 0)
+  );
 }
 
 export function getAllModels(

--- a/packages/typespec-client-generator-core/test/decorators.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators.test.ts
@@ -21,7 +21,7 @@ import {
   shouldGenerateConvenient,
   shouldGenerateProtocol,
 } from "../src/decorators.js";
-import { SdkModelType, SdkOperationGroup, UsageFlags } from "../src/interfaces.js";
+import { SdkOperationGroup, UsageFlags } from "../src/interfaces.js";
 import { getCrossLanguageDefinitionId, getCrossLanguagePackageId } from "../src/public-utils.js";
 import { getAllModels } from "../src/types.js";
 import { SdkTestRunner, createSdkContextTestHelper, createSdkTestRunner } from "./test-host.js";


### PR DESCRIPTION
found with latest stable version when regenerating openai.
the root cause is wrong calculation for operation model map.
we should only calculate it once after model build finish.