### PR TITLE
Replace `x-ms-skip-url-encoding` with `allowReserved`

### DIFF
--- a/.chronus/changes/allow-reserved-2024-8-11-16-40-29.md
+++ b/.chronus/changes/allow-reserved-2024-8-11-16-40-29.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+`x-ms-skip-url-encoding` should be replaced with `allowReserved`

--- a/packages/typespec-azure-resource-manager/lib/common-types/types.tsp
+++ b/packages/typespec-azure-resource-manager/lib/common-types/types.tsp
@@ -537,10 +537,9 @@ model ManagementGroupNameParameter {
 @added(Versions.v4)
 model ScopeParameter {
   /** The scope at which the operation is performed. */
-  @path
+  @path(#{ allowReserved: true })
   @segment("scope")
   @minLength(1)
-  @extension("x-ms-skip-url-encoding", true)
   scope: string;
 }
 

--- a/packages/typespec-azure-resource-manager/lib/parameters.tsp
+++ b/packages/typespec-azure-resource-manager/lib/parameters.tsp
@@ -83,9 +83,8 @@ model ArmLocationResource<BaseType extends
  */
 @doc("The default resourceUri parameter type.")
 model ResourceUriParameter {
-  @path
+  @path(#{ allowReserved: true })
   @doc("The fully qualified Azure Resource manager identifier of the resource.")
-  @extension("x-ms-skip-url-encoding", true)
   @resourceParameterBaseFor([ResourceHome.Extension])
   resourceUri: string;
 }


### PR DESCRIPTION
This is blocking a new RP [kubernetesruntime](https://github.com/Azure/azure-rest-api-specs/blob/f5321f9b29083f9ea4c028e7484504875e04a758/specification/kubernetesruntime/KubernetesRuntime.Management/storageclass.tsp#L273) generating SDK.