### PR TITLE
Fixes typespec-autorest openapi output when multiple services are defined

### DIFF
--- a/.chronus/changes/fix-dup-services-2024-7-27-16-13-52.md
+++ b/.chronus/changes/fix-dup-services-2024-7-27-16-13-52.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Fixes bug where defining multiple services in a project resulted in each openapi output containing the same single service definition.

--- a/packages/samples/test/output/core/rest-metadata-emitter/@azure-tools/typespec-autorest/AnotherService/openapi.json
+++ b/packages/samples/test/output/core/rest-metadata-emitter/@azure-tools/typespec-autorest/AnotherService/openapi.json
@@ -20,111 +20,18 @@
   ],
   "tags": [],
   "paths": {
-    "/users/{id}": {
+    "/test": {
       "get": {
-        "operationId": "Users_GetUser",
-        "parameters": [
-          {
-            "name": "id",
-            "in": "path",
-            "required": true,
-            "type": "string"
-          }
-        ],
+        "operationId": "Test",
+        "parameters": [],
         "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/User"
-            }
-          }
-        }
-      },
-      "post": {
-        "operationId": "Users_CreateUser",
-        "parameters": [
-          {
-            "$ref": "#/parameters/User.id"
-          },
-          {
-            "name": "body",
-            "in": "body",
-            "required": true,
-            "schema": {
-              "$ref": "#/definitions/UserCreate"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "The request has succeeded.",
-            "schema": {
-              "$ref": "#/definitions/User"
-            }
+          "204": {
+            "description": "There is no content to send for this request, but the headers may be useful. "
           }
         }
       }
     }
   },
-  "definitions": {
-    "User": {
-      "type": "object",
-      "properties": {
-        "id": {
-          "type": "string"
-        },
-        "secret": {
-          "type": "string",
-          "x-ms-mutability": [
-            "create"
-          ]
-        },
-        "name": {
-          "type": "string"
-        },
-        "age": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "required": [
-        "id",
-        "secret",
-        "name",
-        "age"
-      ]
-    },
-    "UserCreate": {
-      "type": "object",
-      "properties": {
-        "secret": {
-          "type": "string",
-          "x-ms-mutability": [
-            "create"
-          ]
-        },
-        "name": {
-          "type": "string"
-        },
-        "age": {
-          "type": "integer",
-          "format": "int32"
-        }
-      },
-      "required": [
-        "secret",
-        "name",
-        "age"
-      ]
-    }
-  },
-  "parameters": {
-    "User.id": {
-      "name": "id",
-      "in": "path",
-      "required": true,
-      "type": "string",
-      "x-ms-parameter-location": "method"
-    }
-  }
+  "definitions": {},
+  "parameters": {}
 }

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -106,9 +106,9 @@ import {
   OAuth2FlowType,
   Visibility,
   createMetadataInfo,
-  getAllHttpServices,
   getAuthentication,
   getHeaderFieldOptions,
+  getHttpService,
   getServers,
   getStatusCodeDescription,
   getVisibilitySuffix,
@@ -341,8 +341,8 @@ export async function getOpenAPIForService(
   const [exampleMap, diagnostics] = await loadExamples(program.host, options, context.version);
   program.reportDiagnostics(diagnostics);
 
-  const services = ignoreDiagnostics(getAllHttpServices(program));
-  const routes = services[0].operations;
+  const httpService = ignoreDiagnostics(getHttpService(program, service.type));
+  const routes = httpService.operations;
   reportIfNoRoutes(program, routes);
 
   routes.forEach(emitOperation);

--- a/packages/typespec-autorest/test/services.test.ts
+++ b/packages/typespec-autorest/test/services.test.ts
@@ -1,0 +1,50 @@
+import { deepStrictEqual } from "assert";
+import { it } from "vitest";
+import { openApiFor } from "./test-host.js";
+
+it("supports emitting multiple services", async () => {
+  const { Service, Client } = await openApiFor(
+    `
+      @service({ title: "My service" })
+      namespace Service {
+        op get(): int32;
+      }
+
+      @service({ title: "Other service" })
+      namespace Client {
+        @route("other") op other(): string;
+      }
+      `,
+    ["Service", "Client"]
+  );
+
+  deepStrictEqual(Service.paths, {
+    "/": {
+      get: {
+        operationId: "Get",
+        parameters: [],
+        responses: {
+          200: {
+            description: "The request has succeeded.",
+            schema: { type: "integer", format: "int32" },
+          },
+        },
+      },
+    },
+  });
+
+  deepStrictEqual(Client.paths, {
+    "/other": {
+      get: {
+        operationId: "Other",
+        parameters: [],
+        responses: {
+          200: {
+            description: "The request has succeeded.",
+            schema: { type: "string" },
+          },
+        },
+      },
+    },
+  });
+});


### PR DESCRIPTION
Fixes #1373

Note: Had to regenerate one of the sample specs that was testing emitting multiple services - it turned out to be broken prior to this change as well.