### PR TITLE
[tcgc] remove deprecated `nameInClient` property from `SdkModelPropertyType`s

### DIFF
--- a/.chronus/changes/remove_name_in_client-2024-5-24-13-45-6.md
+++ b/.chronus/changes/remove_name_in_client-2024-5-24-13-45-6.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-client-generator-core"
 ---
 
-remove deprecated nameInClient property from SdkTypes
+remove deprecated `.nameInClient` property from `SdkModelPropertyType`s

--- a/.chronus/changes/remove_name_in_client-2024-5-24-13-45-6.md
+++ b/.chronus/changes/remove_name_in_client-2024-5-24-13-45-6.md
@@ -1,0 +1,7 @@
+---
+changeKind: breaking
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+remove deprecated nameInClient property from SdkTypes

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -153,7 +153,6 @@ function getSdkHttpParameters(
       retval.bodyParam = {
         kind: "body",
         name,
-        nameInClient: name,
         isGeneratedName: true,
         description: getDocHelper(context, tspBody.type).description,
         details: getDocHelper(context, tspBody.type).details,
@@ -259,7 +258,6 @@ function createContentTypeOrAcceptHeader(
   // No need for clientDefaultValue because it's a constant, it only has one value
   return {
     type,
-    nameInClient: name,
     name,
     isGeneratedName: true,
     apiVersions: bodyObject.apiVersions,
@@ -473,7 +471,6 @@ export function getCorrespondingMethodParams(
       const apiVersionParamUpdated: SdkParameter = {
         ...apiVersionParam,
         name: "apiVersion",
-        nameInClient: "apiVersion",
         isGeneratedName: apiVersionParam.name !== "apiVersion",
         optional: false,
         clientDefaultValue:

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -328,10 +328,6 @@ export interface SdkEndpointType extends SdkTypeBase {
 export interface SdkModelPropertyTypeBase {
   __raw?: ModelProperty;
   type: SdkType;
-  /**
-   * @deprecated This property is deprecated. Use `.name` instead.
-   */
-  nameInClient: string;
   name: string;
   isGeneratedName: boolean;
   description?: string;

--- a/packages/typespec-client-generator-core/src/package.ts
+++ b/packages/typespec-client-generator-core/src/package.ts
@@ -413,7 +413,6 @@ function getSdkMethodParameter(
       details: getDocHelper(context, type).details,
       apiVersions,
       type: propertyType,
-      nameInClient: name,
       name,
       isGeneratedName: Boolean(libraryName),
       optional: false,
@@ -478,7 +477,6 @@ function getSdkEndpointParameter(
       templateArguments: [
         {
           name,
-          nameInClient: name,
           isGeneratedName: true,
           description: "Service host",
           kind: "path",
@@ -533,7 +531,6 @@ function getSdkEndpointParameter(
   return diagnostics.wrap({
     kind: "endpoint",
     type,
-    nameInClient: "endpoint",
     name: "endpoint",
     isGeneratedName: true,
     description: "Service host",

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -511,7 +511,6 @@ function addDiscriminatorToModelType(
         ? discriminatorProperty.serializedName
         : discriminator.propertyName,
       type: discriminatorType!,
-      nameInClient: name,
       name,
       isGeneratedName: false,
       onClient: false,
@@ -966,7 +965,6 @@ export function getSdkCredentialParameter(
   return {
     type: getSdkCredentialType(context, client, auth),
     kind: "credential",
-    nameInClient: name,
     name,
     isGeneratedName: true,
     description: "Credential used to authenticate requests to the service.",
@@ -1001,7 +999,6 @@ export function getSdkModelPropertyTypeBase(
     details: docWrapper.details,
     apiVersions,
     type: propertyType,
-    nameInClient: name,
     name,
     isGeneratedName: false,
     optional: type.optional,

--- a/packages/typespec-client-generator-core/test/package.test.ts
+++ b/packages/typespec-client-generator-core/test/package.test.ts
@@ -128,7 +128,6 @@ describe("typespec-client-generator-core: package", () => {
       strictEqual(client.initialization.properties.length, 1);
       const endpointParam = client.initialization.properties[0];
       strictEqual(endpointParam.kind, "endpoint");
-      strictEqual(endpointParam.nameInClient, "endpoint");
       strictEqual(endpointParam.name, "endpoint");
       strictEqual(endpointParam.onClient, true);
       strictEqual(endpointParam.optional, true);
@@ -161,7 +160,6 @@ describe("typespec-client-generator-core: package", () => {
       const credentialParam = client.initialization.properties.filter(
         (p): p is SdkCredentialParameter => p.kind === "credential"
       )[0];
-      strictEqual(credentialParam.nameInClient, "credential");
       strictEqual(credentialParam.name, "credential");
       strictEqual(credentialParam.onClient, true);
       strictEqual(credentialParam.optional, false);
@@ -201,7 +199,6 @@ describe("typespec-client-generator-core: package", () => {
       const credentialParam = client.initialization.properties.filter(
         (p): p is SdkCredentialParameter => p.kind === "credential"
       )[0];
-      strictEqual(credentialParam.nameInClient, "credential");
       strictEqual(credentialParam.name, "credential");
       strictEqual(credentialParam.onClient, true);
       strictEqual(credentialParam.optional, false);
@@ -246,7 +243,6 @@ describe("typespec-client-generator-core: package", () => {
       const credentialParam = client.initialization.properties.filter(
         (p): p is SdkCredentialParameter => p.kind === "credential"
       )[0];
-      strictEqual(credentialParam.nameInClient, "credential");
       strictEqual(credentialParam.name, "credential");
       strictEqual(credentialParam.onClient, true);
       strictEqual(credentialParam.optional, false);
@@ -302,7 +298,6 @@ describe("typespec-client-generator-core: package", () => {
       )[0];
       strictEqual(endpointParam.clientDefaultValue, undefined);
       strictEqual(endpointParam.urlEncode, false);
-      strictEqual(endpointParam.nameInClient, "endpoint");
       strictEqual(endpointParam.name, "endpoint");
       strictEqual(endpointParam.type.kind, "endpoint");
       strictEqual(endpointParam.onClient, true);
@@ -321,7 +316,6 @@ describe("typespec-client-generator-core: package", () => {
       const credentialParam = client.initialization.properties.filter(
         (p): p is SdkCredentialParameter => p.kind === "credential"
       )[0];
-      strictEqual(credentialParam.nameInClient, "credential");
       strictEqual(credentialParam.name, "credential");
       strictEqual(credentialParam.onClient, true);
       strictEqual(credentialParam.optional, false);
@@ -370,7 +364,6 @@ describe("typespec-client-generator-core: package", () => {
       const endpointParam = endpointParams[0];
       strictEqual(endpointParam.clientDefaultValue, undefined);
       strictEqual(endpointParam.urlEncode, false);
-      strictEqual(endpointParam.nameInClient, "endpoint");
       strictEqual(endpointParam.name, "endpoint");
       strictEqual(endpointParam.onClient, true);
       strictEqual(endpointParam.optional, false);
@@ -390,7 +383,6 @@ describe("typespec-client-generator-core: package", () => {
       const apiVersionParam = endpointParamType.templateArguments[1];
       strictEqual(apiVersionParam.clientDefaultValue, "v1.0");
       strictEqual(apiVersionParam.urlEncode, true);
-      strictEqual(apiVersionParam.nameInClient, "apiVersion");
       strictEqual(apiVersionParam.name, "apiVersion");
       strictEqual(apiVersionParam.onClient, true);
       strictEqual(apiVersionParam.optional, false);
@@ -401,7 +393,6 @@ describe("typespec-client-generator-core: package", () => {
         (p): p is SdkCredentialParameter => p.kind === "credential"
       );
       ok(credentialParam);
-      strictEqual(credentialParam.nameInClient, "credential");
       strictEqual(credentialParam.name, "credential");
       strictEqual(credentialParam.onClient, true);
       strictEqual(credentialParam.optional, false);
@@ -470,7 +461,6 @@ describe("typespec-client-generator-core: package", () => {
       const apiVersionParam = client.initialization.properties.filter(
         (p) => p.isApiVersionParam
       )[0];
-      strictEqual(apiVersionParam.nameInClient, "apiVersion");
       strictEqual(apiVersionParam.name, "apiVersion");
       strictEqual(apiVersionParam.onClient, true);
       strictEqual(apiVersionParam.optional, false);
@@ -536,7 +526,6 @@ describe("typespec-client-generator-core: package", () => {
       const apiVersionParam = client.initialization.properties.filter(
         (p) => p.isApiVersionParam
       )[0];
-      strictEqual(apiVersionParam.nameInClient, "apiVersion");
       strictEqual(apiVersionParam.name, "apiVersion");
       strictEqual(apiVersionParam.onClient, true);
       strictEqual(apiVersionParam.optional, false);
@@ -587,7 +576,6 @@ describe("typespec-client-generator-core: package", () => {
 
       strictEqual(mainClient.methods.length, 1);
       strictEqual(mainClient.initialization.properties.length, 1);
-      strictEqual(mainClient.initialization.properties[0].nameInClient, "endpoint");
       strictEqual(mainClient.initialization.properties[0].name, "endpoint");
 
       const clientAccessor = mainClient.methods[0];
@@ -638,7 +626,6 @@ describe("typespec-client-generator-core: package", () => {
       strictEqual(mainClient.methods.length, 2);
       ok(mainClient.initialization);
       strictEqual(mainClient.initialization.properties.length, 1);
-      strictEqual(mainClient.initialization.properties[0].nameInClient, "endpoint");
       strictEqual(mainClient.initialization.properties[0].name, "endpoint");
 
       const fooAccessor = mainClient.methods[0];
@@ -721,7 +708,6 @@ describe("typespec-client-generator-core: package", () => {
 
       const client = sdkPackage.clients[0];
       strictEqual(client.initialization.properties.length, 1);
-      strictEqual(client.initialization.properties[0].nameInClient, "endpoint");
       strictEqual(client.initialization.properties[0].name, "endpoint");
 
       strictEqual(client.methods.length, 1);
@@ -751,10 +737,8 @@ describe("typespec-client-generator-core: package", () => {
       const client = sdkPackage.clients[0];
 
       strictEqual(client.initialization.properties.length, 2);
-      strictEqual(client.initialization.properties[0].nameInClient, "endpoint");
       strictEqual(client.initialization.properties[0].name, "endpoint");
       const clientApiVersionParam = client.initialization.properties[1];
-      strictEqual(clientApiVersionParam.nameInClient, "apiVersion");
       strictEqual(clientApiVersionParam.name, "apiVersion");
       strictEqual(clientApiVersionParam.onClient, true);
       strictEqual(clientApiVersionParam.optional, false);
@@ -798,7 +782,6 @@ describe("typespec-client-generator-core: package", () => {
 
       const client = sdkPackage.clients[0];
       strictEqual(client.initialization.properties.length, 1);
-      strictEqual(client.initialization.properties[0].nameInClient, "endpoint");
       strictEqual(client.initialization.properties[0].name, "endpoint");
 
       const withoutApiVersion = client.methods[0];
@@ -829,11 +812,9 @@ describe("typespec-client-generator-core: package", () => {
 
       const client = sdkPackage.clients[0];
       strictEqual(client.initialization.properties.length, 2);
-      strictEqual(client.initialization.properties[0].nameInClient, "endpoint");
       strictEqual(client.initialization.properties[0].name, "endpoint");
 
       const clientApiVersionParam = client.initialization.properties[1];
-      strictEqual(clientApiVersionParam.nameInClient, "apiVersion");
       strictEqual(clientApiVersionParam.name, "apiVersion");
       strictEqual(clientApiVersionParam.onClient, true);
       strictEqual(clientApiVersionParam.optional, false);
@@ -882,11 +863,9 @@ describe("typespec-client-generator-core: package", () => {
 
       const client = sdkPackage.clients[0];
       strictEqual(client.initialization.properties.length, 2);
-      strictEqual(client.initialization.properties[0].nameInClient, "endpoint");
       strictEqual(client.initialization.properties[0].name, "endpoint");
 
       const clientApiVersionParam = client.initialization.properties[1];
-      strictEqual(clientApiVersionParam.nameInClient, "apiVersion");
       strictEqual(clientApiVersionParam.name, "apiVersion");
       strictEqual(clientApiVersionParam.onClient, true);
       strictEqual(clientApiVersionParam.optional, false);
@@ -911,7 +890,6 @@ describe("typespec-client-generator-core: package", () => {
       const apiVersionParam = withApiVersion.operation.parameters[0];
       strictEqual(apiVersionParam.kind, "path");
       strictEqual(apiVersionParam.serializedName, "apiVersion");
-      strictEqual(apiVersionParam.nameInClient, "apiVersion");
       strictEqual(apiVersionParam.name, "apiVersion");
       strictEqual(apiVersionParam.isApiVersionParam, true);
       strictEqual(apiVersionParam.optional, false);
@@ -937,7 +915,6 @@ describe("typespec-client-generator-core: package", () => {
 
       const methodParam = method.parameters[0];
       strictEqual(methodParam.kind, "method");
-      strictEqual(methodParam.nameInClient, "path");
       strictEqual(methodParam.name, "path");
       strictEqual(methodParam.optional, false);
       strictEqual(methodParam.onClient, false);
@@ -953,7 +930,6 @@ describe("typespec-client-generator-core: package", () => {
 
       strictEqual(pathParam.kind, "path");
       strictEqual(pathParam.serializedName, "path");
-      strictEqual(pathParam.nameInClient, "path");
       strictEqual(pathParam.name, "path");
       strictEqual(pathParam.optional, false);
       strictEqual(pathParam.onClient, false);
@@ -965,7 +941,6 @@ describe("typespec-client-generator-core: package", () => {
 
       const correspondingMethodParams = pathParam.correspondingMethodParams;
       strictEqual(correspondingMethodParams.length, 1);
-      strictEqual(pathParam.nameInClient, correspondingMethodParams[0].nameInClient);
       strictEqual(pathParam.name, correspondingMethodParams[0].name);
     });
 
@@ -1045,7 +1020,6 @@ describe("typespec-client-generator-core: package", () => {
 
       const methodParam = method.parameters[0];
       strictEqual(methodParam.kind, "method");
-      strictEqual(methodParam.nameInClient, "header");
       strictEqual(methodParam.name, "header");
       strictEqual(methodParam.optional, false);
       strictEqual(methodParam.onClient, false);
@@ -1061,7 +1035,6 @@ describe("typespec-client-generator-core: package", () => {
 
       strictEqual(headerParam.kind, "header");
       strictEqual(headerParam.serializedName, "header");
-      strictEqual(headerParam.nameInClient, "header");
       strictEqual(headerParam.name, "header");
       strictEqual(headerParam.optional, false);
       strictEqual(headerParam.onClient, false);
@@ -1071,7 +1044,6 @@ describe("typespec-client-generator-core: package", () => {
 
       const correspondingMethodParams = headerParam.correspondingMethodParams;
       strictEqual(correspondingMethodParams.length, 1);
-      strictEqual(headerParam.nameInClient, correspondingMethodParams[0].nameInClient);
       strictEqual(headerParam.name, correspondingMethodParams[0].name);
     });
 
@@ -1124,7 +1096,6 @@ describe("typespec-client-generator-core: package", () => {
 
       const methodParam = method.parameters[0];
       strictEqual(methodParam.kind, "method");
-      strictEqual(methodParam.nameInClient, "query");
       strictEqual(methodParam.name, "query");
       strictEqual(methodParam.optional, false);
       strictEqual(methodParam.onClient, false);
@@ -1139,7 +1110,6 @@ describe("typespec-client-generator-core: package", () => {
       const queryParam = serviceOperation.parameters[0];
       strictEqual(queryParam.kind, "query");
       strictEqual(queryParam.serializedName, "query");
-      strictEqual(queryParam.nameInClient, "query");
       strictEqual(queryParam.name, "query");
       strictEqual(queryParam.optional, false);
       strictEqual(queryParam.onClient, false);
@@ -1149,7 +1119,6 @@ describe("typespec-client-generator-core: package", () => {
 
       const correspondingMethodParams = queryParam.correspondingMethodParams;
       strictEqual(correspondingMethodParams.length, 1);
-      strictEqual(queryParam.nameInClient, correspondingMethodParams[0].nameInClient);
       strictEqual(queryParam.name, correspondingMethodParams[0].name);
     });
 
@@ -1233,12 +1202,10 @@ describe("typespec-client-generator-core: package", () => {
 
       const correspondingMethodParams = bodyParameter.correspondingMethodParams;
       strictEqual(correspondingMethodParams.length, 1);
-      strictEqual(bodyParameter.nameInClient, correspondingMethodParams[0].nameInClient);
       strictEqual(bodyParameter.name, correspondingMethodParams[0].name);
 
       strictEqual(serviceOperation.parameters.length, 1);
       const contentTypeParam = serviceOperation.parameters[0];
-      strictEqual(contentTypeParam.nameInClient, "contentType");
       strictEqual(contentTypeParam.name, "contentType");
       strictEqual(contentTypeParam.serializedName, "Content-Type");
       strictEqual(contentTypeParam.clientDefaultValue, undefined);
@@ -1318,12 +1285,10 @@ describe("typespec-client-generator-core: package", () => {
 
       const correspondingMethodParams = bodyParameter.correspondingMethodParams;
       strictEqual(correspondingMethodParams.length, 1);
-      strictEqual(bodyParameter.nameInClient, correspondingMethodParams[0].nameInClient);
       strictEqual(bodyParameter.name, correspondingMethodParams[0].name);
 
       strictEqual(serviceOperation.parameters.length, 1);
       const contentTypeParam = serviceOperation.parameters[0];
-      strictEqual(contentTypeParam.nameInClient, "contentType");
       strictEqual(contentTypeParam.name, "contentType");
       strictEqual(contentTypeParam.serializedName, "Content-Type");
       strictEqual(contentTypeParam.clientDefaultValue, undefined);
@@ -1359,7 +1324,6 @@ describe("typespec-client-generator-core: package", () => {
 
       let methodParam = method.parameters[0];
       strictEqual(methodParam.kind, "method");
-      strictEqual(methodParam.nameInClient, "header");
       strictEqual(methodParam.name, "header");
       strictEqual(methodParam.optional, false);
       strictEqual(methodParam.onClient, false);
@@ -1368,7 +1332,6 @@ describe("typespec-client-generator-core: package", () => {
 
       methodParam = method.parameters[1];
       strictEqual(methodParam.kind, "method");
-      strictEqual(methodParam.nameInClient, "query");
       strictEqual(methodParam.name, "query");
       strictEqual(methodParam.optional, false);
       strictEqual(methodParam.onClient, false);
@@ -1377,7 +1340,6 @@ describe("typespec-client-generator-core: package", () => {
 
       methodParam = method.parameters[2];
       strictEqual(methodParam.kind, "method");
-      strictEqual(methodParam.nameInClient, "body");
       strictEqual(methodParam.name, "body");
       strictEqual(methodParam.optional, false);
       strictEqual(methodParam.onClient, false);
@@ -1386,7 +1348,6 @@ describe("typespec-client-generator-core: package", () => {
 
       methodParam = method.parameters[3];
       strictEqual(methodParam.kind, "method");
-      strictEqual(methodParam.nameInClient, "contentType");
       strictEqual(methodParam.name, "contentType");
       strictEqual(methodParam.optional, false);
       strictEqual(methodParam.onClient, false);
@@ -1399,7 +1360,6 @@ describe("typespec-client-generator-core: package", () => {
       ok(serviceOperation.bodyParam);
       const correspondingBodyParams = serviceOperation.bodyParam.correspondingMethodParams;
       strictEqual(correspondingBodyParams.length, 1);
-      strictEqual(correspondingBodyParams[0].nameInClient, "body");
       strictEqual(correspondingBodyParams[0].name, "body");
 
       const parameters = serviceOperation.parameters;
@@ -1409,19 +1369,16 @@ describe("typespec-client-generator-core: package", () => {
       strictEqual(headerParams.length, 2);
       let correspondingHeaderParams = headerParams[0].correspondingMethodParams;
       strictEqual(correspondingHeaderParams.length, 1);
-      strictEqual(correspondingHeaderParams[0].nameInClient, "header");
       strictEqual(correspondingHeaderParams[0].name, "header");
 
       correspondingHeaderParams = headerParams[1].correspondingMethodParams;
       strictEqual(correspondingHeaderParams.length, 1);
-      strictEqual(correspondingHeaderParams[0].nameInClient, "contentType");
       strictEqual(correspondingHeaderParams[0].name, "contentType");
 
       const queryParams = parameters.filter((x): x is SdkQueryParameter => x.kind === "query");
       strictEqual(queryParams.length, 1);
       const correspondingQueryParams = queryParams[0].correspondingMethodParams;
       strictEqual(correspondingQueryParams.length, 1);
-      strictEqual(correspondingQueryParams[0].nameInClient, "query");
       strictEqual(correspondingQueryParams[0].name, "query");
     });
 
@@ -1438,7 +1395,6 @@ describe("typespec-client-generator-core: package", () => {
 
       let methodParam = method.parameters[0];
       strictEqual(methodParam.kind, "method");
-      strictEqual(methodParam.nameInClient, "body");
       strictEqual(methodParam.name, "body");
       strictEqual(methodParam.optional, false);
       strictEqual(methodParam.onClient, false);
@@ -1447,7 +1403,6 @@ describe("typespec-client-generator-core: package", () => {
 
       methodParam = method.parameters[1];
       strictEqual(methodParam.kind, "method");
-      strictEqual(methodParam.nameInClient, "contentType");
       strictEqual(methodParam.name, "contentType");
       strictEqual(methodParam.optional, false);
       strictEqual(methodParam.onClient, false);
@@ -1461,13 +1416,11 @@ describe("typespec-client-generator-core: package", () => {
       ok(serviceOperation.bodyParam);
       const correspondingBodyParams = serviceOperation.bodyParam.correspondingMethodParams;
       strictEqual(correspondingBodyParams.length, 1);
-      strictEqual(correspondingBodyParams[0].nameInClient, "body");
       strictEqual(correspondingBodyParams[0].name, "body");
 
       strictEqual(serviceOperation.parameters.length, 1);
       const correspondingHeaderParams = serviceOperation.parameters[0].correspondingMethodParams;
       strictEqual(correspondingHeaderParams.length, 1);
-      strictEqual(correspondingHeaderParams[0].nameInClient, "contentType");
       strictEqual(correspondingHeaderParams[0].name, "contentType");
     });
     it("ensure content type is a constant if only one possibility", async () => {
@@ -1482,12 +1435,10 @@ describe("typespec-client-generator-core: package", () => {
 
       strictEqual(method.parameters.length, 2);
       const methodBodyParam = method.parameters[0];
-      strictEqual(methodBodyParam.nameInClient, "body");
       strictEqual(methodBodyParam.name, "body");
       strictEqual(methodBodyParam.type, sdkPackage.models[0]);
 
       const methodContentTypeParam = method.parameters[1];
-      strictEqual(methodContentTypeParam.nameInClient, "contentType");
       strictEqual(methodContentTypeParam.name, "contentType");
 
       const serviceOperation = method.operation;
@@ -1501,7 +1452,6 @@ describe("typespec-client-generator-core: package", () => {
 
       strictEqual(serviceOperation.parameters.length, 1);
       const serviceContentTypeParam = serviceOperation.parameters[0];
-      strictEqual(serviceContentTypeParam.nameInClient, "contentType");
       strictEqual(serviceContentTypeParam.name, "contentType");
       strictEqual(serviceContentTypeParam.serializedName, "Content-Type");
       strictEqual(serviceContentTypeParam.clientDefaultValue, undefined);
@@ -1523,13 +1473,11 @@ describe("typespec-client-generator-core: package", () => {
 
       strictEqual(method.parameters.length, 1);
       const methodAcceptParam = method.parameters[0];
-      strictEqual(methodAcceptParam.nameInClient, "accept");
       strictEqual(methodAcceptParam.name, "accept");
 
       const serviceOperation = method.operation;
       strictEqual(serviceOperation.parameters.length, 1);
       const serviceContentTypeParam = serviceOperation.parameters[0];
-      strictEqual(serviceContentTypeParam.nameInClient, "accept");
       strictEqual(serviceContentTypeParam.name, "accept");
       strictEqual(serviceContentTypeParam.serializedName, "Accept");
       strictEqual(serviceContentTypeParam.clientDefaultValue, undefined);
@@ -1565,13 +1513,11 @@ describe("typespec-client-generator-core: package", () => {
 
       strictEqual(method.parameters.length, 1);
       const methodAcceptParam = method.parameters[0];
-      strictEqual(methodAcceptParam.nameInClient, "accept");
       strictEqual(methodAcceptParam.name, "accept");
 
       const serviceOperation = method.operation;
       strictEqual(serviceOperation.parameters.length, 1);
       const serviceContentTypeParam = serviceOperation.parameters[0];
-      strictEqual(serviceContentTypeParam.nameInClient, "accept");
       strictEqual(serviceContentTypeParam.name, "accept");
       strictEqual(serviceContentTypeParam.serializedName, "Accept");
       strictEqual(serviceContentTypeParam.clientDefaultValue, undefined);
@@ -1940,7 +1886,6 @@ describe("typespec-client-generator-core: package", () => {
       const bodyParameter = method.operation.bodyParam;
       ok(bodyParameter);
       strictEqual(bodyParameter.kind, "body");
-      strictEqual(bodyParameter.nameInClient, "widget");
       strictEqual(bodyParameter.name, "widget");
       strictEqual(bodyParameter.onClient, false);
       strictEqual(bodyParameter.optional, false);
@@ -2012,7 +1957,6 @@ describe("typespec-client-generator-core: package", () => {
       ok(pathParam);
       strictEqual(pathParam.kind, "path");
       strictEqual(pathParam.serializedName, "id");
-      strictEqual(pathParam.nameInClient, "id");
       strictEqual(pathParam.name, "id");
       strictEqual(pathParam.optional, false);
       strictEqual(pathParam.onClient, false);
@@ -2029,7 +1973,6 @@ describe("typespec-client-generator-core: package", () => {
 
       const correspondingMethodParams = pathParam.correspondingMethodParams;
       strictEqual(correspondingMethodParams.length, 1);
-      strictEqual(pathParam.nameInClient, correspondingMethodParams[0].nameInClient);
       strictEqual(pathParam.name, correspondingMethodParams[0].name);
     });
     it("vanilla widget update", async () => {
@@ -2043,7 +1986,6 @@ describe("typespec-client-generator-core: package", () => {
 
       let methodParam = method.parameters[0];
       strictEqual(methodParam.kind, "method");
-      strictEqual(methodParam.nameInClient, "id");
       strictEqual(methodParam.name, "id");
       strictEqual(methodParam.optional, false);
       strictEqual(methodParam.onClient, false);
@@ -2052,7 +1994,6 @@ describe("typespec-client-generator-core: package", () => {
 
       methodParam = method.parameters[1];
       strictEqual(methodParam.kind, "method");
-      strictEqual(methodParam.nameInClient, "widget");
       strictEqual(methodParam.name, "widget");
       strictEqual(methodParam.optional, false);
       strictEqual(methodParam.onClient, false);
@@ -2075,7 +2016,6 @@ describe("typespec-client-generator-core: package", () => {
       ok(pathParam);
       strictEqual(pathParam.kind, "path");
       strictEqual(pathParam.serializedName, "id");
-      strictEqual(pathParam.nameInClient, "id");
       strictEqual(pathParam.name, "id");
       strictEqual(pathParam.optional, false);
       strictEqual(pathParam.onClient, false);
@@ -2130,7 +2070,6 @@ describe("typespec-client-generator-core: package", () => {
 
       const methodParam = method.parameters[0];
       strictEqual(methodParam.kind, "method");
-      strictEqual(methodParam.nameInClient, "id");
       strictEqual(methodParam.name, "id");
       strictEqual(methodParam.optional, false);
       strictEqual(methodParam.onClient, false);
@@ -2143,7 +2082,6 @@ describe("typespec-client-generator-core: package", () => {
       ok(pathParam);
       strictEqual(pathParam.kind, "path");
       strictEqual(pathParam.serializedName, "id");
-      strictEqual(pathParam.nameInClient, "id");
       strictEqual(pathParam.name, "id");
       strictEqual(pathParam.optional, false);
       strictEqual(pathParam.onClient, false);
@@ -2152,7 +2090,6 @@ describe("typespec-client-generator-core: package", () => {
 
       const correspondingMethodParams = pathParam.correspondingMethodParams;
       strictEqual(correspondingMethodParams.length, 1);
-      strictEqual(pathParam.nameInClient, correspondingMethodParams[0].nameInClient);
       strictEqual(pathParam.name, correspondingMethodParams[0].name);
     });
     it("vanilla widget list", async () => {
@@ -2390,7 +2327,6 @@ describe("typespec-client-generator-core: package", () => {
       const pathParam = method.operation.parameters.find((x) => x.kind === "path");
       ok(pathParam);
       strictEqual(pathParam.kind, "path");
-      strictEqual(pathParam.nameInClient, "widgetName");
       strictEqual(pathParam.name, "widgetName");
       strictEqual(pathParam.serializedName, "widgetName");
       strictEqual(pathParam.onClient, false);
@@ -2400,7 +2336,6 @@ describe("typespec-client-generator-core: package", () => {
       const queryParam = method.operation.parameters.find((x) => x.kind === "query");
       ok(queryParam);
       strictEqual(queryParam.isApiVersionParam, true);
-      strictEqual(queryParam.nameInClient, "apiVersion");
       strictEqual(queryParam.name, "apiVersion");
       strictEqual(queryParam.serializedName, "api-version");
       strictEqual(queryParam.onClient, true);
@@ -2503,7 +2438,6 @@ describe("typespec-client-generator-core: package", () => {
 
       const pathParam1 = pathParams[0];
       strictEqual(pathParam1.kind, "path");
-      strictEqual(pathParam1.nameInClient, "widgetName");
       strictEqual(pathParam1.name, "widgetName");
       strictEqual(pathParam1.serializedName, "widgetName");
       strictEqual(pathParam1.onClient, false);
@@ -2512,7 +2446,6 @@ describe("typespec-client-generator-core: package", () => {
 
       const pathParam2 = pathParams[1];
       strictEqual(pathParam2.kind, "path");
-      strictEqual(pathParam2.nameInClient, "operationId");
       strictEqual(pathParam2.name, "operationId");
       strictEqual(pathParam2.serializedName, "operationId");
       strictEqual(pathParam2.onClient, false);
@@ -2522,7 +2455,6 @@ describe("typespec-client-generator-core: package", () => {
       const apiVersionParam = getStatus.operation.parameters.find((x) => x.kind === "query");
       ok(apiVersionParam);
       strictEqual(apiVersionParam.isApiVersionParam, true);
-      strictEqual(apiVersionParam.nameInClient, "apiVersion");
       strictEqual(apiVersionParam.name, "apiVersion");
       strictEqual(apiVersionParam.serializedName, "api-version");
       strictEqual(apiVersionParam.onClient, true);
@@ -2535,7 +2467,6 @@ describe("typespec-client-generator-core: package", () => {
 
       const operationAcceptParam = getStatus.operation.parameters.find((x) => x.kind === "header");
       ok(operationAcceptParam);
-      strictEqual(operationAcceptParam.nameInClient, "accept");
       strictEqual(operationAcceptParam.name, "accept");
       strictEqual(operationAcceptParam.clientDefaultValue, undefined);
       strictEqual(operationAcceptParam.onClient, false);
@@ -2598,7 +2529,6 @@ describe("typespec-client-generator-core: package", () => {
       ok(queryParam);
       strictEqual(queryParam.serializedName, "api-version");
       ok(serviceOperation.bodyParam);
-      strictEqual(serviceOperation.bodyParam.nameInClient, "resource");
       strictEqual(serviceOperation.bodyParam.name, "resource");
       strictEqual(serviceOperation.bodyParam.type, widgetModel);
 
@@ -2712,7 +2642,6 @@ describe("typespec-client-generator-core: package", () => {
       const apiVersion = operation.parameters.find((x) => x.isApiVersionParam);
       ok(apiVersion);
       strictEqual(apiVersion.kind, "query");
-      strictEqual(apiVersion.nameInClient, "apiVersion");
       strictEqual(apiVersion.name, "apiVersion");
       strictEqual(apiVersion.serializedName, "api-version");
       strictEqual(apiVersion.onClient, true);
@@ -2849,16 +2778,10 @@ describe("typespec-client-generator-core: package", () => {
       strictEqual(bodyParameter.optional, false);
       strictEqual(bodyParameter.type.kind, "model");
       strictEqual(bodyParameter.type.properties.length, 1);
-      strictEqual(bodyParameter.type.properties[0].nameInClient, "name");
       strictEqual(bodyParameter.type.properties[0].name, "name");
 
       const correspondingMethodParams = bodyParameter.correspondingMethodParams;
       strictEqual(correspondingMethodParams.length, 1);
-
-      strictEqual(
-        bodyParameter.type.properties[0].nameInClient,
-        correspondingMethodParams[0].nameInClient
-      );
       strictEqual(bodyParameter.type.properties[0].name, correspondingMethodParams[0].name);
     });
 
@@ -2912,9 +2835,7 @@ describe("typespec-client-generator-core: package", () => {
       strictEqual(bodyParameter.optional, false);
       strictEqual(bodyParameter.type.kind, "model");
       strictEqual(bodyParameter.type.properties.length, 2);
-      strictEqual(bodyParameter.type.properties[0].nameInClient, "kind");
       strictEqual(bodyParameter.type.properties[0].name, "kind");
-      strictEqual(bodyParameter.type.properties[1].nameInClient, "name");
       strictEqual(bodyParameter.type.properties[1].name, "name");
 
       const correspondingMethodParams = bodyParameter.correspondingMethodParams;

--- a/packages/typespec-client-generator-core/test/types/body-model-property-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/body-model-property-types.test.ts
@@ -106,7 +106,6 @@ describe("typespec-client-generator-core: body model property types", () => {
       (x) => x.kind === "property" && x.serializedName === "encodedWireName"
     );
     ok(jsonEncodedProp);
-    strictEqual(jsonEncodedProp.nameInClient, "jsonEncodedAndProjectedName");
     strictEqual(jsonEncodedProp.name, "jsonEncodedAndProjectedName");
 
     // wire name test with deprecated projected
@@ -114,7 +113,6 @@ describe("typespec-client-generator-core: body model property types", () => {
       (x) => x.kind === "property" && x.serializedName === "realWireName"
     );
     ok(jsonProjectedProp);
-    strictEqual(jsonProjectedProp.nameInClient, "jsonProjectedName");
     strictEqual(jsonProjectedProp.name, "jsonProjectedName");
 
     // regular
@@ -122,7 +120,6 @@ describe("typespec-client-generator-core: body model property types", () => {
       (x) => x.kind === "property" && x.serializedName === "regular"
     );
     ok(regularProp);
-    strictEqual(regularProp.nameInClient, "regular");
     strictEqual(regularProp.name, "regular");
   });
   it("union type", async function () {

--- a/packages/typespec-client-generator-core/test/types/model-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/model-types.test.ts
@@ -146,7 +146,6 @@ describe("typespec-client-generator-core: model types", () => {
     strictEqual(recursiveModel.properties.length, 1);
     const prop = recursiveModel.properties[0];
     strictEqual(prop.kind, "property");
-    strictEqual(prop.nameInClient, "prop");
     strictEqual(prop.name, "prop");
     strictEqual(prop.type.kind, "model");
     strictEqual(prop.type.name, "RecursiveModel");


### PR DESCRIPTION
fixes #446