### PR TITLE
[tcgc] change example mapping logic to allow operation id with/without renaming

### DIFF
--- a/.chronus/changes/fix_example_mapping-2024-8-24-14-45-21.md
+++ b/.chronus/changes/fix_example_mapping-2024-8-24-14-45-21.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+change example mapping logic to allow operation id with/without renaming

--- a/packages/typespec-client-generator-core/test/examples/load.test.ts
+++ b/packages/typespec-client-generator-core/test/examples/load.test.ts
@@ -211,4 +211,46 @@ describe("typespec-client-generator-core: load examples", () => {
     ok(operation);
     strictEqual(operation.examples?.length, 1);
   });
+
+  it("load multiple example of original operation id with @clientName", async () => {
+    await runner.host.addRealTypeSpecFile(
+      "./examples/clientNameOriginal.json",
+      `${__dirname}/load/clientNameOriginal.json`
+    );
+    await runner.host.addRealTypeSpecFile(
+      "./examples/clientNameAnotherOriginal.json",
+      `${__dirname}/load/clientNameAnotherOriginal.json`
+    );
+    await runner.compile(`
+      @service({})
+      namespace TestClient {
+        @clientName("renamedNS")
+        namespace NS {
+          @route("/ns")
+          @clientName("renamedOP")
+          op get(): string;
+        }
+
+        @clientName("renamedIF")
+        namespace IF {
+          @route("/if")
+          @clientName("renamedOP")
+          op get(): string;
+        }
+      }
+    `);
+
+    let operation = (
+      (runner.context.sdkPackage.clients[0].methods[0] as SdkClientAccessor<SdkHttpOperation>)
+        .response.methods[0] as SdkServiceMethod<SdkHttpOperation>
+    ).operation;
+    ok(operation);
+    strictEqual(operation.examples?.length, 1);
+    operation = (
+      (runner.context.sdkPackage.clients[0].methods[1] as SdkClientAccessor<SdkHttpOperation>)
+        .response.methods[0] as SdkServiceMethod<SdkHttpOperation>
+    ).operation;
+    ok(operation);
+    strictEqual(operation.examples?.length, 1);
+  });
 });

--- a/packages/typespec-client-generator-core/test/examples/load/clientNameAnotherOriginal.json
+++ b/packages/typespec-client-generator-core/test/examples/load/clientNameAnotherOriginal.json
@@ -1,0 +1,11 @@
+{
+  "operationId": "IF_get",
+  "title": "renamedIF_renamedOP",
+  "parameters": {},
+  "responses": {
+    "200": {
+      "description": "ARM operation completed successfully.",
+      "body": "test"
+    }
+  }
+}

--- a/packages/typespec-client-generator-core/test/examples/load/clientNameOriginal.json
+++ b/packages/typespec-client-generator-core/test/examples/load/clientNameOriginal.json
@@ -1,0 +1,11 @@
+{
+  "operationId": "NS_get",
+  "title": "renamedNS_renamedOP",
+  "parameters": {},
+  "responses": {
+    "200": {
+      "description": "ARM operation completed successfully.",
+      "body": "test"
+    }
+  }
+}


### PR DESCRIPTION
fix: https://github.com/Azure/typespec-azure/issues/1593