### PR TITLE
fix `@clientName` validation for operation within interface (#1205)

### DIFF
--- a/.chronus/changes/operation-validation-2024-6-19-18-35-46.md
+++ b/.chronus/changes/operation-validation-2024-6-19-18-35-46.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Fix `@clientName` conflict validation that operation defined within an interface

--- a/packages/typespec-client-generator-core/src/validate.ts
+++ b/packages/typespec-client-generator-core/src/validate.ts
@@ -56,6 +56,11 @@ function validateClientNamesPerNamespace(
   // Check for duplicate client names for operations
   validateClientNamesCore(tcgcContext, scope, namespace.operations.values());
 
+  // check for duplicate client names for operations in interfaces
+  for (const item of namespace.interfaces.values()) {
+    validateClientNamesCore(tcgcContext, scope, item.operations.values());
+  }
+
   // Check for duplicate client names for interfaces
   validateClientNamesCore(tcgcContext, scope, namespace.interfaces.values());
 

--- a/packages/typespec-client-generator-core/test/decorators.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators.test.ts
@@ -2857,6 +2857,36 @@ describe("typespec-client-generator-core: decorators", () => {
       ]);
     });
 
+    it("duplicate operation in interface with all language scopes", async () => {
+      const diagnostics = await runner.diagnose(
+        `
+      @service
+      namespace Contoso.WidgetManager;
+      
+      interface C {
+        @clientName("b")
+        @route("/a")
+        op a(): void;
+
+        @route("/b")
+        op b(): void;
+      }
+      `
+      );
+
+      expectDiagnostics(diagnostics, [
+        {
+          code: "@azure-tools/typespec-client-generator-core/duplicate-client-name",
+          message: 'Client name: "b" is duplicated in language scope: "AllScopes"',
+        },
+        {
+          code: "@azure-tools/typespec-client-generator-core/duplicate-client-name",
+          message:
+            'Client name: "b" is defined somewhere causing nameing conflicts in language scope: "AllScopes"',
+        },
+      ]);
+    });
+
     it("duplicate scalar with all language scopes", async () => {
       const diagnostics = await runner.diagnose(
         `


### PR DESCRIPTION
Fix operation client name validation introduced in https://github.com/Azure/typespec-azure/pull/1119