### PR TITLE
fix(tcgc): set sdk method body parameter encode with http content type

### DIFF
--- a/.chronus/changes/tcgc-sync-body-param-encode-2024-7-22-16-51-43.md
+++ b/.chronus/changes/tcgc-sync-body-param-encode-2024-7-22-16-51-43.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+set sdk method body parameter encode with http content type

--- a/packages/typespec-client-generator-core/src/package.ts
+++ b/packages/typespec-client-generator-core/src/package.ts
@@ -74,6 +74,7 @@ import {
   getLibraryName,
 } from "./public-utils.js";
 import {
+  addEncodeInfo,
   getAllModelsWithDiagnostics,
   getClientTypeWithDiagnostics,
   getSdkCredentialParameter,
@@ -247,6 +248,19 @@ function getSdkBasicServiceMethod<TServiceOperation extends SdkServiceOperation>
   const serviceOperation = diagnostics.pipe(
     getSdkServiceOperation<TServiceOperation>(context, operation, methodParameters)
   );
+  // set the correct encode for body parameter according to the content-type
+  if (
+    serviceOperation.bodyParam &&
+    serviceOperation.bodyParam.correspondingMethodParams.length === 1
+  ) {
+    const methodBodyParam = serviceOperation.bodyParam.correspondingMethodParams[0];
+    const contentTypes = serviceOperation.__raw.parameters.body?.contentTypes;
+    const defaultContentType =
+      contentTypes && contentTypes.length > 0 ? contentTypes[0] : "application/json";
+    diagnostics.pipe(
+      addEncodeInfo(context, methodBodyParam.__raw!, methodBodyParam.type, defaultContentType)
+    );
+  }
   const response = getSdkMethodResponse(context, operation, serviceOperation);
   const name = getLibraryName(context, operation);
   return diagnostics.wrap({

--- a/packages/typespec-client-generator-core/test/types/bytes-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/bytes-types.test.ts
@@ -1,0 +1,40 @@
+import { ok, strictEqual } from "assert";
+import { beforeEach, describe, it } from "vitest";
+import { SdkBasicServiceMethod, SdkBuiltInType, SdkHttpOperation } from "../../src/interfaces.js";
+import { SdkTestRunner, createSdkTestRunner } from "../test-host.js";
+
+describe("typespec-client-generator-core: bytes types", () => {
+  let runner: SdkTestRunner;
+
+  beforeEach(async () => {
+    runner = await createSdkTestRunner({ emitterName: "@azure-tools/typespec-java" });
+  });
+
+  describe("bytes SdkMethodParameter", () => {
+    it("should use service operation parameter encoding", async () => {
+      await runner.compile(`
+        @service({})
+        namespace TestClient {
+          op send(@body body: bytes, @header contentType: "application/json; serialization=Avro" | "application/octet-stream"): void;
+        }
+      `);
+      const client = runner.context.sdkPackage.clients[0];
+      ok(client);
+      const method = client.methods[0];
+      ok(method);
+      strictEqual(method.name, "send");
+      const param = method.parameters[0];
+      strictEqual(param.name, "body");
+      strictEqual(param.type.kind, "bytes");
+      strictEqual(param.type.name, "bytes");
+      // this is from SdkHttpServiceOperationParameter
+      strictEqual(param.type.encode, "bytes");
+      strictEqual(method.kind, "basic");
+      const serviceBodyParam = (method as SdkBasicServiceMethod<SdkHttpOperation>).operation
+        .bodyParam;
+      ok(serviceBodyParam);
+      strictEqual(serviceBodyParam.type.kind, "bytes");
+      strictEqual(param.type.encode, (serviceBodyParam.type as SdkBuiltInType).encode);
+    });
+  });
+});


### PR DESCRIPTION
- after fetching the sdk method body parameter, reset its encode according to the underlying http request content-type
- add unit test

fix #1084