### PR TITLE
[tcgc] don't require core-introduced params with `@override`

### DIFF
--- a/.chronus/changes/tcgc-override-apiVersion-2024-7-27-13-4-58.md
+++ b/.chronus/changes/tcgc-override-apiVersion-2024-7-27-13-4-58.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Don't require params introduced by `Azure.Core` with `@override`

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -914,6 +914,11 @@ function collectParams(
           params.push(value);
         } else if (!sourceProp.model) {
           params.push(value);
+        } else {
+          // eslint-disable-next-line no-console
+          console.log(
+            `We are not counting "${sourceProp.name}" as part of a method parameter because it's been added by Azure.Core templates`
+          );
         }
       }
     }

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -59,6 +59,7 @@ import {
   AllScopes,
   clientNameKey,
   getValidApiVersion,
+  isAzureCoreModel,
   parseEmitterName,
 } from "./internal-utils.js";
 import { createStateSymbol, reportDiagnostic } from "./lib.js";
@@ -905,7 +906,15 @@ function collectParams(
       if (value.type.kind === "Model") {
         collectParams(value.type.properties, params);
       } else {
-        params.push(value);
+        let sourceProp = value;
+        while (sourceProp.sourceProperty) {
+          sourceProp = sourceProp.sourceProperty;
+        }
+        if (sourceProp.model && !isAzureCoreModel(sourceProp.model)) {
+          params.push(value);
+        } else if (!sourceProp.model) {
+          params.push(value);
+        }
       }
     }
   });

--- a/packages/typespec-client-generator-core/test/decorators.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators.test.ts
@@ -1,3 +1,4 @@
+import { AzureCoreTestLibrary } from "@azure-tools/typespec-azure-core/testing";
 import { Interface, Model, Namespace, Operation, ignoreDiagnostics } from "@typespec/compiler";
 import { expectDiagnostics } from "@typespec/compiler/testing";
 import { deepStrictEqual, ok, strictEqual } from "assert";
@@ -3783,6 +3784,50 @@ describe("typespec-client-generator-core: decorators", () => {
       ok(method.operation.bodyParam);
       strictEqual(method.operation.bodyParam.correspondingMethodParams.length, 1);
       strictEqual(method.operation.bodyParam.correspondingMethodParams[0], inputParam);
+    });
+
+    it("core template", async () => {
+      const runnerWithCore = await createSdkTestRunner({
+        librariesToAdd: [AzureCoreTestLibrary],
+        autoUsings: ["Azure.Core"],
+        emitterName: "@azure-tools/typespec-java",
+      });
+      await runnerWithCore.compileWithCustomization(
+        `
+        @useDependency(Versions.v1_0_Preview_2)
+        @server("http://localhost:3000", "endpoint")
+        @service()
+        namespace My.Service;
+
+        model Params {
+          foo: string;
+          params: Params[];
+        }
+
+        @route("/template")
+        op templateOp is Azure.Core.RpcOperation<
+          Params,
+          Params
+        >;
+        `,
+        `
+        namespace My.Customizations;
+
+        op templateOp(params: My.Service.Params): My.Service.Params;
+
+        @@override(My.Service.templateOp, My.Customizations.templateOp);
+        `
+      );
+      const sdkPackage = runnerWithCore.context.sdkPackage;
+      const method = sdkPackage.clients[0].methods[0];
+      strictEqual(method.parameters.length, 3);
+      ok(method.parameters.find((x) => x.name === "contentType"));
+      ok(method.parameters.find((x) => x.name === "accept"));
+
+      const paramsParam = method.parameters.find((x) => x.name === "params");
+      ok(paramsParam);
+      strictEqual(paramsParam.type.kind, "model");
+      strictEqual(paramsParam.type.name, "Params");
     });
   });
 });


### PR DESCRIPTION
With `@override`, we require a 1:1 mapping between the actual parameters and the parameters passed in your method signature override. However, this causes issues with `core`-introduced parameters because of template-related issues. On a higher level though, I think it's fair to not require `core` params in the method signature, since we already hide these parameters in the method signature, and these parameters will still be eventually set to the service

cc @trangevi 