### PR TITLE
Disable 1ds codeql

### DIFF
--- a/eng/pipelines/templates/1es-redirect.yml
+++ b/eng/pipelines/templates/1es-redirect.yml
@@ -29,6 +29,10 @@ extends:
     settings:
       skipBuildTagsForGitHubPullRequests: true
     sdl:
+      codeql:
+        compiled:
+          enabled: false
+          justificationForDisabling: CodeQL times our pipelines out by running for 2+ hours before being force canceled.
       credscan:
         suppressionsFile: $(Build.SourcesDirectory)/eng/CredScanSuppression.json
       sourceAnalysisPool:


### PR DESCRIPTION
From Azure sdk for js repo >


> All the other languages have disabled codeql and we are now hitting blocking issues when running codeql on macos (https://dev.azure.com/twcdot/Data/_workitems/edit/138580) and even on the other OS's the configuration causes the builds to run for a long time.

https://github.com/Azure/azure-sdk-for-js/pull/30277