### PR TITLE
Add diff highlighting to website

### DIFF
--- a/packages/website/docusaurus.config.ts
+++ b/packages/website/docusaurus.config.ts
@@ -224,7 +224,7 @@ const config: Config = {
     prism: {
       theme: themes.oneLight,
       darkTheme: themes.oneDark,
-      additionalLanguages: ["csharp", "java", "python", "rust", "cpp", "go"],
+      additionalLanguages: ["csharp", "java", "python", "rust", "cpp", "go", "diff"],
     },
     algolia: {
       // cspell:disable-next-line


### PR DESCRIPTION
Not redering the release notes with `diff` correctly . We already have that in typespec core