### PR TITLE
Migrate azure core library to use generated decorator signature

### DIFF
--- a/.chronus/changes/azure-core-dec-signatures-2024-6-18-17-49-0.md
+++ b/.chronus/changes/azure-core-dec-signatures-2024-6-18-17-49-0.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-core"
+---
+
+Use some more precise types for certain decorators that would have crashed otherwise

--- a/docs/libraries/azure-core/reference/decorators.md
+++ b/docs/libraries/azure-core/reference/decorators.md
@@ -395,7 +395,7 @@ checks.
 #### Target
 
 The model type to mark as a trait.
-`unknown`
+`Model`
 
 #### Parameters
 

--- a/packages/typespec-azure-core/README.md
+++ b/packages/typespec-azure-core/README.md
@@ -486,7 +486,7 @@ checks.
 ##### Target
 
 The model type to mark as a trait.
-`unknown`
+`Model`
 
 ##### Parameters
 

--- a/packages/typespec-azure-core/generated-defs/Azure.Core.Foundations.Private.ts
+++ b/packages/typespec-azure-core/generated-defs/Azure.Core.Foundations.Private.ts
@@ -1,0 +1,83 @@
+import type { DecoratorContext, Model, Operation, Scalar, Type } from "@typespec/compiler";
+
+/**
+ * Provides a Model describing parameter customizations to spread into the target.
+ *
+ * @param customizations Model describing the customization to spread
+ */
+export type SpreadCustomParametersDecorator = (
+  context: DecoratorContext,
+  entity: Model,
+  customizations: Type
+) => void;
+
+/**
+ * Provides a Model describing response property customizations to spread into the target.
+ *
+ * @param customizations Model describing the customization to spread
+ */
+export type SpreadCustomResponsePropertiesDecorator = (
+  context: DecoratorContext,
+  entity: Model,
+  customizations: Type
+) => void;
+
+/**
+ * Checks the Resource parameter of an operation signature to ensure it's a valid resource type.
+ * Also marks the operation as a resource operation.
+ *
+ * @param resourceType The possible resource Type to validate.
+ */
+export type EnsureResourceTypeDecorator = (
+  context: DecoratorContext,
+  entity: Operation,
+  resourceType: Type
+) => void;
+
+/**
+ * Identifies that a model should be treated as an embedding vector.
+ */
+export type EmbeddingVectorDecorator = (
+  context: DecoratorContext,
+  entity: Model,
+  type: Scalar
+) => void;
+
+/**
+ * Configuration for the armResourceIdentifier scalar
+ */
+export type ArmResourceIdentifierConfigDecorator = (
+  context: DecoratorContext,
+  target: Scalar,
+  options: Type
+) => void;
+
+/**
+ * Checks the Resource parameter of an operation signature to ensure it's a valid resource type.
+ */
+export type NeedsRouteDecorator = (context: DecoratorContext, entity: Operation) => void;
+
+/**
+ * Issues a warning if an operation which derives from an operation templated marked with `@ensureVerb`
+ * differs from the verb specified.
+ *
+ * @param templateName : Name of the template operation.
+ * @param verb The intended HTTP verb.
+ */
+export type EnsureVerbDecorator = (
+  context: DecoratorContext,
+  entity: Operation,
+  templateName: string,
+  verb: string
+) => void;
+
+/**
+ * Sets the priority order of default final-state-via options for an operation
+ *
+ * @param states : list of final-state-via options in priority order
+ */
+export type DefaultFinalStateViaDecorator = (
+  context: DecoratorContext,
+  target: Operation,
+  states: unknown
+) => void;

--- a/packages/typespec-azure-core/generated-defs/Azure.Core.Foundations.ts
+++ b/packages/typespec-azure-core/generated-defs/Azure.Core.Foundations.ts
@@ -1,0 +1,28 @@
+import type { DecoratorContext, Model } from "@typespec/compiler";
+
+/**
+ * Deletes any key properties from the model.
+ */
+export type OmitKeyPropertiesDecorator = (context: DecoratorContext, entity: Model) => void;
+
+/**
+ * Identifies a property on a request model that serves as a linked operation parameter.
+ *
+ * @param name Property name on the target
+ */
+export type RequestParameterDecorator = (
+  context: DecoratorContext,
+  entity: Model,
+  name: string
+) => void;
+
+/**
+ * Identifies a property on *all* non-error response models that serve as a linked operation parameter.
+ *
+ * @param name Property name on the target
+ */
+export type ResponsePropertyDecorator = (
+  context: DecoratorContext,
+  entity: Model,
+  name: string
+) => void;

--- a/packages/typespec-azure-core/generated-defs/Azure.Core.Foundations.ts-test.ts
+++ b/packages/typespec-azure-core/generated-defs/Azure.Core.Foundations.ts-test.ts
@@ -1,0 +1,24 @@
+/** An error here would mean that the decorator is not exported or doesn't have the right name. */
+import {
+  $omitKeyProperties,
+  $requestParameter,
+  $responseProperty,
+} from "@azure-tools/typespec-azure-core";
+import type {
+  OmitKeyPropertiesDecorator,
+  RequestParameterDecorator,
+  ResponsePropertyDecorator,
+} from "./Azure.Core.Foundations.js";
+
+type Decorators = {
+  $omitKeyProperties: OmitKeyPropertiesDecorator;
+  $requestParameter: RequestParameterDecorator;
+  $responseProperty: ResponsePropertyDecorator;
+};
+
+/** An error here would mean that the exported decorator is not using the same signature. Make sure to have export const $decName: DecNameDecorator = (...) => ... */
+const _: Decorators = {
+  $omitKeyProperties,
+  $requestParameter,
+  $responseProperty,
+};

