### PR TITLE
Refactor parameter handling in swagger emitter

### DIFF
--- a/.chronus/changes/refactor-autorest-parameter-resolution-2024-6-26-16-6-16.md
+++ b/.chronus/changes/refactor-autorest-parameter-resolution-2024-6-26-16-6-16.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Fix issue what allowed `multi` format on a header

--- a/packages/samples/test/output/core/optional/@azure-tools/typespec-autorest/openapi.json
+++ b/packages/samples/test/output/core/optional/@azure-tools/typespec-autorest/openapi.json
@@ -38,8 +38,7 @@
             "schema": {
               "type": "integer",
               "format": "int64"
-            },
-            "default": 123
+            }
           }
         ],
         "responses": {

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -1317,6 +1317,7 @@ export async function getOpenAPIForService(
     let collectionFormat = getQueryParamOptions(program, param).format;
     if (collectionFormat && !["csv", "ssv", "tsv", "pipes", "multi"].includes(collectionFormat)) {
       collectionFormat = undefined;
+      reportDiagnostic(program, { code: "invalid-multi-collection-format", target: param });
     }
 
     return {
@@ -1351,6 +1352,7 @@ export async function getOpenAPIForService(
     let collectionFormat = getHeaderFieldOptions(program, param).format;
     if (collectionFormat && !["csv", "ssv", "tsv", "pipes"].includes(collectionFormat)) {
       collectionFormat = undefined;
+      reportDiagnostic(program, { code: "invalid-multi-collection-format", target: param });
     }
     return {
       in: "header",

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -1244,7 +1244,7 @@ export async function getOpenAPIForService(
     }
   }
 
-  function getOpenAPI2PArameterBase(
+  function getOpenAPI2ParameterBase(
     param: ModelProperty,
     name: string | undefined
   ): OpenAPI2ParameterBase {

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -1269,7 +1269,7 @@ export async function getOpenAPIForService(
   ): OpenAPI2BodyParameter {
     return {
       in: "body",
-      ...getOpenAPI2PArameterBase(param, name),
+      ...getOpenAPI2ParameterBase(param, name),
       schema: bodySchema,
     };
   }
@@ -1279,7 +1279,7 @@ export async function getOpenAPIForService(
     schemaContext: SchemaContext,
     name?: string
   ): OpenAPI2FormDataParameter {
-    const base = getOpenAPI2PArameterBase(param, name);
+    const base = getOpenAPI2ParameterBase(param, name);
     return {
       in: "formData",
       ...base,
@@ -1313,7 +1313,7 @@ export async function getOpenAPIForService(
     schemaContext: SchemaContext,
     name?: string
   ): OpenAPI2QueryParameter {
-    const base = getOpenAPI2PArameterBase(param, name);
+    const base = getOpenAPI2ParameterBase(param, name);
     let collectionFormat = getQueryParamOptions(program, param).format;
     if (collectionFormat && !["csv", "ssv", "tsv", "pipes", "multi"].includes(collectionFormat)) {
       collectionFormat = undefined;
@@ -1334,7 +1334,7 @@ export async function getOpenAPIForService(
     schemaContext: SchemaContext,
     name?: string
   ): OpenAPI2PathParameter {
-    const base = getOpenAPI2PArameterBase(param, name);
+    const base = getOpenAPI2ParameterBase(param, name);
 
     return {
       in: "path",
@@ -1348,7 +1348,7 @@ export async function getOpenAPIForService(
     schemaContext: SchemaContext,
     name?: string
   ): OpenAPI2HeaderParameter {
-    const base = getOpenAPI2PArameterBase(param, name);
+    const base = getOpenAPI2ParameterBase(param, name);
     let collectionFormat = getHeaderFieldOptions(program, param).format;
     if (collectionFormat && !["csv", "ssv", "tsv", "pipes"].includes(collectionFormat)) {
       collectionFormat = undefined;

--- a/packages/typespec-autorest/src/openapi2-document.ts
+++ b/packages/typespec-autorest/src/openapi2-document.ts
@@ -301,10 +301,10 @@ export type OpenAPI2ParameterType = OpenAPI2Parameter["in"];
 
 export interface OpenAPI2HeaderDefinition {
   type: "string" | "number" | "integer" | "boolean" | "array";
-  items?: OpenAPI2Schema;
   collectionFormat?: "csv" | "ssv" | "tsv" | "pipes";
   description?: string;
   format?: string;
+  items?: PrimitiveItems;
 }
 
 export type OpenAPI2Parameter =
@@ -315,6 +315,10 @@ export type OpenAPI2Parameter =
   | OpenAPI2PathParameter;
 
 export interface OpenAPI2ParameterBase extends Extensions {
+  name: string;
+  description?: string;
+  required?: boolean;
+
   /**
    * Provide a different name to be used in the client.
    */
@@ -323,11 +327,8 @@ export interface OpenAPI2ParameterBase extends Extensions {
 }
 
 export interface OpenAPI2BodyParameter extends OpenAPI2ParameterBase {
-  name: string;
   in: "body";
   schema: OpenAPI2Schema;
-  description?: string;
-  required?: boolean;
   allowEmptyValue?: boolean;
   example?: unknown;
 
@@ -338,6 +339,7 @@ export interface OpenAPI2HeaderParameter extends OpenAPI2HeaderDefinition, OpenA
   name: string;
   in: "header";
   required?: boolean;
+  default?: unknown;
 }
 
 export interface OpenAPI2FormDataParameter extends OpenAPI2ParameterBase {
@@ -359,7 +361,7 @@ export interface OpenAPI2FormDataParameter extends OpenAPI2ParameterBase {
   "x-ms-client-flatten"?: boolean;
 }
 
-export interface PrimitiveItems extends OpenAPI2ParameterBase {
+export interface PrimitiveItems {
   type: "string" | "number" | "integer" | "boolean" | "array" | "file";
   format?: string;
   items?: PrimitiveItems;
@@ -376,7 +378,9 @@ export interface OpenAPI2PathParameter extends OpenAPI2ParameterBase {
   required?: boolean;
   format?: string;
   enum?: string[];
+  items?: PrimitiveItems;
   "x-ms-skip-url-encoding"?: boolean;
+  default?: unknown;
 }
 
 export interface OpenAPI2QueryParameter extends OpenAPI2ParameterBase {
@@ -389,6 +393,8 @@ export interface OpenAPI2QueryParameter extends OpenAPI2ParameterBase {
   required?: boolean;
   format?: string;
   enum?: string[];
+  items?: PrimitiveItems;
+  default?: unknown;
 }
 
 export type HttpMethod = "get" | "put" | "post" | "delete" | "options" | "head" | "patch" | "trace";

--- a/packages/typespec-autorest/test/parameters.test.ts
+++ b/packages/typespec-autorest/test/parameters.test.ts
@@ -355,11 +355,11 @@ describe("typespec-autorest: parameters", () => {
           });
 
           it("array of enum is kept inline", async () => {
-            deepStrictEqual(await testParameter(`@${kind}({format: "multi"})`, "Foo[]"), {
+            deepStrictEqual(await testParameter(`@${kind}({format: "csv"})`, "Foo[]"), {
               in: kind,
               name: "arg1",
               required: true,
-              collectionFormat: "multi",
+              collectionFormat: "csv",
               type: "array",
               items: {
                 type: "string",


### PR DESCRIPTION
When making the URI template PR it was a bit hard to deal with the mess and better to split the refactoring

Also fix issue where `multi` wasn't even allowed for header part https://github.com/Azure/typespec-azure-pr/issues/3825
