### PR TITLE
Fix missing `@bodyRoot`

### DIFF
--- a/.chronus/changes/fix-missing-body-root-2024-3-19-13-3-12.md
+++ b/.chronus/changes/fix-missing-body-root-2024-3-19-13-3-12.md
@@ -1,0 +1,6 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+

--- a/packages/typespec-azure-resource-manager/lib/operations.tsp
+++ b/packages/typespec-azure-resource-manager/lib/operations.tsp
@@ -519,7 +519,7 @@ op ArmResourceActionAsyncBase<
   ...Parameters,
 
   @doc("The content of the action request")
-  @body
+  @bodyRoot
   body: Request,
 ): Response | Error;
 
@@ -581,7 +581,7 @@ op ArmResourceActionSync<
   ...Parameters,
 
   @doc("The content of the action request")
-  @body
+  @bodyRoot
   body: Request,
 ): Response | Error;
 
@@ -666,7 +666,7 @@ op ArmResourceActionNoContentSync<
   ...Parameters,
 
   @doc("The content of the action request")
-  @body
+  @bodyRoot
   body: Request,
 ): ArmNoContentResponse<"Action completed successfully."> | Error;
 


### PR DESCRIPTION
Missed in some templates and it is making some spec fail in spec repo