### PR TITLE
Fix `@azure-tools/typespec-azure-core/non-breaking-versioning` should actually be part of resource-manger

### DIFF
--- a/.chronus/changes/fix-non-breaking-versioning-2024-4-22-14-2-44.md
+++ b/.chronus/changes/fix-non-breaking-versioning-2024-4-22-14-2-44.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-rulesets"
+---
+
+Add `@azure-tools/typespec-azure-core/non-breaking-versioning` back into `resource-manager` ruleset

--- a/packages/typespec-azure-rulesets/src/rulesets/resource-manager.ts
+++ b/packages/typespec-azure-rulesets/src/rulesets/resource-manager.ts
@@ -37,12 +37,10 @@ export default {
     "@azure-tools/typespec-azure-core/use-standard-names": true,
     "@azure-tools/typespec-azure-core/use-standard-operations": true,
     "@azure-tools/typespec-azure-core/no-string-discriminator": true,
+    "@azure-tools/typespec-azure-core/non-breaking-versioning": true,
 
     // Azure core not enabled - Arm has its own conflicting rule
     "@azure-tools/typespec-azure-core/bad-record-type": false,
-
-    // Azure core rules enabled via an optional rulesets
-    "@azure-tools/typespec-azure-core/non-breaking-versioning": false,
 
     // Azure resource manager
     "@azure-tools/typespec-azure-resource-manager/arm-no-record": true,


### PR DESCRIPTION
Wrongly removed from both ruleset previously but the previous behavior of `typespec-resource-manager/all` was to have it included.