### PR TITLE
cut off the base type calculation when this type is a std type

### DIFF
--- a/.chronus/changes/cut-off-base-on-std-type-2024-6-29-16-44-37.md
+++ b/.chronus/changes/cut-off-base-on-std-type-2024-6-29-16-44-37.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-client-generator-core"
 ---
 
-The baseType will be undefined if the SdkBuiltInType is a std type
+The baseType will be undefined if the `SdkBuiltInType`, `SdkDateTimeType`, `SdkDurationType` is a std type

--- a/.chronus/changes/cut-off-base-on-std-type-2024-6-29-16-44-37.md
+++ b/.chronus/changes/cut-off-base-on-std-type-2024-6-29-16-44-37.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+The baseType will be undefined if the SdkBuiltInType is a std type

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -249,9 +249,10 @@ function getSdkBuiltInTypeWithDiagnostics(
     encode: getEncodeHelper(context, type, kind),
     description: docWrapper.description,
     details: docWrapper.details,
-    baseType: type.baseScalar
-      ? diagnostics.pipe(getSdkBuiltInTypeWithDiagnostics(context, type.baseScalar, kind))
-      : undefined,
+    baseType:
+      type.baseScalar && !context.program.checker.isStdType(type) // we only calculate the base type when this type has a base type and this type is not a std type because for std types there is no point of calculating its base type.
+        ? diagnostics.pipe(getSdkBuiltInTypeWithDiagnostics(context, type.baseScalar, kind))
+        : undefined,
     crossLanguageDefinitionId: getCrossLanguageDefinitionId(context, type),
   };
   addEncodeInfo(context, type, stdType);

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -302,9 +302,10 @@ function getSdkDateTimeType(
 ): [SdkDateTimeType, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
   const docWrapper = getDocHelper(context, type);
-  const baseType = type.baseScalar
-    ? diagnostics.pipe(getSdkDateTimeType(context, type.baseScalar, kind))
-    : undefined;
+  const baseType =
+    type.baseScalar && !context.program.checker.isStdType(type) // we only calculate the base type when this type has a base type and this type is not a std type because for std types there is no point of calculating its base type.
+      ? diagnostics.pipe(getSdkDateTimeType(context, type.baseScalar, kind))
+      : undefined;
   const [encode, wireType] = getEncodeInfoForDateTimeOrDuration(
     context,
     getEncode(context.program, type),
@@ -400,9 +401,10 @@ function getSdkDurationTypeWithDiagnostics(
 ): [SdkDurationType, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
   const docWrapper = getDocHelper(context, type);
-  const baseType = type.baseScalar
-    ? diagnostics.pipe(getSdkDurationTypeWithDiagnostics(context, type.baseScalar, kind))
-    : undefined;
+  const baseType =
+    type.baseScalar && !context.program.checker.isStdType(type) // we only calculate the base type when this type has a base type and this type is not a std type because for std types there is no point of calculating its base type.
+      ? diagnostics.pipe(getSdkDurationTypeWithDiagnostics(context, type.baseScalar, kind))
+      : undefined;
   const [encode, wireType] = getEncodeInfoForDateTimeOrDuration(
     context,
     getEncode(context.program, type),

--- a/packages/typespec-client-generator-core/test/types/built-in-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/built-in-types.test.ts
@@ -3,6 +3,7 @@ import { AzureCoreTestLibrary } from "@azure-tools/typespec-azure-core/testing";
 import { expectDiagnostics } from "@typespec/compiler/testing";
 import { ok, strictEqual } from "assert";
 import { beforeEach, describe, it } from "vitest";
+import { SdkBuiltInType } from "../../src/interfaces.js";
 import { getAllModels } from "../../src/types.js";
 import { SdkTestRunner, createSdkTestRunner } from "../test-host.js";
 import { getSdkTypeHelper } from "./utils.js";
@@ -12,6 +13,86 @@ describe("typespec-client-generator-core: built-in types", () => {
 
   beforeEach(async () => {
     runner = await createSdkTestRunner({ emitterName: "@azure-tools/typespec-java" });
+  });
+
+  it("string", async function () {
+    await runner.compileWithBuiltInService(
+      `
+      @usage(Usage.input | Usage.output)
+      @access(Access.public)
+      model Test {
+        prop: string;
+      }
+      `
+    );
+    const sdkType = getSdkTypeHelper(runner);
+    strictEqual(sdkType.kind, "string");
+    strictEqual(sdkType.crossLanguageDefinitionId, "TypeSpec.string");
+    strictEqual(sdkType.baseType, undefined);
+  });
+
+  it("boolean", async function () {
+    await runner.compileWithBuiltInService(
+      `
+      @usage(Usage.input | Usage.output)
+      @access(Access.public)
+      model Test {
+        prop: boolean;
+      }
+    `
+    );
+    const sdkType = getSdkTypeHelper(runner);
+    strictEqual(sdkType.kind, "boolean");
+    strictEqual(sdkType.crossLanguageDefinitionId, "TypeSpec.boolean");
+    strictEqual(sdkType.baseType, undefined);
+  });
+
+  it("integers", async function () {
+    const types = [
+      "int8",
+      "int16",
+      "int32",
+      "int64",
+      "uint8",
+      "uint16",
+      "uint32",
+      "uint64",
+      "integer",
+    ];
+    for (const type of types) {
+      await runner.compileWithBuiltInService(
+        `
+        @usage(Usage.input | Usage.output)
+        @access(Access.public)
+        model Test {
+          prop: ${type};
+        }
+      `
+      );
+      const sdkType = getSdkTypeHelper(runner) as SdkBuiltInType;
+      strictEqual(sdkType.kind, type);
+      strictEqual(sdkType?.crossLanguageDefinitionId, `TypeSpec.${type}`);
+      strictEqual(sdkType?.baseType, undefined);
+    }
+  });
+
+  it("floats", async function () {
+    const types = ["numeric", "float", "float32", "float64"];
+    for (const type of types) {
+      await runner.compileWithBuiltInService(
+        `
+        @usage(Usage.input | Usage.output)
+        @access(Access.public)
+        model Test {
+          prop: ${type};
+        }
+      `
+      );
+      const sdkType = getSdkTypeHelper(runner) as SdkBuiltInType;
+      strictEqual(sdkType.kind, type);
+      strictEqual(sdkType.crossLanguageDefinitionId, `TypeSpec.${type}`);
+      strictEqual(sdkType.baseType, undefined);
+    }
   });
 
   it("decimal", async function () {
@@ -26,6 +107,8 @@ describe("typespec-client-generator-core: built-in types", () => {
     );
     const sdkType = getSdkTypeHelper(runner);
     strictEqual(sdkType.kind, "decimal");
+    strictEqual(sdkType.crossLanguageDefinitionId, "TypeSpec.decimal");
+    strictEqual(sdkType.baseType, undefined);
   });
 
   it("decimal128", async function () {
@@ -40,6 +123,8 @@ describe("typespec-client-generator-core: built-in types", () => {
     );
     const sdkType = getSdkTypeHelper(runner);
     strictEqual(sdkType.kind, "decimal128");
+    strictEqual(sdkType.crossLanguageDefinitionId, "TypeSpec.decimal128");
+    strictEqual(sdkType.baseType, undefined);
   });
 
   it("unknown", async function () {
@@ -69,6 +154,7 @@ describe("typespec-client-generator-core: built-in types", () => {
     const sdkType = getSdkTypeHelper(runner);
     strictEqual(sdkType.kind, "bytes");
     strictEqual(sdkType.encode, "base64");
+    strictEqual(sdkType.baseType, undefined);
   });
 
   it("bytes base64", async function () {
@@ -85,6 +171,7 @@ describe("typespec-client-generator-core: built-in types", () => {
     const sdkType = getSdkTypeHelper(runner);
     strictEqual(sdkType.kind, "bytes");
     strictEqual(sdkType.encode, "base64");
+    strictEqual(sdkType.baseType, undefined);
   });
 
   it("bytes base64url", async function () {
@@ -101,6 +188,7 @@ describe("typespec-client-generator-core: built-in types", () => {
     const sdkType = getSdkTypeHelper(runner);
     strictEqual(sdkType.kind, "bytes");
     strictEqual(sdkType.encode, "base64url");
+    strictEqual(sdkType.baseType, undefined);
   });
 
   it("bytes base64url scalar", async function () {
@@ -124,6 +212,7 @@ describe("typespec-client-generator-core: built-in types", () => {
     strictEqual(sdkType.valueType.crossLanguageDefinitionId, "TestService.Base64UrlBytes");
     strictEqual(sdkType.valueType.baseType?.kind, "bytes");
     strictEqual(sdkType.valueType.baseType.encode, "base64");
+    strictEqual(sdkType.valueType.baseType.baseType, undefined);
   });
 
   it("armId from Core", async function () {

--- a/packages/typespec-client-generator-core/test/types/date-time-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/date-time-types.test.ts
@@ -61,23 +61,23 @@ describe("typespec-client-generator-core: date-time types", () => {
   });
 
   // TODO -- uncomment or modify when https://github.com/microsoft/typespec/issues/4042 is resolved.
-  // it("unixTimestamp32", async () => {
-  //   await runner.compileWithBuiltInService(
-  //     `
-  //     @usage(Usage.input | Usage.output)
-  //     @access(Access.public)
-  //     model Test {
-  //       prop: unixTimestamp32;
-  //     }
-  //     `
-  //   );
-  //   const sdkType = getSdkTypeHelper(runner);
-  //   strictEqual(sdkType.kind, "utcDateTime");
-  //   strictEqual(sdkType.wireType.kind, "int32");
-  //   strictEqual(sdkType.encode, "unixTimestamp");
-  //   strictEqual(sdkType.crossLanguageDefinitionId, "TypeSpec.unixTimestamp32");
-  //   strictEqual(sdkType.baseType, undefined);
-  // });
+  it.skip("unixTimestamp32", async () => {
+    await runner.compileWithBuiltInService(
+      `
+      @usage(Usage.input | Usage.output)
+      @access(Access.public)
+      model Test {
+        prop: unixTimestamp32;
+      }
+      `
+    );
+    const sdkType = getSdkTypeHelper(runner);
+    strictEqual(sdkType.kind, "utcDateTime");
+    strictEqual(sdkType.wireType.kind, "int32");
+    strictEqual(sdkType.encode, "unixTimestamp");
+    strictEqual(sdkType.crossLanguageDefinitionId, "TypeSpec.unixTimestamp32");
+    strictEqual(sdkType.baseType, undefined);
+  });
 
   it("unixTimestamp", async function () {
     await runner.compileWithBuiltInService(

--- a/packages/typespec-client-generator-core/test/types/date-time-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/date-time-types.test.ts
@@ -60,6 +60,25 @@ describe("typespec-client-generator-core: date-time types", () => {
     strictEqual(sdkType.encode, "rfc7231");
   });
 
+  // TODO -- uncomment or modify when https://github.com/microsoft/typespec/issues/4042 is resolved.
+  // it("unixTimestamp32", async () => {
+  //   await runner.compileWithBuiltInService(
+  //     `
+  //     @usage(Usage.input | Usage.output)
+  //     @access(Access.public)
+  //     model Test {
+  //       prop: unixTimestamp32;
+  //     }
+  //     `
+  //   );
+  //   const sdkType = getSdkTypeHelper(runner);
+  //   strictEqual(sdkType.kind, "utcDateTime");
+  //   strictEqual(sdkType.wireType.kind, "int32");
+  //   strictEqual(sdkType.encode, "unixTimestamp");
+  //   strictEqual(sdkType.crossLanguageDefinitionId, "TypeSpec.unixTimestamp32");
+  //   strictEqual(sdkType.baseType, undefined);
+  // });
+
   it("unixTimestamp", async function () {
     await runner.compileWithBuiltInService(
       `

--- a/packages/typespec-client-generator-core/test/types/duration-type.test.ts
+++ b/packages/typespec-client-generator-core/test/types/duration-type.test.ts
@@ -41,6 +41,7 @@ describe("typespec-client-generator-core: duration types", () => {
     strictEqual(sdkType.wireType.kind, "string");
     strictEqual(sdkType.encode, "ISO8601");
   });
+
   it("int32 seconds", async function () {
     await runner.compileWithBuiltInService(
       `


### PR DESCRIPTION
In previous version, the base type on `SdkBuiltInType` will give you every details on those std type, you could even see:
```
int32 -> int64 -> integer -> numeric
```

This is completely redundant.
This PR cuts off those redundant base type calculation once we know that the current type is a std type.
Also adds a few new test cases to test those very basic types.