### PR TITLE
Revert "Fix `@azure-tools/typespec-azure-core/non-breaking-versioning` should actually be part of resource-manger"

### DIFF
--- a/.chronus/changes/fix-non-breaking-versioning-2024-4-22-14-2-44.md
+++ b/.chronus/changes/fix-non-breaking-versioning-2024-4-22-14-2-44.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-azure-rulesets"
----
-
-Add `@azure-tools/typespec-azure-core/non-breaking-versioning` back into `resource-manager` ruleset

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -35,7 +35,8 @@ jobs:
         if: |
           !startsWith(github.head_ref, 'publish/') &&
           !startsWith(github.head_ref, 'dependabot/') &&
-          !startsWith(github.head_ref, 'backmerge/')
+          !startsWith(github.head_ref, 'backmerge/') &&
+          !startsWith(github.head_ref, 'revert-')
 
       - run: node eng/scripts/validate-core-submodule.js
         name: Check that core submodule is merged to core repo

--- a/packages/typespec-azure-rulesets/src/rulesets/resource-manager.ts
+++ b/packages/typespec-azure-rulesets/src/rulesets/resource-manager.ts
@@ -37,10 +37,12 @@ export default {
     "@azure-tools/typespec-azure-core/use-standard-names": true,
     "@azure-tools/typespec-azure-core/use-standard-operations": true,
     "@azure-tools/typespec-azure-core/no-string-discriminator": true,
-    "@azure-tools/typespec-azure-core/non-breaking-versioning": true,
 
     // Azure core not enabled - Arm has its own conflicting rule
     "@azure-tools/typespec-azure-core/bad-record-type": false,
+
+    // Azure core rules enabled via an optional rulesets
+    "@azure-tools/typespec-azure-core/non-breaking-versioning": false,
 
     // Azure resource manager
     "@azure-tools/typespec-azure-resource-manager/arm-no-record": true,


### PR DESCRIPTION
Reverts Azure/typespec-azure#906

Rule wasn’t actually enabled in the ruleset extended so this was correct before 