### PR TITLE
[TCGC][Multipart] Change output for `HttpPart<T>[]`

### DIFF
--- a/.chronus/changes/multipart-array-update-2024-6-29-12-50-4.md
+++ b/.chronus/changes/multipart-array-update-2024-6-29-12-50-4.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Change output for `HttpPart<T>[]`

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1301,10 +1301,6 @@ function updateMultiPartInfo(
   if (base.multipartOptions !== undefined) {
     base.isMultipartFileInput = base.multipartOptions.isFilePart;
   }
-  if (base.multipartOptions?.isMulti && base.type.kind === "array") {
-    // for "images: T[]" or "images: HttpPart<T>[]", return type shall be "T" instead of "T[]"
-    base.type = base.type.valueType;
-  }
 
   return diagnostics.wrap(undefined);
 }

--- a/packages/typespec-client-generator-core/test/types/multipart-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/multipart-types.test.ts
@@ -7,7 +7,6 @@ import {
   SdkClientType,
   SdkHttpOperation,
   UsageFlags,
-  isSdkBuiltInKind,
 } from "../../src/interfaces.js";
 import { getAllModelsWithDiagnostics } from "../../src/types.js";
 import { SdkTestRunner, createSdkTestRunner } from "../test-host.js";

--- a/packages/typespec-client-generator-core/test/types/multipart-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/multipart-types.test.ts
@@ -306,7 +306,7 @@ describe("typespec-client-generator-core: multipart types", () => {
     for (const p of multiPartRequest.properties.values()) {
       strictEqual(p.kind, "property");
       ok(p.multipartOptions);
-      ok(p.type.kind === "bytes" || p.type.kind === "model");
+      ok(p.type.kind === "array");
       strictEqual(p.multipartOptions.isMulti, true);
     }
   });
@@ -383,7 +383,7 @@ describe("typespec-client-generator-core: multipart types", () => {
     ) as SdkBodyModelPropertyType;
     ok(fileArrayMultiParts);
     ok(fileArrayMultiParts.multipartOptions);
-    strictEqual(fileArrayMultiParts.type.kind, "model");
+    strictEqual(fileArrayMultiParts.type.kind, "array");
     strictEqual(fileArrayMultiParts.multipartOptions.isMulti, true);
     ok(fileArrayMultiParts.multipartOptions.filename);
     strictEqual(fileArrayMultiParts.multipartOptions.filename.optional, true);
@@ -514,7 +514,7 @@ describe("typespec-client-generator-core: multipart types", () => {
       (x) => x.name === "stringsMultiParts"
     ) as SdkBodyModelPropertyType;
     ok(stringsMultiParts);
-    strictEqual(stringsMultiParts.type.kind, "string");
+    strictEqual(stringsMultiParts.type.kind, "array");
     ok(stringsMultiParts.multipartOptions);
     strictEqual(stringsMultiParts.multipartOptions.isMulti, true);
   });

--- a/packages/typespec-client-generator-core/test/types/multipart-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/multipart-types.test.ts
@@ -7,6 +7,7 @@ import {
   SdkClientType,
   SdkHttpOperation,
   UsageFlags,
+  isSdkBuiltInKind,
 } from "../../src/interfaces.js";
 import { getAllModelsWithDiagnostics } from "../../src/types.js";
 import { SdkTestRunner, createSdkTestRunner } from "../test-host.js";
@@ -372,6 +373,7 @@ describe("typespec-client-generator-core: multipart types", () => {
     ok(fileArrayOnePart);
     ok(fileArrayOnePart.multipartOptions);
     strictEqual(fileArrayOnePart.type.kind, "array");
+    strictEqual(fileArrayOnePart.type.valueType.kind, "model");
     strictEqual(fileArrayOnePart.multipartOptions.isMulti, false);
     strictEqual(fileArrayOnePart.multipartOptions.filename, undefined);
     strictEqual(fileArrayOnePart.multipartOptions.contentType, undefined);
@@ -384,6 +386,7 @@ describe("typespec-client-generator-core: multipart types", () => {
     ok(fileArrayMultiParts);
     ok(fileArrayMultiParts.multipartOptions);
     strictEqual(fileArrayMultiParts.type.kind, "array");
+    strictEqual(fileArrayMultiParts.type.valueType.kind, "model");
     strictEqual(fileArrayMultiParts.multipartOptions.isMulti, true);
     ok(fileArrayMultiParts.multipartOptions.filename);
     strictEqual(fileArrayMultiParts.multipartOptions.filename.optional, true);
@@ -508,6 +511,7 @@ describe("typespec-client-generator-core: multipart types", () => {
     ) as SdkBodyModelPropertyType;
     ok(stringsOnePart);
     strictEqual(stringsOnePart.type.kind, "array");
+    strictEqual(stringsOnePart.type.valueType.kind, "string");
     ok(stringsOnePart.multipartOptions);
     strictEqual(stringsOnePart.multipartOptions.isMulti, false);
     const stringsMultiParts = MultiPartRequest.properties.find(
@@ -515,6 +519,7 @@ describe("typespec-client-generator-core: multipart types", () => {
     ) as SdkBodyModelPropertyType;
     ok(stringsMultiParts);
     strictEqual(stringsMultiParts.type.kind, "array");
+    strictEqual(stringsMultiParts.type.valueType.kind, "string");
     ok(stringsMultiParts.multipartOptions);
     strictEqual(stringsMultiParts.multipartOptions.isMulti, true);
   });


### PR DESCRIPTION
After discussion with language devs, for `HttpPart<T>[]`, TCGC changes type from:
```
{
  "kind: "model"
  "multipartOptions": {"isMulti": true}
}
```
to 

```
{
  "kind: "array",
  "valueType": {"kind": "model"},
  "multipartOptions": {"isMulti": true}
}
```