### PR TITLE
dpg doc, add caution section to spread doc

### DIFF
--- a/docs/howtos/DataPlane Generation - DPG/08methodInputs.mdx
+++ b/docs/howtos/DataPlane Generation - DPG/08methodInputs.mdx
@@ -133,6 +133,11 @@ public void post(User user);
 
 ## Spread
 
+Please use the *spread* feature with caution.
+- The anonymous model to be spread into operation should have less than 6 settable properties. See [simple methods](https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-parameters).
+- The anonymous model should be stable across api-versions. Adding an optional property across api-versions could result in one additional method overload in SDK client.
+- The anonymous model should not be used in [JSON Merge Patch](https://datatracker.ietf.org/doc/html/rfc7386).
+
 ### Alias
 
 <Tabs>


### PR DESCRIPTION
Adding a caution section about the spread / anonymous model.
It is not always best to do this spread, as it affect SDK signature. For some languages, having lots of method arguments is not a good design.