### PR TITLE
Update core submodule to 854024a

### DIFF
--- a/.chronus/changes/update-core-854024a-2024-9-9-9-46-21.md
+++ b/.chronus/changes/update-core-854024a-2024-9-9-9-46-21.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-autorest"
+  - "@azure-tools/typespec-client-generator-core"
+---
+

--- a/packages/typespec-autorest/test/options.test.ts
+++ b/packages/typespec-autorest/test/options.test.ts
@@ -388,7 +388,7 @@ op test(): void;
   });
 
   describe("'emit-common-types-schema' option", () => {
-    const commonTypesPath = "../../common-types/resource-management/v3/types.json";
+    const commonTypesPath = "common-types/resource-management/v3/types.json";
     const commonCode = `
       @armProviderNamespace
       @useDependency(Azure.Core.Versions.v1_0_Preview_2)

--- a/packages/typespec-autorest/test/options.test.ts
+++ b/packages/typespec-autorest/test/options.test.ts
@@ -388,6 +388,7 @@ op test(): void;
   });
 
   describe("'emit-common-types-schema' option", () => {
+    const commonTypesFolder = resolveVirtualPath("/common-types/resource-management");
     const commonTypesPath = "common-types/resource-management/v3/types.json";
     const commonCode = `
       @armProviderNamespace
@@ -436,6 +437,7 @@ op test(): void;
     it("emits only schema references with 'never' setting", async () => {
       const output = await openapiWithOptions(commonCode, {
         "emit-common-types-schema": "never",
+        "arm-types-dir": commonTypesFolder,
       });
       ok(output.definitions);
       ok(output.definitions["WidgetUpdate"]);
@@ -447,7 +449,9 @@ op test(): void;
     });
 
     it("emits an update schema for TrackedResource by default", async () => {
-      const output = await openapiWithOptions(commonCode, {});
+      const output = await openapiWithOptions(commonCode, {
+        "arm-types-dir": commonTypesFolder,
+      });
       ok(output.definitions);
       ok(output.definitions["WidgetUpdate"]);
       deepStrictEqual(output.definitions["WidgetUpdate"].allOf, [
@@ -460,6 +464,7 @@ op test(): void;
     it("emits update schema when set to `for-visibility-changes`", async () => {
       const output = await openapiWithOptions(commonCode, {
         "emit-common-types-schema": "for-visibility-changes",
+        "arm-types-dir": commonTypesFolder,
       });
       ok(output.definitions);
       ok(output.definitions["WidgetUpdate"]);

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -532,9 +532,7 @@ export function getHttpBodySpreadModel(context: TCGCContext, type: Model): Model
     const projectedProgram = context.program as ProjectedProgram;
     // for case: `op test(...Model):void;`
     if (innerModel.name !== "" && innerModel.properties.size === type.properties.size) {
-      return projectedProgram.projector
-        ? (projectedProgram.projector.projectedTypes.get(innerModel) as Model)
-        : innerModel;
+      return innerModel;
     }
     // for case: `op test(@header h: string, @query q: string, ...Model): void;`
     if (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,39 @@ importers:
         specifier: ^2.1.1
         version: 2.1.1(@types/node@22.7.1)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(jsdom@25.0.0)(terser@5.32.0)
 
+  core/packages/events:
+    devDependencies:
+      '@types/node':
+        specifier: ~22.7.1
+        version: 22.7.1
+      '@typespec/compiler':
+        specifier: workspace:~
+        version: link:../compiler
+      '@typespec/library-linter':
+        specifier: workspace:~
+        version: link:../library-linter
+      '@typespec/tspd':
+        specifier: workspace:~
+        version: link:../tspd
+      '@vitest/coverage-v8':
+        specifier: ^2.1.1
+        version: 2.1.1(vitest@2.1.1(@types/node@22.7.1)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(jsdom@25.0.0)(terser@5.32.0))
+      '@vitest/ui':
+        specifier: ^2.1.1
+        version: 2.1.1(vitest@2.1.1)
+      c8:
+        specifier: ^10.1.2
+        version: 10.1.2
+      rimraf:
+        specifier: ~6.0.1
+        version: 6.0.1
+      typescript:
+        specifier: ~5.6.2
+        version: 5.6.2
+      vitest:
+        specifier: ^2.1.1
+        version: 2.1.1(@types/node@22.7.1)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(jsdom@25.0.0)(terser@5.32.0)
+
   core/packages/html-program-viewer:
     dependencies:
       '@fluentui/react-components':
@@ -539,6 +572,9 @@ importers:
       '@typespec/library-linter':
         specifier: workspace:~
         version: link:../library-linter
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../streams
       '@typespec/tspd':
         specifier: workspace:~
         version: link:../tspd
@@ -1102,6 +1138,9 @@ importers:
       '@typespec/rest':
         specifier: workspace:~
         version: link:../rest
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../streams
       '@typespec/versioning':
         specifier: workspace:~
         version: link:../versioning
@@ -1348,6 +1387,9 @@ importers:
       '@typespec/compiler':
         specifier: workspace:~
         version: link:../compiler
+      '@typespec/events':
+        specifier: workspace:~
+        version: link:../events
       '@typespec/html-program-viewer':
         specifier: workspace:~
         version: link:../html-program-viewer
@@ -1366,9 +1408,18 @@ importers:
       '@typespec/openapi3':
         specifier: workspace:~
         version: link:../openapi3
+      '@typespec/protobuf':
+        specifier: workspace:~
+        version: link:../protobuf
       '@typespec/rest':
         specifier: workspace:~
         version: link:../rest
+      '@typespec/sse':
+        specifier: workspace:~
+        version: link:../sse
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../streams
       '@typespec/versioning':
         specifier: workspace:~
         version: link:../versioning
@@ -1650,6 +1701,81 @@ importers:
       typescript:
         specifier: ~5.6.2
         version: 5.6.2
+
+  core/packages/sse:
+    devDependencies:
+      '@types/node':
+        specifier: ~22.7.1
+        version: 22.7.1
+      '@typespec/compiler':
+        specifier: workspace:~
+        version: link:../compiler
+      '@typespec/events':
+        specifier: workspace:~
+        version: link:../events
+      '@typespec/http':
+        specifier: workspace:~
+        version: link:../http
+      '@typespec/library-linter':
+        specifier: workspace:~
+        version: link:../library-linter
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../streams
+      '@typespec/tspd':
+        specifier: workspace:~
+        version: link:../tspd
+      '@vitest/coverage-v8':
+        specifier: ^2.1.1
+        version: 2.1.1(vitest@2.1.1(@types/node@22.7.1)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(jsdom@25.0.0)(terser@5.32.0))
+      '@vitest/ui':
+        specifier: ^2.1.1
+        version: 2.1.1(vitest@2.1.1)
+      c8:
+        specifier: ^10.1.2
+        version: 10.1.2
+      rimraf:
+        specifier: ~6.0.1
+        version: 6.0.1
+      typescript:
+        specifier: ~5.6.2
+        version: 5.6.2
+      vitest:
+        specifier: ^2.1.1
+        version: 2.1.1(@types/node@22.7.1)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(jsdom@25.0.0)(terser@5.32.0)
+
+  core/packages/streams:
+    devDependencies:
+      '@types/node':
+        specifier: ~22.7.1
+        version: 22.7.1
+      '@typespec/compiler':
+        specifier: workspace:~
+        version: link:../compiler
+      '@typespec/library-linter':
+        specifier: workspace:~
+        version: link:../library-linter
+      '@typespec/tspd':
+        specifier: workspace:~
+        version: link:../tspd
+      '@vitest/coverage-v8':
+        specifier: ^2.1.1
+        version: 2.1.1(vitest@2.1.1(@types/node@22.7.1)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(jsdom@25.0.0)(terser@5.32.0))
+      '@vitest/ui':
+        specifier: ^2.1.1
+        version: 2.1.1(vitest@2.1.1)
+      c8:
+        specifier: ^10.1.2
+        version: 10.1.2
+      rimraf:
+        specifier: ~6.0.1
+        version: 6.0.1
+      typescript:
+        specifier: ~5.6.2
+        version: 5.6.2
+      vitest:
+        specifier: ^2.1.1
+        version: 2.1.1(@types/node@22.7.1)(@vitest/ui@2.1.1)(happy-dom@15.7.4)(jsdom@25.0.0)(terser@5.32.0)
 
   core/packages/tmlanguage-generator:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2028,6 +2028,9 @@ importers:
       '@typespec/compiler':
         specifier: workspace:~
         version: link:../compiler
+      '@typespec/events':
+        specifier: workspace:~
+        version: link:../events
       '@typespec/http':
         specifier: workspace:~
         version: link:../http
@@ -2055,6 +2058,12 @@ importers:
       '@typespec/spec':
         specifier: workspace:*
         version: link:../spec
+      '@typespec/sse':
+        specifier: workspace:~
+        version: link:../sse
+      '@typespec/streams':
+        specifier: workspace:~
+        version: link:../streams
       '@typespec/tspd':
         specifier: workspace:~
         version: link:../tspd


### PR DESCRIPTION
Created this PR instead of using dependabot due to new packages in `core` requiring the pnpm-lock file being updated.

Also updated TCGC to no longer grab projected source models since https://github.com/microsoft/typespec/pull/4445 updated  core to project the source models already.
