### PR TITLE
fix(doc): lro delete should adopt a special status operation

### DIFF
--- a/docs/getstarted/azure-core/step06.md
+++ b/docs/getstarted/azure-core/step06.md
@@ -18,7 +18,10 @@ alias Operations = Azure.Core.ResourceOperations<ServiceTraits>;
 
 interface Widgets {
   @doc("Gets status of a Widget operation.")
+  @sharedRoute
   getWidgetOperationStatus is Operations.GetResourceOperationStatus<Widget>;
+  @sharedRoute
+  getWidgetDeleteOperationStatus is Operations.GetResourceOperationStatus<Widget, never>;
 
   @doc("Fetch a Widget by name.")
   getWidget is Operations.ResourceRead<Widget>;
@@ -28,7 +31,7 @@ interface Widgets {
   createOrUpdateWidget is Operations.LongRunningResourceCreateOrUpdate<Widget>;
 
   @doc("Delete a Widget asynchronously.")
-  @pollingOperation(Widgets.getWidgetOperationStatus)
+  @pollingOperation(Widgets.getWidgetDeleteOperationStatus)
   deleteWidget is Operations.LongRunningResourceDelete<Widget>;
 
   @doc("List Widget resources.")


### PR DESCRIPTION
This is found during investigation of https://github.com/Azure/autorest.csharp/issues/4827 Normally an lro delete status operation should not return content at the end, so when defining lro deelte operation, it should use a special status operation.