### PR TITLE
[Tcgc] Fix getLibraryName for anonymous model which is derived from template

### DIFF
--- a/.chronus/changes/tcgc-fix-get-library-name-2024-7-15-13-4-27.md
+++ b/.chronus/changes/tcgc-fix-get-library-name-2024-7-15-13-4-27.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Fix getLibraryName for anonymous model which is derived from template

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -170,7 +170,12 @@ export function getLibraryName(
   if (friendlyName) return friendlyName;
 
   // 5. if type is derived from template and name is the same as template, add template parameters' name as suffix
-  if (typeof type.name === "string" && type.kind === "Model" && type.templateMapper?.args) {
+  if (
+    typeof type.name === "string" &&
+    type.name !== "" &&
+    type.kind === "Model" &&
+    type.templateMapper?.args
+  ) {
     return (
       type.name +
       type.templateMapper.args

--- a/packages/typespec-client-generator-core/test/types/model-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/model-types.test.ts
@@ -320,6 +320,24 @@ describe("typespec-client-generator-core: model types", () => {
     strictEqual(dog.discriminatorProperty, dogKindProperty);
   });
 
+  it("anonymous model contains template", async () => {
+    await runner.compileWithBuiltInService(`
+
+      model Name {
+        name: string;
+      }
+      model ModelTemplate<T> {
+        prop: T
+      }
+
+      op test(): {prop: ModelTemplate<Name>};
+      `);
+    const models = runner.context.sdkPackage.models;
+    strictEqual(models.length, 3);
+    const modelNames = models.map((model) => model.name).sort();
+    deepStrictEqual(modelNames, ["TestResponse", "Name", "ModelTemplateName"].sort());
+  });
+
   it("union to extensible enum values", async () => {
     await runner.compileWithBuiltInService(`
       union PetKind {


### PR DESCRIPTION
After https://github.com/microsoft/typespec/pull/4144, anonymous model type may also have templateMapper arguments. For this scenario, `getLibraryName` shall not try to generate name from arguments, otherwise may generate model with duplicated name.