### PR TITLE
[tcgc] refine logic of core model filtering

### DIFF
--- a/.chronus/changes/fix_core_model_filter-2024-5-6-15-47-3.md
+++ b/.chronus/changes/fix_core_model_filter-2024-5-6-15-47-3.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+refine logic of core model filtering

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -265,13 +265,13 @@ export function intOrFloat(value: number): "int32" | "float32" {
 }
 
 /**
- * Whether a model is an Azure.Core model or not
+ * Whether a model or enum or union as enum is in Azure.Core[.Foundations] namespace
  * @param t
  * @returns
  */
 export function isAzureCoreModel(t: Type): boolean {
   return (
-    t.kind === "Model" &&
+    (t.kind === "Model" || t.kind === "Enum" || t.kind === "Union") &&
     t.namespace !== undefined &&
     ["Azure.Core", "Azure.Core.Foundations"].includes(getNamespaceFullName(t.namespace))
   );

--- a/packages/typespec-client-generator-core/test/public-utils.test.ts
+++ b/packages/typespec-client-generator-core/test/public-utils.test.ts
@@ -1734,8 +1734,8 @@ describe("typespec-client-generator-core: public-utils", () => {
         });
         await runnerWithCore.compile(lroCode);
         const models = runnerWithCore.context.experimental_sdkPackage.models;
-        strictEqual(models.length, 2);
-        deepStrictEqual(models.map((x) => x.name).sort(), ["ExportedUser", "User"].sort());
+        strictEqual(models.length, 1);
+        deepStrictEqual(models[0].name, "ExportedUser");
       });
       it("filter-out-core-models false", async () => {
         const runnerWithCore = await createSdkTestRunner({
@@ -1746,7 +1746,7 @@ describe("typespec-client-generator-core: public-utils", () => {
         await runnerWithCore.compile(lroCode);
         runnerWithCore.context.filterOutCoreModels = false;
         const models = getAllModels(runnerWithCore.context);
-        strictEqual(models.length, 9);
+        strictEqual(models.length, 8);
         // there should only be one non-core model
         deepStrictEqual(
           models.map((x) => x.name).sort(),
@@ -1758,7 +1758,6 @@ describe("typespec-client-generator-core: public-utils", () => {
             "ExportedUser",
             "ErrorResponse",
             "OperationStatusExportedUserError",
-            "User",
             "Versions",
           ].sort()
         );


### PR DESCRIPTION
previous logic has two problems:
1. it could not handle any models found in model properties, union variants and so on
2. it will include some of the model used in templated model but not used in real operation

new logic:
1. do not do any filtering when traversal
2. do the filtering at final stage of `getAllModels`
3. set usage to `None` to filter out model not used