### PR TITLE
Fix codeql warning on regex

### DIFF
--- a/.chronus/changes/timotheeguerin-patch-1-2024-6-10-15-45-54.md
+++ b/.chronus/changes/timotheeguerin-patch-1-2024-6-10-15-45-54.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Tweak regex to validate Arm keys

--- a/packages/typespec-azure-resource-manager/src/rules/utils.ts
+++ b/packages/typespec-azure-resource-manager/src/rules/utils.ts
@@ -105,7 +105,7 @@ export function getNamespaceName(
 }
 
 export function isValidKey(key: string): boolean {
-  const match = key.match(/^[a-z][A-z0-9-]+$/);
+  const match = key.match(/^[a-z][a-zA-Z0-9-]+$/);
   return match !== undefined && match !== null && match.length === 1;
 }
 


### PR DESCRIPTION
Used in linter rules that expect alphanumeric chars or dash starting with lowercase letter so this seems like the correct regex