### PR TITLE
[TCGC] Change `encode` to optional and no longer use `kind` as its fallback value if there is no encode

### DIFF
--- a/.chronus/changes/optional-encode-2024-8-14-9-51-14.md
+++ b/.chronus/changes/optional-encode-2024-8-14-9-51-14.md
@@ -1,0 +1,8 @@
+---
+changeKind: breaking
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+1. change `encode` in `SdkBuiltInType` to optional.
+2. no longer use the value of `kind` as `encode` when there is no encode on this type.

--- a/docs/howtos/Client Generation/07tcgcTypes.mdx
+++ b/docs/howtos/Client Generation/07tcgcTypes.mdx
@@ -1315,7 +1315,7 @@ There is a one-to-one mapping between the TypeSpec scalar kinds and the `SdkBuil
 ```ts
 export interface SdkBuiltInType extends SdkTypeBase {
   kind: SdkBuiltInKinds;
-  encode: string;
+  encode?: string;
   name: string;
   baseType?: SdkBuiltInType;
   crossLanguageDefinitionId: string;

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -163,7 +163,7 @@ export type SdkType =
 
 export interface SdkBuiltInType extends SdkTypeBase {
   kind: SdkBuiltInKinds;
-  encode: string;
+  encode?: string;
   name: string;
   baseType?: SdkBuiltInType;
   crossLanguageDefinitionId: string;

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -131,17 +131,17 @@ function getUnknownType(context: TCGCContext, type: Type): [SdkBuiltInType, read
   const unknownType: SdkBuiltInType = {
     ...diagnostics.pipe(getSdkTypeBaseHelper(context, type, "unknown")),
     name: getLibraryName(context, type),
-    encode: getEncodeHelper(context, type, "unknown"),
+    encode: getEncodeHelper(context, type),
     crossLanguageDefinitionId: "",
   };
   return diagnostics.wrap(unknownType);
 }
 
-function getEncodeHelper(context: TCGCContext, type: Type, kind: string): string {
+function getEncodeHelper(context: TCGCContext, type: Type): string | undefined {
   if (type.kind === "ModelProperty" || type.kind === "Scalar") {
-    return getEncode(context.program, type)?.encoding || kind;
+    return getEncode(context.program, type)?.encoding;
   }
-  return kind;
+  return undefined;
 }
 
 /**
@@ -190,14 +190,13 @@ export function addEncodeInfo(
   if (isSdkIntKind(innerType.kind)) {
     // only integer type is allowed to be encoded as string
     if (encodeData && "encode" in innerType) {
-      const encode = getEncode(context.program, type);
-      if (encode?.encoding) {
-        innerType.encode = encode.encoding;
+      if (encodeData?.encoding) {
+        innerType.encode = encodeData.encoding;
       }
-      if (encode?.type) {
+      if (encodeData?.type) {
         // if we specify the encoding type in the decorator, we set the `.encode` string
         // to the kind of the encoding type
-        innerType.encode = getSdkBuiltInType(context, encode.type).kind;
+        innerType.encode = getSdkBuiltInType(context, encodeData.type).kind;
       }
     }
   }
@@ -241,7 +240,7 @@ function getSdkBuiltInTypeWithDiagnostics(
   const stdType = {
     ...diagnostics.pipe(getSdkTypeBaseHelper(context, type, kind)),
     name: getLibraryName(context, type),
-    encode: getEncodeHelper(context, type, kind),
+    encode: getEncodeHelper(context, type),
     description: docWrapper.description,
     details: docWrapper.details,
     doc: getDoc(context.program, type),

--- a/packages/typespec-client-generator-core/test/types/built-in-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/built-in-types.test.ts
@@ -295,7 +295,7 @@ describe("typespec-client-generator-core: built-in types", () => {
     ok(etagProperty);
     strictEqual(etagProperty.type.kind, "string");
     strictEqual(etagProperty.type.name, "eTag");
-    strictEqual(etagProperty.type.encode, "string");
+    strictEqual(etagProperty.type.encode, undefined);
     strictEqual(etagProperty.type.crossLanguageDefinitionId, "Azure.Core.eTag");
     strictEqual(etagProperty.type.baseType?.kind, "string");
   });


### PR DESCRIPTION
Fixes https://github.com/Azure/typespec-azure/issues/875