### PR TITLE
[tcgc] no need to add access override along with usage override for orphan model

### DIFF
--- a/.chronus/changes/fix_usage-2024-7-15-13-21-20.md
+++ b/.chronus/changes/fix_usage-2024-7-15-13-21-20.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+no need to add access override along with usage override for orphan model

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1709,10 +1709,8 @@ function handleServiceOrphanType(context: TCGCContext, type: Model | Enum | Unio
     const sdkType = diagnostics.pipe(getClientTypeWithDiagnostics(context, type));
     updateUsageOfModel(context, UsageFlags.Input | UsageFlags.Output, sdkType);
   }
-  if (getAccessOverride(context, type) !== undefined) {
-    const sdkType = diagnostics.pipe(getClientTypeWithDiagnostics(context, type));
-    updateUsageOfModel(context, UsageFlags.None, sdkType);
-  }
+  const sdkType = diagnostics.pipe(getClientTypeWithDiagnostics(context, type));
+  updateUsageOfModel(context, UsageFlags.None, sdkType);
 }
 
 function verifyNoConflictingMultipartModelUsage(

--- a/packages/typespec-client-generator-core/test/decorators.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators.test.ts
@@ -2328,7 +2328,6 @@ describe("typespec-client-generator-core: decorators", () => {
         @test namespace MyService {
           @test
           @usage(Usage.input | Usage.output)
-          @access(Access.public)
           enum Enum1{
             one,
             two,
@@ -2344,7 +2343,6 @@ describe("typespec-client-generator-core: decorators", () => {
 
           @test
           @usage(Usage.input | Usage.output)
-          @access(Access.public)
           model Model1{ prop: string }
 
           @test

--- a/packages/typespec-client-generator-core/test/public-utils.test.ts
+++ b/packages/typespec-client-generator-core/test/public-utils.test.ts
@@ -1517,7 +1517,6 @@ describe("typespec-client-generator-core: public-utils", () => {
         await runner.compileWithBuiltInService(
           `
           @usage(Usage.input | Usage.output)
-          @access(Access.public)
           model A {
             pForA: {
               name: string;
@@ -1545,7 +1544,6 @@ describe("typespec-client-generator-core: public-utils", () => {
         await runner.compileWithBuiltInService(
           `
           @usage(Usage.input | Usage.output)
-          @access(Access.public)
           model A {
             status: "start" | "stop";
           }

--- a/packages/typespec-client-generator-core/test/types/body-model-property-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/body-model-property-types.test.ts
@@ -15,7 +15,6 @@ describe("typespec-client-generator-core: body model property types", () => {
   it("required", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           name: string | int32;
         }
@@ -27,7 +26,6 @@ describe("typespec-client-generator-core: body model property types", () => {
   it("optional", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           name?: string;
         }
@@ -39,7 +37,6 @@ describe("typespec-client-generator-core: body model property types", () => {
   it("readonly", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           @visibility("read")
           name?: string;
@@ -52,7 +49,6 @@ describe("typespec-client-generator-core: body model property types", () => {
   it("not readonly", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           @visibility("read", "create", "update")
           name?: string;
@@ -67,7 +63,6 @@ describe("typespec-client-generator-core: body model property types", () => {
         #suppress "deprecated" "for testing"
         @test
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         @projectedName("java", "JavaTest")
         model Test {
           @projectedName("java", "javaProjectedName")
@@ -125,7 +120,6 @@ describe("typespec-client-generator-core: body model property types", () => {
   it("union type", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           name: string | int32;
         }
@@ -159,7 +153,6 @@ describe("typespec-client-generator-core: body model property types", () => {
         }
 
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           @added(Versions.v1)
           @removed(Versions.v2)

--- a/packages/typespec-client-generator-core/test/types/built-in-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/built-in-types.test.ts
@@ -19,7 +19,6 @@ describe("typespec-client-generator-core: built-in types", () => {
     await runner.compileWithBuiltInService(
       `
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: string;
       }
@@ -35,7 +34,6 @@ describe("typespec-client-generator-core: built-in types", () => {
     await runner.compileWithBuiltInService(
       `
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: boolean;
       }
@@ -63,7 +61,6 @@ describe("typespec-client-generator-core: built-in types", () => {
       await runner.compileWithBuiltInService(
         `
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           prop: ${type};
         }
@@ -82,7 +79,6 @@ describe("typespec-client-generator-core: built-in types", () => {
       await runner.compileWithBuiltInService(
         `
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           prop: ${type};
         }
@@ -99,7 +95,6 @@ describe("typespec-client-generator-core: built-in types", () => {
     await runner.compileWithBuiltInService(
       `
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: decimal;
       }
@@ -115,7 +110,6 @@ describe("typespec-client-generator-core: built-in types", () => {
     await runner.compileWithBuiltInService(
       `
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: decimal128;
       }
@@ -131,7 +125,6 @@ describe("typespec-client-generator-core: built-in types", () => {
     await runner.compileWithBuiltInService(
       `
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: unknown;
       }
@@ -145,7 +138,6 @@ describe("typespec-client-generator-core: built-in types", () => {
     await runner.compileWithBuiltInService(
       `
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: bytes;
       }
@@ -161,7 +153,6 @@ describe("typespec-client-generator-core: built-in types", () => {
     await runner.compileWithBuiltInService(
       `
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         @encode(BytesKnownEncoding.base64)
         prop: bytes;
@@ -178,7 +169,6 @@ describe("typespec-client-generator-core: built-in types", () => {
     await runner.compileWithBuiltInService(
       `
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         @encode(BytesKnownEncoding.base64url)
         prop: bytes;
@@ -198,7 +188,6 @@ describe("typespec-client-generator-core: built-in types", () => {
       scalar Base64UrlBytes extends bytes;
 
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         value: Base64UrlBytes[];
       }
@@ -224,7 +213,6 @@ describe("typespec-client-generator-core: built-in types", () => {
     await runnerWithCore.compileWithBuiltInAzureCoreService(
       `
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         id: Azure.Core.armResourceIdentifier<[
           {
@@ -251,7 +239,6 @@ describe("typespec-client-generator-core: built-in types", () => {
     await runnerWithCore.compileWithBuiltInAzureCoreService(
       `
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         urlScalar: url;
 
@@ -313,7 +300,6 @@ describe("typespec-client-generator-core: built-in types", () => {
       scalar Derived extends Base;
 
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: Derived;
       }
@@ -338,7 +324,6 @@ describe("typespec-client-generator-core: built-in types", () => {
     await runner.compileWithBuiltInService(
       `
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         @format("unknown")
         unknownProp: string;
@@ -402,7 +387,6 @@ describe("typespec-client-generator-core: built-in types", () => {
       scalar TestScalar extends string;
       
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: TestScalar;
       }
@@ -422,7 +406,6 @@ describe("typespec-client-generator-core: built-in types", () => {
     await runner.compileWithBuiltInService(
       `
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         @encode(string)
         value: safeint;
@@ -442,7 +425,6 @@ describe("typespec-client-generator-core: built-in types", () => {
       scalar int32EncodedAsString extends int32;
 
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         value: int32EncodedAsString;
       }

--- a/packages/typespec-client-generator-core/test/types/constant-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/constant-types.test.ts
@@ -13,7 +13,6 @@ describe("typespec-client-generator-core: constant types", () => {
   it("string", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           prop: "json";
         }
@@ -29,7 +28,6 @@ describe("typespec-client-generator-core: constant types", () => {
   it("boolean", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           @test prop: true;
         }
@@ -45,7 +43,6 @@ describe("typespec-client-generator-core: constant types", () => {
   it("number", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           @test prop: 4;
         }

--- a/packages/typespec-client-generator-core/test/types/date-time-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/date-time-types.test.ts
@@ -14,7 +14,6 @@ describe("typespec-client-generator-core: date-time types", () => {
     await runner.compileWithBuiltInService(
       `
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           prop: utcDateTime;
         }
@@ -30,7 +29,6 @@ describe("typespec-client-generator-core: date-time types", () => {
     await runner.compileWithBuiltInService(
       `
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           @encode(DateTimeKnownEncoding.rfc3339)
           prop: utcDateTime;
@@ -47,7 +45,6 @@ describe("typespec-client-generator-core: date-time types", () => {
     await runner.compileWithBuiltInService(
       `
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           @encode(DateTimeKnownEncoding.rfc7231)
           prop: utcDateTime;
@@ -65,7 +62,6 @@ describe("typespec-client-generator-core: date-time types", () => {
     await runner.compileWithBuiltInService(
       `
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: unixTimestamp32;
       }
@@ -83,7 +79,6 @@ describe("typespec-client-generator-core: date-time types", () => {
     await runner.compileWithBuiltInService(
       `
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           @encode(DateTimeKnownEncoding.unixTimestamp, int64)
           value: utcDateTime;
@@ -107,7 +102,6 @@ describe("typespec-client-generator-core: date-time types", () => {
         scalar extraLayerDateTime extends unixTimestampDatetime;
 
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           value: extraLayerDateTime;
         }
@@ -135,7 +129,6 @@ describe("typespec-client-generator-core: date-time types", () => {
     await runner.compileWithBuiltInService(
       `
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           @encode(DateTimeKnownEncoding.unixTimestamp, int64)
           value: utcDateTime | null;
@@ -160,7 +153,6 @@ describe("typespec-client-generator-core: date-time types", () => {
         scalar unixTimestampDateTime extends utcDateTime;
 
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           value: unixTimestampDateTime[];
         }

--- a/packages/typespec-client-generator-core/test/types/duration-type.test.ts
+++ b/packages/typespec-client-generator-core/test/types/duration-type.test.ts
@@ -14,7 +14,6 @@ describe("typespec-client-generator-core: duration types", () => {
     await runner.compileWithBuiltInService(
       `
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           prop: duration;
         }
@@ -29,7 +28,6 @@ describe("typespec-client-generator-core: duration types", () => {
     await runner.compileWithBuiltInService(
       `
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           @encode(DurationKnownEncoding.ISO8601)
           prop: duration;
@@ -46,7 +44,6 @@ describe("typespec-client-generator-core: duration types", () => {
     await runner.compileWithBuiltInService(
       `
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           @encode(DurationKnownEncoding.seconds, int32)
           prop: duration;
@@ -63,7 +60,6 @@ describe("typespec-client-generator-core: duration types", () => {
     await runner.compileWithBuiltInService(
       `
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           @encode(DurationKnownEncoding.seconds, float)
           prop: duration;
@@ -80,7 +76,6 @@ describe("typespec-client-generator-core: duration types", () => {
     await runner.compileWithBuiltInService(
       `
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           @encode(DurationKnownEncoding.seconds, float)
           prop: duration | null;
@@ -105,7 +100,6 @@ describe("typespec-client-generator-core: duration types", () => {
         scalar Float32Duration extends duration;
         
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           value: Float32Duration[];
         }

--- a/packages/typespec-client-generator-core/test/types/enum-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/enum-types.test.ts
@@ -20,7 +20,6 @@ describe("typespec-client-generator-core: enum types", () => {
   it("string extensible", async function () {
     await runner.compileWithBuiltInService(`
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       enum DaysOfWeekExtensibleEnum {
           Monday,
           Tuesday,
@@ -32,7 +31,6 @@ describe("typespec-client-generator-core: enum types", () => {
         }
 
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: DaysOfWeekExtensibleEnum
       }
@@ -67,7 +65,6 @@ describe("typespec-client-generator-core: enum types", () => {
   it("int extensible", async function () {
     await runner.compileWithBuiltInService(`
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       enum Integers {
         one: 1,
         two: 2,
@@ -77,7 +74,6 @@ describe("typespec-client-generator-core: enum types", () => {
       }
 
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: Integers
       }
@@ -105,7 +101,6 @@ describe("typespec-client-generator-core: enum types", () => {
   it("float extensible", async function () {
     await runner.compileWithBuiltInService(`
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       enum Floats {
         a: 1,
         b: 2.1,
@@ -113,7 +108,6 @@ describe("typespec-client-generator-core: enum types", () => {
       }
 
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: Floats
       }
@@ -140,7 +134,6 @@ describe("typespec-client-generator-core: enum types", () => {
   it("union as enum float type", async function () {
     await runner.compileWithBuiltInService(`
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       union Floats {
         float,
         a: 1,
@@ -149,7 +142,6 @@ describe("typespec-client-generator-core: enum types", () => {
       }
 
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: Floats
       }
@@ -175,14 +167,12 @@ describe("typespec-client-generator-core: enum types", () => {
   it("union of union as enum float type", async function () {
     await runner.compileWithBuiltInService(`
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       union BaseEnum {
         int32,
         a: 1,
       }
       
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       union ExtendedEnum {
         BaseEnum,
         b: 2,
@@ -190,7 +180,6 @@ describe("typespec-client-generator-core: enum types", () => {
       }
 
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: ExtendedEnum
       }
@@ -221,7 +210,6 @@ describe("typespec-client-generator-core: enum types", () => {
       @doc(".")
       @fixed
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       enum DaysOfWeekFixedEnum {
         @doc("Monday") Monday,
         @doc("Tuesday") Tuesday,
@@ -234,7 +222,6 @@ describe("typespec-client-generator-core: enum types", () => {
 
       @doc(".")
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         @doc(".")
         prop: DaysOfWeekFixedEnum
@@ -287,7 +274,6 @@ describe("typespec-client-generator-core: enum types", () => {
         @service({})
         namespace MyService {
           @usage(Usage.input | Usage.output)
-          @access(Access.public)
           enum Integers {
             one: 1,
             two: 2,
@@ -297,7 +283,6 @@ describe("typespec-client-generator-core: enum types", () => {
           }
 
           @usage(Usage.input | Usage.output)
-          @access(Access.public)
           model Test {
             prop: Integers
           }
@@ -330,7 +315,6 @@ describe("typespec-client-generator-core: enum types", () => {
         @test namespace MyService {
           @test
           @usage(Usage.input | Usage.output)
-          @access(Access.public)
           enum Enum1{
             one,
             two,
@@ -355,7 +339,6 @@ describe("typespec-client-generator-core: enum types", () => {
         @test namespace MyService {
           @test
           @usage(Usage.input | Usage.output)
-          @access(Access.public)
           @projectedName("java", "JavaEnum1")
           enum Enum1{
             @projectedName("java", "JavaOne")
@@ -374,7 +357,6 @@ describe("typespec-client-generator-core: enum types", () => {
           #suppress "deprecated" "for testing"
           @test
           @usage(Usage.input | Usage.output)
-          @access(Access.public)
           @projectedName("java", "JavaEnum1")
           enum Enum1{
             #suppress "deprecated" "for testing"

--- a/packages/typespec-client-generator-core/test/types/model-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/model-types.test.ts
@@ -132,7 +132,6 @@ describe("typespec-client-generator-core: model types", () => {
   it("recursive model", async () => {
     await runner.compileWithBuiltInService(`
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model RecursiveModel {
         prop: RecursiveModel
       }
@@ -1113,23 +1112,19 @@ describe("typespec-client-generator-core: model types", () => {
   it("additionalProperties of same type", async () => {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model AdditionalPropertiesModel extends Record<string> {
           prop: string;
         }
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model AdditionalPropertiesModel2 is Record<unknown> {
           prop: string;
         }
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model AdditionalPropertiesModel3 {
           prop: string;
           ...Record<string>;
         }
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model NoAdditionalPropertiesModel {
           prop: string;
         }
@@ -1217,14 +1212,12 @@ describe("typespec-client-generator-core: model types", () => {
   it("additionalProperties of different types", async () => {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model AdditionalPropertiesModel {
           prop: string;
           ...Record<float32>;
         }
 
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model AdditionalPropertiesModel2 {
           prop: string;
           ...Record<boolean | float32>;
@@ -1248,11 +1241,9 @@ describe("typespec-client-generator-core: model types", () => {
         @service({})
         namespace MyService {
           @usage(Usage.input)
-          @access(Access.public)
           model InputModel {}
 
           @usage(Usage.output)
-          @access(Access.public)
           model OutputModel {}
         }
       `);
@@ -1269,7 +1260,6 @@ describe("typespec-client-generator-core: model types", () => {
   it("template model", async () => {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Catalog is TrackedResource<CatalogProperties> {
           @pattern("^[A-Za-z0-9_-]{1,50}$")
           @key("catalogName")
@@ -1278,7 +1268,6 @@ describe("typespec-client-generator-core: model types", () => {
         }
 
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model CatalogProperties {
           test?: string;
         }
@@ -1288,7 +1277,6 @@ describe("typespec-client-generator-core: model types", () => {
         }
 
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Deployment is TrackedResource<DeploymentProperties> {
           @key("deploymentName")
           @segment("deployments")
@@ -1296,7 +1284,6 @@ describe("typespec-client-generator-core: model types", () => {
         }
 
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model DeploymentProperties {
           deploymentId?: string;
           deploymentDateUtc?: utcDateTime;
@@ -1333,7 +1320,6 @@ describe("typespec-client-generator-core: model types", () => {
         @test namespace MyService {
           @test
           @usage(Usage.input | Usage.output)
-          @access(Access.public)
           model Model1{}
 
           model Model2{}
@@ -1455,7 +1441,6 @@ describe("typespec-client-generator-core: model types", () => {
         @test namespace MyService {
           @test
           @usage(Usage.input | Usage.output)
-          @access(Access.public)
           model Test{
             prop1: never;
             prop2: void;

--- a/packages/typespec-client-generator-core/test/types/multipart-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/multipart-types.test.ts
@@ -115,7 +115,6 @@ describe("typespec-client-generator-core: multipart types", () => {
         }
 
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model AddressSecondAppearance {
           address: Address;
         }

--- a/packages/typespec-client-generator-core/test/types/tuple-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/tuple-types.test.ts
@@ -14,7 +14,6 @@ describe("typespec-client-generator-core: tuple types", () => {
         @service({})
         namespace MyService;
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model MyFlow {
           scopes: ["https://security.microsoft.com/.default"];
           test: [int32, string]

--- a/packages/typespec-client-generator-core/test/types/union-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/union-types.test.ts
@@ -484,6 +484,7 @@ describe("typespec-client-generator-core: union types", () => {
   it("usage override", async function () {
     await runner.compileWithBuiltInService(`
       @usage(Usage.input | Usage.output)
+      @access(Access.public)
       union UnionAsEnum {
         "A",
         "B",

--- a/packages/typespec-client-generator-core/test/types/union-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/union-types.test.ts
@@ -15,7 +15,6 @@ describe("typespec-client-generator-core: union types", () => {
     await runner.compileWithBuiltInService(
       `
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           name: string | int32;
         }
@@ -33,7 +32,6 @@ describe("typespec-client-generator-core: union types", () => {
   it("nullable", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           name: float32 | null;
         }
@@ -49,7 +47,6 @@ describe("typespec-client-generator-core: union types", () => {
   it("nullable with more types", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           name: string | float32 | null;
         }
@@ -68,7 +65,6 @@ describe("typespec-client-generator-core: union types", () => {
   it("record with nullable", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           name: Record<float32 | null>;
         }
@@ -84,7 +80,6 @@ describe("typespec-client-generator-core: union types", () => {
   it("record with nullable with more types", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           name: Record<string | float32 | null>;
         }
@@ -105,7 +100,6 @@ describe("typespec-client-generator-core: union types", () => {
   it("array with nullable", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           name: (float32 | null)[];
         }
@@ -121,7 +115,6 @@ describe("typespec-client-generator-core: union types", () => {
   it("array with nullable with more types", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           name: (string | float32 | null)[];
         }
@@ -141,19 +134,16 @@ describe("typespec-client-generator-core: union types", () => {
   it("additional property is nullable", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model TestExtends extends Record<string|null> {
           name: string;
         }
 
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model TestIs is Record<string|null> {
           name: string;
         }
 
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model TestSpread {
           name: string;
           ...Record<string|null>
@@ -191,19 +181,16 @@ describe("typespec-client-generator-core: union types", () => {
   it("additional property nullable with more types", async function () {
     await runner.compileWithBuiltInService(`
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model TestExtends extends Record<string|float32|null> {
           name: string;
         }
 
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model TestIs is Record<string|float32|null> {
           name: string;
         }
 
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model TestSpread {
           name: string;
           ...Record<string|float32|null>
@@ -263,7 +250,6 @@ describe("typespec-client-generator-core: union types", () => {
   it("model with simple union property", async function () {
     await runner.compileWithBuiltInService(`
       @usage(Usage.input | Usage.output)
-        @access(Access.public)
       model ModelWithSimpleUnionProperty {
         prop: int32 | int32[];
       }
@@ -283,29 +269,24 @@ describe("typespec-client-generator-core: union types", () => {
   it("model with named union", async function () {
     await runner.compileWithBuiltInService(`
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model BaseModel {
         name: string;
       }
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Model1 extends BaseModel {
         prop1: int32;
       }
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Model2 extends BaseModel {
         prop2: int32;
       }
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       union MyNamedUnion {
         one: Model1,
         two: Model2,
       }
 
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model ModelWithNamedUnionProperty {
         prop: MyNamedUnion;
       }
@@ -344,7 +325,6 @@ describe("typespec-client-generator-core: union types", () => {
         dog, cat, bird
       }
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Home {
         pet: PetKind | null;
       }
@@ -365,7 +345,6 @@ describe("typespec-client-generator-core: union types", () => {
   it("model with nullable union as enum", async function () {
     await runner.compileWithBuiltInService(`
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Home {
         pet: "dog" | "cat" | "bird" | string | null;
       }
@@ -386,13 +365,11 @@ describe("typespec-client-generator-core: union types", () => {
   it("model with nullable model property", async function () {
     await runner.compileWithBuiltInService(`
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model PropertyModel {
         internalProp: string;
       }
 
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: PropertyModel | null;
       }
@@ -413,19 +390,16 @@ describe("typespec-client-generator-core: union types", () => {
   it("mix types", async function () {
     await runner.compileWithBuiltInService(`
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model ModelType {
         name: string;
       }
 
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Test {
         prop: "none" | "auto" | ModelType;
       }
 
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model TestNullable {
         prop: "none" | "auto" | ModelType | null;
       }
@@ -510,7 +484,6 @@ describe("typespec-client-generator-core: union types", () => {
   it("usage override", async function () {
     await runner.compileWithBuiltInService(`
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       union UnionAsEnum {
         "A",
         "B",
@@ -518,7 +491,6 @@ describe("typespec-client-generator-core: union types", () => {
       }
 
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       model Foo {
         prop: string;
       }
@@ -556,7 +528,6 @@ describe("typespec-client-generator-core: union types", () => {
   it("usage override for orphan union as enum", async function () {
     await runner.compileWithBuiltInService(`
       @usage(Usage.input | Usage.output)
-      @access(Access.public)
       union UnionAsEnum {
         "A",
         "B",
@@ -588,7 +559,6 @@ describe("typespec-client-generator-core: union types", () => {
     await runner.compileWithBuiltInService(
       `
         @usage(Usage.input | Usage.output)
-        @access(Access.public)
         model Test {
           name: TestUnion;
         }

--- a/packages/typespec-client-generator-core/test/types/union-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/union-types.test.ts
@@ -491,6 +491,7 @@ describe("typespec-client-generator-core: union types", () => {
       }
 
       @usage(Usage.input | Usage.output)
+      @access(Access.public)
       model Foo {
         prop: string;
       }


### PR DESCRIPTION
this should be a bug that missing in https://github.com/Azure/typespec-azure/pull/925.
since we changed access default to public, we no longer need to add access override along with usage override when we want to expose an orphan model