### PR TITLE
Fix client version params

### DIFF
--- a/.chronus/changes/fix_client_version_params-2024-4-3-14-57-7.md
+++ b/.chronus/changes/fix_client_version_params-2024-4-3-14-57-7.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+tie api version information to clients so we can have diff api version information per client

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -596,7 +596,9 @@ export function createSdkContext<
     diagnostics: diagnostics.diagnostics,
     apiVersion: context.options["api-version"],
     originalProgram: context.program,
-    __clientToApiVersionParameter: new Map(),
+    __namespaceToApiVersionParameter: new Map(),
+    __namespaceToApiVersions: new Map(),
+    __namespaceToApiVersionClientDefaultValue: new Map(),
   };
   sdkContext.experimental_sdkPackage = getSdkPackage(sdkContext);
   if (sdkContext.diagnostics) {

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -596,6 +596,7 @@ export function createSdkContext<
     diagnostics: diagnostics.diagnostics,
     apiVersion: context.options["api-version"],
     originalProgram: context.program,
+    __clientToApiVersionParameter: new Map(),
   };
   sdkContext.experimental_sdkPackage = getSdkPackage(sdkContext);
   if (sdkContext.diagnostics) {

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -111,7 +111,9 @@ function getSdkHttpParameters(
     bodyParam: undefined,
   };
   retval.parameters = httpOperation.parameters.parameters
-    .map((x) => diagnostics.pipe(getSdkHttpParameter(context, x.param, httpOperation.operation, x.type)))
+    .map((x) =>
+      diagnostics.pipe(getSdkHttpParameter(context, x.param, httpOperation.operation, x.type))
+    )
     .filter(
       (x): x is SdkHeaderParameter | SdkQueryParameter | SdkPathParameter =>
         x.kind === "header" || x.kind === "query" || x.kind === "path"
@@ -220,7 +222,13 @@ function getSdkHttpParameters(
   }
   for (const param of retval.parameters) {
     param.correspondingMethodParams = diagnostics.pipe(
-      getCorrespondingMethodParams(context, client, httpOperation.operation.name, methodParameters, param)
+      getCorrespondingMethodParams(
+        context,
+        client,
+        httpOperation.operation.name,
+        methodParameters,
+        param
+      )
     );
   }
   return diagnostics.wrap(retval);
@@ -471,7 +479,7 @@ export function getCorrespondingMethodParams(
         isGeneratedName: apiVersionParam.name !== "apiVersion",
         optional: false,
         clientDefaultValue: context.__namespaceToApiVersionClientDefaultValue.get(client.type),
-      }
+      };
       context.__namespaceToApiVersionParameter.set(client.type, apiVersionParamUpdated);
     }
     return diagnostics.wrap([context.__namespaceToApiVersionParameter.get(client.type)!]);

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -1,6 +1,7 @@
 import { getUnionAsEnum } from "@azure-tools/typespec-azure-core";
 import {
   Diagnostic,
+  Interface,
   Model,
   Namespace,
   Operation,
@@ -98,7 +99,8 @@ export function getClientNamespaceStringHelper(
  */
 export function updateWithApiVersionInformation(
   context: TCGCContext,
-  type: { name: string }
+  type: { name: string },
+  namespace?: Namespace | Interface,
 ): {
   isApiVersionParam: boolean;
   clientDefaultValue?: unknown;
@@ -107,24 +109,12 @@ export function updateWithApiVersionInformation(
   const isApiVersionParam = isApiVersion(context, type);
   return {
     isApiVersionParam,
-    clientDefaultValue: isApiVersionParam ? context.__api_version_client_default_value : undefined,
+    clientDefaultValue: (isApiVersionParam && namespace) ? context.__namespaceToApiVersionClientDefaultValue.get(namespace) : undefined,
     onClient: onClient(context, type),
   };
 }
 
-/**
- *
- * @param context
- * @param type
- * @returns All api versions the type is available on
- */
-export function getAvailableApiVersions(context: TCGCContext, type: Type): string[] {
-  const apiVersions =
-    context.__api_versions ||
-    getVersions(context.program, type)[1]
-      ?.getVersions()
-      .map((x) => x.value);
-  if (!apiVersions) return [];
+export function filterApiVersionsWithDecorators(context: TCGCContext, type: Type, apiVersions: string[]): string[] {
   const addedOnVersions = getAddedOnVersions(context.program, type)?.map((x) => x.value) ?? [];
   const removedOnVersions = getRemovedOnVersions(context.program, type)?.map((x) => x.value) ?? [];
   let added: boolean = addedOnVersions.length ? false : true;
@@ -154,6 +144,28 @@ export function getAvailableApiVersions(context: TCGCContext, type: Type): strin
     }
   }
   return retval;
+}
+
+/**
+ *
+ * @param context
+ * @param type
+ * @param client If it's associated with a client, meaning it's a param etc, we can see if it's available on that client
+ * @returns All api versions the type is available on
+ */
+export function getAvailableApiVersions(context: TCGCContext, type: Type, namespace?: Namespace | Interface): string[] {
+  let cachedApiVersions: string[] = []
+  if (namespace) {
+    cachedApiVersions = context.__namespaceToApiVersions.get(namespace) || [];
+  }
+  
+  const apiVersions =
+  cachedApiVersions ||
+    getVersions(context.program, type)[1]
+      ?.getVersions()
+      .map((x) => x.value);
+  if (!apiVersions) return [];
+  return filterApiVersionsWithDecorators(context, type, apiVersions)
 }
 
 interface DocWrapper {
@@ -268,9 +280,9 @@ export interface TCGCContext {
   generatedNames?: Map<Union | Model, string>;
   httpOperationCache?: Map<Operation, HttpOperation>;
   unionsMap?: Map<Union, SdkUnionType>;
-  __clientToApiVersionParameter: Map<SdkClient | SdkOperationGroup, SdkParameter>;
-  __api_version_client_default_value?: string;
-  __api_versions?: string[];
+  __namespaceToApiVersionParameter: Map<Interface | Namespace, SdkParameter>;
+  __namespaceToApiVersions: Map<Interface | Namespace, string[]>;
+  __namespaceToApiVersionClientDefaultValue: Map<Interface | Namespace, string | undefined>;
   knownScalars?: Record<string, SdkBuiltInKinds>;
   diagnostics: readonly Diagnostic[];
   __subscriptionIdParameter?: SdkParameter;
@@ -286,7 +298,9 @@ export function createTCGCContext(program: Program): TCGCContext {
     emitterName: "__TCGC_INTERNAL__",
     diagnostics: [],
     originalProgram: program,
-    __clientToApiVersionParameter: new Map(),
+    __namespaceToApiVersionParameter: new Map(),
+    __namespaceToApiVersions: new Map(),
+    __namespaceToApiVersionClientDefaultValue: new Map(),
   };
 }
 

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -398,3 +398,8 @@ export function isSubscriptionId(context: TCGCContext, parameter: { name: string
 export function onClient(context: TCGCContext, parameter: { name: string }): boolean {
   return isSubscriptionId(context, parameter) || isApiVersion(context, parameter);
 }
+
+export function getLocationOfOperation(operation: Operation): Namespace | Interface {
+  // have to check interface first, because interfaces are more granular than namespaces
+  return (operation.interface || operation.namespace)!;
+}

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -25,6 +25,7 @@ import {
   SdkHttpResponse,
   SdkModelPropertyType,
   SdkModelType,
+  SdkOperationGroup,
   SdkParameter,
   SdkServiceOperation,
   SdkType,
@@ -267,7 +268,7 @@ export interface TCGCContext {
   generatedNames?: Map<Union | Model, string>;
   httpOperationCache?: Map<Operation, HttpOperation>;
   unionsMap?: Map<Union, SdkUnionType>;
-  __api_version_parameter?: SdkParameter;
+  __clientToApiVersionParameter: Map<SdkClient | SdkOperationGroup, SdkParameter>;
   __api_version_client_default_value?: string;
   __api_versions?: string[];
   knownScalars?: Record<string, SdkBuiltInKinds>;
@@ -285,6 +286,7 @@ export function createTCGCContext(program: Program): TCGCContext {
     emitterName: "__TCGC_INTERNAL__",
     diagnostics: [],
     originalProgram: program,
+    __clientToApiVersionParameter: new Map(),
   };
 }
 

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -26,7 +26,6 @@ import {
   SdkHttpResponse,
   SdkModelPropertyType,
   SdkModelType,
-  SdkOperationGroup,
   SdkParameter,
   SdkServiceOperation,
   SdkType,
@@ -100,7 +99,7 @@ export function getClientNamespaceStringHelper(
 export function updateWithApiVersionInformation(
   context: TCGCContext,
   type: { name: string },
-  namespace?: Namespace | Interface,
+  namespace?: Namespace | Interface
 ): {
   isApiVersionParam: boolean;
   clientDefaultValue?: unknown;
@@ -109,12 +108,19 @@ export function updateWithApiVersionInformation(
   const isApiVersionParam = isApiVersion(context, type);
   return {
     isApiVersionParam,
-    clientDefaultValue: (isApiVersionParam && namespace) ? context.__namespaceToApiVersionClientDefaultValue.get(namespace) : undefined,
+    clientDefaultValue:
+      isApiVersionParam && namespace
+        ? context.__namespaceToApiVersionClientDefaultValue.get(namespace)
+        : undefined,
     onClient: onClient(context, type),
   };
 }
 
-export function filterApiVersionsWithDecorators(context: TCGCContext, type: Type, apiVersions: string[]): string[] {
+export function filterApiVersionsWithDecorators(
+  context: TCGCContext,
+  type: Type,
+  apiVersions: string[]
+): string[] {
   const addedOnVersions = getAddedOnVersions(context.program, type)?.map((x) => x.value) ?? [];
   const removedOnVersions = getRemovedOnVersions(context.program, type)?.map((x) => x.value) ?? [];
   let added: boolean = addedOnVersions.length ? false : true;
@@ -153,19 +159,23 @@ export function filterApiVersionsWithDecorators(context: TCGCContext, type: Type
  * @param client If it's associated with a client, meaning it's a param etc, we can see if it's available on that client
  * @returns All api versions the type is available on
  */
-export function getAvailableApiVersions(context: TCGCContext, type: Type, namespace?: Namespace | Interface): string[] {
-  let cachedApiVersions: string[] = []
+export function getAvailableApiVersions(
+  context: TCGCContext,
+  type: Type,
+  namespace?: Namespace | Interface
+): string[] {
+  let cachedApiVersions: string[] = [];
   if (namespace) {
     cachedApiVersions = context.__namespaceToApiVersions.get(namespace) || [];
   }
-  
+
   const apiVersions =
-  cachedApiVersions ||
+    cachedApiVersions ||
     getVersions(context.program, type)[1]
       ?.getVersions()
       .map((x) => x.value);
   if (!apiVersions) return [];
-  return filterApiVersionsWithDecorators(context, type, apiVersions)
+  return filterApiVersionsWithDecorators(context, type, apiVersions);
 }
 
 interface DocWrapper {

--- a/packages/typespec-client-generator-core/src/package.ts
+++ b/packages/typespec-client-generator-core/src/package.ts
@@ -88,7 +88,7 @@ function getSdkServiceOperation<
   const httpOperation = getHttpOperationWithCache(context, operation);
   if (httpOperation) {
     const sdkHttpOperation = diagnostics.pipe(
-      getSdkHttpOperation(context, client, httpOperation, methodParameters)
+      getSdkHttpOperation(context, httpOperation, methodParameters)
     ) as TServiceOperation;
     return diagnostics.wrap(sdkHttpOperation);
   }
@@ -309,7 +309,7 @@ function getSdkBasicServiceMethod<
       serviceParam: SdkServiceParameter
     ): SdkModelPropertyType[] {
       return ignoreDiagnostics(
-        getCorrespondingMethodParams(context, client, name, methodParameters, serviceParam)
+        getCorrespondingMethodParams(context, operation, methodParameters, serviceParam)
       );
     },
     getResponseMapping: function getResponseMapping(): string | undefined {

--- a/packages/typespec-client-generator-core/src/package.ts
+++ b/packages/typespec-client-generator-core/src/package.ts
@@ -111,8 +111,12 @@ function getSdkLroPagingServiceMethod<
 ): [SdkLroPagingServiceMethod<TServiceOperation>, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
   return diagnostics.wrap({
-    ...diagnostics.pipe(getSdkLroServiceMethod<TOptions, TServiceOperation>(context, client, operation)),
-    ...diagnostics.pipe(getSdkPagingServiceMethod<TOptions, TServiceOperation>(context, client, operation)),
+    ...diagnostics.pipe(
+      getSdkLroServiceMethod<TOptions, TServiceOperation>(context, client, operation)
+    ),
+    ...diagnostics.pipe(
+      getSdkPagingServiceMethod<TOptions, TServiceOperation>(context, client, operation)
+    ),
     kind: "lropaging",
   });
 }
@@ -247,12 +251,16 @@ function getSdkBasicServiceMethod<
   const parameters = httpOperation.parameters;
   // path/query/header parameters
   for (const param of parameters.parameters) {
-    methodParameters.push(diagnostics.pipe(getSdkMethodParameter(context, client, param.param, operation)));
+    methodParameters.push(
+      diagnostics.pipe(getSdkMethodParameter(context, client, param.param, operation))
+    );
   }
   // body parameters
   if (parameters.body?.parameter) {
     methodParameters.push(
-      diagnostics.pipe(getSdkMethodParameter(context, client, parameters.body?.parameter, operation))
+      diagnostics.pipe(
+        getSdkMethodParameter(context, client, parameters.body?.parameter, operation)
+      )
     );
   } else if (parameters.body) {
     if (parameters.body.type.kind === "Model") {
@@ -260,18 +268,29 @@ function getSdkBasicServiceMethod<
       // spread case
       if (type.name === "") {
         for (const prop of type.properties.values()) {
-          methodParameters.push(diagnostics.pipe(getSdkMethodParameter(context, client, prop, operation)));
+          methodParameters.push(
+            diagnostics.pipe(getSdkMethodParameter(context, client, prop, operation))
+          );
         }
       } else {
-        methodParameters.push(diagnostics.pipe(getSdkMethodParameter(context, client, type, operation)));
+        methodParameters.push(
+          diagnostics.pipe(getSdkMethodParameter(context, client, type, operation))
+        );
       }
     } else {
-      methodParameters.push(diagnostics.pipe(getSdkMethodParameter(context, client, parameters.body.type, operation)));
+      methodParameters.push(
+        diagnostics.pipe(getSdkMethodParameter(context, client, parameters.body.type, operation))
+      );
     }
   }
 
   const serviceOperation = diagnostics.pipe(
-    getSdkServiceOperation<TOptions, TServiceOperation>(context, client, operation, methodParameters)
+    getSdkServiceOperation<TOptions, TServiceOperation>(
+      context,
+      client,
+      operation,
+      methodParameters
+    )
   );
   const response = getSdkMethodResponse(operation, serviceOperation);
   const name = getLibraryName(context, operation);
@@ -391,7 +410,7 @@ function getSdkMethodParameter(
   context: TCGCContext,
   client: SdkClient | SdkOperationGroup,
   type: Type,
-  operation: Operation,
+  operation: Operation
 ): [SdkMethodParameter, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
   if (type.kind !== "ModelProperty") {
@@ -571,22 +590,33 @@ function createSdkClientType<
   return diagnostics.wrap(sdkClientType);
 }
 
-function populateApiVersionInformation(
-  context: SdkContext,
-): void {
-  
+function populateApiVersionInformation(context: SdkContext): void {
   for (const client of listClients(context)) {
-    let clientApiVersions = resolveVersions(context.program, client.service).filter((x) => x.rootVersion)
-    .map((x) => x.rootVersion!.value)
-    context.__namespaceToApiVersions.set(client.type, filterApiVersionsWithDecorators(context, client.type, clientApiVersions));
-      
-    context.__namespaceToApiVersionClientDefaultValue.set(client.type, getClientDefaultApiVersion(context, client));
+    let clientApiVersions = resolveVersions(context.program, client.service)
+      .filter((x) => x.rootVersion)
+      .map((x) => x.rootVersion!.value);
+    context.__namespaceToApiVersions.set(
+      client.type,
+      filterApiVersionsWithDecorators(context, client.type, clientApiVersions)
+    );
+
+    context.__namespaceToApiVersionClientDefaultValue.set(
+      client.type,
+      getClientDefaultApiVersion(context, client)
+    );
     for (const og of listOperationGroups(context, client)) {
-      clientApiVersions = resolveVersions(context.program, og.service).filter((x) => x.rootVersion)
-    .map((x) => x.rootVersion!.value)
-      context.__namespaceToApiVersions.set(og.type, filterApiVersionsWithDecorators(context, og.type, clientApiVersions));
-        
-      context.__namespaceToApiVersionClientDefaultValue.set(og.type, getClientDefaultApiVersion(context, og));
+      clientApiVersions = resolveVersions(context.program, og.service)
+        .filter((x) => x.rootVersion)
+        .map((x) => x.rootVersion!.value);
+      context.__namespaceToApiVersions.set(
+        og.type,
+        filterApiVersionsWithDecorators(context, og.type, clientApiVersions)
+      );
+
+      context.__namespaceToApiVersionClientDefaultValue.set(
+        og.type,
+        getClientDefaultApiVersion(context, og)
+      );
     }
   }
 }

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -492,8 +492,8 @@ function addDiscriminatorToModelType(
       isGeneratedName: false,
       onClient: false,
       apiVersions: discriminatorProperty
-        ? getAvailableApiVersions(context, discriminatorProperty.__raw!)
-        : getAvailableApiVersions(context, type),
+        ? getAvailableApiVersions(context, discriminatorProperty.__raw!, type.namespace)
+        : getAvailableApiVersions(context, type, type.namespace),
       isApiVersionParam: false,
       isMultipartFileInput: false, // discriminator property cannot be a file
       flatten: false, // discriminator properties can not be flattened
@@ -537,7 +537,7 @@ export function getSdkModelWithDiagnostics(
       access: undefined, // dummy value since we need to update models map before we can set this
       usage: UsageFlags.None, // dummy value since we need to update models map before we can set this
       crossLanguageDefinitionId: getCrossLanguageDefinitionId(type, name),
-      apiVersions: getAvailableApiVersions(context, type),
+      apiVersions: getAvailableApiVersions(context, type, type.namespace),
       isFormDataType: isMultipartFormData(context, type, operation),
       isError: isErrorModel(context.program, type),
     };
@@ -662,7 +662,7 @@ export function getSdkEnum(context: TCGCContext, type: Enum, operation?: Operati
       usage: UsageFlags.None, // We will add usage as we loop through the operations
       access: undefined, // Dummy value until we update models map
       crossLanguageDefinitionId: getCrossLanguageDefinitionId(type),
-      apiVersions: getAvailableApiVersions(context, type),
+      apiVersions: getAvailableApiVersions(context, type, type.namespace),
       isUnionAsEnum: false,
     };
     for (const member of type.members.values()) {
@@ -718,7 +718,7 @@ function getSdkUnionEnum(context: TCGCContext, type: UnionEnum, operation?: Oper
       usage: UsageFlags.None, // We will add usage as we loop through the operations
       access: undefined, // Dummy value until we update models map
       crossLanguageDefinitionId: getCrossLanguageDefinitionId(union, name),
-      apiVersions: getAvailableApiVersions(context, type.union),
+      apiVersions: getAvailableApiVersions(context, type.union, type.union.namespace),
       isUnionAsEnum: true,
     };
     sdkType.values = getSdkUnionEnumValues(context, type, sdkType);
@@ -756,7 +756,7 @@ function getKnownValuesEnum(
         usage: UsageFlags.None, // We will add usage as we loop through the operations
         access: undefined, // Dummy value until we update models map
         crossLanguageDefinitionId: getCrossLanguageDefinitionId(type),
-        apiVersions: getAvailableApiVersions(context, type),
+        apiVersions: getAvailableApiVersions(context, type, type.namespace),
         isUnionAsEnum: false,
       };
       for (const member of knownValues.members.values()) {
@@ -946,7 +946,7 @@ export function getSdkCredentialParameter(
     name,
     isGeneratedName: true,
     description: "Credential used to authenticate requests to the service.",
-    apiVersions: getAvailableApiVersions(context, client.service),
+    apiVersions: getAvailableApiVersions(context, client.service, client.type),
     onClient: true,
     optional: false,
     isApiVersionParam: false,
@@ -973,14 +973,14 @@ export function getSdkModelPropertyTypeBase(
     __raw: type,
     description: docWrapper.description,
     details: docWrapper.details,
-    apiVersions: getAvailableApiVersions(context, type),
+    apiVersions: getAvailableApiVersions(context, type, operation?.namespace || type.model?.namespace),
     type: propertyType,
     nameInClient: name,
     name,
     isGeneratedName: false,
     optional: type.optional,
     nullable: isNullable(type.type),
-    ...updateWithApiVersionInformation(context, type),
+    ...updateWithApiVersionInformation(context, type, operation?.namespace),
   });
 }
 
@@ -990,9 +990,9 @@ export function getSdkModelPropertyType(
   operation?: Operation
 ): [SdkModelPropertyType, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
-  const base = diagnostics.pipe(getSdkModelPropertyTypeBase(context, type));
+  const base = diagnostics.pipe(getSdkModelPropertyTypeBase(context, type, operation));
 
-  if (isSdkHttpParameter(context, type)) return getSdkHttpParameter(context, type);
+  if (isSdkHttpParameter(context, type)) return getSdkHttpParameter(context, type, operation!);
   // I'm a body model property
   let operationIsMultipart = false;
   if (operation) {
@@ -1022,7 +1022,7 @@ export function getSdkModelPropertyType(
     serializedName: getPropertyNames(context, type)[1],
     isMultipartFileInput: isBytesInput && operationIsMultipart,
     flatten: shouldFlattenProperty(context, type),
-    ...updateWithApiVersionInformation(context, type),
+    ...updateWithApiVersionInformation(context, type, operation?.namespace),
   });
 }
 

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -973,7 +973,11 @@ export function getSdkModelPropertyTypeBase(
     __raw: type,
     description: docWrapper.description,
     details: docWrapper.details,
-    apiVersions: getAvailableApiVersions(context, type, operation?.namespace || type.model?.namespace),
+    apiVersions: getAvailableApiVersions(
+      context,
+      type,
+      operation?.namespace || type.model?.namespace
+    ),
     type: propertyType,
     nameInClient: name,
     name,

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -976,7 +976,7 @@ export function getSdkModelPropertyTypeBase(
     apiVersions: getAvailableApiVersions(
       context,
       type,
-      operation?.namespace || type.model?.namespace
+      operation?.interface || operation?.namespace || type.model?.namespace
     ),
     type: propertyType,
     nameInClient: name,

--- a/packages/typespec-client-generator-core/test/decorators.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators.test.ts
@@ -3297,7 +3297,7 @@ describe("typespec-client-generator-core: decorators", () => {
           test2(): void;
         }
         `
-      )
+      );
       const sdkPackage = runner.context.experimental_sdkPackage;
       strictEqual(sdkPackage.clients.length, 2);
       const versioningClient = sdkPackage.clients.find((x) => x.name === "VersioningClient");
@@ -3305,7 +3305,9 @@ describe("typespec-client-generator-core: decorators", () => {
       strictEqual(versioningClient.methods.length, 2);
 
       strictEqual(versioningClient.initialization.properties.length, 1);
-      const versioningClientEndpoint = versioningClient.initialization.properties.find(x => x.kind === "endpoint");
+      const versioningClientEndpoint = versioningClient.initialization.properties.find(
+        (x) => x.kind === "endpoint"
+      );
       ok(versioningClientEndpoint);
       deepStrictEqual(versioningClientEndpoint.apiVersions, ["v1", "v2"]);
 
@@ -3324,7 +3326,9 @@ describe("typespec-client-generator-core: decorators", () => {
       strictEqual(interfaceV2.methods.length, 1);
 
       strictEqual(interfaceV2.initialization.properties.length, 1);
-      const interfaceV2Endpoint = interfaceV2.initialization.properties.find(x => x.kind === "endpoint");
+      const interfaceV2Endpoint = interfaceV2.initialization.properties.find(
+        (x) => x.kind === "endpoint"
+      );
       ok(interfaceV2Endpoint);
       deepStrictEqual(interfaceV2Endpoint.apiVersions, ["v2"]);
 

--- a/packages/typespec-client-generator-core/test/decorators.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators.test.ts
@@ -3270,6 +3270,70 @@ describe("typespec-client-generator-core: decorators", () => {
       strictEqual(runnerWithVersion.context.experimental_sdkPackage.models.length, 1);
       strictEqual(runnerWithVersion.context.experimental_sdkPackage.models[0].name, "StableModel");
     });
+    it("add client", async () => {
+      await runner.compile(
+        `
+        @service
+        @versioned(Versions)
+        @server(
+          "{endpoint}",
+          "Testserver endpoint",
+          {
+            endpoint: url,
+          }
+        )
+        namespace Versioning;
+        enum Versions {
+          v1: "v1",
+          v2: "v2",
+        }
+        op test(): void;
+
+        @added(Versions.v2)
+        @route("/interface-v2")
+        interface InterfaceV2 {
+          @post
+          @route("/v2")
+          test2(): void;
+        }
+        `
+      )
+      const sdkPackage = runner.context.experimental_sdkPackage;
+      strictEqual(sdkPackage.clients.length, 2);
+      const versioningClient = sdkPackage.clients.find((x) => x.name === "VersioningClient");
+      ok(versioningClient);
+      strictEqual(versioningClient.methods.length, 2);
+
+      strictEqual(versioningClient.initialization.properties.length, 1);
+      const versioningClientEndpoint = versioningClient.initialization.properties.find(x => x.kind === "endpoint");
+      ok(versioningClientEndpoint);
+      deepStrictEqual(versioningClientEndpoint.apiVersions, ["v1", "v2"]);
+
+      const serviceMethod = versioningClient.methods.find((x) => x.kind === "basic");
+      ok(serviceMethod);
+      strictEqual(serviceMethod.name, "test");
+      deepStrictEqual(serviceMethod.apiVersions, ["v1", "v2"]);
+
+      const clientAccessor = versioningClient.methods.find((x) => x.kind === "clientaccessor");
+      ok(clientAccessor);
+      strictEqual(clientAccessor.name, "getInterfaceV2");
+      deepStrictEqual(clientAccessor.apiVersions, ["v2"]);
+
+      const interfaceV2 = sdkPackage.clients.find((x) => x.name === "InterfaceV2");
+      ok(interfaceV2);
+      strictEqual(interfaceV2.methods.length, 1);
+
+      strictEqual(interfaceV2.initialization.properties.length, 1);
+      const interfaceV2Endpoint = interfaceV2.initialization.properties.find(x => x.kind === "endpoint");
+      ok(interfaceV2Endpoint);
+      deepStrictEqual(interfaceV2Endpoint.apiVersions, ["v2"]);
+
+      strictEqual(interfaceV2.methods.length, 1);
+      const test2Method = interfaceV2.methods.find((x) => x.kind === "basic");
+      ok(test2Method);
+      strictEqual(test2Method.name, "test2");
+      deepStrictEqual(test2Method.apiVersions, ["v2"]);
+    });
   });
 
   describe("versioning impact for apis", () => {


### PR DESCRIPTION
Right now, we have all api version information tied to the `sdkContext` as a whole. As an example, this means that when we add a client in a later version, we're not able to have granular handling of api version for the second client.

In this PR, I've made all api version information a mapping from namespace to apiVersion information. I also added a test that reproduces one of the previous issues.

The PR diff is large bc I've had to add parameters everywhere so I'm still passing