--- a/packages/typespec-azure-core/generated-defs/Azure.Core.Traits.Private.ts
+++ b/packages/typespec-azure-core/generated-defs/Azure.Core.Traits.Private.ts
@@ -1,0 +1,91 @@
+import type {
+  DecoratorContext,
+  EnumMember,
+  Interface,
+  Model,
+  ModelProperty,
+  Operation,
+  Type,
+} from "@typespec/compiler";
+
+/**
+ * `@applyTraitOverride` copies the `traitModel` into `target` and renames its envelope
+ * property to enable the trait to override another trait sharing the same name.
+ *
+ * @param target The model into which the trait will be copied.
+ * @param traitModel The trait model type to be overridden.
+ */
+export type ApplyTraitOverrideDecorator = (
+  context: DecoratorContext,
+  target: Model,
+  traitModel: Model
+) => void;
+
+/**
+ * `@ensureAllQueryParams` checks the properties of `paramModel` to ensure they all are marked
+ * with the `@query` decorator.
+ *
+ * @param target The model type where this check will be established.
+ * @param paramModel The actual model type to check for query parameters.
+ */
+export type EnsureAllQueryParamsDecorator = (
+  context: DecoratorContext,
+  target: Model,
+  paramModel: Model
+) => void;
+
+/**
+ * `@ensureAllHeaderParams` checks the properties of `paramModel` to ensure they all are marked
+ * with the `@header` decorator.
+ *
+ * @param target The model type where this check will be established.
+ * @param paramModel The actual model type to check for header properties.
+ */
+export type EnsureAllHeaderParamsDecorator = (
+  context: DecoratorContext,
+  target: Model,
+  paramModel: Model
+) => void;
+
+/**
+ * Copies trait properties from `traitModel` into `target` which conform to the
+ * specified location and contexts.
+ *
+ * @param traitModel The trait model type to be applied.
+ * @param traitLocation The trait location to use for selecting trait properties.
+ * @param traitContexts The trait contexts to use for selecting trait properties.
+ */
+export type AddTraitPropertiesDecorator = (
+  context: DecoratorContext,
+  target: Model,
+  traitModel: Model,
+  traitLocation: EnumMember,
+  traitContexts: Type
+) => void;
+
+/**
+ * `@traitSource` stores the `traitName` of its original trait on the envelope property.
+ *
+ * @param target The trait envelope property where `traitName` will be stored.
+ * @param traitName The name of the original trait to which this property belongs.
+ */
+export type TraitSourceDecorator = (
+  context: DecoratorContext,
+  target: ModelProperty,
+  traitName: string
+) => void;
+
+/**
+ * `@ensureTraitsPresent` checks the envelope properties of `traitModel` to ensure all
+ * of the `expectedTraits` are present as envelope properties.
+ *
+ * @param target The interface or operation where the `traitModel` should be checked.
+ * @param traitModel The trait model type to check.
+ * @param expectedTraits The array of `ExpectedTrait` models which describe each expected trait.
+ */
+export type EnsureTraitsPresentDecorator = (
+  context: DecoratorContext,
+  target: Interface | Operation,
+  traitModel: Model,
+  expectedTraits: Type
+) => void;

--- a/packages/typespec-azure-core/generated-defs/Azure.Core.Traits.ts
+++ b/packages/typespec-azure-core/generated-defs/Azure.Core.Traits.ts
@@ -1,0 +1,49 @@
+import type { DecoratorContext, EnumMember, Model, ModelProperty, Type } from "@typespec/compiler";
+
+/**
+ * `@trait` marks a model type as representing a 'trait' and performs basic validation
+ * checks.
+ *
+ * @param target The model type to mark as a trait.
+ * @param traitName An optional name to uniquely identify the trait.  If unspecified,
+ * the model type name is used.
+ */
+export type TraitDecorator = (context: DecoratorContext, target: Model, traitName?: string) => void;
+
+/**
+ * `@traitLocation` sets the applicable location for a trait on its envelope property.
+ *
+ * @param target The trait envelope property where the context will be applied.
+ * @param contexts An enum member or union of enum members representing the trait's
+ * applicable contexts.
+ */
+export type TraitLocationDecorator = (
+  context: DecoratorContext,
+  target: ModelProperty,
+  contexts: EnumMember
+) => void;
+
+/**
+ * `@traitContext` sets the applicable context for a trait on its envelope property.
+ *
+ * @param target The trait envelope property where the context will be applied.
+ * @param contexts An enum member or union of enum members representing the trait's
+ * applicable contexts.
+ */
+export type TraitContextDecorator = (
+  context: DecoratorContext,
+  target: ModelProperty,
+  contexts: Type
+) => void;
+
+/**
+ * Sets the version for when the trait was added to the specification.  Can be applied
+ * to either a trait model type or its envelope property.
+ *
+ * @param addedVersion The enum member representing the service version.
+ */
+export type TraitAddedDecorator = (
+  context: DecoratorContext,
+  target: Model | ModelProperty,
+  addedVersion: Type
+) => void;

--- a/packages/typespec-azure-core/generated-defs/Azure.Core.Traits.ts-test.ts
+++ b/packages/typespec-azure-core/generated-defs/Azure.Core.Traits.ts-test.ts
@@ -1,0 +1,28 @@
+/** An error here would mean that the decorator is not exported or doesn't have the right name. */
+import {
+  $trait,
+  $traitAdded,
+  $traitContext,
+  $traitLocation,
+} from "@azure-tools/typespec-azure-core";
+import type {
+  TraitAddedDecorator,
+  TraitContextDecorator,
+  TraitDecorator,
+  TraitLocationDecorator,
+} from "./Azure.Core.Traits.js";
+
+type Decorators = {
+  $trait: TraitDecorator;
+  $traitLocation: TraitLocationDecorator;
+  $traitContext: TraitContextDecorator;
+  $traitAdded: TraitAddedDecorator;
+};
+
+/** An error here would mean that the exported decorator is not using the same signature. Make sure to have export const $decName: DecNameDecorator = (...) => ... */
+const _: Decorators = {
+  $trait,
+  $traitLocation,
+  $traitContext,
+  $traitAdded,
+};

