### PR TITLE
[tcgc] deprecate description in `SdkExampleBase`

### DIFF
--- a/.chronus/changes/deprecate_description-2024-8-26-23-19-32.md
+++ b/.chronus/changes/deprecate_description-2024-8-26-23-19-32.md
@@ -1,0 +1,7 @@
+---
+changeKind: deprecation
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+deprecate description in `SdkExampleBase`

--- a/packages/typespec-client-generator-core/src/example.ts
+++ b/packages/typespec-client-generator-core/src/example.ts
@@ -231,6 +231,7 @@ function handleHttpOperationExamples(
     const operationExample: SdkHttpOperationExample = {
       kind: "http",
       name: title,
+      description: title,
       doc: title,
       filePath: example.relativePath,
       parameters: diagnostics.pipe(

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -718,6 +718,10 @@ export enum UsageFlags {
 interface SdkExampleBase {
   kind: string;
   name: string;
+  /**
+   * @deprecated Use `doc` instead.
+   */
+  description: string;
   doc: string;
   filePath: string;
   rawExample: any;


### PR DESCRIPTION
Add back description and make it deprecated to prevent breaking in current version.