### PR TITLE
Optional template parameter to customize the optionality of ARM resource `properties` field

### DIFF
--- a/.chronus/changes/azhang_ARMPropertiesOptional-2024-6-12-15-49-5.md
+++ b/.chronus/changes/azhang_ARMPropertiesOptional-2024-6-12-15-49-5.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Added an optional template parameter on `TrackedResource`, `ProxyResource`, and `ExtensionResource` ARM templates that allows brownfield services to customize the optionality of the ARM resource `properties` field.

--- a/docs/libraries/azure-resource-manager/reference/data-types.md
+++ b/docs/libraries/azure-resource-manager/reference/data-types.md
@@ -465,14 +465,15 @@ Concrete extension resource types can be created by aliasing this type using a s
 See more details on [different Azure Resource Manager resource type here.](https://azure.github.io/typespec-azure/docs/howtos/ARM/resource-type)
 
 ```typespec
-model Azure.ResourceManager.ExtensionResource<Properties>
+model Azure.ResourceManager.ExtensionResource<Properties, OptionalProperties>
 ```
 
 #### Template Parameters
 
-| Name       | Description                                                           |
-| ---------- | --------------------------------------------------------------------- |
-| Properties | A model containing the provider-specific properties for this resource |
+| Name               | Description                                                                                                                                    |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Properties         | A model containing the provider-specific properties for this resource                                                                          |
+| OptionalProperties | A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended. |
 
 #### Properties
 
@@ -631,14 +632,15 @@ Concrete proxy resource types can be created by aliasing this type using a speci
 See more details on [different Azure Resource Manager resource type here.](https://azure.github.io/typespec-azure/docs/howtos/ARM/resource-type)
 
 ```typespec
-model Azure.ResourceManager.ProxyResource<Properties>
+model Azure.ResourceManager.ProxyResource<Properties, OptionalProperties>
 ```
 
 #### Template Parameters
 
-| Name       | Description                                                           |
-| ---------- | --------------------------------------------------------------------- |
-| Properties | A model containing the provider-specific properties for this resource |
+| Name               | Description                                                                                                                                    |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Properties         | A model containing the provider-specific properties for this resource                                                                          |
+| OptionalProperties | A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended. |
 
 #### Properties
 
@@ -877,14 +879,15 @@ Concrete tracked resource types can be created by aliasing this type using a spe
 See more details on [different Azure Resource Manager resource type here.](https://azure.github.io/typespec-azure/docs/howtos/ARM/resource-type)
 
 ```typespec
-model Azure.ResourceManager.TrackedResource<Properties>
+model Azure.ResourceManager.TrackedResource<Properties, OptionalProperties>
 ```
 
 #### Template Parameters
 
-| Name       | Description                                                           |
-| ---------- | --------------------------------------------------------------------- |
-| Properties | A model containing the provider-specific properties for this resource |
+| Name               | Description                                                                                                                                    |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Properties         | A model containing the provider-specific properties for this resource                                                                          |
+| OptionalProperties | A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended. |
 
 #### Properties
 

--- a/docs/libraries/azure-resource-manager/reference/data-types.md
+++ b/docs/libraries/azure-resource-manager/reference/data-types.md
@@ -465,7 +465,7 @@ Concrete extension resource types can be created by aliasing this type using a s
 See more details on [different Azure Resource Manager resource type here.](https://azure.github.io/typespec-azure/docs/howtos/ARM/resource-type)
 
 ```typespec
-model Azure.ResourceManager.ExtensionResource<Properties, OptionalProperties>
+model Azure.ResourceManager.ExtensionResource<Properties, PropertiesOptional>
 ```
 
 #### Template Parameters
@@ -473,7 +473,7 @@ model Azure.ResourceManager.ExtensionResource<Properties, OptionalProperties>
 | Name               | Description                                                                                                                                    |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | Properties         | A model containing the provider-specific properties for this resource                                                                          |
-| OptionalProperties | A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended. |
+| PropertiesOptional | A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended. |
 
 #### Properties
 
@@ -632,7 +632,7 @@ Concrete proxy resource types can be created by aliasing this type using a speci
 See more details on [different Azure Resource Manager resource type here.](https://azure.github.io/typespec-azure/docs/howtos/ARM/resource-type)
 
 ```typespec
-model Azure.ResourceManager.ProxyResource<Properties, OptionalProperties>
+model Azure.ResourceManager.ProxyResource<Properties, PropertiesOptional>
 ```
 
 #### Template Parameters
@@ -640,7 +640,7 @@ model Azure.ResourceManager.ProxyResource<Properties, OptionalProperties>
 | Name               | Description                                                                                                                                    |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | Properties         | A model containing the provider-specific properties for this resource                                                                          |
-| OptionalProperties | A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended. |
+| PropertiesOptional | A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended. |
 
 #### Properties
 
@@ -879,7 +879,7 @@ Concrete tracked resource types can be created by aliasing this type using a spe
 See more details on [different Azure Resource Manager resource type here.](https://azure.github.io/typespec-azure/docs/howtos/ARM/resource-type)
 
 ```typespec
-model Azure.ResourceManager.TrackedResource<Properties, OptionalProperties>
+model Azure.ResourceManager.TrackedResource<Properties, PropertiesOptional>
 ```
 
 #### Template Parameters
@@ -887,7 +887,7 @@ model Azure.ResourceManager.TrackedResource<Properties, OptionalProperties>
 | Name               | Description                                                                                                                                    |
 | ------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | Properties         | A model containing the provider-specific properties for this resource                                                                          |
-| OptionalProperties | A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended. |
+| PropertiesOptional | A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended. |
 
 #### Properties
 

--- a/packages/typespec-azure-resource-manager/lib/models.tsp
+++ b/packages/typespec-azure-resource-manager/lib/models.tsp
@@ -40,16 +40,16 @@ model ResourceNameParameter<
  *
  * See more details on [different Azure Resource Manager resource type here.](https://azure.github.io/typespec-azure/docs/howtos/ARM/resource-type)
  * @template Properties A model containing the provider-specific properties for this resource
- * @template OptionalProperties A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended.
+ * @template PropertiesOptional A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended.
  */
 @doc("Concrete tracked resource types can be created by aliasing this type using a specific property type.")
 @armResourceInternal(Properties)
 @includeInapplicableMetadataInPayload(false)
-model TrackedResource<Properties extends {}, OptionalProperties extends valueof boolean = true>
+model TrackedResource<Properties extends {}, PropertiesOptional extends valueof boolean = true>
   extends Foundations.TrackedResource {
   @doc("The resource-specific properties for this resource.")
   @conditionalClientFlatten
-  @armResourcePropertiesOptionality(OptionalProperties)
+  @armResourcePropertiesOptionality(PropertiesOptional)
   properties?: Properties;
 }
 
@@ -58,16 +58,16 @@ model TrackedResource<Properties extends {}, OptionalProperties extends valueof 
  *
  * See more details on [different Azure Resource Manager resource type here.](https://azure.github.io/typespec-azure/docs/howtos/ARM/resource-type)
  * @template Properties A model containing the provider-specific properties for this resource
- * @template OptionalProperties A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended.
+ * @template PropertiesOptional A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended.
  */
 @doc("Concrete proxy resource types can be created by aliasing this type using a specific property type.")
 @armResourceInternal(Properties)
 @includeInapplicableMetadataInPayload(false)
-model ProxyResource<Properties extends {}, OptionalProperties extends valueof boolean = true>
+model ProxyResource<Properties extends {}, PropertiesOptional extends valueof boolean = true>
   extends Foundations.ProxyResource {
   @doc("The resource-specific properties for this resource.")
   @conditionalClientFlatten
-  @armResourcePropertiesOptionality(OptionalProperties)
+  @armResourcePropertiesOptionality(PropertiesOptional)
   properties?: Properties;
 }
 
@@ -76,17 +76,17 @@ model ProxyResource<Properties extends {}, OptionalProperties extends valueof bo
  *
  * See more details on [different Azure Resource Manager resource type here.](https://azure.github.io/typespec-azure/docs/howtos/ARM/resource-type)
  * @template Properties A model containing the provider-specific properties for this resource
- * @template OptionalProperties A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended.
+ * @template PropertiesOptional A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended.
  */
 @extensionResource
 @doc("Concrete extension resource types can be created by aliasing this type using a specific property type.")
 @armResourceInternal(Properties)
 @includeInapplicableMetadataInPayload(false)
-model ExtensionResource<Properties extends {}, OptionalProperties extends valueof boolean = true>
+model ExtensionResource<Properties extends {}, PropertiesOptional extends valueof boolean = true>
   extends Foundations.ExtensionResource {
   @doc("The resource-specific properties for this resource.")
   @conditionalClientFlatten
-  @armResourcePropertiesOptionality(OptionalProperties)
+  @armResourcePropertiesOptionality(PropertiesOptional)
   properties?: Properties;
 }
 //#region

--- a/packages/typespec-azure-resource-manager/lib/models.tsp
+++ b/packages/typespec-azure-resource-manager/lib/models.tsp
@@ -40,13 +40,16 @@ model ResourceNameParameter<
  *
  * See more details on [different Azure Resource Manager resource type here.](https://azure.github.io/typespec-azure/docs/howtos/ARM/resource-type)
  * @template Properties A model containing the provider-specific properties for this resource
+ * @template OptionalProperties A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended.
  */
 @doc("Concrete tracked resource types can be created by aliasing this type using a specific property type.")
 @armResourceInternal(Properties)
 @includeInapplicableMetadataInPayload(false)
-model TrackedResource<Properties extends {}> extends Foundations.TrackedResource {
+model TrackedResource<Properties extends {}, OptionalProperties extends valueof boolean = true>
+  extends Foundations.TrackedResource {
   @doc("The resource-specific properties for this resource.")
   @conditionalClientFlatten
+  @armResourcePropertiesOptionality(OptionalProperties)
   properties?: Properties;
 }
 
@@ -55,13 +58,16 @@ model TrackedResource<Properties extends {}> extends Foundations.TrackedResource
  *
  * See more details on [different Azure Resource Manager resource type here.](https://azure.github.io/typespec-azure/docs/howtos/ARM/resource-type)
  * @template Properties A model containing the provider-specific properties for this resource
+ * @template OptionalProperties A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended.
  */
 @doc("Concrete proxy resource types can be created by aliasing this type using a specific property type.")
 @armResourceInternal(Properties)
 @includeInapplicableMetadataInPayload(false)
-model ProxyResource<Properties extends {}> extends Foundations.ProxyResource {
+model ProxyResource<Properties extends {}, OptionalProperties extends valueof boolean = true>
+  extends Foundations.ProxyResource {
   @doc("The resource-specific properties for this resource.")
   @conditionalClientFlatten
+  @armResourcePropertiesOptionality(OptionalProperties)
   properties?: Properties;
 }
 
@@ -70,14 +76,17 @@ model ProxyResource<Properties extends {}> extends Foundations.ProxyResource {
  *
  * See more details on [different Azure Resource Manager resource type here.](https://azure.github.io/typespec-azure/docs/howtos/ARM/resource-type)
  * @template Properties A model containing the provider-specific properties for this resource
+ * @template OptionalProperties A boolean flag indicating whether the resource `Properties` field is marked as optional or required. Default true is optional and recommended.
  */
 @extensionResource
 @doc("Concrete extension resource types can be created by aliasing this type using a specific property type.")
 @armResourceInternal(Properties)
 @includeInapplicableMetadataInPayload(false)
-model ExtensionResource<Properties extends {}> extends Foundations.ExtensionResource {
+model ExtensionResource<Properties extends {}, OptionalProperties extends valueof boolean = true>
+  extends Foundations.ExtensionResource {
   @doc("The resource-specific properties for this resource.")
   @conditionalClientFlatten
+  @armResourcePropertiesOptionality(OptionalProperties)
   properties?: Properties;
 }
 //#region

--- a/packages/typespec-azure-resource-manager/lib/private.decorators.tsp
+++ b/packages/typespec-azure-resource-manager/lib/private.decorators.tsp
@@ -97,3 +97,9 @@ extern dec armRenameListByOperation(
   parentFriendlyTypeName?: valueof string,
   applyOperationRename?: valueof boolean
 );
+
+/**
+ * Please DO NOT USE in RestAPI specs.
+ * This decorator is used to adjust optionality on ARM Resource's `properties` field for brownfield service conversion.
+ */
+extern dec armResourcePropertiesOptionality(target: ModelProperty, isOptional: valueof boolean);

--- a/packages/typespec-azure-resource-manager/src/private.decorators.ts
+++ b/packages/typespec-azure-resource-manager/src/private.decorators.ts
@@ -393,3 +393,13 @@ export function $armRenameListByOperation(
     applyOperationRename
   );
 }
+
+export function $armResourcePropertiesOptionality(
+  context: DecoratorContext,
+  target: ModelProperty,
+  isOptional: boolean
+) {
+  if (target.name === "properties") {
+    target.optional = isOptional;
+  }
+}


### PR DESCRIPTION
Added an optional template parameter on `TrackedResource`, `ProxyResource`, and `ExtensionResource` ARM templates that allows brownfield services to customize the optionality of the ARM resource `properties` field.

Closes #131