### PR TITLE
Refine the `statusCodes` of `responses` and `exceptions`

### DIFF
--- a/.chronus/changes/refine-responses-exceptions-2024-8-23-3-2-46.md
+++ b/.chronus/changes/refine-responses-exceptions-2024-8-23-3-2-46.md
@@ -1,0 +1,10 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+In `0.46.1` we changed the type of `responses` in `SdkHttpOperation` from `Map<number | HttpRange, SdkHttpResponse>` to `SdkHttpResponse[]`, `exceptions` in `SdkHttpOperation` from `Map<number | HttpRange | "*", SdkHttpResponse>` to `SdkHttpResponse[]`,
+and added a `statusCodes` property to `SdkHttpResponse`. But the `statusCodes` is defined as `number | HttpRange | "*"`, which loses the information that the responses in `responses` property could never have a `*` as its statusCodes.
+This PR adds a new type `SdkHttpErrorResponse` with the `statusCodes` of `number | HttpRange | "*"`, and changes the type of `statusCodes` in `SdkHttpResponse` to `number | HttpRange` to be precise.

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -31,6 +31,7 @@ import {
   CollectionFormat,
   SdkBodyParameter,
   SdkHeaderParameter,
+  SdkHttpErrorResponse,
   SdkHttpOperation,
   SdkHttpParameter,
   SdkHttpResponse,
@@ -80,9 +81,7 @@ export function getSdkHttpOperation(
   const { responses, exceptions } = diagnostics.pipe(
     getSdkHttpResponseAndExceptions(context, httpOperation)
   );
-  const responsesWithBodies = [...responses.values()]
-    .concat([...exceptions.values()])
-    .filter((r) => r.type);
+  const responsesWithBodies = [...responses.values(), ...exceptions.values()].filter((r) => r.type);
   const parameters = diagnostics.pipe(
     getSdkHttpParameters(context, httpOperation, methodParameters, responsesWithBodies[0])
   );
@@ -117,7 +116,7 @@ function getSdkHttpParameters(
   context: TCGCContext,
   httpOperation: HttpOperation,
   methodParameters: SdkMethodParameter[],
-  responseBody?: SdkHttpResponse
+  responseBody?: SdkHttpResponse | SdkHttpErrorResponse
 ): [SdkHttpParameters, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
   const retval: SdkHttpParameters = {
@@ -259,7 +258,7 @@ function getSdkHttpParameters(
 function createContentTypeOrAcceptHeader(
   context: TCGCContext,
   httpOperation: HttpOperation,
-  bodyObject: SdkBodyParameter | SdkHttpResponse
+  bodyObject: SdkBodyParameter | SdkHttpResponse | SdkHttpErrorResponse
 ): Omit<SdkMethodParameter, "kind"> {
   const name = bodyObject.kind === "body" ? "contentType" : "accept";
   let type: SdkType = getTypeSpecBuiltInType(context, "string");
@@ -412,13 +411,13 @@ function getSdkHttpResponseAndExceptions(
 ): [
   {
     responses: SdkHttpResponse[];
-    exceptions: SdkHttpResponse[];
+    exceptions: SdkHttpErrorResponse[];
   },
   readonly Diagnostic[],
 ] {
   const diagnostics = createDiagnosticCollector();
   const responses: SdkHttpResponse[] = [];
-  const exceptions: SdkHttpResponse[] = [];
+  const exceptions: SdkHttpErrorResponse[] = [];
   for (const response of httpOperation.responses) {
     const headers: SdkServiceResponseHeader[] = [];
     let body: Type | undefined;
@@ -465,12 +464,10 @@ function getSdkHttpResponseAndExceptions(
             : innerResponse.body.type;
       }
     }
-    const sdkResponse: SdkHttpResponse = {
+    const sdkResponse = {
       __raw: response,
-      kind: "http",
       type: body ? diagnostics.pipe(getClientTypeWithDiagnostics(context, body)) : undefined,
       headers,
-      statusCodes: response.statusCodes,
       contentTypes: contentTypes.length > 0 ? contentTypes : undefined,
       defaultContentType: contentTypes.includes("application/json")
         ? "application/json"
@@ -482,10 +479,18 @@ function getSdkHttpResponseAndExceptions(
       ),
       description: response.description,
     };
-    if (sdkResponse.statusCodes === "*" || (body && isErrorModel(context.program, body))) {
-      exceptions.push(sdkResponse);
+    if (response.statusCodes === "*" || (body && isErrorModel(context.program, body))) {
+      exceptions.push({
+        ...sdkResponse,
+        kind: "http",
+        statusCodes: response.statusCodes,
+      });
     } else {
-      responses.push(sdkResponse);
+      responses.push({
+        ...sdkResponse,
+        kind: "http",
+        statusCodes: response.statusCodes,
+      });
     }
   }
   return diagnostics.wrap({ responses, exceptions });

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -550,7 +550,6 @@ interface SdkHttpResponseBase extends SdkServiceResponse {
   contentTypes?: string[];
   defaultContentType?: string;
   description?: string;
-  statusCodes: number | HttpStatusCodeRange | "*";
 }
 
 export interface SdkHttpResponse extends SdkHttpResponseBase {
@@ -560,6 +559,8 @@ export interface SdkHttpResponse extends SdkHttpResponseBase {
 export interface SdkHttpErrorResponse extends SdkHttpResponseBase {
   statusCodes: number | HttpStatusCodeRange | "*";
 }
+
+interface SdkServiceOperationBase {}
 
 export type SdkParameter = SdkEndpointParameter | SdkCredentialParameter | SdkMethodParameter;
 

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -544,7 +544,7 @@ export interface SdkServiceResponse {
   apiVersions: string[];
 }
 
-export interface SdkHttpResponse extends SdkServiceResponse {
+interface SdkHttpResponseBase extends SdkServiceResponse {
   __raw: HttpOperationResponse;
   kind: "http";
   contentTypes?: string[];
@@ -553,7 +553,13 @@ export interface SdkHttpResponse extends SdkServiceResponse {
   statusCodes: number | HttpStatusCodeRange | "*";
 }
 
-interface SdkServiceOperationBase {}
+export interface SdkHttpResponse extends SdkHttpResponseBase {
+  statusCodes: number | HttpStatusCodeRange;
+}
+
+export interface SdkHttpErrorResponse extends SdkHttpResponseBase {
+  statusCodes: number | HttpStatusCodeRange | "*";
+}
 
 export type SdkParameter = SdkEndpointParameter | SdkCredentialParameter | SdkMethodParameter;
 
@@ -566,7 +572,7 @@ export interface SdkHttpOperation extends SdkServiceOperationBase {
   parameters: (SdkPathParameter | SdkQueryParameter | SdkHeaderParameter)[];
   bodyParam?: SdkBodyParameter;
   responses: SdkHttpResponse[];
-  exceptions: SdkHttpResponse[];
+  exceptions: SdkHttpErrorResponse[];
   examples?: SdkHttpOperationExample[];
 }
 


### PR DESCRIPTION
Fixes https://github.com/Azure/typespec-azure/issues/1590

In `0.46.1` we changed the type of `responses` in `SdkHttpOperation` from `Map<number | HttpRange, SdkHttpResponse>` to `SdkHttpResponse[]`, `exceptions` in `SdkHttpOperation` from `Map<number | HttpRange | "*", SdkHttpResponse>` to `SdkHttpResponse[]`,
and added a `statusCodes` property to `SdkHttpResponse`. But the `statusCodes` is defined as `number | HttpRange | "*"`, which loses the information that the responses in `responses` property could never have a `*` as its statusCodes.
This PR adds a new type `SdkHttpErrorResponse` with the `statusCodes` of `number | HttpRange | "*"`, and changes the type of `statusCodes` in `SdkHttpResponse` to `number | HttpRange` to be precise.