--- a/packages/typespec-azure-core/generated-defs/Azure.Core.ts
+++ b/packages/typespec-azure-core/generated-defs/Azure.Core.ts
@@ -1,0 +1,190 @@
+import type {
+  DecoratorContext,
+  Enum,
+  EnumMember,
+  Model,
+  ModelProperty,
+  Operation,
+  Type,
+  Union,
+  UnionVariant,
+} from "@typespec/compiler";
+
+/**
+ * Used for custom StatusMonitor implementation.
+ * Identifies an Enum or ModelProperty as containing long-running operation
+ * status.
+ */
+export type LroStatusDecorator = (
+  context: DecoratorContext,
+  entity: Enum | Union | ModelProperty
+) => void;
+
+/**
+ * Identifies a ModelProperty as containing the final location for the operation result.
+ *
+ * @param finalResult Sets the expected return value for the final result.  Overrides
+ * any value provided in the decorated property, if the property uses ResourceLocation<Resource>.
+ */
+export type FinalLocationDecorator = (
+  context: DecoratorContext,
+  entity: ModelProperty,
+  finalResult?: Type
+) => void;
+
+/**
+ * Identifies a model property as containing the location to poll for operation state.
+ *
+ * @param options PollingOptions for the poller pointed to by this link.  Overrides
+ * settings derived from property value it is decorating, if the value of the
+ * property is ResourceLocation<Resource>
+ */
+export type PollingLocationDecorator = (
+  context: DecoratorContext,
+  entity: ModelProperty,
+  options?: Type
+) => void;
+
+/**
+ * Marks a Model as a paged collection.
+ */
+export type PagedResultDecorator = (context: DecoratorContext, entity: Model) => void;
+
+/**
+ * Identifies the ModelProperty that contains the paged items. Can only be used on a Model marked with `@pagedResult`.
+ */
+export type ItemsDecorator = (context: DecoratorContext, entity: ModelProperty) => void;
+
+/**
+ * Identifies a ModelProperty that contains the next link value. Can only be used on a Model marked with `@pagedResult`.
+ */
+export type NextLinkDecorator = (context: DecoratorContext, entity: ModelProperty) => void;
+
+/**
+ * Marks an Enum as being fixed since enums in Azure are
+ * assumed to be extensible.
+ */
+export type FixedDecorator = (context: DecoratorContext, target: Enum) => void;
+
+/**
+ * Used for custom StatusMonitor implementation.
+ * Identifies an EnumMember as a long-running "Succeeded" terminal state.
+ */
+export type LroSucceededDecorator = (
+  context: DecoratorContext,
+  entity: EnumMember | UnionVariant
+) => void;
+
+/**
+ * Used for custom StatusMonitor implementation.
+ * Identifies an EnumMember as a long-running "Canceled" terminal state.
+ */
+export type LroCanceledDecorator = (
+  context: DecoratorContext,
+  entity: EnumMember | UnionVariant
+) => void;
+
+/**
+ * Used for custom StatusMonitor implementation.
+ * Identifies an enum member as a long-running "Failed" terminal state.
+ */
+export type LroFailedDecorator = (
+  context: DecoratorContext,
+  entity: EnumMember | UnionVariant
+) => void;
+
+/**
+ * Used for custom StatusMonitor implementation.
+ * Identifies a model property of a StatusMonitor as containing the result
+ * of a long-running operation that terminates successfully (Succeeded).
+ */
+export type LroResultDecorator = (context: DecoratorContext, entity: ModelProperty) => void;
+
+/**
+ * Used for custom StatusMonitor implementation.
+ * Identifies a model property of a StatusMonitor as containing the result
+ * of a long-running operation that terminates unsuccessfully (Failed).
+ */
+export type LroErrorResultDecorator = (context: DecoratorContext, entity: ModelProperty) => void;
+
+/**
+ * Identifies an operation that is linked to the target operation.
+ *
+ * @param linkedOperation The linked Operation
+ * @param linkType A string indicating the role of the linked operation
+ * @param parameters Map of `RequestParameter<Name>` and/or `ResponseProperty<Name>` that will
+ * be passed to the linked operation request.
+ */
+export type OperationLinkDecorator = (
+  context: DecoratorContext,
+  entity: Operation,
+  linkedOperation: Operation,
+  linkType: string,
+  parameters?: Type
+) => void;
+
+/**
+ * Used to define how to call custom polling operations for long-running operations.
+ *
+ * @param targetParameter A reference to the polling operation parameter this parameter
+ * provides a value for, or the name of that parameter. The default value is the name of
+ * the decorated parameter or property.
+ */
+export type PollingOperationParameterDecorator = (
+  context: DecoratorContext,
+  entity: ModelProperty,
+  targetParameter?: Type
+) => void;
+
+/**
+ * Identifies that an operation is a polling operation for an LRO.
+ *
+ * @param linkedOperation The linked Operation
+ * @param parameters Map of `RequestParameter<Name>` and/or `ResponseProperty<Name>` that will
+ * be passed to the linked operation request.
+ */
+export type PollingOperationDecorator = (
+  context: DecoratorContext,
+  entity: Operation,
+  linkedOperation: Operation,
+  parameters?: Type
+) => void;
+
+/**
+ * Identifies that an operation is the final operation for an LRO.
+ *
+ * @param linkedOperation The linked Operation
+ * @param parameters Map of `RequestParameter<Name>` and/or `ResponseProperty<Name>` that will
+ * be passed to the linked operation request.
+ */
+export type FinalOperationDecorator = (
+  context: DecoratorContext,
+  entity: Operation,
+  linkedOperation: Operation,
+  parameters?: Type
+) => void;
+
+/**
+ * Overrides the final state value for an operation
+ *
+ * @param finalState The desired final state value
+ */
+export type UseFinalStateViaDecorator = (
+  context: DecoratorContext,
+  entity: Operation,
+  finalState: "original-uri" | "operation-location" | "location" | "azure-async-operation"
+) => void;
+
+/**
+ * Identifies that an operation is used to retrieve the next page for paged operations.
+ *
+ * @param linkedOperation The linked Operation
+ * @param parameters Map of `RequestParameter<Name>` and/or `ResponseProperty<Name>` that will
+ * be passed to the linked operation request.
+ */
+export type NextPageOperationDecorator = (
+  context: DecoratorContext,
+  entity: Operation,
+  linkedOperation: Operation,
+  parameters?: Type
+) => void;

--- a/packages/typespec-azure-core/generated-defs/Azure.Core.ts-test.ts
+++ b/packages/typespec-azure-core/generated-defs/Azure.Core.ts-test.ts
@@ -1,0 +1,84 @@
+/** An error here would mean that the decorator is not exported or doesn't have the right name. */
+import {
+  $finalLocation,
+  $finalOperation,
+  $fixed,
+  $items,
+  $lroCanceled,
+  $lroErrorResult,
+  $lroFailed,
+  $lroResult,
+  $lroStatus,
+  $lroSucceeded,
+  $nextLink,
+  $nextPageOperation,
+  $operationLink,
+  $pagedResult,
+  $pollingLocation,
+  $pollingOperation,
+  $pollingOperationParameter,
+  $useFinalStateVia,
+} from "@azure-tools/typespec-azure-core";
+import type {
+  FinalLocationDecorator,
+  FinalOperationDecorator,
+  FixedDecorator,
+  ItemsDecorator,
+  LroCanceledDecorator,
+  LroErrorResultDecorator,
+  LroFailedDecorator,
+  LroResultDecorator,
+  LroStatusDecorator,
+  LroSucceededDecorator,
+  NextLinkDecorator,
+  NextPageOperationDecorator,
+  OperationLinkDecorator,
+  PagedResultDecorator,
+  PollingLocationDecorator,
+  PollingOperationDecorator,
+  PollingOperationParameterDecorator,
+  UseFinalStateViaDecorator,
+} from "./Azure.Core.js";
+
+type Decorators = {
+  $lroStatus: LroStatusDecorator;
+  $finalLocation: FinalLocationDecorator;
+  $pollingLocation: PollingLocationDecorator;
+  $pagedResult: PagedResultDecorator;
+  $items: ItemsDecorator;
+  $nextLink: NextLinkDecorator;
+  $fixed: FixedDecorator;
+  $lroSucceeded: LroSucceededDecorator;
+  $lroCanceled: LroCanceledDecorator;
+  $lroFailed: LroFailedDecorator;
+  $lroResult: LroResultDecorator;
+  $lroErrorResult: LroErrorResultDecorator;
+  $operationLink: OperationLinkDecorator;
+  $pollingOperationParameter: PollingOperationParameterDecorator;
+  $pollingOperation: PollingOperationDecorator;
+  $finalOperation: FinalOperationDecorator;
+  $useFinalStateVia: UseFinalStateViaDecorator;
+  $nextPageOperation: NextPageOperationDecorator;
+};
+
+/** An error here would mean that the exported decorator is not using the same signature. Make sure to have export const $decName: DecNameDecorator = (...) => ... */
+const _: Decorators = {
+  $lroStatus,
+  $finalLocation,
+  $pollingLocation,
+  $pagedResult,
+  $items,
+  $nextLink,
+  $fixed,
+  $lroSucceeded,
+  $lroCanceled,
+  $lroFailed,
+  $lroResult,
+  $lroErrorResult,
+  $operationLink,
+  $pollingOperationParameter,
+  $pollingOperation,
+  $finalOperation,
+  $useFinalStateVia,
+  $nextPageOperation,
+};

