### PR TITLE
Do not omit unreferenced non version enum when `omit-unreachable-types` is not set to true

### DIFF
--- a/.chronus/changes/fix-omitted-non-version-enums-2024-4-15-8-39-12.md
+++ b/.chronus/changes/fix-omitted-non-version-enums-2024-4-15-8-39-12.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Do not omit unreferenced non version enum when `omit-unreachable-types` is not set to true

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -1243,8 +1243,8 @@ export async function getOpenAPIForService(
     }
 
     function isVersionEnum(program: Program, enumObj: Enum): boolean {
-      const versions = getVersionsForEnum(program, enumObj);
-      if (versions !== undefined && versions.length > 0) {
+      const [_, map] = getVersionsForEnum(program, enumObj);
+      if (map !== undefined && map.getVersions()[0].enumMember.enum === enumObj) {
         return true;
       }
       return false;

--- a/packages/typespec-autorest/test/options.test.ts
+++ b/packages/typespec-autorest/test/options.test.ts
@@ -245,6 +245,19 @@ op test(): void;
       });
       deepStrictEqual(Object.keys(output.definitions!), ["NotReferenced", "Versions"]);
     });
+
+    it("doesn't omit other enums", async () => {
+      const output = await openapiWithOptions(
+        `@service
+        @versioned(Versions)
+        namespace My {
+          enum Versions {v1, v2}
+          enum NotReferenced {a, b}
+        }`,
+        {}
+      );
+      deepStrictEqual(Object.keys(output.definitions!), ["NotReferenced"]);
+    });
   });
 
   describe("include-x-typespec-name", () => {


### PR DESCRIPTION
fix #838

The `isVersionEnum` function was just completely wrong and just returned true for any enum when used in a versioned spec.