### PR TITLE
Remove typespec-autorest from arm

### DIFF
--- a/packages/typespec-azure-resource-manager/lib/arm.tsp
+++ b/packages/typespec-azure-resource-manager/lib/arm.tsp
@@ -3,7 +3,6 @@ import "@typespec/openapi";
 import "@typespec/http";
 import "@typespec/rest";
 import "@typespec/versioning";
-import "@azure-tools/typespec-autorest";
 import "@azure-tools/typespec-azure-core";
 
 import "./arm.foundations.tsp";
@@ -22,7 +21,6 @@ using TypeSpec.Http;
 using TypeSpec.Rest;
 using TypeSpec.Versioning;
 using TypeSpec.OpenAPI;
-using Autorest;
 using Azure.ResourceManager.Foundations;
 
 @versioned(Azure.ResourceManager.Versions)

--- a/packages/typespec-azure-resource-manager/lib/interfaces.tsp
+++ b/packages/typespec-azure-resource-manager/lib/interfaces.tsp
@@ -1,7 +1,6 @@
 using TypeSpec.Http;
 using TypeSpec.Rest;
 using TypeSpec.OpenAPI;
-using Autorest;
 using Azure.ResourceManager.Foundations;
 using Azure.ResourceManager.Private;
 

--- a/packages/typespec-azure-resource-manager/lib/operations.tsp
+++ b/packages/typespec-azure-resource-manager/lib/operations.tsp
@@ -1,7 +1,6 @@
 using TypeSpec.Http;
 using TypeSpec.Rest;
 using TypeSpec.OpenAPI;
-using Autorest;
 using Azure.ResourceManager.Foundations;
 
 namespace Azure.ResourceManager;

--- a/packages/typespec-azure-resource-manager/lib/private-links.tsp
+++ b/packages/typespec-azure-resource-manager/lib/private-links.tsp
@@ -2,7 +2,6 @@ import "@typespec/openapi";
 import "@typespec/http";
 import "@typespec/rest";
 import "@typespec/versioning";
-import "@azure-tools/typespec-autorest";
 import "@azure-tools/typespec-azure-core";
 
 using TypeSpec.Http;

--- a/packages/typespec-azure-resource-manager/package.json
+++ b/packages/typespec-azure-resource-manager/package.json
@@ -52,7 +52,6 @@
     "!dist/test/**"
   ],
   "peerDependencies": {
-    "@azure-tools/typespec-autorest": "workspace:~",
     "@azure-tools/typespec-azure-core": "workspace:~",
     "@typespec/compiler": "workspace:~",
     "@typespec/http": "workspace:~",

--- a/packages/typespec-azure-resource-manager/scaffolding.json
+++ b/packages/typespec-azure-resource-manager/scaffolding.json
@@ -5,7 +5,6 @@
     "libraries": [
       "@typespec/rest",
       "@typespec/openapi",
-      "@azure-tools/typespec-autorest",
       "@azure-tools/typespec-azure-core",
       "@azure-tools/typespec-azure-resource-manager"
     ]

--- a/packages/typespec-azure-resource-manager/tsconfig.json
+++ b/packages/typespec-azure-resource-manager/tsconfig.json
@@ -6,7 +6,6 @@
     { "path": "../../core/packages/rest/tsconfig.json" },
     { "path": "../../core/packages/openapi/tsconfig.json" },
     { "path": "../typespec-azure-core/tsconfig.json" },
-    { "path": "../typespec-autorest/tsconfig.json" }
   ],
   "compilerOptions": {
     "outDir": "dist",

--- a/packages/typespec-azure-resource-manager/tsconfig.json
+++ b/packages/typespec-azure-resource-manager/tsconfig.json
@@ -5,7 +5,7 @@
     { "path": "../../core/packages/compiler/tsconfig.json" },
     { "path": "../../core/packages/rest/tsconfig.json" },
     { "path": "../../core/packages/openapi/tsconfig.json" },
-    { "path": "../typespec-azure-core/tsconfig.json" },
+    { "path": "../typespec-azure-core/tsconfig.json" }
   ],
   "compilerOptions": {
     "outDir": "dist",


### PR DESCRIPTION
I don't have the skills to finish this PR, but we'd really like to remove autorest as dependency of the ARM package, and as far as I see, the only thing remaining is `private.decorators.ts` with:

```typescript
import { RefProducerParams, setRefProducer } from "@azure-tools/typespec-autorest";
```

And some code that uses it, so I thought I could push what I did so far :p 