--- a/packages/typespec-azure-core/lib/traits.tsp
+++ b/packages/typespec-azure-core/lib/traits.tsp
@@ -55,7 +55,7 @@ enum TraitContext {
  */
 @added(Azure.Core.Versions.v1_0_Preview_2)
 @Private.applyTraitOverride(Trait)
-model TraitOverride<Trait> {}
+model TraitOverride<Trait extends Model> {}
 
 /**
  * Declares a trait that is applied as a query parameter.
@@ -220,7 +220,7 @@ model NoRepeatableRequests {
  * @param traitName An optional name to uniquely identify the trait.  If unspecified,
  *        the model type name is used.
  */
-extern dec trait(target: unknown, traitName?: valueof string);
+extern dec trait(target: Model, traitName?: valueof string);
 
 /**
  * `@traitContext` sets the applicable context for a trait on its envelope property.
@@ -300,7 +300,7 @@ namespace Azure {
          * @param target The model into which the trait will be copied.
          * @param traitModel The trait model type to be overridden.
          */
-        extern dec applyTraitOverride(target: unknown, traitModel: unknown);
+        extern dec applyTraitOverride(target: Model, traitModel: Model);
 
         /**
          * `@ensureTraitsPresent` checks the envelope properties of `traitModel` to ensure all
@@ -323,7 +323,7 @@ namespace Azure {
          * @param target The model type where this check will be established.
          * @param paramModel The actual model type to check for query parameters.
          */
-        extern dec ensureAllQueryParams(target: unknown, paramModel: Model);
+        extern dec ensureAllQueryParams(target: Model, paramModel: Model);
 
         /**
          * `@ensureAllHeaderParams` checks the properties of `paramModel` to ensure they all are marked
@@ -332,7 +332,7 @@ namespace Azure {
          * @param target The model type where this check will be established.
          * @param paramModel The actual model type to check for header properties.
          */
-        extern dec ensureAllHeaderParams(target: unknown, paramModel: Model);
+        extern dec ensureAllHeaderParams(target: Model, paramModel: Model);
       }
     }
   }

--- a/packages/typespec-azure-core/package.json
+++ b/packages/typespec-azure-core/package.json
@@ -35,8 +35,9 @@
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",
-    "build": "tsc -p . && npm run lint-typespec-library",
+    "build": "npm run gen-extern-signature && tsc -p . && npm run lint-typespec-library",
     "watch": "tsc -p . --watch",
+    "gen-extern-signature": "tspd --enable-experimental gen-extern-signature .",
     "lint-typespec-library": "tsp compile . --warn-as-error --import @typespec/library-linter --no-emit",
     "test": "vitest run",
     "test:watch": "vitest -w",

