### PR TITLE
Fix [Bug]: Wrong `null` tagging in ManagedServiceIdentity

### DIFF
--- a/.chronus/changes/fix-managed-identity-def-issue-2024-6-2-18-48-2.md
+++ b/.chronus/changes/fix-managed-identity-def-issue-2024-6-2-18-48-2.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Fix the type inconsistancy issue for property userAssignedIdentities in common types V5 ManagedServiceIdentity

--- a/.chronus/changes/fix-managed-identity-def-issue-2024-6-2-18-48-2.md
+++ b/.chronus/changes/fix-managed-identity-def-issue-2024-6-2-18-48-2.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-azure-resource-manager"
 ---
 
-Fix the type inconsistancy issue for property userAssignedIdentities in common types V5 ManagedServiceIdentity
+Fix the type discrepancy issue for property userAssignedIdentities in common types V5 ManagedServiceIdentity

--- a/docs/libraries/azure-resource-manager/reference/data-types.md
+++ b/docs/libraries/azure-resource-manager/reference/data-types.md
@@ -1235,7 +1235,7 @@ model Azure.ResourceManager.CommonTypes.ManagedServiceIdentity
 | principalId?            | `Core.uuid`                                                                                                  | The service principal ID of the system assigned identity. This property will only be provided for a system assigned identity. |
 | tenantId?               | `Core.uuid`                                                                                                  | The tenant ID of the system assigned identity. This property will only be provided for a system assigned identity.            |
 | type                    | [`ManagedServiceIdentityType`](./data-types.md#Azure.ResourceManager.CommonTypes.ManagedServiceIdentityType) | The type of managed identity assigned to this resource.                                                                       |
-| userAssignedIdentities? | `Record<ResourceManager.CommonTypes.UserAssignedIdentity> \| null`                                           | The identities assigned to this resource by the user.                                                                         |
+| userAssignedIdentities? | `Record<ResourceManager.CommonTypes.UserAssignedIdentity \| null>`                                           | The identities assigned to this resource by the user.                                                                         |
 
 ### `ManagementGroupNameParameter` {#Azure.ResourceManager.CommonTypes.ManagementGroupNameParameter}
 

--- a/docs/libraries/azure-resource-manager/reference/data-types.md
+++ b/docs/libraries/azure-resource-manager/reference/data-types.md
@@ -1695,9 +1695,9 @@ model Azure.ResourceManager.CommonTypes.UserAssignedIdentities
 
 #### Properties
 
-| Name | Type                                                                                             | Description           |
-| ---- | ------------------------------------------------------------------------------------------------ | --------------------- |
-|      | [`UserAssignedIdentity`](./data-types.md#Azure.ResourceManager.CommonTypes.UserAssignedIdentity) | Additional properties |
+| Name | Type                                                       | Description           |
+| ---- | ---------------------------------------------------------- | --------------------- |
+|      | `ResourceManager.CommonTypes.UserAssignedIdentity \| null` | Additional properties |
 
 ### `UserAssignedIdentity` {#Azure.ResourceManager.CommonTypes.UserAssignedIdentity}
 

--- a/packages/typespec-azure-resource-manager/lib/common-types/managed-identity.tsp
+++ b/packages/typespec-azure-resource-manager/lib/common-types/managed-identity.tsp
@@ -24,7 +24,7 @@ model ManagedServiceIdentity {
 
   /** The identities assigned to this resource by the user. */
   @typeChangedFrom(Versions.v5, Record<UserAssignedIdentity>)
-  userAssignedIdentities?: Record<UserAssignedIdentity> | null;
+  userAssignedIdentities?: Record<UserAssignedIdentity | null>;
 }
 
 /**

--- a/packages/typespec-azure-resource-manager/lib/common-types/managed-identity.tsp
+++ b/packages/typespec-azure-resource-manager/lib/common-types/managed-identity.tsp
@@ -4,8 +4,8 @@ using TypeSpec.Versioning;
 namespace Azure.ResourceManager.CommonTypes;
 
 /** The set of user assigned identities associated with the resource. The userAssignedIdentities dictionary keys will be ARM resource ids in the form: '/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ManagedIdentity/userAssignedIdentities/{identityName}. The dictionary values can be empty objects ({}) in requests. */
-#deprecated "Do not use this model. Instead, use Record<UserAssignedIdentity> directly. Using this model will result in a different client SDK when generated from TypeSpec compared to the Swagger."
-model UserAssignedIdentities is Record<UserAssignedIdentity>;
+#deprecated "Do not use this model. Instead, use Record<UserAssignedIdentity | null> directly. Using this model will result in a different client SDK when generated from TypeSpec compared to the Swagger."
+model UserAssignedIdentities is Record<UserAssignedIdentity | null>;
 
 /**
  * Managed service identity (system assigned and/or user assigned identities)


### PR DESCRIPTION
fixes https://github.com/Azure/typespec-azure/issues/1110

to match with the swagger definition https://github.com/Azure/azure-rest-api-specs/blob/87a08b955c257c773a3bd42553c718d4b1092955/specification/common-types/resource-management/v5/managedidentity.json#L9-L16