### PR TITLE
[wip] test-host fixes for adding streaming support

### DIFF
--- a/packages/typespec-autorest-canonical/package.json
+++ b/packages/typespec-autorest-canonical/package.json
@@ -70,6 +70,7 @@
     "@typespec/library-linter": "workspace:~",
     "@typespec/openapi": "workspace:~",
     "@typespec/rest": "workspace:~",
+    "@typespec/streams": "workspace:~",
     "@typespec/tspd": "workspace:~",
     "@typespec/versioning": "workspace:~",
     "@vitest/coverage-v8": "^2.1.1",

--- a/packages/typespec-autorest-canonical/test/test-host.ts
+++ b/packages/typespec-autorest-canonical/test/test-host.ts
@@ -13,6 +13,7 @@ import {
 import { HttpTestLibrary } from "@typespec/http/testing";
 import { OpenAPITestLibrary } from "@typespec/openapi/testing";
 import { RestTestLibrary } from "@typespec/rest/testing";
+import { StreamsTestLibrary } from "@typespec/streams/testing";
 import { VersioningTestLibrary } from "@typespec/versioning/testing";
 import { ok } from "assert";
 import { AutorestCanonicalEmitterOptions } from "../src/lib.js";
@@ -21,6 +22,7 @@ import { AutorestCanonicalTestLibrary } from "../src/testing/index.js";
 export async function createAutorestCanonicalTestHost() {
   return createTestHost({
     libraries: [
+      StreamsTestLibrary,
       HttpTestLibrary,
       RestTestLibrary,
       OpenAPITestLibrary,

--- a/packages/typespec-autorest/package.json
+++ b/packages/typespec-autorest/package.json
@@ -75,6 +75,7 @@
     "@typespec/library-linter": "workspace:~",
     "@typespec/openapi": "workspace:~",
     "@typespec/rest": "workspace:~",
+    "@typespec/streams": "workspace:~",
     "@typespec/tspd": "workspace:~",
     "@typespec/versioning": "workspace:~",
     "@vitest/coverage-v8": "^2.1.1",

--- a/packages/typespec-autorest/test/test-host.ts
+++ b/packages/typespec-autorest/test/test-host.ts
@@ -12,6 +12,7 @@ import {
 import { HttpTestLibrary } from "@typespec/http/testing";
 import { OpenAPITestLibrary } from "@typespec/openapi/testing";
 import { RestTestLibrary } from "@typespec/rest/testing";
+import { StreamsTestLibrary } from "@typespec/streams/testing";
 import { VersioningTestLibrary } from "@typespec/versioning/testing";
 import { ok } from "assert";
 import { AutorestEmitterOptions } from "../src/lib.js";
@@ -21,6 +22,7 @@ import { AutorestTestLibrary } from "../src/testing/index.js";
 export async function createAutorestTestHost() {
   return createTestHost({
     libraries: [
+      StreamsTestLibrary,
       HttpTestLibrary,
       RestTestLibrary,
       OpenAPITestLibrary,

--- a/packages/typespec-azure-core/package.json
+++ b/packages/typespec-azure-core/package.json
@@ -64,6 +64,7 @@
     "@typespec/library-linter": "workspace:~",
     "@typespec/openapi": "workspace:~",
     "@typespec/rest": "workspace:~",
+    "@typespec/streams": "workspace:~",
     "@typespec/tspd": "workspace:~",
     "@typespec/versioning": "workspace:~",
     "@vitest/coverage-v8": "^2.1.1",

--- a/packages/typespec-azure-core/test/test-host.ts
+++ b/packages/typespec-azure-core/test/test-host.ts
@@ -17,6 +17,7 @@ import {
 import { HttpTestLibrary } from "@typespec/http/testing";
 import { OpenAPITestLibrary } from "@typespec/openapi/testing";
 import { RestTestLibrary } from "@typespec/rest/testing";
+import { StreamsTestLibrary } from "@typespec/streams/testing";
 import { buildVersionProjections } from "@typespec/versioning";
 import { VersioningTestLibrary } from "@typespec/versioning/testing";
 import { AzureCoreTestLibrary } from "../src/testing/index.js";
@@ -25,6 +26,7 @@ export async function createAzureCoreTestHost() {
   return createTestHost({
     libraries: [
       AzureCoreTestLibrary,
+      StreamsTestLibrary,
       HttpTestLibrary,
       RestTestLibrary,
       VersioningTestLibrary,

--- a/packages/typespec-azure-portal-core/package.json
+++ b/packages/typespec-azure-portal-core/package.json
@@ -42,6 +42,7 @@
     "@typespec/library-linter": "workspace:~",
     "@typespec/openapi": "workspace:~",
     "@typespec/rest": "workspace:~",
+    "@typespec/streams": "workspace:~",
     "@typespec/tspd": "workspace:~",
     "@typespec/versioning": "workspace:~",
     "@vitest/coverage-v8": "^2.1.1",

--- a/packages/typespec-azure-portal-core/test/test-host.ts
+++ b/packages/typespec-azure-portal-core/test/test-host.ts
@@ -6,12 +6,14 @@ import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
 import { HttpTestLibrary } from "@typespec/http/testing";
 import { OpenAPITestLibrary } from "@typespec/openapi/testing";
 import { RestTestLibrary } from "@typespec/rest/testing";
+import { StreamsTestLibrary } from "@typespec/streams/testing";
 import { VersioningTestLibrary } from "@typespec/versioning/testing";
 import { PortalCoreTestLibrary } from "../src/testing/index.js";
 
 export async function createPortalCoreHost() {
   return createTestHost({
     libraries: [
+      StreamsTestLibrary,
       RestTestLibrary,
       AzureResourceManagerTestLibrary,
       HttpTestLibrary,

--- a/packages/typespec-azure-resource-manager/package.json
+++ b/packages/typespec-azure-resource-manager/package.json
@@ -73,6 +73,7 @@
     "@typespec/library-linter": "workspace:~",
     "@typespec/openapi": "workspace:~",
     "@typespec/rest": "workspace:~",
+    "@typespec/streams": "workspace:~",
     "@typespec/tspd": "workspace:~",
     "@typespec/versioning": "workspace:~",
     "@vitest/coverage-v8": "^2.1.1",

--- a/packages/typespec-azure-resource-manager/test/test-host.ts
+++ b/packages/typespec-azure-resource-manager/test/test-host.ts
@@ -4,6 +4,7 @@ import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
 import { HttpTestLibrary } from "@typespec/http/testing";
 import { OpenAPITestLibrary } from "@typespec/openapi/testing";
 import { RestTestLibrary } from "@typespec/rest/testing";
+import { StreamsTestLibrary } from "@typespec/streams/testing";
 import { VersioningTestLibrary } from "@typespec/versioning/testing";
 import { $lib } from "../src/lib.js";
 import { AzureResourceManagerTestLibrary } from "../src/testing/index.js";
@@ -11,6 +12,7 @@ import { AzureResourceManagerTestLibrary } from "../src/testing/index.js";
 export async function createAzureResourceManagerTestHost() {
   return createTestHost({
     libraries: [
+      StreamsTestLibrary,
       HttpTestLibrary,
       RestTestLibrary,
       OpenAPITestLibrary,

--- a/packages/typespec-client-generator-core/package.json
+++ b/packages/typespec-client-generator-core/package.json
@@ -77,6 +77,7 @@
     "@typespec/openapi": "workspace:~",
     "@typespec/prettier-plugin-typespec": "workspace:~",
     "@typespec/rest": "workspace:~",
+    "@typespec/streams": "workspace:~",
     "@typespec/tspd": "workspace:~",
     "@typespec/xml": "workspace:~",
     "@vitest/coverage-v8": "^2.1.1",

--- a/packages/typespec-client-generator-core/test/test-host.ts
+++ b/packages/typespec-client-generator-core/test/test-host.ts
@@ -9,6 +9,7 @@ import {
 } from "@typespec/compiler/testing";
 import { HttpTestLibrary } from "@typespec/http/testing";
 import { RestTestLibrary } from "@typespec/rest/testing";
+import { StreamsTestLibrary } from "@typespec/streams/testing";
 import { VersioningTestLibrary } from "@typespec/versioning/testing";
 import { CreateSdkContextOptions, createSdkContext } from "../src/decorators.js";
 import {
@@ -20,7 +21,13 @@ import {
 import { SdkTestLibrary } from "../src/testing/index.js";
 
 export async function createSdkTestHost(options: CreateSdkTestRunnerOptions = {}) {
-  let libraries = [SdkTestLibrary, HttpTestLibrary, RestTestLibrary, VersioningTestLibrary];
+  let libraries = [
+    SdkTestLibrary,
+    StreamsTestLibrary,
+    HttpTestLibrary,
+    RestTestLibrary,
+    VersioningTestLibrary,
+  ];
   if (options.librariesToAdd) {
     libraries = libraries.concat(options.librariesToAdd);
   }

--- a/packages/typespec-service-csharp/package.json
+++ b/packages/typespec-service-csharp/package.json
@@ -65,6 +65,7 @@
     "@typespec/library-linter": "workspace:~",
     "@typespec/openapi": "workspace:~",
     "@typespec/rest": "workspace:~",
+    "@typespec/streams": "workspace:~",
     "@typespec/tspd": "workspace:~",
     "@vitest/coverage-v8": "^2.1.1",
     "c8": "^10.1.2",

--- a/packages/typespec-service-csharp/test/test-host.ts
+++ b/packages/typespec-service-csharp/test/test-host.ts
@@ -2,6 +2,7 @@ import { AzureCoreTestLibrary } from "@azure-tools/typespec-azure-core/testing";
 import { createTestHost, createTestWrapper } from "@typespec/compiler/testing";
 import { HttpTestLibrary } from "@typespec/http/testing";
 import { RestTestLibrary } from "@typespec/rest/testing";
+import { StreamsTestLibrary } from "@typespec/streams/testing";
 import { VersioningTestLibrary } from "@typespec/versioning/testing";
 import { CSharpServiceEmitterOptions } from "../src/lib.js";
 import { CSharpServiceEmitterTestLibrary } from "../src/testing/index.js";
@@ -9,6 +10,7 @@ import { CSharpServiceEmitterTestLibrary } from "../src/testing/index.js";
 export async function createCSharpServiceEmitterTestHost() {
   const result = await createTestHost({
     libraries: [
+      StreamsTestLibrary,
       HttpTestLibrary,
       RestTestLibrary,
       AzureCoreTestLibrary,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,39 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1(@types/node@22.7.1)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(jsdom@25.0.0)(terser@5.32.0)
 
+  core/packages/events:
+    devDependencies:
+      '@types/node':
+        specifier: ~22.7.1
+        version: 22.7.1
+      '@typespec/compiler':
+        specifier: workspace:~
+        version: link:../compiler
+      '@typespec/library-linter':
+        specifier: workspace:~
+        version: link:../library-linter
+      '@typespec/tspd':
+        specifier: workspace:~
+        version: link:../tspd
+      '@vitest/coverage-v8':
+        specifier: ^2.1.1
+        version: 2.1.1(vitest@2.1.1(@types/node@22.7.1)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(jsdom@25.0.0)(terser@5.32.0))
+      '@vitest/ui':
+        specifier: ^2.1.1
+        version: 2.1.1(vitest@2.1.1)
+      c8:
+        specifier: ^10.1.2
+        version: 10.1.2
+      rimraf:
+        specifier: ~6.0.1
+        version: 6.0.1
+      typescript:
+        specifier: ~5.6.2
+        version: 5.6.2
+      vitest:
+        specifier: ^2.1.1
+        version: 2.1.1(@types/node@22.7.1)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(jsdom@25.0.0)(terser@5.32.0)
+
   core/packages/html-program-viewer:
     dependencies:
       '@fluentui/react-components':
@@ -539,6 +572,9 @@ importers:
       '@typespec/library-linter':
         specifier: workspace:~
         version: link:../library-linter
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../streams
       '@typespec/tspd':
         specifier: workspace:~
         version: link:../tspd
@@ -588,6 +624,9 @@ importers:
       '@typespec/rest':
         specifier: workspace:~
         version: link:../rest
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../streams
       '@typespec/tspd':
         specifier: workspace:~
         version: link:../tspd
@@ -802,6 +841,9 @@ importers:
       '@typespec/rest':
         specifier: workspace:~
         version: link:../rest
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../streams
       '@typespec/tspd':
         specifier: workspace:~
         version: link:../tspd
@@ -854,6 +896,9 @@ importers:
       '@typespec/rest':
         specifier: workspace:~
         version: link:../rest
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../streams
       '@typespec/tspd':
         specifier: workspace:~
         version: link:../tspd
@@ -1269,6 +1314,9 @@ importers:
       '@typespec/library-linter':
         specifier: workspace:~
         version: link:../library-linter
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../streams
       '@typespec/tspd':
         specifier: workspace:~
         version: link:../tspd
@@ -1299,6 +1347,9 @@ importers:
       '@typespec/compiler':
         specifier: workspace:~
         version: link:../compiler
+      '@typespec/events':
+        specifier: workspace:~
+        version: link:../events
       '@typespec/html-program-viewer':
         specifier: workspace:~
         version: link:../html-program-viewer
@@ -1320,6 +1371,12 @@ importers:
       '@typespec/rest':
         specifier: workspace:~
         version: link:../rest
+      '@typespec/sse':
+        specifier: workspace:~
+        version: link:../sse
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../streams
       '@typespec/versioning':
         specifier: workspace:~
         version: link:../versioning
@@ -1595,6 +1652,81 @@ importers:
       typescript:
         specifier: ~5.6.2
         version: 5.6.2
+
+  core/packages/sse:
+    devDependencies:
+      '@types/node':
+        specifier: ~22.7.1
+        version: 22.7.1
+      '@typespec/compiler':
+        specifier: workspace:~
+        version: link:../compiler
+      '@typespec/events':
+        specifier: workspace:~
+        version: link:../events
+      '@typespec/http':
+        specifier: workspace:~
+        version: link:../http
+      '@typespec/library-linter':
+        specifier: workspace:~
+        version: link:../library-linter
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../streams
+      '@typespec/tspd':
+        specifier: workspace:~
+        version: link:../tspd
+      '@vitest/coverage-v8':
+        specifier: ^2.1.1
+        version: 2.1.1(vitest@2.1.1(@types/node@22.7.1)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(jsdom@25.0.0)(terser@5.32.0))
+      '@vitest/ui':
+        specifier: ^2.1.1
+        version: 2.1.1(vitest@2.1.1)
+      c8:
+        specifier: ^10.1.2
+        version: 10.1.2
+      rimraf:
+        specifier: ~6.0.1
+        version: 6.0.1
+      typescript:
+        specifier: ~5.6.2
+        version: 5.6.2
+      vitest:
+        specifier: ^2.1.1
+        version: 2.1.1(@types/node@22.7.1)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(jsdom@25.0.0)(terser@5.32.0)
+
+  core/packages/streams:
+    devDependencies:
+      '@types/node':
+        specifier: ~22.7.1
+        version: 22.7.1
+      '@typespec/compiler':
+        specifier: workspace:~
+        version: link:../compiler
+      '@typespec/library-linter':
+        specifier: workspace:~
+        version: link:../library-linter
+      '@typespec/tspd':
+        specifier: workspace:~
+        version: link:../tspd
+      '@vitest/coverage-v8':
+        specifier: ^2.1.1
+        version: 2.1.1(vitest@2.1.1(@types/node@22.7.1)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(jsdom@25.0.0)(terser@5.32.0))
+      '@vitest/ui':
+        specifier: ^2.1.1
+        version: 2.1.1(vitest@2.1.1)
+      c8:
+        specifier: ^10.1.2
+        version: 10.1.2
+      rimraf:
+        specifier: ~6.0.1
+        version: 6.0.1
+      typescript:
+        specifier: ~5.6.2
+        version: 5.6.2
+      vitest:
+        specifier: ^2.1.1
+        version: 2.1.1(@types/node@22.7.1)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(jsdom@25.0.0)(terser@5.32.0)
 
   core/packages/tmlanguage-generator:
     dependencies:
@@ -2058,6 +2190,9 @@ importers:
       '@typespec/rest':
         specifier: workspace:~
         version: link:../../core/packages/rest
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../../core/packages/streams
       '@typespec/tspd':
         specifier: workspace:~
         version: link:../../core/packages/tspd
@@ -2118,6 +2253,9 @@ importers:
       '@typespec/rest':
         specifier: workspace:~
         version: link:../../core/packages/rest
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../../core/packages/streams
       '@typespec/tspd':
         specifier: workspace:~
         version: link:../../core/packages/tspd
@@ -2166,6 +2304,9 @@ importers:
       '@typespec/rest':
         specifier: workspace:~
         version: link:../../core/packages/rest
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../../core/packages/streams
       '@typespec/tspd':
         specifier: workspace:~
         version: link:../../core/packages/tspd
@@ -2311,6 +2452,9 @@ importers:
       '@typespec/rest':
         specifier: workspace:~
         version: link:../../core/packages/rest
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../../core/packages/streams
       '@typespec/tspd':
         specifier: workspace:~
         version: link:../../core/packages/tspd
@@ -2369,6 +2513,9 @@ importers:
       '@typespec/rest':
         specifier: workspace:~
         version: link:../../core/packages/rest
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../../core/packages/streams
       '@typespec/tspd':
         specifier: workspace:~
         version: link:../../core/packages/tspd
@@ -2478,6 +2625,9 @@ importers:
       '@typespec/rest':
         specifier: workspace:~
         version: link:../../core/packages/rest
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../../core/packages/streams
       '@typespec/tspd':
         specifier: workspace:~
         version: link:../../core/packages/tspd
@@ -2536,6 +2686,9 @@ importers:
       '@typespec/rest':
         specifier: workspace:~
         version: link:../../core/packages/rest
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../../core/packages/streams
       '@typespec/tspd':
         specifier: workspace:~
         version: link:../../core/packages/tspd


### PR DESCRIPTION
Changes needed once https://github.com/microsoft/typespec/pull/4513 is merged

The only change required is adding the `Streams` library to each package's `test-host.ts` file, since the testing host requires all libraries to be explicitly passed in. This is needed because with the streams PR in TypeSpec core, http takes a dependency on the streams library.