### PR TITLE
Add back legacy way to specify body param name

### DIFF
--- a/.chronus/changes/fix-add-legacy-json-name-2024-8-3-8-9-1.md
+++ b/.chronus/changes/fix-add-legacy-json-name-2024-8-3-8-9-1.md
@@ -1,0 +1,6 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -1288,7 +1288,7 @@ export async function getOpenAPIForService(
       reportDeprecated(
         program,
         "Using encodedName for the body property is meaningless. That property is not serialized as Json. If wanting to rename it use @Azure.ClientGenerator.Core.clientName",
-        param
+        param.decorators.find((x) => x.definition?.name === "@encodedName")?.node ?? param
       );
     } else {
       // For body parameter the only value of the name is in the client so no need to keep the original one

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -1290,6 +1290,11 @@ export async function getOpenAPIForService(
         "Using encodedName for the body property is meaningless. That property is not serialized as Json. If wanting to rename it use @Azure.ClientGenerator.Core.clientName",
         param.decorators.find((x) => x.definition?.name === "@encodedName")?.node ?? param
       );
+      result.name = jsonName;
+
+      if (!result["x-ms-client-name"]) {
+        result["x-ms-client-name"] = param.name;
+      }
     } else {
       // For body parameter the only value of the name is in the client so no need to keep the original one
       if (result["x-ms-client-name"]) {

--- a/packages/typespec-autorest/test/parameters.test.ts
+++ b/packages/typespec-autorest/test/parameters.test.ts
@@ -310,6 +310,19 @@ describe("body parameters", () => {
     expect(res.paths["/"].post.parameters[0]).toMatchObject({ in: "body", name: "bar" });
   });
 
+  it("set x-ms-client-name with @clientName when also using encodedName", async () => {
+    const res = await openApiFor(
+      `
+      #suppress "deprecated" "For tests"
+      op test(@body @encodedName("application/json", "jsonName") @clientName("bar") foo: string): void;`
+    );
+    expect(res.paths["/"].post.parameters[0]).toMatchObject({
+      in: "body",
+      name: "jsonName",
+      "x-ms-client-name": "bar",
+    });
+  });
+
   it("using @body ignore any metadata property underneath", async () => {
     const res = await openApiFor(`@get op read(
       @body body: {


### PR DESCRIPTION
Having `@clientName` just always override the name instead of setting x-ms-client-name result in many spec having their param change completely which is then detected as breaking change even though it isn't really. 

As there is a decent amount of failures for this (~130) i think its easier if for now we can just add an escape hatch