### PR TITLE
remove unused isErrorOrChildOfError

### DIFF
--- a/.chronus/changes/remove_is_error_child_of_error-2024-5-24-15-29-24.md
+++ b/.chronus/changes/remove_is_error_child_of_error-2024-5-24-15-29-24.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+remove unused isErrorOrChildOfError

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -614,21 +614,6 @@ function buildNameFromContextPaths(
   return createName;
 }
 
-/**
- *
- * @deprecated This function is deprecated. You should use isErrorModel from the standard TypeSpec library
- */
-export function isErrorOrChildOfError(context: TCGCContext, model: Model): boolean {
-  const errorDecorator = isErrorModel(context.program, model);
-  if (errorDecorator) return true;
-  let baseModel = model.baseModel;
-  while (baseModel) {
-    if (isErrorModel(context.program, baseModel)) return true;
-    baseModel = baseModel.baseModel;
-  }
-  return false;
-}
-
 export function getHttpOperationWithCache(
   context: TCGCContext,
   operation: Operation

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -15,7 +15,6 @@ import {
   getNamespaceFullName,
   getProjectedName,
   ignoreDiagnostics,
-  isErrorModel,
   listServices,
   resolveEncodedName,
 } from "@typespec/compiler";


### PR DESCRIPTION
Right after we added this function, `isErrorModel` from `@typespec/compiler` would check inheritance for error. I've checked and no one uses this. Since it was never used, I'm going to go ahead and remove it