--- a/packages/typespec-azure-core/src/decorators.ts
+++ b/packages/typespec-azure-core/src/decorators.ts
@@ -1,4 +1,4 @@
-import { createDiagnostic, createStateSymbol, reportDiagnostic } from "./lib.js";
+import { AzureCoreStateKeys, createDiagnostic, reportDiagnostic } from "./lib.js";
 import { getAllProperties } from "./utils.js";
 
 import {
@@ -84,22 +84,18 @@ export const FinalOperationKey = "final";
 
 // @fixed
 
-const fixedKey = createStateSymbol("fixed");
-
 export const $fixed: FixedDecorator = (context: DecoratorContext, target: Enum) => {
-  context.program.stateMap(fixedKey).set(target, true);
+  context.program.stateMap(AzureCoreStateKeys.fixed).set(target, true);
 };
 
 export function isFixed(program: Program, target: Enum): boolean {
-  return program.stateMap(fixedKey).get(target) !== undefined;
+  return program.stateMap(AzureCoreStateKeys.fixed).get(target) !== undefined;
 }
 
 // pagedResult
 
-const pagedResultsKey = createStateSymbol("pagedResult");
-
 export const $pagedResult: PagedResultDecorator = (context: DecoratorContext, entity: Model) => {
-  context.program.stateMap(pagedResultsKey).set(entity, true);
+  context.program.stateMap(AzureCoreStateKeys.pagedResult).set(entity, true);
 };
 
 export interface PagedResultMetadata {
@@ -188,7 +184,7 @@ export function getPagedResult(
   let metadata: PagedResultMetadata | undefined = undefined;
   switch (entity.kind) {
     case "Model":
-      if (program.stateMap(pagedResultsKey).get(entity)) {
+      if (program.stateMap(AzureCoreStateKeys.pagedResult).get(entity)) {
         metadata = { modelType: entity };
         const items = _getItems(program, entity);
         if (items !== undefined) {
@@ -260,30 +256,26 @@ export function getPagedResult(
   return metadata;
 }
 
-const itemsPropertyKey = createStateSymbol("items");
-
 export const $items: ItemsDecorator = (context: DecoratorContext, entity: ModelProperty) => {
-  context.program.stateMap(itemsPropertyKey).set(entity, true);
+  context.program.stateMap(AzureCoreStateKeys.items).set(entity, true);
 };
 
 /**
  * Returns `true` if the property is marked with `@items`.
  */
 export function getItems(program: Program, entity: Type): boolean | undefined {
-  return program.stateMap(itemsPropertyKey).get(entity);
+  return program.stateMap(AzureCoreStateKeys.items).get(entity);
 }
 
-const nextLinkPropertyKey = createStateSymbol("nextLink");
-
 export const $nextLink: NextLinkDecorator = (context: DecoratorContext, entity: ModelProperty) => {
-  context.program.stateMap(nextLinkPropertyKey).set(entity, true);
+  context.program.stateMap(AzureCoreStateKeys.nextLink).set(entity, true);
 };
 
 /**
  * Returns `true` if the property is marked with `@nextLink`.
  */
 export function getNextLink(program: Program, entity: Type): boolean | undefined {
-  return program.stateMap(nextLinkPropertyKey).get(entity);
+  return program.stateMap(AzureCoreStateKeys.nextLink).get(entity);
 }
 
 /**
@@ -304,15 +296,13 @@ export interface LongRunningStates {
   states: string[];
 }
 
-const lroStatusKey = createStateSymbol("lroStatus");
-
 export const $lroStatus: LroStatusDecorator = (
   context: DecoratorContext,
   entity: Enum | Union | ModelProperty
 ) => {
   const [states, diagnostics] = extractLroStates(context.program, entity);
   if (diagnostics.length > 0) context.program.reportDiagnostics(diagnostics);
-  context.program.stateMap(lroStatusKey).set(entity, states);
+  context.program.stateMap(AzureCoreStateKeys.lroStatus).set(entity, states);
 };
 
 // Internal use only
@@ -465,7 +455,7 @@ export function getLongRunningStates(
   }
 
   // Otherwise just check the type itself
-  return program.stateMap(lroStatusKey).get(entity);
+  return program.stateMap(AzureCoreStateKeys.lroStatus).get(entity);
 }
 
 /**
@@ -492,10 +482,10 @@ export function getLroStatusProperty(program: Program, target: Model): ModelProp
   }
   const props = getAllProperties(target);
   for (const [_, prop] of props.entries()) {
-    let values = program.stateMap(lroStatusKey).get(prop);
+    let values = program.stateMap(AzureCoreStateKeys.lroStatus).get(prop);
     if (values !== undefined) return prop;
     if (prop.type.kind === "Enum" || prop.type.kind === "Union") {
-      values = program.stateMap(lroStatusKey).get(prop.type);
+      values = program.stateMap(AzureCoreStateKeys.lroStatus).get(prop.type);
       if (values !== undefined) return prop;
     }
   }
@@ -511,8 +501,6 @@ export function getLroStatusProperty(program: Program, target: Model): ModelProp
 
 //@lroResult
 
-const lroResultKey = createStateSymbol("lroResult");
-
 /**
  * Marks the property in a StatusMonitor that contains the logical result
  * of a successful operation.
@@ -520,7 +508,7 @@ const lroResultKey = createStateSymbol("lroResult");
  * @param entity The model property that contains the logical result.
  */
 export const $lroResult = (context: DecoratorContext, entity: ModelProperty) => {
-  context.program.stateMap(lroResultKey).set(entity, entity);
+  context.program.stateMap(AzureCoreStateKeys.lroResult).set(entity, entity);
 };
 
 /**
@@ -540,7 +528,7 @@ export function getLroResult(
   let resultProperty: ModelProperty | undefined = undefined;
   let defaultProperty: ModelProperty | undefined = undefined;
   for (const prop of walkPropertiesInherited(entity)) {
-    const candidateProperty = program.stateMap(lroResultKey).get(prop);
+    const candidateProperty = program.stateMap(AzureCoreStateKeys.lroResult).get(prop);
     if (candidateProperty !== undefined) {
       resultProperty = candidateProperty;
       count++;
@@ -566,8 +554,6 @@ export function getLroResult(
 
 //@lroErrorResult
 
-const lroErrorResultKey = createStateSymbol("lroErrorResult");
-
 /**
  * Marks the property in a StatusMonitor that contains the error result
  * of a failed operation.
@@ -579,7 +565,7 @@ export const $lroErrorResult: LroErrorResultDecorator = (
   entity: ModelProperty
 ) => {
   const { program } = context;
-  program.stateMap(lroErrorResultKey).set(entity, entity);
+  program.stateMap(AzureCoreStateKeys.lroErrorResult).set(entity, entity);
 };
 
 /**
@@ -599,7 +585,7 @@ export function getLroErrorResult(
   let resultProperty: ModelProperty | undefined = undefined;
   let defaultProperty: ModelProperty | undefined = undefined;
   for (const prop of walkPropertiesInherited(entity)) {
-    const candidateProperty = program.stateMap(lroErrorResultKey).get(prop);
+    const candidateProperty = program.stateMap(AzureCoreStateKeys.lroErrorResult).get(prop);
     if (candidateProperty !== undefined) {
       resultProperty = candidateProperty;
       count++;
@@ -624,7 +610,6 @@ export function getLroErrorResult(
 
 //@pollingOperationParameter
 
-const pollingParameterKey = createStateSymbol("pollingOperationParameter");
 export const $pollingOperationParameter: PollingOperationParameterDecorator = (
   context: DecoratorContext,
   entity: ModelProperty,
@@ -642,74 +627,67 @@ export const $pollingOperationParameter: PollingOperationParameterDecorator = (
     default:
       storedValue = undefined;
   }
-  program.stateMap(pollingParameterKey).set(entity, storedValue ?? entity.name);
+  program
+    .stateMap(AzureCoreStateKeys.pollingOperationParameter)
+    .set(entity, storedValue ?? entity.name);
 };
 
 export function getPollingOperationParameter(
   program: Program,
   entity: ModelProperty
 ): string | ModelProperty | undefined {
-  return program.stateMap(pollingParameterKey).get(entity);
+  return program.stateMap(AzureCoreStateKeys.pollingOperationParameter).get(entity);
 }
 
 // @lroSucceeded
-
-const lroSucceededKey = createStateSymbol("lroSucceeded");
 
 export const $lroSucceeded: LroSucceededDecorator = (
   context: DecoratorContext,
   entity: EnumMember | UnionVariant
 ) => {
-  context.program.stateSet(lroSucceededKey).add(entity);
+  context.program.stateSet(AzureCoreStateKeys.lroSucceeded).add(entity);
 };
 
 /**
  *  Returns `true` if the enum member represents a "succeeded" state.
  */
 export function isLroSucceededState(program: Program, entity: EnumMember | UnionVariant) {
-  return program.stateSet(lroSucceededKey).has(entity);
+  return program.stateSet(AzureCoreStateKeys.lroSucceeded).has(entity);
 }
 
 // @lroCanceled
-
-const lroCanceledKey = createStateSymbol("lroCanceled");
 
 export const $lroCanceled: LroCanceledDecorator = (
   context: DecoratorContext,
   entity: EnumMember | UnionVariant
 ) => {
-  context.program.stateSet(lroCanceledKey).add(entity);
+  context.program.stateSet(AzureCoreStateKeys.lroCanceled).add(entity);
 };
 
 /**
  *  Returns `true` if the enum member represents a "canceled" state.
  */
 export function isLroCanceledState(program: Program, entity: EnumMember | UnionVariant) {
-  return program.stateSet(lroCanceledKey).has(entity);
+  return program.stateSet(AzureCoreStateKeys.lroCanceled).has(entity);
 }
 
 // @lroFailed
-
-const lroFailedKey = createStateSymbol("lroFailed");
 
 export const $lroFailed: LroFailedDecorator = (
   context: DecoratorContext,
   entity: EnumMember | UnionVariant
 ) => {
-  context.program.stateSet(lroFailedKey).add(entity);
+  context.program.stateSet(AzureCoreStateKeys.lroFailed).add(entity);
 };
 
 /**
  *  Returns `true` if the enum member represents a "failed" state.
  */
 export function isLroFailedState(program: Program, entity: EnumMember | UnionVariant): boolean {
-  return program.stateSet(lroFailedKey).has(entity);
+  return program.stateSet(AzureCoreStateKeys.lroFailed).has(entity);
 }
 
 // @pollingLocation
-
-const pollingLocationsKey = createStateSymbol("pollingLocations");
-const pollingLocationInfoKey = createStateSymbol("pollingLocationInfo");
 
 /** Extra information about polling control stored with a polling link */
 export type PollingLocationInfo = StatusMonitorPollingLocationInfo;
@@ -753,11 +731,11 @@ export const $pollingLocation: PollingLocationDecorator = (
     if (isNeverType(options)) return;
     const info = extractPollingLocationInfo(program, entity, options);
     if (info) {
-      program.stateMap(pollingLocationInfoKey).set(entity, info);
+      program.stateMap(AzureCoreStateKeys.pollingLocationInfo).set(entity, info);
     }
   }
 
-  program.stateSet(pollingLocationsKey).add(entity);
+  program.stateSet(AzureCoreStateKeys.pollingOperationParameter).add(entity);
 };
 
 /**
@@ -769,7 +747,7 @@ export function getPollingLocationInfo(
   program: Program,
   target: ModelProperty
 ): PollingLocationInfo | undefined {
-  return program.stateMap(pollingLocationInfoKey).get(target);
+  return program.stateMap(AzureCoreStateKeys.pollingLocationInfo).get(target);
 }
 
 function extractUnionVariantValue(type: Type): string | undefined {
@@ -854,13 +832,10 @@ function extractStatusMonitorLocationInfo(
  *  Returns `true` if the property is marked with @pollingLocation.
  */
 export function isPollingLocation(program: Program, entity: ModelProperty): boolean {
-  return program.stateSet(pollingLocationsKey).has(entity);
+  return program.stateSet(AzureCoreStateKeys.pollingOperationParameter).has(entity);
 }
 
 // @finalLocation
-
-const finalLocationsKey = createStateSymbol("finalLocations");
-const finalLocationResultsKey = createStateSymbol("finalLocationResults");
 
 export const $finalLocation: FinalLocationDecorator = (
   context: DecoratorContext,
@@ -869,14 +844,14 @@ export const $finalLocation: FinalLocationDecorator = (
 ) => {
   const { program } = context;
   if (finalResult !== undefined && isNeverType(finalResult)) return;
-  program.stateSet(finalLocationsKey).add(entity);
+  program.stateSet(AzureCoreStateKeys.finalLocations).add(entity);
   switch (finalResult?.kind) {
     case "Model":
-      program.stateMap(finalLocationResultsKey).set(entity, finalResult);
+      program.stateMap(AzureCoreStateKeys.finalLocationResults).set(entity, finalResult);
       break;
     case "Intrinsic":
       if (isVoidType(finalResult)) {
-        program.stateMap(finalLocationResultsKey).set(entity, finalResult);
+        program.stateMap(AzureCoreStateKeys.finalLocationResults).set(entity, finalResult);
       }
   }
 };
@@ -885,17 +860,16 @@ export const $finalLocation: FinalLocationDecorator = (
  *  Returns `true` if the property is marked with @finalLocation.
  */
 export function isFinalLocation(program: Program, entity: ModelProperty): boolean {
-  return program.stateSet(finalLocationsKey).has(entity);
+  return program.stateSet(AzureCoreStateKeys.finalLocations).has(entity);
 }
 
 export function getFinalLocationValue(
   program: Program,
   entity: ModelProperty
 ): Model | IntrinsicType | undefined {
-  return program.stateMap(finalLocationResultsKey).get(entity);
+  return program.stateMap(AzureCoreStateKeys.finalLocationResults).get(entity);
 }
 
-const finalStateOverrideKey = createStateSymbol("finalStateOverride");
 /**
  * overrides the final state for an lro
  * @param context The execution context for the decorator
@@ -935,7 +909,7 @@ export const $useFinalStateVia: UseFinalStateViaDecorator = (
   const operation = ignoreDiagnostics(getHttpOperation(program, entity));
   const storedValue = validateFinalState(program, operation, finalStateVia);
   if (storedValue !== undefined || operation.verb === "put") {
-    program.stateMap(finalStateOverrideKey).set(entity, finalStateVia);
+    program.stateMap(AzureCoreStateKeys.finalStateOverride).set(entity, finalStateVia);
   }
   if (
     storedValue === undefined &&
@@ -1059,7 +1033,7 @@ export function getFinalStateOverride(
   program: Program,
   operation: Operation
 ): FinalStateValue | undefined {
-  return program.stateMap(finalStateOverrideKey).get(operation);
+  return program.stateMap(AzureCoreStateKeys.finalStateOverride).get(operation);
 }
 
 export const $omitKeyProperties: OmitKeyPropertiesDecorator = (
@@ -1084,8 +1058,6 @@ export interface OperationLinkMetadata {
   result?: ResultInfo;
 }
 
-const operationLinkKey = createStateSymbol("operationLink");
-
 export const $operationLink: OperationLinkDecorator = (
   context: DecoratorContext,
   entity: Operation,
@@ -1108,7 +1080,7 @@ export const $operationLink: OperationLinkDecorator = (
   }
 
   // An operation may have many operationLinks, so treat them as a collection
-  let items = context.program.stateMap(operationLinkKey).get(entity) as Map<
+  let items = context.program.stateMap(AzureCoreStateKeys.operationLink).get(entity) as Map<
     string,
     OperationLinkMetadata
   >;
@@ -1123,7 +1095,7 @@ export const $operationLink: OperationLinkDecorator = (
     parameterMap: operationInfo?.getInvocationInfo()?.parameterMap,
     result: operationInfo?.getResultInfo(),
   } as OperationLinkMetadata);
-  context.program.stateMap(operationLinkKey).set(entity, items);
+  context.program.stateMap(AzureCoreStateKeys.operationLink).set(entity, items);
 };
 
 /**
@@ -1134,7 +1106,7 @@ export function getOperationLink(
   entity: Operation,
   linkType: string
 ): OperationLinkMetadata | undefined {
-  const items = program.stateMap(operationLinkKey).get(entity) as Map<
+  const items = program.stateMap(AzureCoreStateKeys.operationLink).get(entity) as Map<
     string,
     OperationLinkMetadata
   >;
@@ -1151,7 +1123,10 @@ export function getOperationLinks(
   program: Program,
   entity: Operation
 ): Map<string, OperationLinkMetadata> | undefined {
-  return program.stateMap(operationLinkKey).get(entity) as Map<string, OperationLinkMetadata>;
+  return program.stateMap(AzureCoreStateKeys.operationLink).get(entity) as Map<
+    string,
+    OperationLinkMetadata
+  >;
 }
 
 export const $pollingOperation: PollingOperationDecorator = (
@@ -1240,27 +1215,27 @@ export const $nextPageOperation: NextPageOperationDecorator = (
   context.call($operationLink, entity, linkedOperation, "nextPage", parameters);
 };
 
-const requestParameterKey = createStateSymbol("requestParameter");
-
 export const $requestParameter = (context: DecoratorContext, entity: Model, name: string) => {
-  context.program.stateMap(requestParameterKey).set(entity, name);
+  context.program.stateMap(AzureCoreStateKeys.requestParameter).set(entity, name);
 };
 
 export function getRequestParameter(program: Program, entity: ModelProperty): string | undefined {
   if (entity.type.kind !== "Model") return undefined;
-  const parameterName: string | undefined = program.stateMap(requestParameterKey).get(entity.type);
+  const parameterName: string | undefined = program
+    .stateMap(AzureCoreStateKeys.requestParameter)
+    .get(entity.type);
   return parameterName;
 }
 
-const responsePropertyKey = createStateSymbol("responseParameter");
-
 export const $responseProperty = (context: DecoratorContext, entity: Model, name: string) => {
-  context.program.stateMap(responsePropertyKey).set(entity, name);
+  context.program.stateMap(AzureCoreStateKeys.responseParameter).set(entity, name);
 };
 
 export function getResponseProperty(program: Program, entity: ModelProperty): string | undefined {
   if (entity.type.kind !== "Model") return undefined;
-  const parameterName: string | undefined = program.stateMap(responsePropertyKey).get(entity.type);
+  const parameterName: string | undefined = program
+    .stateMap(AzureCoreStateKeys.responseParameter)
+    .get(entity.type);
   return parameterName;
 }
 
@@ -1320,8 +1295,6 @@ export const $spreadCustomResponseProperties: SpreadCustomResponsePropertiesDeco
   }
 };
 
-const resourceOperationKey = createStateSymbol("resourceOperation");
-
 export const $ensureResourceType: EnsureResourceTypeDecorator = (
   context: DecoratorContext,
   entity: Operation,
@@ -1332,7 +1305,7 @@ export const $ensureResourceType: EnsureResourceTypeDecorator = (
   }
 
   // Mark the operation as a resource operation
-  context.program.stateSet(resourceOperationKey).add(entity);
+  context.program.stateSet(AzureCoreStateKeys.resourceOperation).add(entity);
 
   if (resourceType.kind !== "Model") {
     context.program.reportDiagnostic({
@@ -1378,21 +1351,19 @@ export const $ensureResourceType: EnsureResourceTypeDecorator = (
 };
 
 export function isResourceOperation(program: Program, operation: Operation): boolean {
-  return program.stateSet(resourceOperationKey).has(operation);
+  return program.stateSet(AzureCoreStateKeys.resourceOperation).has(operation);
 }
-
-const needsRouteKey = createStateSymbol("needsRoute");
 
 export const $needsRoute: NeedsRouteDecorator = (context: DecoratorContext, entity: Operation) => {
   // If the operation is not templated, add it to the list of operations to
   // check later
   if (entity.node.templateParameters.length === 0) {
-    context.program.stateSet(needsRouteKey).add(entity);
+    context.program.stateSet(AzureCoreStateKeys.needsRoute).add(entity);
   }
 };
 
 export function checkRpcRoutes(program: Program) {
-  (program.stateSet(needsRouteKey) as Set<Operation>).forEach((op: Operation) => {
+  (program.stateSet(AzureCoreStateKeys.needsRoute) as Set<Operation>).forEach((op: Operation) => {
     if (
       op.node.templateParameters.length === 0 &&
       !isAutoRoute(program, op) &&
@@ -1406,19 +1377,17 @@ export function checkRpcRoutes(program: Program) {
   });
 }
 
-const ensureVerbKey = createStateSymbol("ensureVerb");
-
 export const $ensureVerb: EnsureVerbDecorator = (
   context: DecoratorContext,
   entity: Operation,
   templateName: string,
   verb: string
 ) => {
-  context.program.stateMap(ensureVerbKey).set(entity, [templateName, verb]);
+  context.program.stateMap(AzureCoreStateKeys.ensureVerb).set(entity, [templateName, verb]);
 };
 
 export function checkEnsureVerb(program: Program) {
-  const opMap = program.stateMap(ensureVerbKey) as Map<Operation, string>;
+  const opMap = program.stateMap(AzureCoreStateKeys.ensureVerb) as Map<Operation, string>;
   for (const [operation, [templateName, requiredVerb]] of opMap.entries()) {
     if (isTemplateDeclarationOrInstance(operation)) continue;
     const verb = getHttpOperation(program, operation)[0].verb.toString().toLowerCase();
@@ -1437,8 +1406,6 @@ export function checkEnsureVerb(program: Program) {
   }
 }
 
-const embeddingVectorKey = createStateSymbol("embeddingVector");
-
 export interface EmbeddingVectorMetadata {
   elementType: Type;
 }
@@ -1452,7 +1419,7 @@ export const $embeddingVector: EmbeddingVectorDecorator = (
   const metadata: EmbeddingVectorMetadata = {
     elementType: elementType,
   };
-  context.program.stateMap(embeddingVectorKey).set(entity, metadata);
+  context.program.stateMap(AzureCoreStateKeys.embeddingVector).set(entity, metadata);
 };
 
 /**
@@ -1465,10 +1432,8 @@ export function getAsEmbeddingVector(
   program: Program,
   model: Model
 ): EmbeddingVectorMetadata | undefined {
-  return program.stateMap(embeddingVectorKey).get(model);
+  return program.stateMap(AzureCoreStateKeys.embeddingVector).get(model);
 }
-
-const armResourceIdentifierConfigKey = createStateSymbol("armResourceIdentifierConfig");
 
 export interface ArmResourceIdentifierConfig {
   readonly allowedResources: readonly ArmResourceIdentifierAllowedResource[];
@@ -1509,7 +1474,7 @@ export const $armResourceIdentifierConfig: ArmResourceIdentifierConfigDecorator 
 
   if (data) {
     context.program
-      .stateMap(armResourceIdentifierConfigKey)
+      .stateMap(AzureCoreStateKeys.armResourceIdentifierConfig)
       .set(entity, { allowedResources: data });
   }
 };
@@ -1519,7 +1484,7 @@ export function getArmResourceIdentifierConfig(
   program: Program,
   entity: Scalar
 ): ArmResourceIdentifierConfig {
-  return program.stateMap(armResourceIdentifierConfigKey).get(entity);
+  return program.stateMap(AzureCoreStateKeys.armResourceIdentifierConfig).get(entity);
 }
 
 export const $defaultFinalStateVia: DefaultFinalStateViaDecorator = (
@@ -1552,7 +1517,7 @@ export const $defaultFinalStateVia: DefaultFinalStateViaDecorator = (
   }
   const storedValue = validateFinalStates(program, target, finalStateValues);
   if (storedValue !== undefined) {
-    program.stateMap(finalStateOverrideKey).set(target, storedValue);
+    program.stateMap(AzureCoreStateKeys.finalStateOverride).set(target, storedValue);
   }
 };
 

--- a/packages/typespec-azure-core/src/lib.ts
+++ b/packages/typespec-azure-core/src/lib.ts
@@ -226,6 +226,13 @@ export const $lib = createTypeSpecLibrary({
       },
     },
   },
+
+  state: {},
 });
 
-export const { reportDiagnostic, createDiagnostic, createStateSymbol } = $lib;
+export const {
+  reportDiagnostic,
+  createDiagnostic,
+  createStateSymbol,
+  stateKeys: AzureCoreStateKeys,
+} = $lib;

--- a/packages/typespec-azure-core/src/lib.ts
+++ b/packages/typespec-azure-core/src/lib.ts
@@ -227,12 +227,38 @@ export const $lib = createTypeSpecLibrary({
     },
   },
 
-  state: {},
+  state: {
+    fixed: { description: "Data for `@fixed` decorator" },
+    pagedResult: { description: "Data for `@pagedResult` decorator" },
+    items: { description: "Data for `@items` decorator" },
+    nextLink: { description: "Data for `@nextLink` decorator" },
+    lroStatus: { description: "Data for `@lroStatus` decorator" },
+    lroSucceeded: { description: "Data for `@lroSucceeded` decorator" },
+    lroCanceled: { description: "Data for `@lroCanceled` decorator" },
+    lroFailed: { description: "Data for `@lroFailed` decorator" },
+    lroResult: { description: "Data for `@lroResult` decorator" },
+    lroErrorResult: { description: "Data for `@lroErrorResult` decorator" },
+    pollingOperationParameter: { description: "Data for `@pollingOperationParameter` decorator" },
+    pollingLocationInfo: { description: "Data for `@pollingLocationInfo` decorator" },
+    finalLocations: { description: "Data for `@finalLocations` decorator" },
+    finalLocationResults: { description: "Data for `@finalLocationResults` decorator" },
+    finalStateOverride: { description: "Data for `@finalStateOverride` decorator" },
+    needsRoute: { description: "Data for `@needsRoute` decorator" },
+    ensureVerb: { description: "Data for `@ensureVerb` decorator" },
+    embeddingVector: { description: "Data for `@embeddingVector` decorator" },
+    armResourceIdentifierConfig: {
+      description: "Data for `@armResourceIdentifierConfig` decorator",
+    },
+    operationLink: { description: "Data for `@operationLink` decorator" },
+    requestParameter: { description: "Data for `@requestParameter` decorator" },
+    responseParameter: { description: "Data for `@responseParameter` decorator" },
+    resourceOperation: { description: "Data for `@resourceOperation` decorator" },
+    traitSource: { description: "Data for `@traitSource` decorator" },
+    trait: { description: "Data for `@trait` decorator" },
+    traitContext: { description: "Data for `@traitContext` decorator" },
+    traitLocation: { description: "Data for `@traitLocation` decorator" },
+  },
+  // AzureCoreStateKeys.traitLocation
 });
 
-export const {
-  reportDiagnostic,
-  createDiagnostic,
-  createStateSymbol,
-  stateKeys: AzureCoreStateKeys,
-} = $lib;
+export const { reportDiagnostic, createDiagnostic, stateKeys: AzureCoreStateKeys } = $lib;

--- a/packages/typespec-azure-core/src/traits.ts
+++ b/packages/typespec-azure-core/src/traits.ts
@@ -27,16 +27,15 @@ import {
   EnsureTraitsPresentDecorator,
   TraitSourceDecorator,
 } from "../generated-defs/Azure.Core.Traits.Private.js";
-import { createStateSymbol, reportDiagnostic } from "./lib.js";
+import { AzureCoreStateKeys, reportDiagnostic } from "./lib.js";
 
-const traitSourceKey = createStateSymbol("traitSource");
 export const $traitSource: TraitSourceDecorator = (
   context: DecoratorContext,
   target: ModelProperty,
   traitName: string
 ) => {
   // Store the source trait name on the envelope property
-  context.program.stateMap(traitSourceKey).set(target, traitName);
+  context.program.stateMap(AzureCoreStateKeys.traitSource).set(target, traitName);
 };
 
 /**
@@ -45,12 +44,11 @@ export const $traitSource: TraitSourceDecorator = (
  * @param property The model property for which the trait name should be retrieved
  */
 export function getSourceTraitName(program: Program, property: ModelProperty): string | undefined {
-  return program.stateMap(traitSourceKey).get(property);
+  return program.stateMap(AzureCoreStateKeys.traitSource).get(property);
 }
 
 setTypeSpecNamespace("Traits.Private", $traitSource);
 
-const traitKey = createStateSymbol("trait");
 export const $trait: TraitDecorator = (
   context: DecoratorContext,
   target: Model,
@@ -114,7 +112,7 @@ export const $trait: TraitDecorator = (
   });
 
   // Mark the model as a trait type and store its name
-  context.program.stateMap(traitKey).set(target, traitName);
+  context.program.stateMap(AzureCoreStateKeys.trait).set(target, traitName);
 };
 
 setTypeSpecNamespace("Traits", $trait);
@@ -125,7 +123,7 @@ setTypeSpecNamespace("Traits", $trait);
  * @param property The model type to consider
  */
 export function isTraitModel(program: Program, model: Model): boolean {
-  return program.stateMap(traitKey).has(model) !== undefined;
+  return program.stateMap(AzureCoreStateKeys.trait).has(model) !== undefined;
 }
 
 /*
@@ -134,17 +132,16 @@ export function isTraitModel(program: Program, model: Model): boolean {
  * @param property The model type to consider
  */
 export function getTraitName(program: Program, model: Model): string | undefined {
-  return program.stateMap(traitKey).get(model);
+  return program.stateMap(AzureCoreStateKeys.trait).get(model);
 }
 
-const traitContextKey = createStateSymbol("traitContext");
 export const $traitContext: TraitContextDecorator = (
   context: DecoratorContext,
   target: ModelProperty,
   traitContext: Type
 ) => {
   context.program
-    .stateMap(traitContextKey)
+    .stateMap(AzureCoreStateKeys.traitContext)
     .set(target, normalizeTraitContexts(context.program, traitContext));
 };
 
@@ -188,7 +185,7 @@ function getTraitContextsOrUndefined(
 ): EnumMember[] | undefined {
   // Sometimes we need to know whether a trait context was explicitly set on a
   // property without defaulting to an empty array
-  return program.stateMap(traitContextKey).get(property);
+  return program.stateMap(AzureCoreStateKeys.traitContext).get(property);
 }
 
 /*
@@ -198,16 +195,15 @@ function getTraitContextsOrUndefined(
  * @param property The model property for which the trait contexts should be retrieved
  */
 export function getTraitContexts(program: Program, property: ModelProperty): EnumMember[] {
-  return program.stateMap(traitContextKey).get(property) || [];
+  return program.stateMap(AzureCoreStateKeys.traitContext).get(property) || [];
 }
 
-const traitLocationKey = createStateSymbol("traitLocation");
 export const $traitLocation: TraitLocationDecorator = (
   context: DecoratorContext,
   target: ModelProperty,
   traitLocation: EnumMember
 ) => {
-  context.program.stateMap(traitLocationKey).set(target, traitLocation);
+  context.program.stateMap(AzureCoreStateKeys.traitLocation).set(target, traitLocation);
 };
 
 setTypeSpecNamespace("Traits", $traitLocation);
@@ -221,7 +217,7 @@ export function getTraitLocation(
   program: Program,
   property: ModelProperty
 ): EnumMember | undefined {
-  return program.stateMap(traitLocationKey).get(property);
+  return program.stateMap(AzureCoreStateKeys.traitLocation).get(property);
 }
 
 const traitAddedKey = Symbol("traitLocation");

--- a/packages/typespec-azure-core/tsconfig.json
+++ b/packages/typespec-azure-core/tsconfig.json
@@ -11,5 +11,5 @@
     "rootDir": ".",
     "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"
   },
-  "include": ["src/**/*.ts", "test/**/*.ts"]
+  "include": ["src/**/*.ts", "generated-defs/**/*.ts", "test/**/*.ts"]
 }


### PR DESCRIPTION
Step to having all our libraries use tspd to generate the signatures and make sure they are in sync.

There is quite a lot of times we expected the wrong type which would cause a crash. This fix a few to get the more precise type in the TypeSpec if it was going to crash originally. Otherwise expand the type in the TS 