### PR TITLE
Require documentation of unions

### DIFF
--- a/.chronus/changes/tsp-unionDocs-2024-3-25-19-26-44.md
+++ b/.chronus/changes/tsp-unionDocs-2024-3-25-19-26-44.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-core"
+---
+
+Require documentation on most unions.

--- a/packages/typespec-azure-core/src/rules/require-docs.ts
+++ b/packages/typespec-azure-core/src/rules/require-docs.ts
@@ -68,8 +68,6 @@ function isExcludedDiscriminator(
 function getUnionName(union: Union): string {
   if (union.name !== undefined) {
     return union.name;
-  } else if (union.symbol !== undefined) {
-    return union.symbol.name;
   }
   return "{anonymous}";
 }
@@ -175,7 +173,7 @@ export const requireDocumentation = createRule({
           if (!getDoc(context.program, variant)) {
             // symbols don't need documentation
             if (typeof variant.name !== "string") {
-              return;
+              continue;
             }
             context.reportDiagnostic({
               target: variant,

--- a/packages/typespec-azure-core/test/rules/require-docs.test.ts
+++ b/packages/typespec-azure-core/test/rules/require-docs.test.ts
@@ -138,5 +138,34 @@ describe("typespec-azure-core: documentation-required rule", () => {
         )
         .toBeValid();
     });
+
+    it("on union (non-discriminator)", async () => {
+      await tester
+        .expect(
+          `
+      union PetKind {      
+        Cat: "Cat",
+        string,
+      }`
+        )
+        .toEmitDiagnostics([
+          {
+            code: "@azure-tools/typespec-azure-core/documentation-required",
+            message:
+              "The Union named 'PetKind' should have a documentation or description, use doc comment /** */ to provide it.",
+          },
+          {
+            code: "@azure-tools/typespec-azure-core/documentation-required",
+            message:
+              "The UnionVariant named 'Cat' should have a documentation or description, use doc comment /** */ to provide it.",
+          },
+          // FIXME: Should this require documentation?
+          // {
+          //   code: "@azure-tools/typespec-azure-core/documentation-required",
+          //   message:
+          //     "The UnionVariant named 'string' should have a documentation or description, use doc comment /** */ to provide it.",
+          // },
+        ]);
+    });
   });
 });

--- a/packages/typespec-azure-core/test/rules/require-docs.test.ts
+++ b/packages/typespec-azure-core/test/rules/require-docs.test.ts
@@ -145,6 +145,7 @@ describe("typespec-azure-core: documentation-required rule", () => {
           `
       union PetKind {      
         Cat: "Cat",
+        "Dog",
         string,
       }`
         )
@@ -159,12 +160,11 @@ describe("typespec-azure-core: documentation-required rule", () => {
             message:
               "The UnionVariant named 'Cat' should have a documentation or description, use doc comment /** */ to provide it.",
           },
-          // FIXME: Should this require documentation?
-          // {
-          //   code: "@azure-tools/typespec-azure-core/documentation-required",
-          //   message:
-          //     "The UnionVariant named 'string' should have a documentation or description, use doc comment /** */ to provide it.",
-          // },
+          {
+            code: "@azure-tools/typespec-azure-core/documentation-required",
+            message:
+              "The UnionVariant named 'Dog' should have a documentation or description, use doc comment /** */ to provide it.",
+          },
         ]);
     });
   });


### PR DESCRIPTION
Closes #516 .

This PR:
- Exempts discriminator unions from requiring documentation
- Requires documentation of the union itself
- Requires documentation of named union variants, but not symbolic variants

**REST API Specs**
Violations: 27
https://github.com/Azure/azure-rest-api-specs/pull/28849