### PR TITLE
[tcgc] remove projection for source model since typespec core has already fixed the issue

### DIFF
--- a/.chronus/changes/fix_spread_body-2024-9-10-14-19-3.md
+++ b/.chronus/changes/fix_spread_body-2024-9-10-14-19-3.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+remove projection for source model since typespec core has already fixed the issue

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -166,7 +166,7 @@ function getSdkHttpParameters(
         type = diagnostics.pipe(
           getClientTypeWithDiagnostics(
             context,
-            getHttpBodySpreadModel(context, tspBody.type as Model),
+            getHttpBodySpreadModel(tspBody.type as Model),
             httpOperation.operation,
           ),
         );

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -15,7 +15,6 @@ import {
   NumericLiteral,
   Operation,
   Program,
-  ProjectedProgram,
   StringLiteral,
   Type,
   Union,

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -526,10 +526,9 @@ export function isHttpBodySpread(httpBody: HttpOperationBody | HttpOperationMult
  * @param type
  * @returns
  */
-export function getHttpBodySpreadModel(context: TCGCContext, type: Model): Model {
+export function getHttpBodySpreadModel(type: Model): Model {
   if (type.sourceModels.length === 1 && type.sourceModels[0].usage === "spread") {
     const innerModel = type.sourceModels[0].model;
-    const projectedProgram = context.program as ProjectedProgram;
     // for case: `op test(...Model):void;`
     if (innerModel.name !== "" && innerModel.properties.size === type.properties.size) {
       return innerModel;
@@ -541,9 +540,7 @@ export function getHttpBodySpreadModel(context: TCGCContext, type: Model): Model
       innerModel.sourceModels[0].model.name !== "" &&
       innerModel.sourceModels[0].model.properties.size === type.properties.size
     ) {
-      return projectedProgram.projector
-        ? (projectedProgram.projector.projectedTypes.get(innerModel.sourceModels[0].model) as Model)
-        : innerModel.sourceModels[0].model;
+      return innerModel.sourceModels[0].model;
     }
   }
   return type;

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -383,7 +383,7 @@ function getContextPath(
       result = [{ name: root.name }];
       let bodyType: Type;
       if (isHttpBodySpread(httpOperation.parameters.body)) {
-        bodyType = getHttpBodySpreadModel(context, httpOperation.parameters.body.type as Model);
+        bodyType = getHttpBodySpreadModel(httpOperation.parameters.body.type as Model);
       } else {
         bodyType = httpOperation.parameters.body.type;
       }

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1345,7 +1345,7 @@ export function getSdkModelPropertyType(
     const httpBody = httpOperation.parameters.body;
     if (httpBody) {
       const httpBodyType = isHttpBodySpread(httpBody)
-        ? getHttpBodySpreadModel(context, httpBody.type as Model)
+        ? getHttpBodySpreadModel(httpBody.type as Model)
         : httpBody.type;
       if (type.model === httpBodyType) {
         // only try to add multipartOptions for property of body
@@ -1560,7 +1560,7 @@ function updateTypesFromOperation(
       sdkType = diagnostics.pipe(
         getClientTypeWithDiagnostics(
           context,
-          getHttpBodySpreadModel(context, httpBody.type as Model),
+          getHttpBodySpreadModel(httpBody.type as Model),
           operation,
         ),
       );

--- a/packages/typespec-client-generator-core/test/packages/spread.test.ts
+++ b/packages/typespec-client-generator-core/test/packages/spread.test.ts
@@ -1,7 +1,12 @@
 import { AzureCoreTestLibrary } from "@azure-tools/typespec-azure-core/testing";
 import { deepStrictEqual, ok, strictEqual } from "assert";
 import { beforeEach, describe, it } from "vitest";
-import { SdkClientType, SdkHttpOperation, SdkServiceMethod, UsageFlags } from "../../src/interfaces.js";
+import {
+  SdkClientType,
+  SdkHttpOperation,
+  SdkServiceMethod,
+  UsageFlags,
+} from "../../src/interfaces.js";
 import { getAllModels } from "../../src/types.js";
 import { SdkTestRunner, createSdkTestRunner } from "../test-host.js";
 import { getServiceMethodOfClient } from "./utils.js";
@@ -942,9 +947,17 @@ describe("typespec-client-generator-core: spread", () => {
     strictEqual(sdkPackage.models[1].access, "public");
 
     const client = sdkPackage.clients[0];
-    deepStrictEqual((client.methods[0] as SdkServiceMethod<SdkHttpOperation>).operation.bodyParam?.type, sdkPackage.models[0]);
-    deepStrictEqual((client.methods[1] as SdkServiceMethod<SdkHttpOperation>).operation.bodyParam?.type, sdkPackage.models[0]);
-    deepStrictEqual((client.methods[2] as SdkServiceMethod<SdkHttpOperation>).operation.bodyParam?.type, sdkPackage.models[1]);
-    
+    deepStrictEqual(
+      (client.methods[0] as SdkServiceMethod<SdkHttpOperation>).operation.bodyParam?.type,
+      sdkPackage.models[0],
+    );
+    deepStrictEqual(
+      (client.methods[1] as SdkServiceMethod<SdkHttpOperation>).operation.bodyParam?.type,
+      sdkPackage.models[0],
+    );
+    deepStrictEqual(
+      (client.methods[2] as SdkServiceMethod<SdkHttpOperation>).operation.bodyParam?.type,
+      sdkPackage.models[1],
+    );
   });
 });

--- a/packages/typespec-client-generator-core/test/packages/spread.test.ts
+++ b/packages/typespec-client-generator-core/test/packages/spread.test.ts
@@ -1,7 +1,7 @@
 import { AzureCoreTestLibrary } from "@azure-tools/typespec-azure-core/testing";
 import { deepStrictEqual, ok, strictEqual } from "assert";
 import { beforeEach, describe, it } from "vitest";
-import { SdkClientType, SdkHttpOperation, UsageFlags } from "../../src/interfaces.js";
+import { SdkClientType, SdkHttpOperation, SdkServiceMethod, UsageFlags } from "../../src/interfaces.js";
 import { getAllModels } from "../../src/types.js";
 import { SdkTestRunner, createSdkTestRunner } from "../test-host.js";
 import { getServiceMethodOfClient } from "./utils.js";
@@ -920,10 +920,14 @@ describe("typespec-client-generator-core: spread", () => {
       @route("modelref1")
       @post
       op ref1(...Test): void;
-    
+
       @route("modelref2")
       @post
-      op ref2(@body body: Ref): void;
+      op ref2(@header header: string, ...Test): void;
+    
+      @route("modelref3")
+      @post
+      op ref3(@body body: Ref): void;
     `);
     const sdkPackage = runner.context.sdkPackage;
     strictEqual(sdkPackage.models.length, 2);
@@ -936,5 +940,11 @@ describe("typespec-client-generator-core: spread", () => {
     strictEqual(sdkPackage.models[1].name, "Ref");
     strictEqual(sdkPackage.models[1].usage, UsageFlags.Input | UsageFlags.Json);
     strictEqual(sdkPackage.models[1].access, "public");
+
+    const client = sdkPackage.clients[0];
+    deepStrictEqual((client.methods[0] as SdkServiceMethod<SdkHttpOperation>).operation.bodyParam?.type, sdkPackage.models[0]);
+    deepStrictEqual((client.methods[1] as SdkServiceMethod<SdkHttpOperation>).operation.bodyParam?.type, sdkPackage.models[0]);
+    deepStrictEqual((client.methods[2] as SdkServiceMethod<SdkHttpOperation>).operation.bodyParam?.type, sdkPackage.models[1]);
+    
   });
 });


### PR DESCRIPTION
because of this fix: https://github.com/microsoft/typespec/issues/4280, tcgc should not do projection again which will cause undefined issue when finding spread body model.