### PR TITLE
Core: Fix `rpc-operation-request-body` rule

### DIFF
--- a/.chronus/changes/core-fixRpcOperationRequestBodyRule-2024-3-29-20-4-13.md
+++ b/.chronus/changes/core-fixRpcOperationRequestBodyRule-2024-3-29-20-4-13.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-core"
+---
+
+Fix `rpc-operation-request-body` rule not actually checking for a body parameter.

--- a/packages/typespec-azure-core/src/rules/rpc-operation-request-body.ts
+++ b/packages/typespec-azure-core/src/rules/rpc-operation-request-body.ts
@@ -26,8 +26,9 @@ export const rpcOperationRequestBodyRule = createRule({
             operation.namespace?.namespace?.name === "Azure"
           ) {
             const httpOperation = getHttpOperation(context.program, originalOperation)[0];
+            const bodyParam = httpOperation.parameters.body;
             const verb = httpOperation.verb.toLowerCase();
-            if (verb === "get" || verb === "delete") {
+            if ((verb === "get" || verb === "delete") && bodyParam !== undefined) {
               context.reportDiagnostic({
                 target: originalOperation,
                 messageId: "noBodyAllowed",

--- a/packages/typespec-azure-core/test/rules/rpc-operation-request-body.test.ts
+++ b/packages/typespec-azure-core/test/rules/rpc-operation-request-body.test.ts
@@ -20,6 +20,38 @@ describe("typespec-azure-core: rpc-operation-request-body", () => {
     );
   });
 
+  it("allow RPCOperation with `@get` and empty body", async () => {
+    await tester
+      .expect(
+        `
+        model Widget {
+          name: string;
+        }
+
+        @get
+        @route ("/")
+        op getWidget is RpcOperation<{}, Widget>;
+      `
+      )
+      .toBeValid();
+  });
+
+  it("allow RPCOperation with `@delete` and empty body", async () => {
+    await tester
+      .expect(
+        `
+        model Widget {
+          name: string;
+        }
+
+        @delete
+        @route ("/")
+        op deleteWidget is RpcOperation<{}, Widget>;
+      `
+      )
+      .toBeValid();
+  });
+
   it("emits warning when RPCOperation is marked with `@get` and has a request body", async () => {
     await tester
       .expect(


### PR DESCRIPTION
Turns out this rule was never actually looking for a request body at all. It only cared if you were using the RpcOperation tempalte with `@get` or `@delete`!

Fixes #684.