### PR TITLE
dpg doc, add caution section to spread doc

### DIFF
--- a/docs/howtos/DataPlane Generation - DPG/08methodInputs.mdx
+++ b/docs/howtos/DataPlane Generation - DPG/08methodInputs.mdx
@@ -179,6 +179,11 @@ public void post(User user);
 
 ## Spread
 
+Please use the *spread* feature with caution.
+- The anonymous model to be spread into operation should have less than 6 settable properties. See [simple methods](https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-parameters).
+- The anonymous model should be stable across api-versions. Adding an optional property across api-versions could result in one additional method overload in SDK client.
+- The anonymous model should not be used in [JSON Merge Patch](https://datatracker.ietf.org/doc/html/rfc7386).
+
 ### Alias
 
 <Tabs>

--- a/docs/howtos/DataPlane Generation - DPG/08methodInputs.mdx
+++ b/docs/howtos/DataPlane Generation - DPG/08methodInputs.mdx
@@ -179,7 +179,8 @@ public void post(User user);
 
 ## Spread
 
-Please use the *spread* feature with caution.
+Please use the _spread_ feature with caution.
+
 - The anonymous model to be spread into operation should have less than 6 settable properties. See [simple methods](https://azure.github.io/azure-sdk/dotnet_introduction.html#dotnet-parameters).
 - The anonymous model should be stable across api-versions. Adding an optional property across api-versions could result in one additional method overload in SDK client.
 - The anonymous model should not be used in [JSON Merge Patch](https://datatracker.ietf.org/doc/html/rfc7386).


### PR DESCRIPTION
Adding a caution section about the spread / anonymous model.
It is not always best to do this spread, as it affect SDK signature. For some languages, having lots of method arguments is not a good design.

---

.NET and Java have guideline on "simple methods" that should not have more than 6 arguments.

Python and TypeScript/JavaScript does not have such guideline (AFAIK). Python has keyword argument. TypeScript does not put optional arguments to method.

Since here the pattern applies to all languages, I am trying to adopt a stricter advice.