### PR TITLE
Fix when rendering version enum only include current member and mark it modelAsString: true

### DIFF
--- a/.chronus/changes/fix-emit-api-version-2024-4-25-9-53-10.md
+++ b/.chronus/changes/fix-emit-api-version-2024-4-25-9-53-10.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+When emitting version enum only include current version and mark with `modelAsString: true`

--- a/packages/samples/test/output/core/versioning/@azure-tools/typespec-autorest/v1/openapi.json
+++ b/packages/samples/test/output/core/versioning/@azure-tools/typespec-autorest/v1/openapi.json
@@ -121,12 +121,17 @@
       "required": true,
       "type": "string",
       "enum": [
-        "v1",
-        "v2"
+        "v1"
       ],
       "x-ms-enum": {
         "name": "Versions",
-        "modelAsString": false
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "v1",
+            "value": "v1"
+          }
+        ]
       },
       "x-ms-parameter-location": "method",
       "x-ms-client-name": "apiVersion"

--- a/packages/samples/test/output/core/versioning/@azure-tools/typespec-autorest/v2/openapi.json
+++ b/packages/samples/test/output/core/versioning/@azure-tools/typespec-autorest/v2/openapi.json
@@ -149,12 +149,17 @@
       "required": true,
       "type": "string",
       "enum": [
-        "v1",
         "v2"
       ],
       "x-ms-enum": {
         "name": "Versions",
-        "modelAsString": false
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "v2",
+            "value": "v2"
+          }
+        ]
       },
       "x-ms-parameter-location": "method",
       "x-ms-client-name": "apiVersion"

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -1259,14 +1259,14 @@ export async function getOpenAPIForService(
       }
       return false;
     }
+  }
 
-    function isVersionEnum(program: Program, enumObj: Enum): boolean {
-      const [_, map] = getVersionsForEnum(program, enumObj);
-      if (map !== undefined && map.getVersions()[0].enumMember.enum === enumObj) {
-        return true;
-      }
-      return false;
+  function isVersionEnum(program: Program, enumObj: Enum): boolean {
+    const [_, map] = getVersionsForEnum(program, enumObj);
+    if (map !== undefined && map.getVersions()[0].enumMember.enum === enumObj) {
+      return true;
     }
+    return false;
   }
 
   function emitTags() {
@@ -1322,6 +1322,34 @@ export async function getOpenAPIForService(
     return {};
   }
 
+  /**
+   * Version enum is special so we we just render the current version with modelAsString: true
+   */
+  function getSchemaForVersionEnum(e: Enum, currentVersion: string): OpenAPI2Schema {
+    const member = [...e.members.values()].find((x) => (x.value ?? x.name) === currentVersion);
+    compilerAssert(
+      member,
+      `Version enum ${e.name} does not have a member for ${currentVersion}.`,
+      e
+    );
+    return {
+      type: "string",
+      description: getDoc(program, e),
+      enum: [member.value ?? member.name],
+      "x-ms-enum": {
+        name: e.name,
+        modelAsString: true,
+        values: [
+          {
+            name: member.name,
+            value: member.value ?? member.name,
+            description: getDoc(program, member),
+          },
+        ],
+      },
+    };
+  }
+
   function getSchemaForEnum(e: Enum): OpenAPI2Schema {
     const values = [];
     if (e.members.size === 0) {
@@ -1338,6 +1366,10 @@ export async function getOpenAPIForService(
       }
     }
 
+    // If we are rendering a specific version and trying to render the version enum we should treat it specially to only include the current version.
+    if (isVersionEnum(program, e) && context.version) {
+      return getSchemaForVersionEnum(e, context.version);
+    }
     const schema: OpenAPI2Schema = { type, description: getDoc(program, e) };
     if (values.length > 0) {
       schema.enum = values;


### PR DESCRIPTION
This ensure that when the version enum is still referenced that 
1. we still mark it as modelAsString true to not be flagged as a breaking change in spec repo(even though it won't matter as it gets special treatment)
2. only include the emitted version member so adding new versions in the future don't update the previous one