### PR TITLE
[Canonical Emitter] Fix included versions value in canonical emitter

### DIFF
--- a/.chronus/changes/fix-canonical-included-versions-2024-7-31-11-30-47.md
+++ b/.chronus/changes/fix-canonical-included-versions-2024-7-31-11-30-47.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-autorest-canonical"
+---
+
+fix the included versions value in typespec-autorest-canonical emitter

--- a/packages/typespec-autorest-canonical/src/emitter.ts
+++ b/packages/typespec-autorest-canonical/src/emitter.ts
@@ -97,7 +97,7 @@ async function emitAllServices(
     const result = await getOpenAPIForService(context, options);
     const includedVersions = getVersion(program, service.type)
       ?.getVersions()
-      ?.map((item) => item.value);
+      ?.map((item) => item.value ?? item.name);
     result.document.info["x-canonical-included-versions"] = includedVersions;
     result.document.info["x-typespec-generated"] = [
       {

--- a/packages/typespec-autorest-canonical/src/emitter.ts
+++ b/packages/typespec-autorest-canonical/src/emitter.ts
@@ -97,7 +97,7 @@ async function emitAllServices(
     const result = await getOpenAPIForService(context, options);
     const includedVersions = getVersion(program, service.type)
       ?.getVersions()
-      ?.map((item) => item.name);
+      ?.map((item) => item.value);
     result.document.info["x-canonical-included-versions"] = includedVersions;
     result.document.info["x-typespec-generated"] = [
       {

--- a/packages/typespec-autorest-canonical/test/versioning.test.ts
+++ b/packages/typespec-autorest-canonical/test/versioning.test.ts
@@ -202,3 +202,66 @@ it("Diagnostics for unsupported versioning decorators.", async () => {
     },
   ]);
 });
+
+it("Get correct included versions when there is no value", async () => {
+  const v = await openApiFor(
+    `
+    @versioned(Versions)
+    @service({title: "My Service"})
+    namespace MyService {
+      enum Versions {
+        @useDependency(MyLibrary.Versions.A)
+        v1,
+        @useDependency(MyLibrary.Versions.B)
+        v2,
+        @useDependency(MyLibrary.Versions.C)
+        v3
+      }
+
+      model Test {
+        prop1: string;
+        @added(Versions.v2) prop2: string;
+        @removed(Versions.v2) prop3: string;
+        @madeOptional(Versions.v3) prop5?: string;
+      }
+
+      @route("/read1")
+      op read1(): Test;
+      op read2(): MyLibrary.Foo;
+    }
+
+    @versioned(Versions)
+    namespace MyLibrary {
+      enum Versions {A, B, C}
+
+      model Foo {
+        prop1: string;
+        @added(Versions.B) prop2: string;
+        @added(Versions.C) prop3: string;
+      }
+    }
+  `
+  );
+  strictEqual(v.info.version, canonicalVersion);
+  deepStrictEqual(v.info["x-canonical-included-versions"], ["v1", "v2", "v3"]);
+  deepStrictEqual(v.definitions.Test, {
+    type: "object",
+    properties: {
+      prop1: { type: "string" },
+      prop2: { type: "string" },
+      prop3: { type: "string" },
+      prop5: { type: "string" },
+    },
+    required: ["prop1", "prop2", "prop3"],
+  });
+
+  deepStrictEqual(v.definitions["MyLibrary.Foo"], {
+    type: "object",
+    properties: {
+      prop1: { type: "string" },
+      prop2: { type: "string" },
+      prop3: { type: "string" },
+    },
+    required: ["prop1", "prop2", "prop3"],
+  });
+});

--- a/packages/typespec-autorest-canonical/test/versioning.test.ts
+++ b/packages/typespec-autorest-canonical/test/versioning.test.ts
@@ -12,11 +12,11 @@ it("works with models", async () => {
     namespace MyService {
       enum Versions {
         @useDependency(MyLibrary.Versions.A)
-        v1,
+        v1: "2020-11-01-preview",
         @useDependency(MyLibrary.Versions.B)
-        v2,
+        v2: "2021-05-01-preview",
         @useDependency(MyLibrary.Versions.C)
-        v3
+        v3: "2022-05-01-preview"
       }
 
       model Test {
@@ -44,7 +44,11 @@ it("works with models", async () => {
   `
   );
   strictEqual(v.info.version, canonicalVersion);
-  deepStrictEqual(v.info["x-canonical-included-versions"], ["v1", "v2", "v3"]);
+  deepStrictEqual(v.info["x-canonical-included-versions"], [
+    "2020-11-01-preview",
+    "2021-05-01-preview",
+    "2022-05-01-preview",
+  ]);
   deepStrictEqual(v.definitions.Test, {
     type: "object",
     properties: {


### PR DESCRIPTION
Fix the included versions value in canonical emitter. 

It returned the version name, should return version value instead. Updated the test case.