### PR TITLE
Remove examples-directory from feeds 

### DIFF
--- a/eng/feeds/arm-canonical/tspconfig.yaml
+++ b/eng/feeds/arm-canonical/tspconfig.yaml
@@ -7,7 +7,6 @@ options:
     emitter-output-dir: "{project-root}/.."
     azure-resource-provider-folder: "resource-manager"
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json"
-    examples-directory: "{project-root}/examples"
   "@azure-tools/typespec-autorest-canonical":
     emitter-output-dir: "{project-root}/.."
     azure-resource-provider-folder: "resource-manager"

--- a/eng/feeds/arm/tspconfig.yaml
+++ b/eng/feeds/arm/tspconfig.yaml
@@ -6,7 +6,6 @@ options:
     emitter-output-dir: "{project-root}/.."
     azure-resource-provider-folder: "resource-manager"
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json"
-    examples-directory: "{project-root}/examples"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"

--- a/eng/feeds/arm/tspconfig_stand_alone.yaml
+++ b/eng/feeds/arm/tspconfig_stand_alone.yaml
@@ -7,7 +7,6 @@ options:
     use-read-only-status-schema: true
     azure-resource-provider-folder: "resource-manager"
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json"
-    examples-directory: "{project-root}/examples"
 linter:
   extends:
     - "@azure-tools/typespec-azure-rulesets/resource-manager"

--- a/eng/feeds/data-plane/tspconfig.yaml
+++ b/eng/feeds/data-plane/tspconfig.yaml
@@ -10,7 +10,6 @@ options:
   "@azure-tools/typespec-autorest":
     azure-resource-provider-folder: "data-plane"
     emitter-output-dir: "{project-root}/.."
-    examples-directory: "{project-root}/examples"
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json"
   "@azure-tools/typespec-python":    
     package-dir: "{{#normalizePackageName}}{{parameters.ServiceNamespace}}{{/normalizePackageName}}"

--- a/eng/feeds/data-plane/tspconfig_stand_alone.yaml
+++ b/eng/feeds/data-plane/tspconfig_stand_alone.yaml
@@ -10,7 +10,6 @@ options:
   "@azure-tools/typespec-autorest":
     azure-resource-provider-folder: "data-plane"
     ## emitter-output-dir: "{project-root}/.."
-    examples-directory: "{project-root}/examples"
     output-file: "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json"
   "@azure-tools/typespec-python":    
     package-dir: "{{#normalizePackageName}}{{parameters.ServiceNamespace}}{{/normalizePackageName}}"


### PR DESCRIPTION
Remove `examples-directory` option from the templates as the default value is already that now.