### PR TITLE
[@azure-tools/azure-http-specs] - Azure Specific Spec Scenarios to test Typespec

### DIFF
--- a/packages/azure-http-specs/.gitignore
+++ b/packages/azure-http-specs/.gitignore
@@ -1,0 +1,1 @@
+spec-coverage.json

--- a/packages/azure-http-specs/CHANGELOG.md
+++ b/packages/azure-http-specs/CHANGELOG.md
@@ -1,0 +1,1 @@
+# @azure-tools/azure-http-specs

--- a/packages/azure-http-specs/README.md
+++ b/packages/azure-http-specs/README.md
@@ -1,0 +1,36 @@
+# Azure HTTP Specs
+
+This package contains all the scenarios that should be supported by a client generator.
+
+## Development
+
+1. [FOLLOW THE MONOREPO INSTRUCTION](@azure-tools/typespec-azure-monorepo) to get the environment setup.
+2. Scenarios should be in `./specs` folder
+
+#### Writing scenarios
+
+**PENDING**
+
+#### Writing mockapis
+
+**PENDING**
+
+#### Validate the scenarios are valid
+
+```
+pnpm run validate-scenarios
+```
+
+#### Validate the mock apis are valid
+
+```
+pnpm run validate-mock-apis
+```
+
+#### Start mock api server
+
+This will start the server using the mock apis. When writing a mock api use this command to start the server.
+
+```bash
+pnpm run serve
+```

--- a/packages/azure-http-specs/package.json
+++ b/packages/azure-http-specs/package.json
@@ -1,0 +1,60 @@
+{
+  "name": "@azure-tools/azure-http-specs",
+  "version": "0.1.0",
+  "description": "Spec scenarios and mock apis",
+  "main": "dist/index.js",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "watch": "tsc -p ./tsconfig.build.json --watch",
+    "build": "tsc -p ./tsconfig.build.json",
+    "clean": "rimraf dist/ temp/",
+    "test:e2e": "pnpm validate-scenarios  && pnpm validate-mock-apis && pnpm validate-client-server",
+    "validate-scenarios": "spec-core validate-scenarios ./specs",
+    "generate-scenarios-summary": "spec-core generate-scenarios-summary ./specs",
+    "validate-mock-apis": "spec-core validate-mock-apis ./specs",
+    "check-scenario-coverage": "spec-core check-coverage ./specs",
+    "validate-client-server": "concurrently \"spec-core server start ./specs\" \"npm run client\" && spec-core server stop",
+    "client": "spec-core server-test ./specs",
+    "serve": "spec-core serve ./specs",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azure/typespec-azure.git"
+  },
+  "author": "Microsoft",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/Azure/typespec-azure/issues"
+  },
+  "homepage": "https://azure.github.io/typespec-azure",
+  "dependencies": {
+    "@typespec/spec-core": "workspace:~",
+    "@typespec/spec-api": "workspace:~",
+    "@typespec/spec-lib": "workspace:~"
+  },
+  "devDependencies": {
+    "@azure-tools/typespec-azure-resource-manager": "workspace:~",
+    "@azure-tools/typespec-client-generator-core": "workspace:~",
+    "@azure-tools/typespec-autorest": "workspace:~",
+    "@typespec/openapi3": "workspace:~",
+    "@typespec/openapi": "workspace:~",
+    "@types/multer": "^1.4.10",
+    "@types/node": "^22.1.0",
+    "concurrently": "^9.0.1",
+    "typescript": "~5.6.2",
+    "rimraf": "^6.0.1"
+  },
+  "peerDependencies": {
+    "@azure-tools/typespec-azure-core": "workspace:~",
+    "@typespec/versioning": "workspace:~",
+    "@typespec/compiler": "workspace:~",
+    "@typespec/rest": "workspace:~",
+    "@typespec/http": "workspace:~",
+    "@typespec/xml": "workspace:~"
+  }
+}

--- a/packages/azure-http-specs/package.json
+++ b/packages/azure-http-specs/package.json
@@ -46,8 +46,8 @@
     "@types/multer": "^1.4.10",
     "@types/node": "^22.1.0",
     "concurrently": "^9.0.1",
-    "typescript": "~5.6.2",
-    "rimraf": "^6.0.1"
+    "typescript": "~5.6.3",
+    "rimraf": "~6.0.1"
   },
   "peerDependencies": {
     "@azure-tools/typespec-azure-core": "workspace:~",

--- a/packages/azure-http-specs/package.json
+++ b/packages/azure-http-specs/package.json
@@ -44,7 +44,7 @@
     "@typespec/openapi3": "workspace:~",
     "@typespec/openapi": "workspace:~",
     "@types/multer": "^1.4.10",
-    "@types/node": "^22.1.0",
+    "@types/node": "~22.7.5",
     "concurrently": "^9.0.1",
     "typescript": "~5.6.3",
     "rimraf": "~6.0.1"

--- a/packages/azure-http-specs/specs/README.md
+++ b/packages/azure-http-specs/specs/README.md
@@ -1,0 +1,9 @@
+# HTTP Spec scenarios
+
+Structure:
+
+- one folder per scenario with entry point called `main.tsp`
+
+## Tests
+
+**Pending**

--- a/packages/azure-http-specs/specs/README.md
+++ b/packages/azure-http-specs/specs/README.md
@@ -1,9 +1,0 @@
-# HTTP Spec scenarios
-
-Structure:
-
-- one folder per scenario with entry point called `main.tsp`
-
-## Tests
-
-**Pending**

--- a/packages/azure-http-specs/specs/azure/client-generator-core/access/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/access/main.tsp
@@ -1,0 +1,191 @@
+import "@typespec/http";
+import "@typespec/spec-lib";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+using SpecLib;
+
+@doc("Test for internal decorator.")
+@scenarioService("/azure/client-generator-core/access")
+namespace _Specs_.Azure.ClientGenerator.Core.Access;
+
+@route("/publicOperation")
+@global.Azure.ClientGenerator.Core.operationGroup
+@scenario
+@scenarioDoc("""
+  This scenario contains public operations. It should be generated and exported.
+  Expected query parameter: name=<any string>
+  Expected response body:
+  ```json
+  {
+    "name": <any string>
+  }
+  ```
+  """)
+namespace PublicOperation {
+  @doc("Used in a public operation, should be generated and exported.")
+  model NoDecoratorModelInPublic {
+    name: string;
+  }
+
+  @doc("Used in a public operation, should be generated and exported.")
+  @global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.public)
+  model PublicDecoratorModelInPublic {
+    name: string;
+  }
+
+  @route("/noDecoratorInPublic")
+  @get
+  @global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.public)
+  op noDecoratorInPublic(@query name: string): NoDecoratorModelInPublic;
+
+  @route("/publicDecoratorInPublic")
+  @get
+  @global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.public)
+  op publicDecoratorInPublic(@query name: string): PublicDecoratorModelInPublic;
+}
+
+@route("/internalOperation")
+@global.Azure.ClientGenerator.Core.operationGroup
+@scenario
+@scenarioDoc("""
+  This scenario contains internal operations. All should be generated but not exposed.
+  Expected query parameter: name=<any string>
+  Expected response body:
+  ```json
+  {
+    "name": <any string>
+  }
+  ```
+  """)
+namespace InternalOperation {
+  @doc("Used in an internal operation, should be generated but not exported.")
+  model NoDecoratorModelInInternal {
+    name: string;
+  }
+
+  @doc("Used in an internal operation, should be generated but not exported.")
+  @global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.internal)
+  model InternalDecoratorModelInInternal {
+    name: string;
+  }
+
+  @doc("Used in an internal operation but with public decorator, should be generated and exported.")
+  @global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.public)
+  model PublicDecoratorModelInInternal {
+    name: string;
+  }
+
+  @route("/noDecoratorInInternal")
+  @get
+  @global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.internal)
+  op noDecoratorInInternal(@query name: string): NoDecoratorModelInInternal;
+
+  @route("/internalDecoratorInInternal")
+  @get
+  @global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.internal)
+  op internalDecoratorInInternal(@query name: string): InternalDecoratorModelInInternal;
+
+  @route("/publicDecoratorInInternal")
+  @get
+  @global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.internal)
+  op publicDecoratorInInternal(@query name: string): PublicDecoratorModelInInternal;
+}
+
+@route("/sharedModelInOperation")
+@global.Azure.ClientGenerator.Core.operationGroup
+@scenario
+@scenarioDoc("""
+  This scenario contains two operations, one public, another internal. The public one should be generated and exported while the internal one should be generated but not exposed.
+  Expected query parameter: name=<any string>
+  Expected response body:
+  ```json
+  {
+    "name": <any string>
+  }
+  ```
+  """)
+namespace SharedModelInOperation {
+  @doc("Used by both public and internal operation. It should be generated and exported.")
+  model SharedModel {
+    name: string;
+  }
+
+  @route("/public")
+  @get
+  @global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.public)
+  op public(@query name: string): SharedModel;
+
+  @route("/internal")
+  @get
+  @global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.internal)
+  op internal(@query name: string): SharedModel;
+}
+
+@route("/relativeModelInOperation")
+@global.Azure.ClientGenerator.Core.operationGroup
+@scenario
+@scenarioDoc("""
+  This scenario contains internal operations. All should be generated but not exposed.
+  """)
+namespace RelativeModelInOperation {
+  @doc("Used in internal operations, should be generated but not exported.")
+  model OuterModel extends BaseModel {
+    inner: InnerModel;
+  }
+
+  @doc("Used in internal operations, should be generated but not exported.")
+  model InnerModel {
+    name: string;
+  }
+
+  @doc("Used in internal operations, should be generated but not exported.")
+  model BaseModel {
+    name: string;
+  }
+
+  @doc("Used in internal operations, should be generated but not exported.")
+  @discriminator("kind")
+  model AbstractModel {
+    name: string;
+  }
+
+  @doc("Used in internal operations, should be generated but not exported.")
+  model RealModel extends AbstractModel {
+    kind: "real";
+  }
+
+  @doc("""
+    Expected query parameter: name=<any string>
+    Expected response body:
+    ```json
+    {
+      "name": <any string>,
+      "inner":
+      {
+        "name": <any string>
+      }
+    }
+    ```
+    """)
+  @route("/operation")
+  @get
+  @global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.internal)
+  op operation(@query name: string): OuterModel;
+
+  @doc("""
+    Expected query parameter: kind=<any string>
+    Expected response body:
+    ```json
+    {
+      "name": <any string>,
+      "kind": "real"
+    }
+    ```
+    """)
+  @route("/discriminator")
+  @get
+  @global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.internal)
+  op discriminator(@query kind: string): AbstractModel;
+}

--- a/packages/azure-http-specs/specs/azure/client-generator-core/access/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/access/mockapi.ts
@@ -1,0 +1,101 @@
+import {
+  json,
+  MockApiDefinition,
+  MockRequest,
+  passOnSuccess,
+  ScenarioMockApi,
+  ValidationError,
+} from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+function createMockApiDefinitions(route: string): MockApiDefinition {
+  return {
+    uri: `/azure/client-generator-core/access/${route}`,
+    method: "get",
+    request: {
+      params: {
+        name: "sample",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({ name: "sample" }),
+    },
+    handler: (req: MockRequest) => {
+      if (!("name" in req.query)) {
+        throw new ValidationError("Should submit name query", "any string", undefined);
+      }
+      return {
+        status: 200,
+        body: json({ name: req.query["name"] }),
+      };
+    },
+    kind: "MockApiDefinition",
+  };
+}
+
+Scenarios.Azure_ClientGenerator_Core_Access_PublicOperation = passOnSuccess([
+  createMockApiDefinitions("publicOperation/noDecoratorInPublic"),
+  createMockApiDefinitions("publicOperation/publicDecoratorInPublic"),
+]);
+
+Scenarios.Azure_ClientGenerator_Core_Access_InternalOperation = passOnSuccess([
+  createMockApiDefinitions("internalOperation/noDecoratorInInternal"),
+  createMockApiDefinitions("internalOperation/internalDecoratorInInternal"),
+  createMockApiDefinitions("internalOperation/publicDecoratorInInternal"),
+]);
+
+Scenarios.Azure_ClientGenerator_Core_Access_SharedModelInOperation = passOnSuccess([
+  createMockApiDefinitions("sharedModelInOperation/public"),
+  createMockApiDefinitions("sharedModelInOperation/internal"),
+]);
+
+Scenarios.Azure_ClientGenerator_Core_Access_RelativeModelInOperation = passOnSuccess([
+  {
+    uri: "/azure/client-generator-core/access/relativeModelInOperation/operation",
+    method: "get",
+    request: {
+      params: {
+        name: "Madge",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({ name: "Madge", inner: { name: "Madge" } }),
+    },
+    handler: (req: MockRequest) => {
+      if (!("name" in req.query)) {
+        throw new ValidationError("Should submit name query", "any string", undefined);
+      }
+      return {
+        status: 200,
+        body: json({ name: "Madge", inner: { name: "Madge" } }),
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/client-generator-core/access/relativeModelInOperation/discriminator",
+    method: "get",
+    request: {
+      params: {
+        kind: "real",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({ name: "Madge", kind: "real" }),
+    },
+    handler: (req: MockRequest) => {
+      if (!("kind" in req.query)) {
+        throw new ValidationError("Should submit name query", "any string", undefined);
+      }
+      return {
+        status: 200,
+        body: json({ name: "Madge", kind: "real" }),
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+]);

--- a/packages/azure-http-specs/specs/azure/client-generator-core/flatten-property/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/flatten-property/main.tsp
@@ -1,0 +1,108 @@
+import "@typespec/http";
+import "@typespec/spec-lib";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Http;
+using global.Azure.ClientGenerator.Core;
+using SpecLib;
+
+@doc("Illustrates the model flatten cases.")
+@scenarioService("/azure/client-generator-core/flatten-property")
+namespace _Specs_.Azure.ClientGenerator.Core.FlattenProperty;
+
+@doc("This is the model with one level of flattening.")
+model FlattenModel {
+  name: string;
+
+  #suppress "deprecated" "@flattenProperty decorator is not recommended to use."
+  @flattenProperty
+  properties: ChildModel;
+}
+
+@doc("This is the model with two levels of flattening.")
+model NestedFlattenModel {
+  name: string;
+
+  #suppress "deprecated" "@flattenProperty decorator is not recommended to use."
+  @flattenProperty
+  properties: ChildFlattenModel;
+}
+
+@doc("This is the child model to be flattened.")
+model ChildModel {
+  description: string;
+  age: int32;
+}
+
+@doc("This is the child model to be flattened. And it has flattened property as well.")
+model ChildFlattenModel {
+  summary: string;
+
+  #suppress "deprecated" "@flattenProperty decorator is not recommended to use."
+  @flattenProperty
+  properties: ChildModel;
+}
+
+@scenario
+@route("/flattenModel")
+@scenarioDoc("""
+  Update and receive model with 1 level of flattening.
+  Expected input body:
+  ```json
+  {
+    "name": "foo",
+    "properties": {
+      "description": "bar",
+      "age": 10
+    }
+  }
+  ```
+  
+  Expected response body:
+  ```json
+  {
+    "name": "test",
+    "properties": {
+      "description": "test",
+      "age": 1
+    }
+  }
+  ```
+  """)
+@put
+op putFlattenModel(@body input: FlattenModel): FlattenModel;
+
+@scenario
+@route("/nestedFlattenModel")
+@scenarioDoc("""
+  Update and receive model with 2 levels of flattening.
+  Expected input body:
+  ```json
+  {
+    "name": "foo",
+    "properties": {
+      "summary": "bar",
+      "properties": {
+        "description": "test",
+        "age": 10
+      }
+    }
+  }
+  ```
+  
+  Expected response body:
+  ```json
+  {
+    "name": "test",
+    "properties": {
+      "summary": "test",
+      "properties": {
+        "description": "foo",
+        "age": 1
+      }
+    }
+  }
+  ```
+  """)
+@put
+op putNestedFlattenModel(@body input: NestedFlattenModel): NestedFlattenModel;

--- a/packages/azure-http-specs/specs/azure/client-generator-core/flatten-property/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/flatten-property/mockapi.ts
@@ -1,0 +1,76 @@
+import {
+  json,
+  MockApiDefinition,
+  MockRequest,
+  passOnSuccess,
+  ScenarioMockApi,
+} from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+function createMockApiDefinitions(route: string, request: any, response: any): MockApiDefinition {
+  return {
+    uri: `/azure/client-generator-core/flatten-property/${route}`,
+    method: "put",
+    request: {
+      body: request,
+    },
+    response: {
+      status: 200,
+      body: json(response),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.bodyEquals(request);
+      return {
+        status: 200,
+        body: json(response),
+      };
+    },
+    kind: "MockApiDefinition",
+  };
+}
+
+Scenarios.Azure_ClientGenerator_Core_FlattenProperty_putFlattenModel = passOnSuccess(
+  createMockApiDefinitions(
+    "flattenModel",
+    {
+      name: "foo",
+      properties: {
+        description: "bar",
+        age: 10,
+      },
+    },
+    {
+      name: "test",
+      properties: {
+        description: "test",
+        age: 1,
+      },
+    },
+  ),
+);
+
+Scenarios.Azure_ClientGenerator_Core_FlattenProperty_putNestedFlattenModel = passOnSuccess(
+  createMockApiDefinitions(
+    "nestedFlattenModel",
+    {
+      name: "foo",
+      properties: {
+        summary: "bar",
+        properties: {
+          description: "test",
+          age: 10,
+        },
+      },
+    },
+    {
+      name: "test",
+      properties: {
+        summary: "test",
+        properties: {
+          description: "foo",
+          age: 1,
+        },
+      },
+    },
+  ),
+);

--- a/packages/azure-http-specs/specs/azure/client-generator-core/usage/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/usage/main.tsp
@@ -1,0 +1,98 @@
+import "@typespec/http";
+import "@typespec/spec-lib";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+using SpecLib;
+
+@doc("Test for internal decorator.")
+@scenarioService("/azure/client-generator-core/usage")
+namespace _Specs_.Azure.ClientGenerator.Core.Usage;
+
+@scenario
+@scenarioDoc("""
+  This scenario contains two public operations. Both should be generated and exported.
+  The models are override to roundtrip, so they should be generated and exported as well.
+  """)
+namespace ModelInOperation {
+  @doc("Usage override to roundtrip.")
+  @global.Azure.ClientGenerator.Core.usage(
+    global.Azure.ClientGenerator.Core.Usage.input | global.Azure.ClientGenerator.Core.Usage.output
+  )
+  model InputModel {
+    name: string;
+  }
+
+  @doc("""
+    Expected body parameter: 
+    ```json
+    {
+      "name": <any string>
+    }
+    ```
+    """)
+  @route("/inputToInputOutput")
+  @post
+  op inputToInputOutput(@body body: InputModel): void;
+
+  @doc("Usage override to roundtrip.")
+  @global.Azure.ClientGenerator.Core.usage(
+    global.Azure.ClientGenerator.Core.Usage.input | global.Azure.ClientGenerator.Core.Usage.output
+  )
+  model OutputModel {
+    name: string;
+  }
+
+  @doc("""
+    Expected response body: 
+    ```json
+    {
+      "name": <any string>
+    }
+    ```
+    """)
+  @route("/outputToInputOutput")
+  @get
+  op outputToInputOutput(): OutputModel;
+
+  model ResultModel {
+    name: string;
+  }
+
+  model RoundTripModel {
+    @visibility("read")
+    result: ResultModel;
+  }
+
+  @doc("""
+    "ResultModel" should be usage=output, as it is read-only and does not exist in request body.
+    
+    Expected body parameter: 
+    ```json
+    {
+    }
+    ```
+    
+    Expected response body: 
+    ```json
+    {
+      "result": {
+        "name": <any string>
+      }
+    }
+    ```
+    """)
+  @route("/modelInReadOnlyProperty")
+  @put
+  op modelInReadOnlyProperty(@body body: RoundTripModel): {
+    @body body: RoundTripModel;
+  };
+}
+
+@doc("Not used anywhere, but access is override to public so still need to be generated and exported with serialization.")
+@global.Azure.ClientGenerator.Core.usage(global.Azure.ClientGenerator.Core.Usage.input)
+@global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.public)
+model OrphanModel {
+  name: string;
+}

--- a/packages/azure-http-specs/specs/azure/client-generator-core/usage/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/usage/mockapi.ts
@@ -1,0 +1,56 @@
+import { json, MockRequest, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Azure_ClientGenerator_Core_Usage_ModelInOperation = passOnSuccess([
+  {
+    uri: "/azure/client-generator-core/usage/inputToInputOutput",
+    method: "post",
+    request: {
+      body: {
+        name: "Madge",
+      },
+    },
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      const validBody = { name: "Madge" };
+      req.expect.bodyEquals(validBody);
+      return { status: 204 };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/client-generator-core/usage/outputToInputOutput",
+    method: "get",
+    request: {},
+    response: {
+      status: 200,
+      body: json({ name: "Madge" }),
+    },
+    handler: (req: MockRequest) => {
+      return {
+        status: 200,
+        body: json({ name: "Madge" }),
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/client-generator-core/usage/modelInReadOnlyProperty",
+    method: "put",
+    request: {},
+    response: {
+      status: 200,
+      body: json({ result: { name: "Madge" } }),
+    },
+    handler: (req: MockRequest) => {
+      return {
+        status: 200,
+        body: json({ result: { name: "Madge" } }),
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+]);

--- a/packages/azure-http-specs/specs/azure/core/basic/client.tsp
+++ b/packages/azure-http-specs/specs/azure/core/basic/client.tsp
@@ -1,0 +1,6 @@
+import "@azure-tools/typespec-client-generator-core";
+import "./main.tsp";
+
+using Azure.ClientGenerator.Core;
+
+@@convenientAPI(_Specs_.Azure.Core.Basic.createOrUpdate, false, "csharp");

--- a/packages/azure-http-specs/specs/azure/core/basic/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/basic/main.tsp
@@ -1,0 +1,261 @@
+import "@typespec/spec-lib";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-client-generator-core";
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+
+using Azure.Core;
+using global.Azure.Core.Traits;
+using global.Azure.Core.Foundations;
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using SpecLib;
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "For spec"
+@doc("Illustrates bodies templated with Azure Core")
+@scenarioService(
+  "/azure/core/basic",
+  {
+    versioned: Versions,
+  }
+)
+namespace _Specs_.Azure.Core.Basic;
+
+@doc("The version of the API.")
+enum Versions {
+  @doc("The version 2022-12-01-preview.")
+  @useDependency(global.Azure.Core.Versions.v1_0_Preview_2)
+  v2022_12_01_preview: "2022-12-01-preview",
+}
+
+alias ResourceOperations = global.Azure.Core.ResourceOperations<NoConditionalRequests &
+  NoRepeatableRequests &
+  NoClientRequestId>;
+
+@resource("users")
+@doc("Details about a user.")
+model User {
+  @key
+  @doc("The user's id.")
+  @visibility("read")
+  id: int32;
+
+  @doc("The user's name.")
+  name: string;
+
+  @doc("The user's order list")
+  orders?: UserOrder[];
+
+  ...global.Azure.Core.EtagProperty;
+}
+
+@doc("UserOrder for testing list with expand.")
+@resource("user")
+model UserOrder {
+  @key
+  @doc("The user's id.")
+  @visibility("read")
+  id: int32;
+
+  @doc("The user's id.")
+  userId: int32;
+
+  @doc("The user's order detail")
+  detail: string;
+}
+
+@doc("The parameters for exporting a user.")
+model UserExportParams {
+  @query
+  @doc("The format of the data.")
+  format: string;
+}
+
+@scenario
+@doc("Creates or updates a User")
+@summary("Adds a user or updates a user's fields.")
+@scenarioDoc("""
+  Should only generate models named User and UserOrder.
+  
+  Expected path parameter: id=1
+  Expected query parameter: api-version=2022-12-01-preview
+  
+  Expected input body:
+  ```json
+  {
+    "name": "Madge"
+  }
+  ```
+  
+  Expected response body:
+  ```json
+  {
+    "id": 1,
+    "name": "Madge"
+  }
+  ```
+  """)
+op createOrUpdate is ResourceOperations.ResourceCreateOrUpdate<User>;
+
+@scenario
+@doc("Creates or replaces a User")
+@summary("Adds a user or replaces a user's fields.")
+@scenarioDoc("""
+  Should only generate models named User and UserOrder.
+  
+  Expected path parameter: id=1
+  Expected query parameter: api-version=2022-12-01-preview
+  
+  Expected input body:
+  ```json
+  {
+    "name": "Madge"
+  }
+  ```
+  
+  Expected response body:
+  ```json
+  {
+    "id": 1,
+    "name": "Madge",
+    "etag": "11bdc430-65e8-45ad-81d9-8ffa60d55b59"
+  }
+  ```
+  """)
+op createOrReplace is ResourceOperations.ResourceCreateOrReplace<User>;
+
+@scenario
+@doc("Gets a User")
+@summary("Gets a user.")
+@scenarioDoc("""
+  Should only generate models named User and UserOrder.
+  
+  Expected path parameter: id=1
+  Expected query parameter: api-version=2022-12-01-preview
+  
+  Expected response body:
+  ```json
+  {
+    "id": 1,
+    "name": "Madge",
+    "etag": "11bdc430-65e8-45ad-81d9-8ffa60d55b59"
+  }
+  ```
+  """)
+op get is ResourceOperations.ResourceRead<User>;
+
+@scenario
+@doc("Lists all Users")
+@summary("Lists all users.")
+@scenarioDoc("""
+  Should only generate models named User and UserOrder.
+  
+  Should not generate visible model like CustomPage.
+  
+  Expected query parameter: api-version=2022-12-01-preview&top=5&skip=10&orderby=id&filter=id%20lt%2010&select=id&select=orders&select=etag&expand=orders
+  
+  Expected response body:
+  ```json
+  {
+    "value":[
+       {
+          "id":1,
+          "name":"Madge",
+          "etag": "11bdc430-65e8-45ad-81d9-8ffa60d55b59",
+          "orders": [{ "id": 1, "userId": 1, detail: "a recorder" }]
+       },
+       {
+          "id":2,
+          "name":"John",
+          "etag": "11bdc430-65e8-45ad-81d9-8ffa60d55b5a",
+          "orders": [{ "id": 2, "userId": 2, "detail": "a TV" }]
+       }
+    ]
+  }
+  ```
+  """)
+op list is ResourceOperations.ResourceList<
+  User,
+  ListQueryParametersTrait<global.Azure.Core.StandardListQueryParameters &
+    global.Azure.Core.OrderByQueryParameter &
+    global.Azure.Core.FilterQueryParameter &
+    global.Azure.Core.SelectQueryParameter &
+    global.Azure.Core.ExpandQueryParameter>
+>;
+
+@scenario
+@doc("Deletes a User")
+@summary("Deletes a user.")
+@scenarioDoc("""
+  Expected path parameter: id=1
+  
+  Expected query parameter: api-version=2022-12-01-preview
+  
+  Expected response of status code 204 with empty body.
+  """)
+op delete is ResourceOperations.ResourceDelete<User>;
+
+@scenario
+@doc("Exports a User")
+@summary("Exports a user.")
+@scenarioDoc("""
+  Should only generate models named User and UserOrder.
+  
+  Expected path parameter: id=1
+  Expected query parameter: format=json
+  Expected query parameter: api-version=2022-12-01-preview
+  
+  Expected response body:
+  ```json
+  {
+    "id": 1,
+    "name": "Madge",
+    "etag": "11bdc430-65e8-45ad-81d9-8ffa60d55b59"
+  }
+  ```
+  """)
+op export is ResourceOperations.ResourceAction<User, UserExportParams, User>;
+
+model UserList {
+  users: User[];
+}
+
+@scenario
+@doc("Exports all users")
+@summary("Exports all users.")
+@scenarioDoc("""
+  Should generate a model named User.
+  
+  Expected query parameter: format=json
+  Expected query parameter: api-version=2022-12-01-preview
+  
+  Expected response body:
+  ```json
+  {
+    "users":[
+      {
+        "id": 1,
+        "name": "Madge",
+        "etag": "11bdc430-65e8-45ad-81d9-8ffa60d55b59"
+      },
+      {
+        "id": 2,
+        "name": "John",
+        "etag": "22bdc430-65e8-45ad-81d9-8ffa60d55b59"
+      }
+    ]
+  }
+  ```
+  """)
+@collectionAction(User, "exportallusers")
+@post
+op exportAllUsers is ResourceOperations.ResourceCollectionAction<
+  User,
+  UserExportParams,
+  UserList,
+  {
+    apiVersion: "2022-12-01-preview";
+  }
+>;

--- a/packages/azure-http-specs/specs/azure/core/basic/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/basic/mockapi.ts
@@ -1,0 +1,196 @@
+import {
+  json,
+  MockRequest,
+  passOnSuccess,
+  ScenarioMockApi,
+  ValidationError,
+} from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+const validUser = { id: 1, name: "Madge", etag: "11bdc430-65e8-45ad-81d9-8ffa60d55b59" };
+const validUser2 = { id: 2, name: "John", etag: "22bdc430-65e8-45ad-81d9-8ffa60d55b59" };
+Scenarios.Azure_Core_Basic_createOrUpdate = passOnSuccess({
+  uri: "/azure/core/basic/users/:id",
+  method: "patch",
+  request: {
+    params: {
+      id: "1",
+      "api-version": "2022-12-01-preview",
+    },
+    headers: {
+      "Content-Type": "application/merge-patch+json",
+    },
+    body: { name: "Madge" },
+  },
+  response: { status: 200, body: json(validUser) },
+  handler: (req: MockRequest) => {
+    if (req.params.id !== "1") {
+      throw new ValidationError("Expected path param id=1", "1", req.params.id);
+    }
+    req.expect.containsHeader("content-type", "application/merge-patch+json");
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+    const validBody = { name: "Madge" };
+    req.expect.bodyEquals(validBody);
+    return { status: 200, body: json(validUser) };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_Core_Basic_createOrReplace = passOnSuccess({
+  uri: "/azure/core/basic/users/:id",
+  method: "put",
+  request: {
+    params: {
+      id: "1",
+      "api-version": "2022-12-01-preview",
+    },
+    body: { name: "Madge" },
+  },
+  response: { status: 200, body: json(validUser) },
+  handler: (req: MockRequest) => {
+    if (req.params.id !== "1") {
+      throw new ValidationError("Expected path param id=1", "1", req.params.id);
+    }
+    req.expect.containsHeader("content-type", "application/json");
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+    const validBody = { name: "Madge" };
+    req.expect.bodyEquals(validBody);
+    return { status: 200, body: json(validUser) };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_Core_Basic_get = passOnSuccess({
+  uri: "/azure/core/basic/users/:id",
+  method: "get",
+  request: {
+    params: {
+      id: "1",
+      "api-version": "2022-12-01-preview",
+    },
+  },
+  response: { status: 200, body: json(validUser) },
+  handler: (req: MockRequest) => {
+    if (req.params.id !== "1") {
+      throw new ValidationError("Expected path param id=1", "1", req.params.id);
+    }
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+    return { status: 200, body: json(validUser) };
+  },
+  kind: "MockApiDefinition",
+});
+const responseBody = {
+  value: [
+    {
+      id: 1,
+      name: "Madge",
+      etag: "11bdc430-65e8-45ad-81d9-8ffa60d55b59",
+      orders: [{ id: 1, userId: 1, detail: "a recorder" }],
+    },
+    {
+      id: 2,
+      name: "John",
+      etag: "11bdc430-65e8-45ad-81d9-8ffa60d55b5a",
+      orders: [{ id: 2, userId: 2, detail: "a TV" }],
+    },
+  ],
+};
+Scenarios.Azure_Core_Basic_list = passOnSuccess({
+  uri: "/azure/core/basic/users",
+  method: "get",
+  request: {
+    params: {
+      "api-version": "2022-12-01-preview",
+      top: 5,
+      skip: 10,
+      orderby: "id",
+      filter: "id lt 10",
+      select: ["id", "orders", "etag"],
+      expand: "orders",
+    },
+  },
+  response: { status: 200, body: json(responseBody) },
+  handler: (req: MockRequest) => {
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+    req.expect.containsQueryParam("top", "5");
+    req.expect.containsQueryParam("skip", "10");
+    req.expect.containsQueryParam("orderby", "id");
+    req.expect.containsQueryParam("filter", "id lt 10");
+    if (!req.originalRequest.originalUrl.includes("select[]=id&select[]=orders&select[]=etag")) {
+      throw new ValidationError(
+        "Expected query param select[]=id&select[]=orders&select[]=etag ",
+        "select[]=id&select[]=orders&select[]=etag",
+        req.originalRequest.originalUrl,
+      );
+    }
+    req.expect.containsQueryParam("expand", "orders");
+    return { status: 200, body: json(responseBody) };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_Core_Basic_delete = passOnSuccess({
+  uri: "/azure/core/basic/users/:id",
+  method: "delete",
+  request: {
+    params: {
+      id: "1",
+      "api-version": "2022-12-01-preview",
+    },
+  },
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    if (req.params.id !== "1") {
+      throw new ValidationError("Expected path param id=1", "1", req.params.id);
+    }
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+    return { status: 204 };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_Core_Basic_export = passOnSuccess({
+  uri: "/azure/core/basic/users/:id[:]export",
+  method: "post",
+  request: {
+    params: {
+      id: "1",
+      format: "json",
+      "api-version": "2022-12-01-preview",
+    },
+  },
+  response: {
+    status: 200,
+    body: json(validUser),
+  },
+  handler: (req: MockRequest) => {
+    if (req.params.id !== "1") {
+      throw new ValidationError("Expected path param id=1", "1", req.params.id);
+    }
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+    req.expect.containsQueryParam("format", "json");
+    return { status: 200, body: json(validUser) };
+  },
+  kind: "MockApiDefinition",
+});
+
+const expectBody = { users: [validUser, validUser2] };
+Scenarios.Azure_Core_Basic_exportAllUsers = passOnSuccess({
+  uri: "/azure/core/basic/users:exportallusers",
+  method: "post",
+  request: {
+    params: {
+      format: "json",
+      "api-version": "2022-12-01-preview",
+    },
+  },
+  response: { status: 200, body: json(expectBody) },
+  handler: (req: MockRequest) => {
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+    req.expect.containsQueryParam("format", "json");
+    return { status: 200, body: json(expectBody) };
+  },
+  kind: "MockApiDefinition",
+});

--- a/packages/azure-http-specs/specs/azure/core/lro/rpc/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/lro/rpc/main.tsp
@@ -1,0 +1,114 @@
+import "@azure-tools/typespec-azure-core";
+import "@typespec/spec-lib";
+import "@typespec/rest";
+import "@typespec/versioning";
+
+using Azure.Core;
+using global.Azure.Core.Traits;
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using SpecLib;
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "For spec"
+@doc("Illustrates bodies templated with Azure Core with long-running RPC operation")
+@scenarioService(
+  "/azure/core/lro/rpc",
+  {
+    versioned: Versions,
+  }
+)
+namespace _Specs_.Azure.Core.Lro.Rpc;
+
+@doc("The API version.")
+enum Versions {
+  @doc("The 2022-12-01-preview version.")
+  @useDependency(global.Azure.Core.Versions.v1_0_Preview_2)
+  v2022_12_01_preview: "2022-12-01-preview",
+}
+
+@doc("Options for the generation.")
+model GenerationOptions {
+  @doc("Prompt.")
+  prompt: string;
+}
+
+model GenerationResponse is global.Azure.Core.Foundations.OperationStatus<GenerationResult>;
+// fix warning in Azure.Core.Foundations.OperationStatus
+@@visibility(global.Azure.Core.Foundations.OperationStatus.id, "read");
+
+@doc("Result of the generation.")
+model GenerationResult {
+  @doc("The data.")
+  data: string;
+}
+
+@scenario
+@doc("Generate data.")
+@summary("Generate data.")
+@scenarioDoc("""
+  Should generate model GenerationOptions and GenerationResult.
+  GenerationResponse could be generated, depending on implementation.
+  
+  Expected verb: POST
+  Expected request body:
+  ```json
+  {
+    "prompt": "text"
+  }
+  ```
+  
+  Expected status code: 202
+  Expected response header: operation-location={endpoint}/generations/operations/operation1
+  Expected response body:
+  ```json
+  {
+    "id": "operation1",
+    "status": "InProgress"
+  }
+  ```
+  
+  Expected verb: GET
+  Expected URL: {endpoint}/generations/operations/operation1
+  
+  Expected status code: 200
+  Expected response body:
+  ```json
+  {
+    "id": "operation1",
+    "status": "InProgress"
+  }
+  ```
+  
+  Expected verb: GET
+  Expected URL: {endpoint}/generations/operations/operation1
+  
+  Expected status code: 200
+  Expected response body:
+  ```json
+  {
+    "id": "operation1",
+    "status": "Succeeded",
+    "result": {
+      "data": "text data"
+    }
+  }
+  ```
+  """)
+@route("/generations:submit")
+op longRunningRpc is global.Azure.Core.LongRunningRpcOperation<
+  BodyParameter<GenerationOptions>,
+  GenerationResponse,
+  GenerationResult
+>;
+
+alias BodyParameter<
+  T,
+  TName extends valueof string = "body",
+  TDoc extends valueof string = "The body parameter."
+> = {
+  @doc(TDoc)
+  @friendlyName(TName)
+  @bodyRoot
+  body: T;
+};

--- a/packages/azure-http-specs/specs/azure/core/lro/rpc/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/lro/rpc/mockapi.ts
@@ -1,0 +1,78 @@
+import { json, MockRequest, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+let generationPollCount = 0;
+
+Scenarios.Azure_Core_Lro_Rpc_longRunningRpc = passOnSuccess([
+  {
+    uri: "/azure/core/lro/rpc/generations:submit",
+    method: "post",
+    request: {
+      body: { prompt: "text" },
+      params: {
+        "api-version": "2022-12-01-preview",
+      },
+    },
+    response: {
+      status: 202,
+      headers: {
+        "operation-location": `/azure/core/lro/rpc/generations/operations/operation1`,
+      },
+      body: json({ id: "operation1", status: "InProgress" }),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+      req.expect.bodyEquals({ prompt: "text" });
+      generationPollCount = 0;
+      return {
+        status: 202,
+        headers: {
+          "operation-location": `${req.baseUrl}/azure/core/lro/rpc/generations/operations/operation1`,
+        },
+        body: json({ id: "operation1", status: "InProgress" }),
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/core/lro/rpc/generations/operations/operation1",
+    method: "get",
+    request: {
+      params: {
+        "api-version": "2022-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({ id: "operation1", status: "InProgress" }),
+    },
+    handler: lroHandler,
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/core/lro/rpc/generations/operations/operation1",
+    method: "get",
+    request: {
+      params: {
+        "api-version": "2022-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({ id: "operation1", status: "Succeeded", result: { data: "text data" } }),
+    },
+    handler: lroHandler,
+    kind: "MockApiDefinition",
+  },
+]);
+
+function lroHandler(req: MockRequest) {
+  req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+  const response =
+    generationPollCount > 0
+      ? { id: "operation1", status: "Succeeded", result: { data: "text data" } }
+      : { id: "operation1", status: "InProgress" };
+  generationPollCount += 1;
+  return { status: 200, body: json(response) };
+}

--- a/packages/azure-http-specs/specs/azure/core/lro/standard/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/lro/standard/main.tsp
@@ -1,0 +1,218 @@
+import "@azure-tools/typespec-azure-core";
+import "@typespec/spec-lib";
+import "@typespec/rest";
+import "@typespec/versioning";
+
+using Azure.Core;
+using global.Azure.Core.Traits;
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using SpecLib;
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "For spec"
+@doc("Illustrates bodies templated with Azure Core with long-running operation")
+@scenarioService(
+  "/azure/core/lro/standard",
+  {
+    versioned: Versions,
+  }
+)
+namespace _Specs_.Azure.Core.Lro.Standard;
+
+@doc("The API version.")
+enum Versions {
+  @doc("The 2022-12-01-preview version.")
+  @useDependency(global.Azure.Core.Versions.v1_0_Preview_2)
+  v2022_12_01_preview: "2022-12-01-preview",
+}
+
+alias ResourceOperations = global.Azure.Core.ResourceOperations<NoConditionalRequests &
+  NoRepeatableRequests &
+  NoClientRequestId>;
+
+@resource("users")
+@doc("Details about a user.")
+model User {
+  @key
+  @visibility("read")
+  @doc("The name of user.")
+  name: string;
+
+  @doc("The role of user")
+  role: string;
+}
+
+@doc("The parameters for exporting a user.")
+model UserExportParams {
+  @query
+  @doc("The format of the data.")
+  format: string;
+}
+
+@doc("The exported user data.")
+model ExportedUser {
+  @doc("The name of user.")
+  name: string;
+
+  @doc("The exported URI.")
+  resourceUri: string;
+}
+
+@scenario
+@doc("Creates or replaces a User")
+@summary("Adds a user or replaces a user's fields.")
+@scenarioDoc("""
+  Should only generate one model named User.
+  
+  Expected verb: PUT
+  Expected path parameter: name=madge
+  
+  Expected request body:
+  ```json
+  {
+    "role": "contributor"
+  }
+  ```
+  
+  Expected status code: 201
+  Expected response header: operation-location={endpoint}/users/madge/operations/operation1
+  Expected response body:
+  ```json
+  {
+    "name": "madge",
+    "role": "contributor"
+  }
+  ```
+  
+  Expected verb: GET
+  Expected URL: {endpoint}/users/madge/operations/operation1
+  
+  Expected status code: 200
+  Expected response body:
+  ```json
+  {
+    "id": "operation1",
+    "status": "InProgress"
+  }
+  ```
+  
+  Expected verb: GET
+  Expected URL: {endpoint}/users/madge/operations/operation1
+  
+  Expected status code: 200
+  Expected response body:
+  ```json
+  {
+    "id": "operation1",
+    "status": "Succeeded"
+  }
+  ```
+  
+  (The last GET call on resource URL is optional)
+  Expected verb: GET
+  Expected URL: {endpoint}/users/madge
+  
+  Expected status code: 200
+  Expected response body:
+  ```json
+  {
+    "name": "madge",
+    "role": "contributor"
+  }
+  ```
+  """)
+op createOrReplace is ResourceOperations.LongRunningResourceCreateOrReplace<User>;
+
+@scenario
+@doc("Deletes a User")
+@summary("Deletes a user.")
+@scenarioDoc("""
+  Expected verb: DELETE
+  Expected path parameter: name=madge
+  
+  Expected status code: 202
+  Expected response header: operation-location={endpoint}/users/madge/operations/operation2
+  Expected response body:
+  ```json
+  {
+    "id": "operation2",
+    "status": "InProgress"
+  }
+  ```
+  
+  Expected verb: GET
+  Expected URL: {endpoint}/users/madge/operations/operation2
+  
+  Expected status code: 200
+  Expected response body:
+  ```json
+  {
+    "id": "operation2",
+    "status": "InProgress"
+  }
+  ```
+  
+  Expected verb: GET
+  Expected URL: {endpoint}/users/madge/operations/operation2
+  
+  Expected status code: 200
+  Expected response body:
+  ```json
+  {
+    "id": "operation2",
+    "status": "Succeeded"
+  }
+  ```
+  """)
+op delete is ResourceOperations.LongRunningResourceDelete<User>;
+
+@scenario
+@doc("Exports a User")
+@summary("Exports a user.")
+@scenarioDoc("""
+  Should only generate one model named ExportedUser.
+  
+  Expected verb: POST
+  Expected path parameter: name=madge
+  Expected query parameter: format=json
+  
+  Expected status code: 202
+  Expected response header: operation-location={endpoint}/users/madge/operations/operation3
+  Expected response body:
+  ```json
+  {
+    "id": "operation3",
+    "status": "InProgress"
+  }
+  ```
+  
+  Expected verb: GET
+  Expected URL: {endpoint}/users/madge/operations/operation3
+  
+  Expected status code: 200
+  Expected response body:
+  ```json
+  {
+    "id": "operation3",
+    "status": "InProgress"
+  }
+  ```
+  
+  Expected verb: GET
+  Expected URL: {endpoint}/users/madge/operations/operation3
+  
+  Expected status code: 200
+  Expected response body:
+  ```json
+  {
+    "id": "operation3",
+    "status": "Succeeded",
+    "result": {
+      "name": "madge",
+      "resourceUri": "/users/madge"
+    }
+  }
+  ```
+  """)
+op export is ResourceOperations.LongRunningResourceAction<User, UserExportParams, ExportedUser>;

--- a/packages/azure-http-specs/specs/azure/core/lro/standard/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/lro/standard/mockapi.ts
@@ -1,0 +1,246 @@
+import { json, MockRequest, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+const validUser = { name: "madge", role: "contributor" };
+let createOrReplacePollCount = 0;
+let deletePollCount = 0;
+let exportPollCount = 0;
+
+function createOrReplaceLroHandler(req: MockRequest) {
+  req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+  const response =
+    createOrReplacePollCount > 0
+      ? { id: "operation1", status: "Succeeded" }
+      : { id: "operation1", status: "InProgress" };
+  createOrReplacePollCount += 1;
+  return { status: 200, body: json(response) };
+}
+
+function deleteLroHandler(req: MockRequest) {
+  req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+  const response =
+    deletePollCount > 0
+      ? { id: "operation2", status: "Succeeded" }
+      : { id: "operation2", status: "InProgress" };
+  deletePollCount += 1;
+  return { status: 200, body: json(response) };
+}
+
+function exportLroHandler(req: MockRequest) {
+  req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+  const response =
+    exportPollCount > 0
+      ? {
+          id: "operation3",
+          status: "Succeeded",
+          result: { name: "madge", resourceUri: "/users/madge" },
+        }
+      : { id: "operation3", status: "InProgress" };
+  exportPollCount += 1;
+  return { status: 200, body: json(response) };
+}
+
+Scenarios.Azure_Core_Lro_Standard_createOrReplace = passOnSuccess([
+  {
+    uri: "/azure/core/lro/standard/users/madge",
+    method: "put",
+    request: {
+      body: { role: "contributor" },
+      params: {
+        "api-version": "2022-12-01-preview",
+      },
+    },
+    response: {
+      status: 201,
+      headers: {
+        "operation-location": `/azure/core/lro/standard/users/madge/operations/operation1`,
+      },
+      body: json(validUser),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+      req.expect.bodyEquals({ role: "contributor" });
+      createOrReplacePollCount = 0;
+      return {
+        status: 201,
+        headers: {
+          "operation-location": `${req.baseUrl}/azure/core/lro/standard/users/madge/operations/operation1`,
+        },
+        body: json(validUser),
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/core/lro/standard/users/madge/operations/operation1",
+    method: "get",
+    request: {
+      params: {
+        "api-version": "2022-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({ id: "operation1", status: "InProgress" }),
+    },
+    handler: createOrReplaceLroHandler,
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/core/lro/standard/users/madge/operations/operation1",
+    method: "get",
+    request: {
+      params: {
+        "api-version": "2022-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({ id: "operation1", status: "Succeeded" }),
+    },
+    handler: createOrReplaceLroHandler,
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/core/lro/standard/users/madge",
+    method: "get",
+    request: {},
+    response: {
+      status: 200,
+      body: json(validUser),
+    },
+    handler: (req: MockRequest) => {
+      return { status: 200, body: json(validUser) };
+    },
+    kind: "MockApiDefinition",
+  },
+]);
+
+Scenarios.Azure_Core_Lro_Standard_delete = passOnSuccess([
+  {
+    uri: "/azure/core/lro/standard/users/madge",
+    method: "delete",
+    request: {
+      params: {
+        "api-version": "2022-12-01-preview",
+      },
+    },
+    response: {
+      status: 202,
+      headers: {
+        "operation-location": `/azure/core/lro/standard/users/madge/operations/operation2`,
+      },
+      body: json({ id: "operation2", status: "InProgress" }),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+      deletePollCount = 0;
+      return {
+        status: 202,
+        headers: {
+          "operation-location": `${req.baseUrl}/azure/core/lro/standard/users/madge/operations/operation2`,
+        },
+        body: json({ id: "operation2", status: "InProgress" }),
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/core/lro/standard/users/madge/operations/operation2",
+    method: "get",
+    request: {
+      params: {
+        "api-version": "2022-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({ id: "operation2", status: "InProgress" }),
+    },
+    handler: deleteLroHandler,
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/core/lro/standard/users/madge/operations/operation2",
+    method: "get",
+    request: {
+      params: {
+        "api-version": "2022-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({ id: "operation2", status: "Succeeded" }),
+    },
+    handler: deleteLroHandler,
+    kind: "MockApiDefinition",
+  },
+]);
+
+Scenarios.Azure_Core_Lro_Standard_export = passOnSuccess([
+  {
+    uri: "/azure/core/lro/standard/users/madge:export",
+    method: "post",
+    request: {
+      params: {
+        "api-version": "2022-12-01-preview",
+        format: "json",
+      },
+    },
+    response: {
+      status: 202,
+      headers: {
+        "operation-location": `/azure/core/lro/standard/users/madge/operations/operation3`,
+      },
+      body: json({ id: "operation3", status: "InProgress" }),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+      req.expect.containsQueryParam("format", "json");
+      exportPollCount = 0;
+      return {
+        status: 202,
+        headers: {
+          "operation-location": `${req.baseUrl}/azure/core/lro/standard/users/madge/operations/operation3`,
+        },
+        body: json({ id: "operation3", status: "InProgress" }),
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/core/lro/standard/users/madge/operations/operation3",
+    method: "get",
+    request: {
+      params: {
+        "api-version": "2022-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({ id: "operation3", status: "InProgress" }),
+    },
+    handler: exportLroHandler,
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/core/lro/standard/users/madge/operations/operation3",
+    method: "get",
+    request: {
+      params: {
+        "api-version": "2022-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({
+        id: "operation3",
+        status: "Succeeded",
+        result: { name: "madge", resourceUri: "/users/madge" },
+      }),
+    },
+    handler: exportLroHandler,
+    kind: "MockApiDefinition",
+  },
+]);

--- a/packages/azure-http-specs/specs/azure/core/model/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/model/main.tsp
@@ -1,0 +1,65 @@
+import "@typespec/http";
+import "@typespec/spec-lib";
+import "@azure-tools/typespec-client-generator-core";
+import "@azure-tools/typespec-azure-core";
+import "@typespec/versioning";
+
+using TypeSpec.Http;
+using global.Azure.ClientGenerator.Core;
+using global.Azure.Core;
+using TypeSpec.Versioning;
+using SpecLib;
+
+@scenarioService(
+  "/azure/core/model",
+  {
+    versioned: Versions,
+  }
+)
+namespace _Specs_.Azure.Core.Model;
+@doc("The version of the API.")
+enum Versions {
+  @doc("The version 2022-12-01-preview.")
+  @useDependency(global.Azure.Core.Versions.v1_0_Preview_2)
+  v2022_12_01_preview: "2022-12-01-preview",
+}
+model AzureEmbeddingModel {
+  embedding: EmbeddingVector<int32>;
+}
+
+@operationGroup
+@route("/embeddingVector")
+interface AzureCoreEmbeddingVector {
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing"
+  @scenario
+  @scenarioDoc("Expect to handle an embedding vector. Mock api will return [0, 1, 2, 3, 4]")
+  @get
+  @doc("get an embedding vector")
+  get(): EmbeddingVector<int32>;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing"
+  @scenario
+  @scenarioDoc("Expect to send an embedding vector. Mock api expect to receive [0, 1, 2, 3, 4]")
+  @put
+  @doc("put an embedding vector")
+  put(@body @doc("_") body: EmbeddingVector<int32>): void;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing"
+  @scenario
+  @scenarioDoc("""
+    Expect to send a model which has an embedding vector property.
+    
+    Expected request body:
+    ```json
+    {"embedding": [0, 1, 2, 3, 4]}
+    ```
+    
+    Expected response body:
+    ```json
+    {"embedding": [5, 6, 7, 8, 9]}
+    ```
+    """)
+  @post
+  @doc("post a model which has an embeddingVector property")
+  post(@body @doc("_") body: AzureEmbeddingModel): AzureEmbeddingModel;
+}

--- a/packages/azure-http-specs/specs/azure/core/model/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/model/mockapi.ts
@@ -1,0 +1,44 @@
+import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Azure_Core_Model_AzureCoreEmbeddingVector_get = passOnSuccess({
+  uri: "/azure/core/model/embeddingVector",
+  method: "get",
+  request: {},
+  response: { status: 200, body: json([0, 1, 2, 3, 4]) },
+  handler: (req) => {
+    return { status: 200, body: json([0, 1, 2, 3, 4]) };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_Core_Model_AzureCoreEmbeddingVector_put = passOnSuccess({
+  uri: "/azure/core/model/embeddingVector",
+  method: "put",
+  request: {
+    body: [0, 1, 2, 3, 4],
+  },
+  response: { status: 204 },
+  handler: (req) => {
+    req.expect.bodyEquals([0, 1, 2, 3, 4]);
+    return { status: 204 };
+  },
+  kind: "MockApiDefinition",
+});
+
+const responseBody = { embedding: [5, 6, 7, 8, 9] };
+Scenarios.Azure_Core_Model_AzureCoreEmbeddingVector_post = passOnSuccess({
+  uri: "/azure/core/model/embeddingVector",
+  method: "post",
+  request: { body: { embedding: [0, 1, 2, 3, 4] } },
+  response: { status: 200, body: json(responseBody) },
+  handler: (req) => {
+    req.expect.bodyEquals({ embedding: [0, 1, 2, 3, 4] });
+    return {
+      status: 200,
+      body: json(responseBody),
+    };
+  },
+  kind: "MockApiDefinition",
+});

--- a/packages/azure-http-specs/specs/azure/core/page/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/page/main.tsp
@@ -1,0 +1,206 @@
+import "@azure-tools/typespec-azure-core";
+import "@typespec/spec-lib";
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+
+using Azure.Core;
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using SpecLib;
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "For spec"
+@doc("Illustrates bodies templated with Azure Core with paging support")
+@scenarioService(
+  "/azure/core/page",
+  {
+    versioned: Versions,
+  }
+)
+namespace _Specs_.Azure.Core.Page;
+
+@doc("The version of the API.")
+enum Versions {
+  @doc("The version 2022-12-01-preview.")
+  @useDependency(global.Azure.Core.Versions.v1_0_Preview_2)
+  v2022_12_01_preview: "2022-12-01-preview",
+}
+
+@resource("users")
+@doc("Details about a user.")
+model User {
+  @key
+  @doc("The user's id.")
+  @visibility("read")
+  id: int32;
+
+  @doc("The user's name.")
+  name: string;
+
+  @doc("The user's order list")
+  orders?: UserOrder[];
+
+  ...global.Azure.Core.EtagProperty;
+}
+
+@doc("UserOrder for testing list with expand.")
+@resource("user")
+model UserOrder {
+  @key
+  @doc("The user's id.")
+  @visibility("read")
+  id: int32;
+
+  @doc("The user's id.")
+  userId: int32;
+
+  @doc("The user's order detail")
+  detail: string;
+}
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing global.Azure.Core.Page"
+@scenario
+@doc("List with Azure.Core.Page<>.")
+@route("/page")
+@scenarioDoc("""
+  Should only generate models named User and UserOrder.
+  
+  Should not generate visible model like Page.
+  
+  Expected query parameter: api-version=2022-12-01-preview
+  
+  Expected response body:
+  ```json
+  {
+    "value":[
+       {
+          "id":1,
+          "name":"Madge",
+          "etag": "11bdc430-65e8-45ad-81d9-8ffa60d55b59"
+       }
+    ]
+  }
+  ```
+  """)
+op listWithPage is global.Azure.Core.Foundations.Operation<{}, global.Azure.Core.Page<User>>;
+
+@doc("The parameters for listing users.")
+model ListItemInput {
+  @doc("The body of the input.")
+  @body
+  bodyInput: ListItemInputBody;
+
+  @doc("Another query parameter.")
+  @query
+  another?: ListItemInputExtensibleEnum;
+}
+
+@doc("An extensible enum input parameter.")
+enum ListItemInputExtensibleEnum {
+  @doc("The first enum value.")
+  First,
+
+  @doc("The second enum value.")
+  Second,
+}
+
+@doc("The body of the input.")
+model ListItemInputBody {
+  @doc("The name of the input.")
+  inputName: string;
+}
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing global.Azure.Core.Page"
+@scenario
+@doc("List with extensible enum parameter Azure.Core.Page<>.")
+@route("/parameters")
+@scenarioDoc("""
+  Expected query parameter: api-version=2022-12-01-preview&another=Second
+  
+  Expected body parameter: {"inputName": "Madge"}
+  
+  Expected response body:
+  ```json
+  {
+    "value":[
+       {
+          "id": 1,
+          "name": "Madge",
+          "etag": "11bdc430-65e8-45ad-81d9-8ffa60d55b59"
+       }
+    ]
+  }
+  ```
+  """)
+@get
+op listWithParameters is global.Azure.Core.Foundations.Operation<
+  ListItemInput,
+  global.Azure.Core.Page<User>
+>;
+
+@friendlyName("{name}ListResults", T)
+@global.Azure.Core.pagedResult
+model CustomPageModel<T> {
+  @global.Azure.Core.items
+  @doc("List of items.")
+  items: T[];
+
+  @global.Azure.Core.nextLink
+  @doc("Link to fetch more items.")
+  nextLink?: string;
+}
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing global.Azure.Core.Page"
+@scenario
+@doc("List with custom page model.")
+@route("/custom-page")
+@scenarioDoc("""
+  Should ideally only generate models named User and UserOrder. If your language has to, you can also generate CustomPageModel
+  
+  Expected query parameter: api-version=2022-12-01-preview
+  
+  Expected response body:
+  ```json
+  {
+    "items":[
+       {
+          "id":1,
+          "name":"Madge",
+          "etag": "11bdc430-65e8-45ad-81d9-8ffa60d55b59"
+       }
+    ]
+  }
+  ```
+  """)
+op listWithCustomPageModel is global.Azure.Core.Foundations.Operation<{}, CustomPageModel<User>>;
+
+@doc("First item.")
+model FirstItem {
+  @doc("The id of the item.")
+  @visibility("read")
+  id: int32;
+}
+
+@doc("Second item.")
+model SecondItem {
+  @doc("The name of the item.")
+  @visibility("read")
+  name: string;
+}
+
+@scenario
+@scenarioDoc("""
+  This scenario is to test two operations with two different page item types.
+  """)
+interface TwoModelsAsPageItem {
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing global.Azure.Core.Page"
+  @doc("Two operations with two different page item types should be successfully generated. Should generate model for FirstItem.")
+  @route("/first-item")
+  listFirstItem is global.Azure.Core.Foundations.Operation<{}, global.Azure.Core.Page<FirstItem>>;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing global.Azure.Core.Page"
+  @doc("Two operations with two different page item types should be successfully generated. Should generate model for SecondItem.")
+  @route("/second-item")
+  listSecondItem is global.Azure.Core.Foundations.Operation<{}, global.Azure.Core.Page<SecondItem>>;
+}

--- a/packages/azure-http-specs/specs/azure/core/page/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/page/mockapi.ts
@@ -1,0 +1,85 @@
+import { json, MockRequest, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+const validUser = { id: 1, name: "Madge", etag: "11bdc430-65e8-45ad-81d9-8ffa60d55b59" };
+
+Scenarios.Azure_Core_Page_listWithPage = passOnSuccess({
+  uri: "/azure/core/page/page",
+  method: "get",
+  request: {},
+  response: { status: 200, body: json({ value: [validUser] }) },
+  handler: (req: MockRequest) => {
+    const responseBody = {
+      value: [validUser],
+    };
+    return { status: 200, body: json(responseBody) };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_Core_Page_listWithParameters = passOnSuccess({
+  uri: "/azure/core/page/parameters",
+  method: "get",
+  request: {
+    params: {
+      another: "Second",
+    },
+    body: { inputName: "Madge" },
+  },
+  response: { status: 200, body: json({ value: [validUser] }) },
+  handler: (req: MockRequest) => {
+    req.expect.containsQueryParam("another", "Second");
+
+    const validBody = { inputName: "Madge" };
+    req.expect.bodyEquals(validBody);
+
+    const responseBody = {
+      value: [validUser],
+    };
+    return { status: 200, body: json(responseBody) };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_Core_Page_TwoModelsAsPageItem = passOnSuccess([
+  {
+    uri: "/azure/core/page/first-item",
+    method: "get",
+    request: {},
+    response: { status: 200, body: json({ value: [{ id: 1 }] }) },
+    handler: (req: MockRequest) => {
+      const responseBody = {
+        value: [{ id: 1 }],
+      };
+      return { status: 200, body: json(responseBody) };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/core/page/second-item",
+    method: "get",
+    request: {},
+    response: { status: 200, body: json({ value: [{ name: "Madge" }] }) },
+    handler: (req: MockRequest) => {
+      const responseBody = {
+        value: [{ name: "Madge" }],
+      };
+      return { status: 200, body: json(responseBody) };
+    },
+    kind: "MockApiDefinition",
+  },
+]);
+
+Scenarios.Azure_Core_Page_listWithCustomPageModel = passOnSuccess({
+  uri: "/azure/core/page/custom-page",
+  method: "get",
+  request: {},
+  response: { status: 200, body: json({ items: [validUser] }) },
+  handler: (req: MockRequest) => {
+    const responseBody = {
+      items: [validUser],
+    };
+    return { status: 200, body: json(responseBody) };
+  },
+  kind: "MockApiDefinition",
+});

--- a/packages/azure-http-specs/specs/azure/core/scalar/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/scalar/main.tsp
@@ -1,0 +1,88 @@
+import "@typespec/http";
+import "@typespec/spec-lib";
+import "@azure-tools/typespec-client-generator-core";
+import "@azure-tools/typespec-azure-core";
+import "@typespec/versioning";
+
+using TypeSpec.Http;
+using global.Azure.ClientGenerator.Core;
+using global.Azure.Core;
+using TypeSpec.Versioning;
+using SpecLib;
+
+@scenarioService(
+  "/azure/core/scalar",
+  {
+    versioned: Versions,
+  }
+)
+namespace _Specs_.Azure.Core.Scalar;
+@doc("The version of the API.")
+enum Versions {
+  @doc("The version 2022-12-01-preview.")
+  @useDependency(global.Azure.Core.Versions.v1_0_Preview_2)
+  v2022_12_01_preview: "2022-12-01-preview",
+}
+model AzureLocationModel {
+  location: azureLocation;
+}
+
+@operationGroup
+@route("/azureLocation")
+interface AzureLocationScalar {
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing"
+  @scenario
+  @scenarioDoc("Expect to handle a azureLocation value. Mock api will return 'eastus'")
+  @get
+  @doc("get azureLocation value")
+  get(): azureLocation;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing"
+  @scenario
+  @scenarioDoc("Expect to send a azureLocation value. Mock api expect to receive 'eastus'")
+  @put
+  @doc("put azureLocation value")
+  put(@body @doc("_") body: azureLocation): void;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing"
+  @scenario
+  @scenarioDoc("""
+    Expect to send a model which has an azureLocation property.
+    
+    Expected request body:
+    ```json
+    {"location": "eastus"}
+    ```
+    
+    Expected response body:
+    ```json
+    {"location": "eastus"}
+    ```
+    """)
+  @scenarioDoc("Expect to send a model who has an azureLocation property. Mock api expect to receive '{location: eastus}'")
+  @post
+  @doc("post a model which has azureLocation property")
+  post(@body @doc("_") body: AzureLocationModel): AzureLocationModel;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing"
+  @scenario
+  @scenarioDoc("""
+    Expect to send a azureLocation value as header.
+    Expected header parameter: `region="eastus"`
+    """)
+  @post
+  @route("/header")
+  @doc("azureLocation value header")
+  header(@header @doc("_") region: azureLocation): void;
+
+  #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing"
+  @scenario
+  @scenarioDoc("""
+    Expect to send a azureLocation value as query.
+    Expected query parameter: `region="eastus"`
+    """)
+  @post
+  @doc("azureLocation value query")
+  @route("/query")
+  query(@query @doc("_") region: azureLocation): void;
+}

--- a/packages/azure-http-specs/specs/azure/core/scalar/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/scalar/mockapi.ts
@@ -1,0 +1,80 @@
+import { json, MockRequest, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+// string value
+Scenarios.Azure_Core_Scalar_AzureLocationScalar_get = passOnSuccess({
+  uri: "/azure/core/scalar/azureLocation",
+  method: "get",
+  request: {},
+  response: { status: 200, body: json("eastus") },
+  handler: (req: MockRequest) => {
+    return { status: 200, body: json("eastus") };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_Core_Scalar_AzureLocationScalar_put = passOnSuccess({
+  uri: "/azure/core/scalar/azureLocation",
+  method: "put",
+  request: {
+    body: "eastus",
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  },
+  response: { status: 204 },
+  handler: (req: MockRequest) => {
+    req.expect.bodyEquals("eastus");
+    return { status: 204 };
+  },
+  kind: "MockApiDefinition",
+});
+
+const azureLocation = { location: "eastus" };
+Scenarios.Azure_Core_Scalar_AzureLocationScalar_post = passOnSuccess({
+  uri: "/azure/core/scalar/azureLocation",
+  method: "post",
+  request: { body: azureLocation },
+  response: { status: 200, body: json(azureLocation) },
+  handler: (req: MockRequest) => {
+    req.expect.bodyEquals({ location: "eastus" });
+    return {
+      status: 200,
+      body: json(azureLocation),
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_Core_Scalar_AzureLocationScalar_header = passOnSuccess({
+  uri: "/azure/core/scalar/azureLocation/header",
+  method: "post",
+  request: {
+    headers: {
+      region: "eastus",
+    },
+  },
+  response: { status: 204 },
+  handler: (req: MockRequest) => {
+    req.expect.containsHeader("region", "eastus");
+    return { status: 204 };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_Core_Scalar_AzureLocationScalar_query = passOnSuccess({
+  uri: "/azure/core/scalar/azureLocation/query",
+  method: "post",
+  request: {
+    params: {
+      region: "eastus",
+    },
+  },
+  response: { status: 204 },
+  handler: (req: MockRequest) => {
+    req.expect.containsQueryParam("region", "eastus");
+    return { status: 204 };
+  },
+  kind: "MockApiDefinition",
+});

--- a/packages/azure-http-specs/specs/azure/core/traits/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/traits/main.tsp
@@ -1,0 +1,141 @@
+import "@azure-tools/typespec-azure-core";
+import "@typespec/spec-lib";
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+
+using global.Azure.Core;
+using global.Azure.Core.Traits;
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using SpecLib;
+
+#suppress "@azure-tools/typespec-azure-core/casing-style" "For spec"
+@doc("Illustrates Azure Core operation customizations by traits")
+@scenarioService(
+  "/azure/core/traits",
+  {
+    versioned: Versions,
+  }
+)
+@versioned(Versions)
+namespace _Specs_.Azure.Core.Traits;
+
+@doc("Service versions")
+enum Versions {
+  @doc("2022-12-01-preview")
+  @useDependency(global.Azure.Core.Versions.v1_0_Preview_2)
+  v2022_12_01_preview: "2022-12-01-preview",
+}
+
+alias SmokeOperationsWithTraits = global.Azure.Core.ResourceOperations<NoRepeatableRequests &
+  SupportsConditionalRequests &
+  SupportsClientRequestId>;
+
+alias RepeatableOperationsWithTraits = global.Azure.Core.ResourceOperations<SupportsRepeatableRequests &
+  NoConditionalRequests &
+  NoClientRequestId>;
+
+@doc("Sample Model")
+@resource("user")
+model User {
+  @key
+  @doc("The user's id.")
+  @visibility("read")
+  id: int32;
+
+  @doc("The user's name.")
+  name?: string;
+}
+
+@scenario
+@doc("Get a resource, sending and receiving headers.")
+@scenarioDoc("""
+  SDK should not genreate `clientRequestId` paramerter but use policy to auto-set the header.
+  Expected path parameter: id=1
+  Expected query parameter: api-version=2022-12-01-preview
+  Expected header parameters:
+  - foo=123
+  - if-match=valid
+  - if-none-match=invalid
+  - if-unmodified-since=Fri, 26 Aug 2022 14:38:00 GMT
+  - if-modified-since=Thu, 26 Aug 2021 14:38:00 GMT
+  - x-ms-client-request-id=<any uuid string>
+  
+  Expected response header:
+  - bar="456"
+  - x-ms-client-request-id=<uuid string same with request header>
+  - etag="11bdc430-65e8-45ad-81d9-8ffa60d55b59"
+  
+  Expected response body:
+  ```json
+  {
+    "id": 1,
+    "name": "Madge"
+  }
+  ```
+  """)
+op smokeTest is SmokeOperationsWithTraits.ResourceRead<
+  User,
+  RequestHeadersTrait<{
+    @doc("header in request")
+    @header
+    foo: string;
+  }> &
+    ResponseHeadersTrait<{
+      @header bar: string;
+    }>
+>;
+
+@doc("User action param")
+model UserActionParam {
+  @doc("User action value.")
+  userActionValue: string;
+}
+
+@doc("User action response")
+model UserActionResponse {
+  @doc("User action result.")
+  userActionResult: string;
+}
+
+@scenario
+@doc("Test for repeatable requests")
+@scenarioDoc("""
+  Expected path parameter: id=1
+  Expected header parameters:
+  - repeatability-request-id=<any uuid>
+  - repeatability-first-sent=<any HTTP header date>
+  Expected request body:
+  ```json
+  {
+    "userActionValue": "test"
+  }
+  ```
+  
+  Expected response header:
+  - repeatability-result=accepted
+  Expected response body:
+  ```json
+  {
+    "userActionResult": "test"
+  }
+  ```
+  """)
+op repeatableAction is RepeatableOperationsWithTraits.ResourceAction<
+  User,
+  BodyParameter<UserActionParam>,
+  UserActionResponse
+>;
+
+alias BodyParameter<
+  T,
+  TName extends valueof string = "body",
+  TDoc extends valueof string = "The body parameter."
+> = {
+  @doc(TDoc)
+  @friendlyName(TName)
+  @bodyRoot
+  body: T;
+};

--- a/packages/azure-http-specs/specs/azure/core/traits/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/traits/mockapi.ts
@@ -1,0 +1,131 @@
+import {
+  json,
+  MockRequest,
+  passOnSuccess,
+  ScenarioMockApi,
+  validateValueFormat,
+  ValidationError,
+} from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+const validUser = {
+  id: 1,
+  name: "Madge",
+};
+
+Scenarios.Azure_Core_Traits_smokeTest = passOnSuccess({
+  uri: "/azure/core/traits/user/:id",
+  method: "get",
+  request: {
+    params: {
+      id: "1",
+    },
+    headers: {
+      foo: "123",
+      "If-Match": '"valid"',
+      "If-None-Match": '"invalid"',
+      "If-Modified-Since": "Thu, 26 Aug 2021 14:38:00 GMT",
+      "If-Unmodified-Since": "Fri, 26 Aug 2022 14:38:00 GMT",
+      "x-ms-client-request-id": "86aede1f-96fa-4e7f-b1e1-bf8a947cb804",
+    },
+  },
+  response: {
+    status: 200,
+    body: json(validUser),
+    headers: {
+      bar: "456",
+      etag: "11bdc430-65e8-45ad-81d9-8ffa60d55b59",
+      "x-ms-client-request-id": "86aede1f-96fa-4e7f-b1e1-bf8a947cb804",
+    },
+  },
+  handler: (req: MockRequest) => {
+    if (!("x-ms-client-request-id" in req.headers)) {
+      throw new ValidationError(
+        "Should submit header x-ms-client-request-id",
+        "any uuid",
+        undefined,
+      );
+    }
+    if (req.params.id !== "1") {
+      throw new ValidationError("Expected path param id=1", "1", req.params.id);
+    }
+    req.expect.containsHeader("foo", "123");
+    const if_none_match = req.headers["if-none-match"];
+    const if_match = req.headers["if-match"];
+    if (if_none_match !== '"invalid"' && if_match !== '"valid"') {
+      throw new ValidationError(
+        `Expected header "if-none-match" equals "invalid" but got ${if_none_match} or "if-match" equals "valid" but got ${if_match}`,
+        `"if-match": "valid" or "if-none-match": "invalid"`,
+        `"if-match": ${if_match} or "if-none-match": ${if_none_match}`,
+      );
+    }
+    req.expect.containsHeader("if-unmodified-since", "Fri, 26 Aug 2022 14:38:00 GMT");
+    req.expect.containsHeader("if-modified-since", "Thu, 26 Aug 2021 14:38:00 GMT");
+    return {
+      status: 200,
+      body: json(validUser),
+      headers: {
+        bar: "456",
+        etag: "11bdc430-65e8-45ad-81d9-8ffa60d55b59",
+        "x-ms-client-request-id": req.headers["x-ms-client-request-id"],
+      },
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_Core_Traits_repeatableAction = passOnSuccess({
+  uri: "/azure/core/traits/user/:id:repeatableAction",
+  method: "post",
+  request: {
+    body: {
+      userActionValue: "test",
+    },
+    headers: {
+      "Repeatability-Request-ID": "86aede1f-96fa-4e7f-b1e1-bf8a947cb804",
+      "Repeatability-First-Sent": "Mon, 27 Nov 2023 11:58:00 GMT",
+    },
+    params: {
+      id: "1",
+    },
+  },
+  response: {
+    status: 200,
+    body: json({ userActionResult: "test" }),
+    headers: {
+      "repeatability-result": "accepted",
+    },
+  },
+  handler: (req: MockRequest) => {
+    if (req.params.id !== "1") {
+      throw new ValidationError("Expected path param id=1", "1", req.params.id);
+    }
+
+    if (!("repeatability-request-id" in req.headers)) {
+      throw new ValidationError("Repeatability-Request-ID is missing", "A UUID string", undefined);
+    }
+    if (!("repeatability-first-sent" in req.headers)) {
+      throw new ValidationError(
+        "Repeatability-First-Sent is missing",
+        "A date-time in headers format",
+        undefined,
+      );
+    }
+
+    validateValueFormat(req.headers["repeatability-request-id"], "uuid");
+    validateValueFormat(req.headers["repeatability-first-sent"], "rfc7231");
+
+    const validBody = { userActionValue: "test" };
+    req.expect.bodyEquals(validBody);
+
+    return {
+      status: 200,
+      body: json({ userActionResult: "test" }),
+      headers: {
+        "repeatability-result": "accepted",
+      },
+    };
+  },
+  kind: "MockApiDefinition",
+});

--- a/packages/azure-http-specs/specs/azure/example/basic/client.tsp
+++ b/packages/azure-http-specs/specs/azure/example/basic/client.tsp
@@ -1,0 +1,53 @@
+import "@azure-tools/typespec-client-generator-core";
+import "@typespec/spec-lib";
+import "./main.tsp";
+
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+using SpecLib;
+
+@TypeSpec.Versioning.useDependency(_Specs_.Azure.Example.Basic.Versions.v2022_12_01_preview)
+@route("/azure/example/basic")
+namespace Client;
+
+@client({
+  name: "AzureExampleClient",
+  service: _Specs_.Azure.Example.Basic,
+})
+interface AzureExampleClient {
+  @scenario
+  @scenarioDoc("""
+    Expected request and response is same as the JSON example at examples/2022-12-01-preview/basic.json
+    
+    When generate the code, one need to set the "examples-directory" option.
+    
+    Expected query parameter: query-param=query&api-version=2022-12-01-preview
+    Expected header parameter: header-param=header
+    
+    Expected input body:
+    ```json
+    {
+      "stringProperty": "text",
+      "modelProperty": {
+        "int32Property": 1,
+        "float32Property": 1.5,
+        "enumProperty": "EnumValue1"
+      },
+      "arrayProperty": [
+        "item"
+      ],
+      "recordProperty": {
+        "record": "value"
+      }
+    }
+    ```
+    
+    Expected response body:
+    ```json
+    {
+      "stringProperty": "text"
+    }
+    ```
+    """)
+  basicAction is _Specs_.Azure.Example.Basic.ServiceOperationGroup.basic;
+}

--- a/packages/azure-http-specs/specs/azure/example/basic/examples/2022-12-01-preview/basic.json
+++ b/packages/azure-http-specs/specs/azure/example/basic/examples/2022-12-01-preview/basic.json
@@ -1,0 +1,26 @@
+{
+  "operationId": "ServiceOperationGroup_Basic",
+  "title": "Basic action",
+  "parameters": {
+    "api-version": "2022-12-01-preview",
+    "query-param": "query",
+    "header-param": "header",
+    "body": {
+      "stringProperty": "text",
+      "modelProperty": {
+        "int32Property": 1,
+        "float32Property": 1.5,
+        "enumProperty": "EnumValue1"
+      },
+      "arrayProperty": ["item"],
+      "recordProperty": {
+        "record": "value"
+      }
+    }
+  },
+  "responses": {
+    "200": {
+      "stringProperty": "text"
+    }
+  }
+}

--- a/packages/azure-http-specs/specs/azure/example/basic/main.tsp
+++ b/packages/azure-http-specs/specs/azure/example/basic/main.tsp
@@ -1,0 +1,61 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/spec-lib";
+import "@typespec/versioning";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using SpecLib;
+
+/** Test for loading JSON example and generating sample code. */
+@scenarioService(
+  "/azure/example/basic",
+  {
+    versioned: Versions,
+  }
+)
+namespace _Specs_.Azure.Example.Basic;
+
+enum Versions {
+  v2022_12_01_preview: "2022-12-01-preview",
+}
+
+model ApiVersionParameter {
+  @query("api-version")
+  @minLength(1)
+  @doc("The API version to use for this operation.")
+  apiVersion: string;
+}
+
+model ActionRequest {
+  stringProperty: string;
+  modelProperty?: Model;
+  arrayProperty?: Array<string>;
+  recordProperty?: Record<string>;
+}
+
+model Model {
+  int32Property?: int32;
+  float32Property?: float32;
+  enumProperty?: Enum;
+}
+
+union Enum {
+  string,
+  "EnumValue1",
+}
+
+model ActionResponse is ActionRequest;
+
+interface ServiceOperationGroup {
+  #suppress "@typespec/spec-lib/missing-scenario" "scenario defined in client.tsp"
+  @route("/basic")
+  @post
+  basic(
+    ...ApiVersionParameter,
+    @query("query-param") queryParam: string,
+    @header("header-param") headerParam: string,
+    @body body: ActionRequest,
+  ): ActionResponse;
+}

--- a/packages/azure-http-specs/specs/azure/example/basic/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/example/basic/mockapi.ts
@@ -1,0 +1,60 @@
+import { json, MockRequest, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Client_AzureExampleClient_basicAction = passOnSuccess({
+  uri: "/azure/example/basic/basic",
+  method: "post",
+  request: {
+    params: {
+      "api-version": "2022-12-01-preview",
+      "query-param": "query",
+    },
+    headers: {
+      "header-param": "header",
+    },
+    body: {
+      stringProperty: "text",
+      modelProperty: {
+        int32Property: 1,
+        float32Property: 1.5,
+        enumProperty: "EnumValue1",
+      },
+      arrayProperty: ["item"],
+      recordProperty: {
+        record: "value",
+      },
+    },
+  },
+  response: {
+    status: 200,
+    body: json({
+      stringProperty: "text",
+    }),
+  },
+  handler: (req: MockRequest) => {
+    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
+    req.expect.containsQueryParam("query-param", "query");
+    req.expect.containsHeader("header-param", "header");
+    const validBody = {
+      stringProperty: "text",
+      modelProperty: {
+        int32Property: 1,
+        float32Property: 1.5,
+        enumProperty: "EnumValue1",
+      },
+      arrayProperty: ["item"],
+      recordProperty: {
+        record: "value",
+      },
+    };
+    req.expect.bodyEquals(validBody);
+    return {
+      status: 200,
+      body: json({
+        stringProperty: "text",
+      }),
+    };
+  },
+  kind: "MockApiDefinition",
+});

--- a/packages/azure-http-specs/specs/azure/resource-manager/models/common-types/managed-identity/main.tsp
+++ b/packages/azure-http-specs/specs/azure/resource-manager/models/common-types/managed-identity/main.tsp
@@ -1,0 +1,163 @@
+import "@typespec/spec-lib";
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.Core;
+using Azure.ResourceManager;
+using TypeSpec.OpenAPI;
+using SpecLib;
+
+@armProviderNamespace
+@service
+@versioned(Versions)
+@doc("Arm Managed Identity Provider management API.")
+namespace Azure.ResourceManager.Models.CommonTypes.ManagedIdentity;
+
+@doc("Azure API versions.")
+enum Versions {
+  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
+  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
+  @doc("Preview API version 2023-12-01-preview.")
+  v2023_12_01_preview: "2023-12-01-preview",
+}
+
+@resource("managedIdentityTrackedResources")
+model ManagedIdentityTrackedResource is TrackedResource<ManagedIdentityTrackedResourceProperties> {
+  @key("managedIdentityTrackedResourceName")
+  @path
+  @segment("managedIdentityTrackedResources")
+  @doc("arm resource name for path")
+  @pattern("^[A-Za-z0-9]([A-Za-z0-9-_.]{0,62}[A-Za-z0-9])?$")
+  name: string;
+
+  ...ManagedServiceIdentityProperty;
+}
+
+@doc("Managed Identity Arm Resource Properties.")
+model ManagedIdentityTrackedResourceProperties {
+  @visibility("read")
+  @doc("The status of the last operation.")
+  provisioningState: string;
+}
+
+@armResourceOperations
+interface ManagedIdentityTrackedResources {
+  @scenario
+  @scenarioDoc("""
+    Resource GET operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.CommonTypes.ManagedIdentity/managedIdentityTrackedResources/identity",
+    Expected query parameter: api-version=2023-12-01-preview
+    
+    Expected response body:
+    ```json
+    {
+      "id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.CommonTypes.ManagedIdentity/managedIdentityTrackedResources/identity",
+      "location": "eastus",
+      "tags": {
+        "tagKey1": "tagValue1"
+      },
+      "identity": {
+        "type": "SystemAssigned",
+        "principalId": <any uuid string>
+        "tenantId": <any uuid string>
+       },
+      "properties": {
+        "provisioningState": "Succeeded"
+      }
+    }
+    ```
+    """)
+  get is ArmResourceRead<ManagedIdentityTrackedResource>;
+
+  @scenario
+  @scenarioDoc("""
+    Resource PUT operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.CommonTypes.ManagedIdentity/managedIdentityTrackedResources/identity",
+    Expected query parameter: api-version=2023-12-01-preview
+    Expected request body:
+    ```json
+    {
+      "location": "eastus",
+      "tags": {
+        "tagKey1": "tagValue1"
+      },
+      "properties": {},
+      "identity": {
+        "type": "SystemAssigned"
+      }
+    }
+    ```
+     Expected response body:
+    ```json
+    {
+      "id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.CommonTypes.ManagedIdentity/managedIdentityTrackedResources/identity",
+      "location": "eastus",
+      "tags": {
+        "tagKey1": "tagValue1"
+      },
+      "identity": {
+        "type": "SystemAssigned",
+        "principalId": <any uuid string>,
+        "tenantId": <any uuid string>
+       },
+      "properties": {
+        "provisioningState": "Succeeded"
+      }
+    }
+    ```
+    """)
+  createWithSystemAssigned is ArmResourceCreateOrReplaceSync<ManagedIdentityTrackedResource>;
+
+  @scenario
+  @scenarioDoc("""
+    Resource PATCH operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.CommonTypes.ManagedIdentity/managedIdentityTrackedResources/identity",
+    Expected query parameter: api-version=2023-12-01-preview
+    Expected request body:
+    ```json
+    {
+      "identity": {
+        "type": "SystemAssigned,UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {}
+        }
+      }
+    }
+    ```
+     Expected response body:
+    ```json
+    {
+      "id":"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.CommonTypes.ManagedIdentity/managedIdentityTrackedResources/identity",
+      "location": "eastus",
+      "tags": {
+        "tagKey1": "tagValue1"
+      },
+      "identity": {
+        "type": "SystemAssigned,UserAssigned",
+        "userAssignedIdentities": {
+          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1": {
+            "principalId": <any uuid string>,
+            "clientId": <any uuid string>
+          },
+        },
+        "principalId": <any uuid string>,
+        "tenantId": <any uuid string>
+      },
+      "properties": {
+        "provisioningState": "Succeeded"
+      }
+    }
+    ```
+    """)
+  updateWithUserAssignedAndSystemAssigned is ArmResourcePatchSync<
+    ManagedIdentityTrackedResource,
+    ManagedIdentityTrackedResourceProperties
+  >;
+}

--- a/packages/azure-http-specs/specs/azure/resource-manager/models/common-types/managed-identity/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/models/common-types/managed-identity/mockapi.ts
@@ -1,0 +1,221 @@
+import {
+  json,
+  MockRequest,
+  passOnSuccess,
+  ScenarioMockApi,
+  ValidationError,
+} from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+const SUBSCRIPTION_ID_EXPECTED = "00000000-0000-0000-0000-000000000000";
+const PRINCIPAL_ID_EXPECTED = "00000000-0000-0000-0000-000000000000";
+const TENANT_ID_EXPECTED = "00000000-0000-0000-0000-000000000000";
+const CLIENT_ID_EXPECTED = "00000000-0000-0000-0000-000000000000";
+const LOCATION_REGION_EXPECTED = "eastus";
+const RESOURCE_GROUP_EXPECTED = "test-rg";
+const IDENTITY_TYPE_SYSTEM_ASSIGNED_EXPECTED = "SystemAssigned";
+const IDENTITY_TYPE_SYSTEM_USER_ASSIGNED_EXPECTED = "SystemAssigned,UserAssigned";
+const validSystemAssignedManagedIdentityResource = {
+  id: `/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/resourceGroups/${RESOURCE_GROUP_EXPECTED}/providers/Azure.ResourceManager.Models.CommonTypes.ManagedIdentity/managedIdentityTrackedResources/identity`,
+  location: `${LOCATION_REGION_EXPECTED}`,
+  tags: {
+    tagKey1: "tagValue1",
+  },
+  identity: {
+    type: `${IDENTITY_TYPE_SYSTEM_ASSIGNED_EXPECTED}`,
+    principalId: `${PRINCIPAL_ID_EXPECTED}`,
+    tenantId: `${TENANT_ID_EXPECTED}`,
+  },
+  properties: {
+    provisioningState: "Succeeded",
+  },
+};
+
+const validUserAssignedAndSystemAssignedManagedIdentityResource = {
+  id: `/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/resourceGroups/${RESOURCE_GROUP_EXPECTED}/providers/Azure.ResourceManager.Models.CommonTypes.ManagedIdentity/managedIdentityTrackedResources/identity`,
+  location: `${LOCATION_REGION_EXPECTED}`,
+  tags: {
+    tagKey1: "tagValue1",
+  },
+  identity: {
+    type: `${IDENTITY_TYPE_SYSTEM_USER_ASSIGNED_EXPECTED}`,
+    userAssignedIdentities: {
+      "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1":
+        {
+          principalId: `${PRINCIPAL_ID_EXPECTED}`,
+          clientId: `${CLIENT_ID_EXPECTED}`,
+        },
+    },
+    principalId: `${PRINCIPAL_ID_EXPECTED}`,
+    tenantId: `${TENANT_ID_EXPECTED}`,
+  },
+  properties: {
+    provisioningState: "Succeeded",
+  },
+};
+
+const createExpectedIdentity = {
+  type: `${IDENTITY_TYPE_SYSTEM_ASSIGNED_EXPECTED}`,
+};
+
+const updateExpectedIdentity = {
+  type: `${IDENTITY_TYPE_SYSTEM_USER_ASSIGNED_EXPECTED}`,
+  userAssignedIdentities: {
+    "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Microsoft.ManagedIdentity/userAssignedIdentities/id1":
+      {},
+  },
+};
+
+// managed identity tracked resource
+Scenarios.Azure_ResourceManager_Models_CommonTypes_ManagedIdentity_ManagedIdentityTrackedResources_get =
+  passOnSuccess({
+    uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.CommonTypes.ManagedIdentity/managedIdentityTrackedResources/:managedIdentityResourceName",
+    method: "get",
+    request: {
+      params: {
+        subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+        resourceGroup: RESOURCE_GROUP_EXPECTED,
+        managedIdentityResourceName: "identity",
+        "api-version": "2023-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json(validSystemAssignedManagedIdentityResource),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected subscriptionId",
+          SUBSCRIPTION_ID_EXPECTED,
+          req.params.subscriptionId,
+        );
+      }
+      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected resourceGroup",
+          RESOURCE_GROUP_EXPECTED,
+          req.params.resourceGroup,
+        );
+      }
+      if (req.params.managedIdentityResourceName.toLowerCase() !== "identity") {
+        throw new ValidationError(
+          "Unexpected managed identity resource name",
+          "identity",
+          req.params.managedIdentityResourceName,
+        );
+      }
+      return {
+        status: 200,
+        body: json(validSystemAssignedManagedIdentityResource),
+      };
+    },
+    kind: "MockApiDefinition",
+  });
+
+Scenarios.Azure_ResourceManager_Models_CommonTypes_ManagedIdentity_ManagedIdentityTrackedResources_createWithSystemAssigned =
+  passOnSuccess({
+    uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.CommonTypes.ManagedIdentity/managedIdentityTrackedResources/:managedIdentityResourceName",
+    method: "put",
+    request: {
+      body: {
+        identity: createExpectedIdentity,
+      },
+      params: {
+        subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+        resourceGroup: RESOURCE_GROUP_EXPECTED,
+        managedIdentityResourceName: "identity",
+        "api-version": "2023-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json(validSystemAssignedManagedIdentityResource),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected subscriptionId",
+          SUBSCRIPTION_ID_EXPECTED,
+          req.params.subscriptionId,
+        );
+      }
+      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected resourceGroup",
+          RESOURCE_GROUP_EXPECTED,
+          req.params.resourceGroup,
+        );
+      }
+      if (req.params.managedIdentityResourceName.toLowerCase() !== "identity") {
+        throw new ValidationError(
+          "Unexpected managed identity resource name",
+          "identity",
+          req.params.managedIdentityResourceName,
+        );
+      }
+      req.expect.deepEqual(req.body["identity"], createExpectedIdentity);
+      return {
+        status: 200,
+        body: json(validSystemAssignedManagedIdentityResource),
+      };
+    },
+    kind: "MockApiDefinition",
+  });
+
+Scenarios.Azure_ResourceManager_Models_CommonTypes_ManagedIdentity_ManagedIdentityTrackedResources_updateWithUserAssignedAndSystemAssigned =
+  passOnSuccess({
+    uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.CommonTypes.ManagedIdentity/managedIdentityTrackedResources/:managedIdentityResourceName",
+    method: "patch",
+    request: {
+      body: {
+        identity: updateExpectedIdentity,
+      },
+      headers: {
+        "Content-Type": "application/merge-patch+json",
+      },
+      params: {
+        subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+        resourceGroup: RESOURCE_GROUP_EXPECTED,
+        managedIdentityResourceName: "identity",
+        "api-version": "2023-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json(validUserAssignedAndSystemAssignedManagedIdentityResource),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected subscriptionId",
+          SUBSCRIPTION_ID_EXPECTED,
+          req.params.subscriptionId,
+        );
+      }
+      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected resourceGroup",
+          RESOURCE_GROUP_EXPECTED,
+          req.params.resourceGroup,
+        );
+      }
+      if (req.params.managedIdentityResourceName.toLowerCase() !== "identity") {
+        throw new ValidationError(
+          "Unexpected managed identity resource name",
+          "identity",
+          req.params.managedIdentityResourceName,
+        );
+      }
+      req.expect.deepEqual(req.body["identity"], updateExpectedIdentity);
+      return {
+        status: 200,
+        body: json(validUserAssignedAndSystemAssignedManagedIdentityResource),
+      };
+    },
+    kind: "MockApiDefinition",
+  });

--- a/packages/azure-http-specs/specs/azure/resource-manager/models/resources/main.tsp
+++ b/packages/azure-http-specs/specs/azure/resource-manager/models/resources/main.tsp
@@ -1,0 +1,41 @@
+import "@typespec/spec-lib";
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@azure-tools/typespec-client-generator-core";
+import "./toplevel.tsp";
+import "./nested.tsp";
+import "./singleton.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.Core;
+using Azure.ResourceManager;
+using TypeSpec.OpenAPI;
+using SpecLib;
+
+@armProviderNamespace
+@service
+@versioned(Versions)
+@doc("Arm Resource Provider management API.")
+namespace Azure.ResourceManager.Models.Resources;
+
+@doc("Azure API versions.")
+enum Versions {
+  @armCommonTypesVersion(CommonTypes.Versions.v5)
+  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
+  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
+  @doc("Preview API version 2023-12-01-preview.")
+  v2023_12_01_preview: "2023-12-01-preview",
+}
+
+union ProvisioningState {
+  ResourceProvisioningState,
+  Provisioning: "Provisioning",
+  Updating: "Updating",
+  Deleting: "Deleting",
+  Accepted: "Accepted",
+}

--- a/packages/azure-http-specs/specs/azure/resource-manager/models/resources/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/models/resources/mockapi.ts
@@ -1,0 +1,880 @@
+import {
+  json,
+  MockRequest,
+  passOnSuccess,
+  ScenarioMockApi,
+  ValidationError,
+} from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+const SUBSCRIPTION_ID_EXPECTED = "00000000-0000-0000-0000-000000000000";
+const RESOURCE_GROUP_EXPECTED = "test-rg";
+const validTopLevelResource = {
+  id: `/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/resourceGroups/${RESOURCE_GROUP_EXPECTED}/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top`,
+  name: "top",
+  type: "Azure.ResourceManager.Models.Resources/topLevelTrackedResources",
+  location: "eastus",
+  properties: {
+    provisioningState: "Succeeded",
+    description: "valid",
+  },
+  systemData: {
+    createdBy: "AzureSDK",
+    createdByType: "User",
+    createdAt: "2024-10-04T00:56:07.442Z",
+    lastModifiedBy: "AzureSDK",
+    lastModifiedAt: "2024-10-04T00:56:07.442Z",
+    lastModifiedByType: "User",
+  },
+};
+
+const validNestedResource = {
+  id: `/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/resourceGroups/${RESOURCE_GROUP_EXPECTED}/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested`,
+  name: "nested",
+  type: "Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources",
+  properties: {
+    provisioningState: "Succeeded",
+    description: "valid",
+  },
+  systemData: {
+    createdBy: "AzureSDK",
+    createdByType: "User",
+    createdAt: "2024-10-04T00:56:07.442Z",
+    lastModifiedBy: "AzureSDK",
+    lastModifiedAt: "2024-10-04T00:56:07.442Z",
+    lastModifiedByType: "User",
+  },
+};
+
+const validSingletonResource = {
+  id: `/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/resourceGroups/${RESOURCE_GROUP_EXPECTED}/providers/Azure.ResourceManager.Models.Resources/singletonTrackedResources/default`,
+  name: "default",
+  type: "Azure.ResourceManager.Models.Resources/singletonTrackedResources",
+  location: "eastus",
+  properties: {
+    provisioningState: "Succeeded",
+    description: "valid",
+  },
+  systemData: {
+    createdBy: "AzureSDK",
+    createdByType: "User",
+    createdAt: "2024-10-04T00:56:07.442Z",
+    lastModifiedBy: "AzureSDK",
+    lastModifiedAt: "2024-10-04T00:56:07.442Z",
+    lastModifiedByType: "User",
+  },
+};
+
+// singleton tracked resource
+Scenarios.Azure_ResourceManager_Models_Resources_SingletonTrackedResources_getByResourceGroup =
+  passOnSuccess({
+    uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/singletonTrackedResources/default",
+    method: "get",
+    request: {
+      params: {
+        subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+        resourceGroup: RESOURCE_GROUP_EXPECTED,
+        "api-version": "2023-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json(validSingletonResource),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected subscriptionId",
+          SUBSCRIPTION_ID_EXPECTED,
+          req.params.subscriptionId,
+        );
+      }
+      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected resourceGroup",
+          RESOURCE_GROUP_EXPECTED,
+          req.params.resourceGroup,
+        );
+      }
+      return {
+        status: 200,
+        body: json(validSingletonResource),
+      };
+    },
+    kind: "MockApiDefinition",
+  });
+
+Scenarios.Azure_ResourceManager_Models_Resources_SingletonTrackedResources_createOrUpdate =
+  passOnSuccess({
+    uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/singletonTrackedResources/default",
+    method: "put",
+    request: {
+      params: {
+        subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+        resourceGroup: RESOURCE_GROUP_EXPECTED,
+        "api-version": "2023-12-01-preview",
+      },
+      body: {
+        location: "eastus",
+        properties: {
+          description: "valid",
+        },
+      },
+    },
+    response: {
+      status: 200,
+      body: json(validSingletonResource),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected subscriptionId",
+          SUBSCRIPTION_ID_EXPECTED,
+          req.params.subscriptionId,
+        );
+      }
+      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected resourceGroup",
+          RESOURCE_GROUP_EXPECTED,
+          req.params.resourceGroup,
+        );
+      }
+      req.expect.bodyEquals({
+        location: "eastus",
+        properties: {
+          description: "valid",
+        },
+      });
+      return {
+        status: 200,
+        body: json(validSingletonResource),
+      };
+    },
+    kind: "MockApiDefinition",
+  });
+
+Scenarios.Azure_ResourceManager_Models_Resources_SingletonTrackedResources_update = passOnSuccess({
+  uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/singletonTrackedResources/default",
+  method: "patch",
+  request: {
+    params: {
+      subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+      resourceGroup: RESOURCE_GROUP_EXPECTED,
+      "api-version": "2023-12-01-preview",
+    },
+    body: {
+      location: "eastus2",
+      properties: {
+        description: "valid2",
+      },
+    },
+    headers: {
+      "Content-Type": "application/merge-patch+json",
+    },
+  },
+  response: {
+    status: 200,
+    body: json({
+      ...validSingletonResource,
+      location: "eastus2",
+      properties: {
+        provisioningState: "Succeeded",
+        description: "valid2",
+      },
+    }),
+  },
+  handler: (req: MockRequest) => {
+    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+    if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+      throw new ValidationError(
+        "Unexpected subscriptionId",
+        SUBSCRIPTION_ID_EXPECTED,
+        req.params.subscriptionId,
+      );
+    }
+    if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+      throw new ValidationError(
+        "Unexpected resourceGroup",
+        RESOURCE_GROUP_EXPECTED,
+        req.params.resourceGroup,
+      );
+    }
+    req.expect.bodyEquals({
+      location: "eastus2",
+      properties: {
+        description: "valid2",
+      },
+    });
+    const resource = JSON.parse(JSON.stringify(validSingletonResource));
+    resource.location = "eastus2";
+    resource.properties.description = "valid2";
+    return {
+      status: 200,
+      body: json(resource),
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_ResourceManager_Models_Resources_SingletonTrackedResources_listByResourceGroup =
+  passOnSuccess({
+    uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/singletonTrackedResources",
+    method: "get",
+    request: {
+      params: {
+        subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+        resourceGroup: RESOURCE_GROUP_EXPECTED,
+        "api-version": "2023-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({
+        value: [validSingletonResource],
+      }),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected subscriptionId",
+          SUBSCRIPTION_ID_EXPECTED,
+          req.params.subscriptionId,
+        );
+      }
+      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected resourceGroup",
+          RESOURCE_GROUP_EXPECTED,
+          req.params.resourceGroup,
+        );
+      }
+      return {
+        status: 200,
+        body: json({
+          value: [validSingletonResource],
+        }),
+      };
+    },
+    kind: "MockApiDefinition",
+  });
+
+Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_actionSync =
+  passOnSuccess({
+    uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName/actionSync",
+    method: "post",
+    request: {
+      params: {
+        subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+        resourceGroup: RESOURCE_GROUP_EXPECTED,
+        topLevelResourceName: "top",
+        "api-version": "2023-12-01-preview",
+      },
+      body: {
+        message: "Resource action at top level.",
+        urgent: true,
+      },
+    },
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected subscriptionId",
+          SUBSCRIPTION_ID_EXPECTED,
+          req.params.subscriptionId,
+        );
+      }
+      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected resourceGroup",
+          RESOURCE_GROUP_EXPECTED,
+          req.params.resourceGroup,
+        );
+      }
+      if (req.params.topLevelResourceName.toLowerCase() !== "top") {
+        throw new ValidationError(
+          "Unexpected top level resource name",
+          "top",
+          req.params.topLevelResourceName,
+        );
+      }
+      req.expect.bodyEquals({
+        message: "Resource action at top level.",
+        urgent: true,
+      });
+      return {
+        status: 204,
+      };
+    },
+    kind: "MockApiDefinition",
+  });
+
+// top level tracked resource
+Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_get = passOnSuccess({
+  uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName",
+  method: "get",
+  request: {
+    params: {
+      subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+      resourceGroup: RESOURCE_GROUP_EXPECTED,
+      topLevelResourceName: "top",
+      "api-version": "2023-12-01-preview",
+    },
+  },
+  response: {
+    status: 200,
+    body: json(validTopLevelResource),
+  },
+  handler: (req: MockRequest) => {
+    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+    if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+      throw new ValidationError(
+        "Unexpected subscriptionId",
+        SUBSCRIPTION_ID_EXPECTED,
+        req.params.subscriptionId,
+      );
+    }
+    if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+      throw new ValidationError(
+        "Unexpected resourceGroup",
+        RESOURCE_GROUP_EXPECTED,
+        req.params.resourceGroup,
+      );
+    }
+    if (req.params.topLevelResourceName.toLowerCase() !== "top") {
+      throw new ValidationError(
+        "Unexpected top level resource name",
+        "top",
+        req.params.topLevelResourceName,
+      );
+    }
+    return {
+      status: 200,
+      body: json(validTopLevelResource),
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_createOrReplace =
+  passOnSuccess({
+    uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName",
+    method: "put",
+    request: {
+      params: {
+        subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+        resourceGroup: RESOURCE_GROUP_EXPECTED,
+        topLevelResourceName: "top",
+        "api-version": "2023-12-01-preview",
+      },
+      body: {
+        location: "eastus",
+        properties: {
+          description: "valid",
+        },
+      },
+    },
+    response: {
+      status: 200,
+      body: json(validTopLevelResource),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected subscriptionId",
+          SUBSCRIPTION_ID_EXPECTED,
+          req.params.subscriptionId,
+        );
+      }
+      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected resourceGroup",
+          RESOURCE_GROUP_EXPECTED,
+          req.params.resourceGroup,
+        );
+      }
+      if (req.params.topLevelResourceName.toLowerCase() !== "top") {
+        throw new ValidationError(
+          "Unexpected top level resource name",
+          "top",
+          req.params.topLevelResourceName,
+        );
+      }
+      req.expect.bodyEquals({
+        location: "eastus",
+        properties: {
+          description: "valid",
+        },
+      });
+      return {
+        status: 200,
+        body: json(validTopLevelResource),
+      };
+    },
+    kind: "MockApiDefinition",
+  });
+
+Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_update = passOnSuccess({
+  uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName",
+  method: "patch",
+  request: {
+    params: {
+      subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+      resourceGroup: RESOURCE_GROUP_EXPECTED,
+      topLevelResourceName: "top",
+      "api-version": "2023-12-01-preview",
+    },
+    body: {
+      properties: {
+        description: "valid2",
+      },
+    },
+    headers: {
+      "Content-Type": "application/merge-patch+json",
+    },
+  },
+  response: {
+    status: 200,
+    body: json({
+      ...validTopLevelResource,
+      properties: {
+        provisioningState: "Succeeded",
+        description: "valid2",
+      },
+    }),
+  },
+  handler: (req: MockRequest) => {
+    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+    if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+      throw new ValidationError(
+        "Unexpected subscriptionId",
+        SUBSCRIPTION_ID_EXPECTED,
+        req.params.subscriptionId,
+      );
+    }
+    if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+      throw new ValidationError(
+        "Unexpected resourceGroup",
+        RESOURCE_GROUP_EXPECTED,
+        req.params.resourceGroup,
+      );
+    }
+    if (req.params.topLevelResourceName.toLowerCase() !== "top") {
+      throw new ValidationError(
+        "Unexpected top level resource name",
+        "top",
+        req.params.topLevelResourceName,
+      );
+    }
+    req.expect.deepEqual(req.body.properties, {
+      description: "valid2",
+    });
+    const resource = JSON.parse(JSON.stringify(validTopLevelResource));
+    resource.properties.description = "valid2";
+    return {
+      status: 200,
+      body: json(resource),
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_delete = passOnSuccess({
+  uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName",
+  method: "delete",
+  request: {
+    params: {
+      subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+      resourceGroup: RESOURCE_GROUP_EXPECTED,
+      topLevelResourceName: "top",
+      "api-version": "2023-12-01-preview",
+    },
+  },
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+    if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+      throw new ValidationError(
+        "Unexpected subscriptionId",
+        SUBSCRIPTION_ID_EXPECTED,
+        req.params.subscriptionId,
+      );
+    }
+    if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+      throw new ValidationError(
+        "Unexpected resourceGroup",
+        RESOURCE_GROUP_EXPECTED,
+        req.params.resourceGroup,
+      );
+    }
+    if (req.params.topLevelResourceName.toLowerCase() !== "top") {
+      throw new ValidationError(
+        "Unexpected top level resource name",
+        "top",
+        req.params.topLevelResourceName,
+      );
+    }
+    return {
+      status: 204,
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_listByResourceGroup =
+  passOnSuccess({
+    uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources",
+    method: "get",
+    request: {
+      params: {
+        subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+        resourceGroup: RESOURCE_GROUP_EXPECTED,
+        "api-version": "2023-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({
+        value: [validTopLevelResource],
+      }),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected subscriptionId",
+          SUBSCRIPTION_ID_EXPECTED,
+          req.params.subscriptionId,
+        );
+      }
+      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected resourceGroup",
+          RESOURCE_GROUP_EXPECTED,
+          req.params.resourceGroup,
+        );
+      }
+      return {
+        status: 200,
+        body: json({
+          value: [validTopLevelResource],
+        }),
+      };
+    },
+    kind: "MockApiDefinition",
+  });
+
+Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_listBySubscription =
+  passOnSuccess({
+    uri: "/subscriptions/:subscriptionId/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources",
+    method: "get",
+    request: {
+      params: {
+        subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+        "api-version": "2023-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({
+        value: [validTopLevelResource],
+      }),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected subscriptionId",
+          SUBSCRIPTION_ID_EXPECTED,
+          req.params.subscriptionId,
+        );
+      }
+      return {
+        status: 200,
+        body: json({
+          value: [validTopLevelResource],
+        }),
+      };
+    },
+    kind: "MockApiDefinition",
+  });
+
+// nested proxy resource
+Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_get = passOnSuccess({
+  uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources/:nestedResourceName",
+  method: "get",
+  request: {
+    params: {
+      subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+      resourceGroup: RESOURCE_GROUP_EXPECTED,
+      topLevelResourceName: "top",
+      nestedResourceName: "nested",
+      "api-version": "2023-12-01-preview",
+    },
+  },
+  response: {
+    status: 200,
+    body: json(validNestedResource),
+  },
+  handler: (req: MockRequest) => {
+    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+    if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+      throw new ValidationError(
+        "Unexpected subscriptionId",
+        SUBSCRIPTION_ID_EXPECTED,
+        req.params.subscriptionId,
+      );
+    }
+    if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+      throw new ValidationError(
+        "Unexpected resourceGroup",
+        RESOURCE_GROUP_EXPECTED,
+        req.params.resourceGroup,
+      );
+    }
+    if (req.params.topLevelResourceName.toLowerCase() !== "top") {
+      throw new ValidationError(
+        "Unexpected top level resource name",
+        "top",
+        req.params.topLevelResourceName,
+      );
+    }
+    if (req.params.nestedResourceName.toLowerCase() !== "nested") {
+      throw new ValidationError(
+        "Unexpected nested resource name",
+        "nested",
+        req.params.nestedResourceName,
+      );
+    }
+    return {
+      status: 200,
+      body: json(validNestedResource),
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_createOrReplace =
+  passOnSuccess({
+    uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources/:nestedResourceName",
+    method: "put",
+    request: {
+      params: {
+        subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+        resourceGroup: RESOURCE_GROUP_EXPECTED,
+        topLevelResourceName: "top",
+        nestedResourceName: "nested",
+        "api-version": "2023-12-01-preview",
+      },
+      body: {
+        properties: {
+          description: "valid",
+        },
+      },
+    },
+    response: {
+      status: 200,
+      body: json(validNestedResource),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected subscriptionId",
+          SUBSCRIPTION_ID_EXPECTED,
+          req.params.subscriptionId,
+        );
+      }
+      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected resourceGroup",
+          RESOURCE_GROUP_EXPECTED,
+          req.params.resourceGroup,
+        );
+      }
+      if (req.params.topLevelResourceName.toLowerCase() !== "top") {
+        throw new ValidationError(
+          "Unexpected top level resource name",
+          "top",
+          req.params.topLevelResourceName,
+        );
+      }
+      if (req.params.nestedResourceName.toLowerCase() !== "nested") {
+        throw new ValidationError(
+          "Unexpected nested resource name",
+          "nested",
+          req.params.nestedResourceName,
+        );
+      }
+      req.expect.bodyEquals({
+        properties: {
+          description: "valid",
+        },
+      });
+      return {
+        status: 200,
+        body: json(validNestedResource),
+      };
+    },
+    kind: "MockApiDefinition",
+  });
+
+Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_update = passOnSuccess({
+  uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources/:nestedResourceName",
+  method: "patch",
+  request: {
+    params: {
+      subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+      resourceGroup: RESOURCE_GROUP_EXPECTED,
+      topLevelResourceName: "top",
+      nestedResourceName: "nested",
+      "api-version": "2023-12-01-preview",
+    },
+    body: {
+      properties: {
+        description: "valid2",
+      },
+    },
+    headers: {
+      "Content-Type": "application/merge-patch+json",
+    },
+  },
+  response: {
+    status: 200,
+    body: json({
+      ...validNestedResource,
+      properties: {
+        provisioningState: "Succeeded",
+        description: "valid2",
+      },
+    }),
+  },
+  handler: (req: MockRequest) => {
+    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+    if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+      throw new ValidationError(
+        "Unexpected subscriptionId",
+        SUBSCRIPTION_ID_EXPECTED,
+        req.params.subscriptionId,
+      );
+    }
+    if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+      throw new ValidationError(
+        "Unexpected resourceGroup",
+        RESOURCE_GROUP_EXPECTED,
+        req.params.resourceGroup,
+      );
+    }
+    if (req.params.topLevelResourceName.toLowerCase() !== "top") {
+      throw new ValidationError(
+        "Unexpected top level resource name",
+        "top",
+        req.params.topLevelResourceName,
+      );
+    }
+    if (req.params.nestedResourceName.toLowerCase() !== "nested") {
+      throw new ValidationError(
+        "Unexpected nested resource name",
+        "nested",
+        req.params.nestedResourceName,
+      );
+    }
+    req.expect.bodyEquals({
+      properties: {
+        description: "valid2",
+      },
+    });
+    const resource = JSON.parse(JSON.stringify(validNestedResource));
+    resource.properties.description = "valid2";
+    return {
+      status: 200,
+      body: json(resource),
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_delete = passOnSuccess({
+  uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources/:nestedResourceName",
+  method: "delete",
+  request: {
+    params: {
+      subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+      resourceGroup: RESOURCE_GROUP_EXPECTED,
+      topLevelResourceName: "top",
+      nestedResourceName: "nested",
+      "api-version": "2023-12-01-preview",
+    },
+  },
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+    return {
+      status: 204,
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_listByTopLevelTrackedResource =
+  passOnSuccess({
+    uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/:topLevelResourceName/nestedProxyResources",
+    method: "get",
+    request: {
+      params: {
+        subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+        resourceGroup: RESOURCE_GROUP_EXPECTED,
+        topLevelResourceName: "top",
+        "api-version": "2023-12-01-preview",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({
+        value: [validNestedResource],
+      }),
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
+      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected subscriptionId",
+          SUBSCRIPTION_ID_EXPECTED,
+          req.params.subscriptionId,
+        );
+      }
+      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
+        throw new ValidationError(
+          "Unexpected resourceGroup",
+          RESOURCE_GROUP_EXPECTED,
+          req.params.resourceGroup,
+        );
+      }
+      if (req.params.topLevelResourceName.toLowerCase() !== "top") {
+        throw new ValidationError(
+          "Unexpected top level resource name",
+          "top",
+          req.params.topLevelResourceName,
+        );
+      }
+      return {
+        status: 200,
+        body: json({
+          value: [validNestedResource],
+        }),
+      };
+    },
+    kind: "MockApiDefinition",
+  });

--- a/packages/azure-http-specs/specs/azure/resource-manager/models/resources/nested.tsp
+++ b/packages/azure-http-specs/specs/azure/resource-manager/models/resources/nested.tsp
@@ -1,0 +1,179 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using Azure.Core;
+using Azure.ResourceManager;
+using TypeSpec.OpenAPI;
+using SpecLib;
+
+namespace Azure.ResourceManager.Models.Resources;
+
+@doc("Nested child of Top Level Tracked Resource.")
+@parentResource(TopLevelTrackedResource)
+model NestedProxyResource is ProxyResource<NestedProxyResourceProperties> {
+  @key("nextedProxyResourceName")
+  @doc("Name of the nested resource.")
+  @visibility("read")
+  @path
+  @segment("nestedProxyResources")
+  @pattern("^[A-Za-z0-9]([A-Za-z0-9-_.]{0,62}[A-Za-z0-9])?$")
+  name: string;
+}
+
+@doc("Nested Proxy Resource Properties.")
+model NestedProxyResourceProperties {
+  @visibility("read")
+  @doc("Provisioning State of the nested child Resource")
+  provisioningState?: ProvisioningState;
+
+  @doc("Nested resource description.")
+  description?: string;
+}
+
+@armResourceOperations
+interface NestedProxyResources {
+  @scenario
+  @scenarioDoc("""
+    Resource GET operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+    Expected query parameter: api-version=2023-12-01-preview
+    
+    Expected response body:
+    ```json
+    {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
+      "name": "nested",
+      "type": "nested",
+      "properties":{
+        "description": "valid",
+        "provisioningState": "Succeeded"
+      },
+      "systemData": {
+        "createdBy": "AzureSDK",
+        "createdByType": "User",
+        "createdAt": <any date>,
+        "lastModifiedBy": "AzureSDK",
+        "lastModifiedAt": <any date>,
+        "lastModifiedByType": "User",
+      }
+    }
+    ```
+    """)
+  get is ArmResourceRead<NestedProxyResource>;
+
+  @scenario
+  @scenarioDoc("""
+    Resource PUT operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+    Expected query parameter: api-version=2023-12-01-preview
+    Expected request body:
+    ```json
+    {
+      "properties":{
+        "description": "valid"
+      }
+    }
+    ```
+    Expected response body:
+    ```json
+    {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
+      "name": "nested",
+      "type": "nested",
+      "properties":{
+        "description": "valid",
+        "provisioningState": "Succeeded"
+      },
+      "systemData": {
+        "createdBy": "AzureSDK",
+        "createdByType": "User",
+        "createdAt": <any date>,
+        "lastModifiedBy": "AzureSDK",
+        "lastModifiedAt": <any date>,
+        "lastModifiedByType": "User",
+      }
+    }
+    ```
+    """)
+  createOrReplace is ArmResourceCreateOrReplaceAsync<NestedProxyResource>;
+
+  @scenario
+  @scenarioDoc("""
+    Resource PATCH operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+    Expected query parameter: api-version=2023-12-01-preview
+    Expected request body:
+    ```json
+    {
+      "properties":{
+        "description": "valid2"
+      }
+    }
+    ```
+    Expected response body:
+    ```json
+    {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
+      "name": "nested",
+      "type": "nested",
+      "properties":{
+        "description": "valid2",
+        "provisioningState": "Succeeded"
+      },
+      "systemData": {
+        "createdBy": "AzureSDK",
+        "createdByType": "User",
+        "createdAt": <any date>,
+        "lastModifiedBy": "AzureSDK",
+        "lastModifiedAt": <any date>,
+        "lastModifiedByType": "User",
+      }
+    }
+    ```
+    """)
+  update is ArmResourcePatchAsync<NestedProxyResource, NestedProxyResourceProperties>;
+
+  @scenario
+  @scenarioDoc("""
+    Resource DELETE operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+    Expected query parameter: api-version=2023-12-01-preview
+    Expected response status code: 204
+    """)
+  delete is ArmResourceDeleteWithoutOkAsync<NestedProxyResource>;
+
+  @scenario
+  @scenarioDoc("""
+    Resource LIST by parent resource operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested
+    Expected query parameter: api-version=2023-12-01-preview
+    
+    Expected response body:
+    ```json
+    {
+      "value": [{
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/nestedProxyResources/nested",
+        "name": "nested",
+        "type": "nested",
+        "properties":{
+          "description": "valid",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "AzureSDK",
+          "createdByType": "User",
+          "createdAt": <any date>,
+          "lastModifiedBy": "AzureSDK",
+          "lastModifiedAt": <any date>,
+          "lastModifiedByType": "User",
+        }
+      }]
+    }
+    ```
+    """)
+  listByTopLevelTrackedResource is ArmResourceListByParent<NestedProxyResource>;
+}

--- a/packages/azure-http-specs/specs/azure/resource-manager/models/resources/singleton.tsp
+++ b/packages/azure-http-specs/specs/azure/resource-manager/models/resources/singleton.tsp
@@ -1,0 +1,169 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using Azure.Core;
+using Azure.ResourceManager;
+using TypeSpec.OpenAPI;
+using SpecLib;
+
+namespace Azure.ResourceManager.Models.Resources;
+
+@singleton("default")
+model SingletonTrackedResource is TrackedResource<SingletonTrackedResourceProperties> {
+  ...ResourceNameParameter<SingletonTrackedResource>;
+}
+
+@doc("Singleton Arm Resource Properties.")
+model SingletonTrackedResourceProperties {
+  @visibility("read")
+  @doc("The status of the last operation.")
+  provisioningState?: ProvisioningState;
+
+  @doc("The description of the resource.")
+  description?: string;
+}
+
+@armResourceOperations
+interface SingletonTrackedResources {
+  @scenario
+  @scenarioDoc("""
+    Resource GET operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/singletonTrackedResources/default
+    Expected query parameter: api-version=2023-12-01-preview
+    
+    Expected response body:
+    ```json
+    {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/singletonTrackedResources/default",
+      "name": "default",
+      "type": "Azure.ResourceManager.Models.Resources/singletonTrackedResources",
+      "location": "eastus",
+      "properties":{
+        "description": "valid",
+        "provisioningState": "Succeeded"
+      },
+      "systemData": {
+        "createdBy": "AzureSDK",
+        "createdByType": "User",
+        "createdAt": <any date>,
+        "lastModifiedBy": "AzureSDK",
+        "lastModifiedAt": <any date>,
+        "lastModifiedByType": "User",
+      }
+    }
+    ```
+    """)
+  getByResourceGroup is ArmResourceRead<SingletonTrackedResource>;
+
+  @scenario
+  @scenarioDoc("""
+    Resource PUT operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/singletonTrackedResources/default
+    Expected query parameter: api-version=2023-12-01-preview
+    Expected request body:
+    ```json
+    {
+      "location": "eastus",
+      "properties": {
+        "description": "valid"
+      }
+    }
+    ```
+    Expected response body:
+    ```json
+    {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/singletonTrackedResources/default",
+      "name": "default",
+      "type": "Azure.ResourceManager.Models.Resources/singletonTrackedResources",
+      "location": "eastus",
+      "properties": {
+        "description": "valid",
+        "provisioningState": "Succeeded"
+      },
+      "systemData": {
+        "createdBy": "AzureSDK",
+        "createdByType": "User",
+        "createdAt": <any date>,
+        "lastModifiedBy": "AzureSDK",
+        "lastModifiedAt": <any date>,
+        "lastModifiedByType": "User",
+      }
+    }
+    ```
+    """)
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<SingletonTrackedResource>;
+
+  @scenario
+  @scenarioDoc("""
+    Resource PATCH operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/singletonTrackedResources/default
+    Expected query parameter: api-version=2023-12-01-preview
+    Expected request body:
+    ```json
+    {
+      "location": "eastus2",
+      "properties": {
+        "description": "valid2"
+      }
+    }
+    ```
+    Expected response body:
+    ```json
+    {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/singletonTrackedResources/default",
+      "name": "default",
+      "type": "Azure.ResourceManager.Models.Resources/singletonTrackedResources",
+      "location": "eastus2",
+      "properties":{
+        "description": "valid2",
+        "provisioningState": "Succeeded"
+      },
+      "systemData": {
+        "createdBy": "AzureSDK",
+        "createdByType": "User",
+        "createdAt": <any date>,
+        "lastModifiedBy": "AzureSDK",
+        "lastModifiedAt": <any date>,
+        "lastModifiedByType": "User",
+      }
+    }
+    ```
+    """)
+  update is ArmResourcePatchSync<SingletonTrackedResource, SingletonTrackedResourceProperties>;
+
+  @scenario
+  @scenarioDoc("""
+    Resource LIST by resource group operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/singletonTrackedResources
+    Expected query parameter: api-version=2023-12-01-preview
+    
+    Expected response body:
+    ```json
+    {
+      "value": [{
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/singletonTrackedResources/default",
+        "name": "default",
+        "type": "Azure.ResourceManager.Models.Resources/singletonTrackedResources",
+        "location": "eastus",
+        "properties":{
+          "description": "valid",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "AzureSDK",
+          "createdByType": "User",
+          "createdAt": <any date>,
+          "lastModifiedBy": "AzureSDK",
+          "lastModifiedAt": <any date>,
+          "lastModifiedByType": "User",
+        }
+      }]
+    }
+    ```
+    """)
+  listByResourceGroup is ArmResourceListByParent<SingletonTrackedResource>;
+}

--- a/packages/azure-http-specs/specs/azure/resource-manager/models/resources/toplevel.tsp
+++ b/packages/azure-http-specs/specs/azure/resource-manager/models/resources/toplevel.tsp
@@ -1,0 +1,239 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using Azure.Core;
+using Azure.ResourceManager;
+using TypeSpec.OpenAPI;
+using SpecLib;
+
+namespace Azure.ResourceManager.Models.Resources;
+
+@resource("topLevelTrackedResources")
+model TopLevelTrackedResource is TrackedResource<TopLevelTrackedResourceProperties> {
+  @key("topLevelTrackedResourceName")
+  @path
+  @segment("topLevelTrackedResources")
+  @doc("arm resource name for path")
+  @pattern("^[A-Za-z0-9]([A-Za-z0-9-_.]{0,62}[A-Za-z0-9])?$")
+  name: string;
+}
+
+@doc("Top Level Arm Resource Properties.")
+model TopLevelTrackedResourceProperties {
+  @visibility("read")
+  @doc("The status of the last operation.")
+  provisioningState?: ProvisioningState;
+
+  @doc("The description of the resource.")
+  description?: string;
+}
+
+@doc("The details of a user notification.")
+model NotificationDetails {
+  @doc("The notification message.")
+  message: string;
+
+  @doc("If true, the notification is urgent.")
+  urgent: boolean;
+}
+
+@armResourceOperations
+interface TopLevelTrackedResources {
+  @scenario
+  @scenarioDoc("""
+    Resource GET operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top
+    Expected query parameter: api-version=2023-12-01-preview
+    
+    Expected response body:
+    ```json
+    {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
+      "name": "top",
+      "type": "topLevel",
+      "location": "eastus",
+      "properties":{
+        "description": "valid",
+        "provisioningState": "Succeeded"
+      },
+      "systemData": {
+        "createdBy": "AzureSDK",
+        "createdByType": "User",
+        "createdAt": <any date>,
+        "lastModifiedBy": "AzureSDK",
+        "lastModifiedAt": <any date>,
+        "lastModifiedByType": "User",
+      }
+    }
+    ```
+    """)
+  get is ArmResourceRead<TopLevelTrackedResource>;
+
+  @scenario
+  @scenarioDoc("""
+    Resource PUT operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top
+    Expected query parameter: api-version=2023-12-01-preview
+    Expected request body:
+    ```json
+    {
+      "location": "eastus",
+      "properties": {
+        "description": "valid"
+      }
+    }
+    ```
+    Expected response body:
+    ```json
+    {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
+      "name": "top",
+      "type": "topLevel",
+      "location": "eastus",
+      "properties": {
+        "description": "valid",
+        "provisioningState": "Succeeded"
+      },
+      "systemData": {
+        "createdBy": "AzureSDK",
+        "createdByType": "User",
+        "createdAt": <any date>,
+        "lastModifiedBy": "AzureSDK",
+        "lastModifiedAt": <any date>,
+        "lastModifiedByType": "User",
+      }
+    }
+    ```
+    """)
+  createOrReplace is ArmResourceCreateOrReplaceAsync<TopLevelTrackedResource>;
+
+  @scenario
+  @scenarioDoc("""
+    Resource PATCH operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top
+    Expected query parameter: api-version=2023-12-01-preview
+    Expected request body:
+    ```json
+    {
+      "properties": {
+        "description": "valid2"
+      }
+    }
+    ```
+    Expected response body:
+    ```json
+    {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
+      "name": "top",
+      "type": "topLevel",
+      "location": "eastus",
+      "properties":{
+        "description": "valid2",
+        "provisioningState": "Succeeded"
+      },
+      "systemData": {
+        "createdBy": "AzureSDK",
+        "createdByType": "User",
+        "createdAt": <any date>,
+        "lastModifiedBy": "AzureSDK",
+        "lastModifiedAt": <any date>,
+        "lastModifiedByType": "User",
+      }
+    }
+    ```
+    """)
+  update is ArmResourcePatchAsync<TopLevelTrackedResource, TopLevelTrackedResourceProperties>;
+
+  @scenario
+  @scenarioDoc("""
+    Resource DELETE operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top
+    Expected query parameter: api-version=2023-12-01-preview
+    ```
+    Expected response status code: 204
+    """)
+  delete is ArmResourceDeleteWithoutOkAsync<TopLevelTrackedResource>;
+
+  @scenario
+  @scenarioDoc("""
+    Resource LIST by resource group operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources
+    Expected query parameter: api-version=2023-12-01-preview
+    
+    Expected response body:
+    ```json
+    {
+      "value": [{
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
+        "name": "top",
+        "type": "topLevel",
+        "location": "eastus",
+        "properties":{
+          "description": "valid",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "AzureSDK",
+          "createdByType": "User",
+          "createdAt": <any date>,
+          "lastModifiedBy": "AzureSDK",
+          "lastModifiedAt": <any date>,
+          "lastModifiedByType": "User",
+        }
+      }]
+    }
+    ```
+    """)
+  listByResourceGroup is ArmResourceListByParent<TopLevelTrackedResource>;
+
+  @scenario
+  @scenarioDoc("""
+    Resource LIST by subscription operation.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources
+    Expected query parameter: api-version=2023-12-01-preview
+    
+    Expected response body:
+    ```json
+    {
+      "value": [{
+        "id": "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top",
+        "name": "top",
+        "type": "topLevel",
+        "location": "eastus",
+        "properties":{
+          "description": "valid",
+          "provisioningState": "Succeeded"
+        },
+        "systemData": {
+          "createdBy": "AzureSDK",
+          "createdByType": "User",
+          "createdAt": <any date>,
+          "lastModifiedBy": "AzureSDK",
+          "lastModifiedAt": <any date>,
+          "lastModifiedByType": "User",
+        }
+      }]
+    }
+    ```
+    """)
+  listBySubscription is ArmListBySubscription<TopLevelTrackedResource>;
+
+  @scenario
+  @scenarioDoc("""
+      Resource sync action.
+      Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.Models.Resources/topLevelTrackedResources/top/actionSync
+      Expected query parameter: api-version=2023-12-01-preview
+      Expected request body:
+      ```json
+      {
+        "message": "Resource action at top level.",
+        "urgent": true
+      }
+      ```
+    """)
+  actionSync is ArmResourceActionNoContentSync<TopLevelTrackedResource, NotificationDetails>;
+}

--- a/packages/azure-http-specs/specs/azure/special-headers/client-request-id/main.tsp
+++ b/packages/azure-http-specs/specs/azure/special-headers/client-request-id/main.tsp
@@ -1,0 +1,29 @@
+import "@typespec/http";
+import "@typespec/spec-lib";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+using SpecLib;
+
+@doc("Azure client request id header configurations.")
+@scenarioService("/azure/special-headers/x-ms-client-request-id")
+@scenario
+@scenarioDoc("""
+  Test case for azure client request id header. SDK should not generate `clientRequestId` paramerter but use policy to auto-set the header.
+  Expected header parameters:
+  - x-ms-client-request-id=<any uuid string>
+  Expected response header:
+  - x-ms-client-request-id=<uuid string same with request header>
+  """)
+namespace Azure.SpecialHeaders.XmsClientRequestId;
+
+@doc("""
+  Get operation with azure `x-ms-client-request-id` header.
+  """)
+@get
+@route("/")
+op get(
+  @header("x-ms-client-request-id")
+  clientRequestId?: string,
+): NoContentResponse;

--- a/packages/azure-http-specs/specs/azure/special-headers/client-request-id/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/special-headers/client-request-id/mockapi.ts
@@ -1,0 +1,34 @@
+import {
+  MockRequest,
+  passOnSuccess,
+  ScenarioMockApi,
+  validateValueFormat,
+} from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Azure_SpecialHeaders_XmsClientRequestId = passOnSuccess({
+  uri: "/azure/special-headers/x-ms-client-request-id",
+  method: "get",
+  request: {
+    headers: {
+      "x-ms-client-request-id": "123e4567-e89b-12d3-a456-426614174000",
+    },
+  },
+  response: {
+    status: 204,
+    headers: {
+      "x-ms-client-request-id": "123e4567-e89b-12d3-a456-426614174000",
+    },
+  },
+  handler: (req: MockRequest) => {
+    validateValueFormat(req.headers["x-ms-client-request-id"], "uuid");
+    return {
+      status: 204,
+      headers: {
+        ["x-ms-client-request-id"]: req.headers["x-ms-client-request-id"],
+      },
+    };
+  },
+  kind: "MockApiDefinition",
+});

--- a/packages/azure-http-specs/specs/client/naming/main.tsp
+++ b/packages/azure-http-specs/specs/client/naming/main.tsp
@@ -1,0 +1,241 @@
+import "@typespec/http";
+import "@typespec/spec-lib";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+using SpecLib;
+
+/**
+ * Describe changing names of types in a client with `@clientName`
+ */
+@scenarioService("/client/naming")
+namespace Client.Naming;
+
+@route("/property")
+namespace Property {
+  model LanguageClientNameModel {
+    @doc("Pass in true")
+    @clientName("CSName", "csharp")
+    @clientName("GoName", "go")
+    @clientName("JavaName", "java")
+    @clientName("TSName", "javascript")
+    @clientName("python_name", "python")
+    defaultName: boolean;
+  }
+
+  model ClientNameModel {
+    @doc("Pass in true")
+    @clientName("clientName")
+    defaultName: boolean;
+  }
+
+  model ClientNameAndJsonEncodedNameModel {
+    @doc("Pass in true")
+    @clientName("clientName")
+    @encodedName("application/json", "wireName")
+    defaultName: boolean;
+  }
+
+  @scenario
+  @scenarioDoc("""
+    Testing that we can project the client name in our generated SDKs.
+    Your generated SDK should generate ClientNameModel with one property `clientName` with wire name `defaultName`.
+    
+    Expected request body:
+    ```json
+    {"defaultName": true}
+    ```
+    """)
+  @route("/client")
+  @post
+  op client(@body body: ClientNameModel): NoContentResponse;
+
+  @scenario
+  @scenarioDoc("""
+    Testing that we can project the language specific name in our generated SDKs.
+    Your generated SDK should generate LanguageClientNameModel with one property with your language specific property name and wire name `defaultName`.
+    
+    Expected request body:
+    ```json
+    {"defaultName": true}
+    ```
+    """)
+  @route("/language")
+  @post
+  op language(@body body: LanguageClientNameModel): NoContentResponse;
+
+  @scenario
+  @scenarioDoc("""
+    Testing that we can project the client name and the wire name.
+    Your generated SDK should generate ClientNameAndJsonEncodedNameModel with one property with client name `clientName` and wire name `wireName`.
+    
+    Expected request body:
+    ```json
+    {"wireName": true}
+    ```
+    """)
+  @route("/compatible-with-encoded-name")
+  @post
+  op compatibleWithEncodedName(@body body: ClientNameAndJsonEncodedNameModel): NoContentResponse;
+}
+
+@scenario
+@scenarioDoc("""
+  Testing that we can project the operation name.
+  Your generated SDK should generate an operation called `clientName`.
+  
+  Expected status code: 204
+  """)
+@route("/operation")
+@clientName("clientName")
+@post
+op operation(): NoContentResponse;
+
+@scenario
+@scenarioDoc("""
+  Testing that we can project a parameter name.
+  Your generated SDK should generate an operation `parameter` with a single parameter called `clientName`.
+  
+  Expected query parameter: `defaultName="true"`
+  
+  """)
+@route("/parameter")
+@post
+op parameter(
+  @clientName("clientName")
+  @query
+  defaultName: string,
+): NoContentResponse;
+
+@route("/header")
+namespace Header {
+  @scenario
+  @scenarioDoc("""
+    Testing that we can project a header name.
+    Your generated SDK should generate an operation header `parameter` with a single parameter called `clientName`.
+    
+    Expected header parameter: `default-name="true"`
+    """)
+  @post
+  op request(
+    @clientName("clientName")
+    @header
+    `default-name`: string,
+  ): void;
+
+  @scenario
+  @scenarioDoc("""
+    Testing that we can project a header name.
+    Your generated SDK should generate an operation header `parameter` with a single parameter called `clientName`.
+    
+    Expected response header: `default-name="true"`
+    """)
+  @get
+  op response(): {
+    @statusCode _: 204;
+
+    @clientName("clientName")
+    @header
+    `default-name`: string;
+  };
+}
+
+@route("/model")
+@operationGroup
+@clientName("ClientModel")
+namespace Model {
+  @clientName("CSModel", "csharp")
+  @clientName("GoModel", "go")
+  @clientName("JavaModel", "java")
+  @clientName("TSModel", "javascript")
+  @clientName("PythonModel", "python")
+  model ModelWithLanguageClientName {
+    @doc("Pass in true")
+    defaultName: boolean;
+  }
+
+  @clientName("ClientModel")
+  model ModelWithClientClientName {
+    @doc("Pass in true")
+    defaultName: boolean;
+  }
+
+  @scenario
+  @scenarioDoc("""
+    Testing that we can project the client name in our generated SDKs.
+    Your generated SDK should generate the model with name `ClientModel`.
+    
+    Expected request body:
+    ```json
+    {"defaultName": true}
+    ```
+    """)
+  @route("/client")
+  @post
+  op client(@bodyRoot body: ModelWithClientClientName): NoContentResponse;
+
+  @scenario
+  @scenarioDoc("""
+    Testing that we can project the language specific name in our generated SDKs.
+    Your generated SDK should generate the model with your language specific model name.
+    
+    Expected request body:
+    ```json
+    {"defaultName": true}
+    ```
+    """)
+  @route("/language")
+  @post
+  op language(@bodyRoot body: ModelWithLanguageClientName): NoContentResponse;
+}
+
+@operationGroup
+@route("/union-enum")
+namespace UnionEnum {
+  @clientName("ClientExtensibleEnum")
+  union ServerExtensibleEnum {
+    string,
+    EnumValue1: "value1",
+  }
+
+  union ExtensibleEnum {
+    string,
+
+    @clientName("ClientEnumValue1")
+    EnumValue1: "value1",
+
+    @clientName("ClientEnumValue2")
+    "value2",
+  }
+
+  @scenario
+  @scenarioDoc("""
+      Testing that we can project a enum name and enum value name.
+      Your generated SDK should generate an Enum "ClientExtensibleEnum".
+      (The exact name may depend on language convention)
+    
+      Expected request body:
+      ```json
+      "value1"
+      ```
+    """)
+  @route("/union-enum-name")
+  @post
+  op unionEnumName(@body body: ServerExtensibleEnum): NoContentResponse;
+
+  @scenario
+  @scenarioDoc("""
+      Testing that we can project a enum name and enum value name.
+      Your generated SDK should generate an Enum with members "ClientEnumValue1", "ClientEnumValue2".
+      (The exact name may depend on language convention)
+    
+      Expected request body:
+      ```json
+      "value1"
+      ```
+    """)
+  @route("/union-enum-member-name")
+  @post
+  op unionEnumMemberName(@body body: ExtensibleEnum): NoContentResponse;
+}

--- a/packages/azure-http-specs/specs/client/naming/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/naming/mockapi.ts
@@ -1,0 +1,207 @@
+import { MockRequest, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Client_Naming_Property_client = passOnSuccess({
+  uri: "/client/naming/property/client",
+  method: "post",
+  request: {
+    body: { defaultName: true },
+  },
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    req.expect.bodyEquals({ defaultName: true });
+    return {
+      status: 204,
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Client_Naming_Property_language = passOnSuccess({
+  uri: "/client/naming/property/language",
+  method: "post",
+  request: {
+    body: { defaultName: true },
+  },
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    req.expect.bodyEquals({ defaultName: true });
+    return {
+      status: 204,
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Client_Naming_Property_compatibleWithEncodedName = passOnSuccess({
+  uri: `/client/naming/property/compatible-with-encoded-name`,
+  method: "post",
+  request: {
+    body: { wireName: true },
+  },
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    req.expect.bodyEquals({ wireName: true });
+    return {
+      status: 204,
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Client_Naming_operation = passOnSuccess({
+  uri: `/client/naming/operation`,
+  method: "post",
+  request: {},
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    return {
+      status: 204,
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Client_Naming_parameter = passOnSuccess({
+  uri: `/client/naming/parameter`,
+  method: "post",
+  request: {
+    params: { defaultName: "true" },
+  },
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    req.expect.containsQueryParam("defaultName", "true");
+    return {
+      status: 204,
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Client_Naming_Header_request = passOnSuccess({
+  uri: `/client/naming/header`,
+  method: "post",
+  request: {
+    headers: { "default-name": "true" },
+  },
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    req.expect.containsHeader("default-name", "true");
+    return {
+      status: 204,
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Client_Naming_Header_response = passOnSuccess({
+  uri: `/client/naming/header`,
+  method: "get",
+  request: {},
+  response: {
+    status: 204,
+    headers: {
+      "default-name": "true",
+    },
+  },
+  handler: (req: MockRequest) => {
+    return {
+      status: 204,
+      headers: {
+        "default-name": "true",
+      },
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Client_Naming_Model_client = passOnSuccess({
+  uri: `/client/naming/model/client`,
+  method: "post",
+  request: {
+    body: { defaultName: true },
+  },
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    req.expect.bodyEquals({ defaultName: true });
+    return {
+      status: 204,
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Client_Naming_Model_language = passOnSuccess({
+  uri: `/client/naming/model/language`,
+  method: "post",
+  request: {
+    body: { defaultName: true },
+  },
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    req.expect.bodyEquals({ defaultName: true });
+    return {
+      status: 204,
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Client_Naming_UnionEnum_unionEnumName = passOnSuccess({
+  uri: `/client/naming/union-enum/union-enum-name`,
+  method: "post",
+  request: {
+    body: "value1",
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  },
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    req.expect.bodyEquals("value1");
+    return {
+      status: 204,
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Client_Naming_UnionEnum_unionEnumMemberName = passOnSuccess({
+  uri: `/client/naming/union-enum/union-enum-member-name`,
+  method: "post",
+  request: {
+    body: "value1",
+    headers: {
+      "Content-Type": "text/plain",
+    },
+  },
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    req.expect.bodyEquals("value1");
+    return {
+      status: 204,
+    };
+  },
+  kind: "MockApiDefinition",
+});

--- a/packages/azure-http-specs/specs/client/structure/client-operation-group/client.tsp
+++ b/packages/azure-http-specs/specs/client/structure/client-operation-group/client.tsp
@@ -1,0 +1,76 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+import "@typespec/spec-lib";
+
+using Azure.ClientGenerator.Core;
+using SpecLib;
+
+@scenarioDoc("""
+  This is to show we can have multiple clients, with multiple operation groups in each client.
+  
+  ```ts
+  const client1 = new FirstClient("client-operation-group");
+  
+  client1.one();
+  
+  client1.group3.two();
+  client1.group3.three();
+  
+  client1.group4.four();
+  ```
+  """)
+@scenario
+@client({
+  name: "FirstClient",
+  service: Client.Structure.Service,
+})
+namespace Client.Structure.ClientOperationGroup {
+  op one is Client.Structure.Service.one;
+
+  @operationGroup
+  interface Group3 {
+    two is Client.Structure.Service.two;
+    three is Client.Structure.Service.Foo.three;
+  }
+
+  @operationGroup
+  interface Group4 {
+    four is Client.Structure.Service.Foo.four;
+  }
+}
+
+@scenarioDoc("""
+  This is to show we can have multiple clients, with multiple operation groups in each client.
+  The client and its operation groups can be moved to a sub namespace/package.
+  
+  ```ts
+  const client2 = new SubNamespace.SecondClient("client-operation-group");
+  
+  client2.five();
+  client2.group5.six();
+  ```
+  """)
+@scenario
+@client(
+  {
+    name: "SubNamespace.SecondClient",
+    service: Client.Structure.Service,
+  },
+  "csharp,java,python"
+)
+@client(
+  {
+    name: "SecondClient",
+    service: Client.Structure.Service,
+  },
+  "javascript,go"
+)
+namespace Client.Structure.AnotherClientOperationGroup {
+  op five is Client.Structure.Service.Bar.five;
+
+  #suppress "@azure-tools/typespec-client-generator-core/client-service" "issue https://github.com/Azure/typespec-azure/issues/1326"
+  @operationGroup
+  interface Group5 {
+    six is Client.Structure.Service.Bar.six;
+  }
+}

--- a/packages/azure-http-specs/specs/client/structure/client-operation-group/main.tsp
+++ b/packages/azure-http-specs/specs/client/structure/client-operation-group/main.tsp
@@ -1,0 +1,5 @@
+/**
+ * DO NOT GENERATE FROM THIS FILE USE client.tsp
+ * This is just to simulate a service entrypoint
+ */
+import "../common/service.tsp";

--- a/packages/azure-http-specs/specs/client/structure/client-operation-group/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/structure/client-operation-group/mockapi.ts
@@ -1,0 +1,16 @@
+import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { createServerTests } from "../common/service.js";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Client_Structure_ClientOperationGroup = passOnSuccess([
+  createServerTests("/client/structure/client-operation-group/one"),
+  createServerTests("/client/structure/client-operation-group/two"),
+  createServerTests("/client/structure/client-operation-group/three"),
+  createServerTests("/client/structure/client-operation-group/four"),
+]);
+
+Scenarios.Client_Structure_AnotherClientOperationGroup = passOnSuccess([
+  createServerTests("/client/structure/client-operation-group/five"),
+  createServerTests("/client/structure/client-operation-group/six"),
+]);

--- a/packages/azure-http-specs/specs/client/structure/common/service.ts
+++ b/packages/azure-http-specs/specs/client/structure/common/service.ts
@@ -1,0 +1,14 @@
+import { MockApiDefinition, MockRequest } from "@typespec/spec-api";
+
+export function createServerTests(uri: string): MockApiDefinition {
+  return {
+    uri: uri,
+    method: "post",
+    request: {},
+    response: { status: 204 },
+    handler: (req: MockRequest) => {
+      return { status: 204 };
+    },
+    kind: "MockApiDefinition",
+  };
+}

--- a/packages/azure-http-specs/specs/client/structure/common/service.tsp
+++ b/packages/azure-http-specs/specs/client/structure/common/service.tsp
@@ -1,0 +1,97 @@
+import "@typespec/rest";
+import "@azure-tools/typespec-client-generator-core";
+import "@typespec/spec-lib";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using Azure.ClientGenerator;
+using Azure.ClientGenerator.Core;
+
+@doc("""
+  Test that we can use @client and @operationGroup decorators to customize client side code structure, such as:
+  1. have everything as default.
+  2. to rename client or operation group
+  3. one client can have more than one operations groups
+  4. split one interface into two clients
+  5. have two clients with operations come from different interfaces
+  6. have two clients with a hierarchy relation.
+  """)
+@server(
+  "{endpoint}/client/structure/{client}",
+  "",
+  {
+    @doc("Need to be set as 'http://localhost:3000' in client.")
+    endpoint: url,
+
+    @doc("Need to be set as 'default', 'multi-client', 'renamed-operation', 'two-operation-group' in client.")
+    client: ClientType,
+  }
+)
+@service({
+  title: "MultiClient",
+})
+namespace Client.Structure.Service;
+
+enum ClientType {
+  Default: "default",
+  MultiClient: "multi-client",
+  RenamedOperation: "renamed-operation",
+  TwoOperationGroup: "two-operation-group",
+  ClientOperationGroup: "client-operation-group",
+}
+
+#suppress "@typespec/spec-lib/missing-scenario" "This is by design those operations get defined as scenarios in the client"
+@route("/one")
+@post
+op one(): void;
+
+#suppress "@typespec/spec-lib/missing-scenario" "This is by design those operations get defined as scenarios in the client"
+@route("/two")
+@post
+op two(): void;
+
+interface Foo {
+  #suppress "@typespec/spec-lib/missing-scenario" "This is by design those operations get defined as scenarios in the client"
+  @route("/three")
+  @post
+  three(): void;
+
+  #suppress "@typespec/spec-lib/missing-scenario" "This is by design those operations get defined as scenarios in the client"
+  @route("/four")
+  @post
+  four(): void;
+}
+
+interface Bar {
+  #suppress "@typespec/spec-lib/missing-scenario" "This is by design those operations get defined as scenarios in the client"
+  @route("/five")
+  @post
+  five(): void;
+  #suppress "@typespec/spec-lib/missing-scenario" "This is by design those operations get defined as scenarios in the client"
+  @route("/six")
+  @post
+  six(): void;
+}
+
+namespace Baz {
+  interface Foo {
+    #suppress "@typespec/spec-lib/missing-scenario" "This is by design those operations get defined as scenarios in the client"
+    @route("/seven")
+    @post
+    seven(): void;
+  }
+}
+
+namespace Qux {
+  #suppress "@typespec/spec-lib/missing-scenario" "This is by design those operations get defined as scenarios in the client"
+  @route("/eight")
+  @post
+  op eight(): void;
+
+  interface Bar {
+    #suppress "@typespec/spec-lib/missing-scenario" "This is by design those operations get defined as scenarios in the client"
+    @route("/nine")
+    @post
+    nine(): void;
+  }
+}

--- a/packages/azure-http-specs/specs/client/structure/default/client.tsp
+++ b/packages/azure-http-specs/specs/client/structure/default/client.tsp
@@ -1,0 +1,24 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+import "@typespec/spec-lib";
+
+using SpecLib;
+
+@@scenario(Client.Structure.Service);
+@@scenarioDoc(Client.Structure.Service,
+  """
+    This is to show that if we don't do any customization. The client side should be able to call the api like
+    ```ts
+    const client = new ServiceClient("default");
+    client.one();
+    client.two();
+    client.foo.three();
+    client.foo.four();
+    client.bar.five();
+    client.bar.six();
+    client.baz.foo.seven();
+    client.qux.eight();
+    client.qux.bar.nine();
+    ```
+    """
+);

--- a/packages/azure-http-specs/specs/client/structure/default/main.tsp
+++ b/packages/azure-http-specs/specs/client/structure/default/main.tsp
@@ -1,0 +1,5 @@
+/**
+ * DO NOT GENERATE FROM THIS FILE USE client.tsp
+ * This is just to simulate a service entrypoint
+ */
+import "../common/service.tsp";

--- a/packages/azure-http-specs/specs/client/structure/default/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/structure/default/mockapi.ts
@@ -1,0 +1,16 @@
+import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { createServerTests } from "../common/service.js";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Client_Structure_Service = passOnSuccess([
+  createServerTests("/client/structure/default/one"),
+  createServerTests("/client/structure/default/two"),
+  createServerTests("/client/structure/default/three"),
+  createServerTests("/client/structure/default/four"),
+  createServerTests("/client/structure/default/five"),
+  createServerTests("/client/structure/default/six"),
+  createServerTests("/client/structure/default/seven"),
+  createServerTests("/client/structure/default/eight"),
+  createServerTests("/client/structure/default/nine"),
+]);

--- a/packages/azure-http-specs/specs/client/structure/multi-client/client.tsp
+++ b/packages/azure-http-specs/specs/client/structure/multi-client/client.tsp
@@ -1,0 +1,44 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+import "@typespec/spec-lib";
+
+using Azure.ClientGenerator.Core;
+using SpecLib;
+
+@scenarioDoc("""
+  Include multiple clients in the same spec.
+  ```ts
+  const clientA = new ClientAClient("multi-client");
+  const clientB = new ClientBClient("multi-client");
+  
+  clientA.renamedOne();
+  clientA.renamedThree();
+  clientA.renamedFive();
+  
+  clientB.renamedTwo();
+  clientB.renamedFour();
+  clientB.renamedSix();
+  ```
+  """)
+@scenario
+namespace Client.Structure.MultiClient;
+
+@client({
+  name: "ClientAClient",
+  service: Client.Structure.Service,
+})
+interface ClientA {
+  renamedOne is Client.Structure.Service.one;
+  renamedThree is Client.Structure.Service.Foo.three;
+  renamedFive is Client.Structure.Service.Bar.five;
+}
+
+@client({
+  name: "ClientBClient",
+  service: Client.Structure.Service,
+})
+interface ClientB {
+  renamedTwo is Client.Structure.Service.two;
+  renamedFour is Client.Structure.Service.Foo.four;
+  renamedSix is Client.Structure.Service.Bar.six;
+}

--- a/packages/azure-http-specs/specs/client/structure/multi-client/main.tsp
+++ b/packages/azure-http-specs/specs/client/structure/multi-client/main.tsp
@@ -1,0 +1,5 @@
+/**
+ * DO NOT GENERATE FROM THIS FILE USE client.tsp
+ * This is just to simulate a service entrypoint
+ */
+import "../common/service.tsp";

--- a/packages/azure-http-specs/specs/client/structure/multi-client/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/structure/multi-client/mockapi.ts
@@ -1,0 +1,13 @@
+import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { createServerTests } from "../common/service.js";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Client_Structure_MultiClient = passOnSuccess([
+  createServerTests("/client/structure/multi-client/one"),
+  createServerTests("/client/structure/multi-client/two"),
+  createServerTests("/client/structure/multi-client/three"),
+  createServerTests("/client/structure/multi-client/four"),
+  createServerTests("/client/structure/multi-client/five"),
+  createServerTests("/client/structure/multi-client/six"),
+]);

--- a/packages/azure-http-specs/specs/client/structure/renamed-operation/client.tsp
+++ b/packages/azure-http-specs/specs/client/structure/renamed-operation/client.tsp
@@ -1,0 +1,40 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+import "@typespec/spec-lib";
+
+using Azure.ClientGenerator.Core;
+using SpecLib;
+
+@scenarioDoc("""
+  This is to show we can have more than one operation group in a client. The client side should be able to call the api like
+  ```ts
+  const client = new RenamedOperationClient("renamed-operation");
+  
+  client.renamedOne();
+  client.renamedThree();
+  client.renamedFive();
+  
+  client.group.renamedTwo();
+  client.group.renamedFour();
+  client.group.renamedSix();
+  ```
+  """)
+@client({
+  name: "RenamedOperationClient",
+  service: Client.Structure.Service,
+})
+@scenario
+namespace Client.Structure.RenamedOperation;
+
+// Those operations are renamed at the root
+op renamedOne is Client.Structure.Service.one;
+op renamedThree is Client.Structure.Service.Foo.three;
+op renamedFive is Client.Structure.Service.Bar.five;
+
+// Those operations are renamed inside an operation group
+@operationGroup
+interface Group {
+  renamedTwo is Client.Structure.Service.two;
+  renamedFour is Client.Structure.Service.Foo.four;
+  renamedSix is Client.Structure.Service.Bar.six;
+}

--- a/packages/azure-http-specs/specs/client/structure/renamed-operation/main.tsp
+++ b/packages/azure-http-specs/specs/client/structure/renamed-operation/main.tsp
@@ -1,0 +1,5 @@
+/**
+ * DO NOT GENERATE FROM THIS FILE USE client.tsp
+ * This is just to simulate a service entrypoint
+ */
+import "../common/service.tsp";

--- a/packages/azure-http-specs/specs/client/structure/renamed-operation/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/structure/renamed-operation/mockapi.ts
@@ -1,0 +1,13 @@
+import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { createServerTests } from "../common/service.js";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Client_Structure_RenamedOperation = passOnSuccess([
+  createServerTests("/client/structure/renamed-operation/one"),
+  createServerTests("/client/structure/renamed-operation/two"),
+  createServerTests("/client/structure/renamed-operation/three"),
+  createServerTests("/client/structure/renamed-operation/four"),
+  createServerTests("/client/structure/renamed-operation/five"),
+  createServerTests("/client/structure/renamed-operation/six"),
+]);

--- a/packages/azure-http-specs/specs/client/structure/two-operation-group/client.tsp
+++ b/packages/azure-http-specs/specs/client/structure/two-operation-group/client.tsp
@@ -1,0 +1,42 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+import "@typespec/spec-lib";
+
+using Azure.ClientGenerator.Core;
+using SpecLib;
+
+@scenarioDoc("""
+  This is to show we can have more than one operation group in a client. The client side should be able to call the api like
+  
+  ```ts
+  const client = new TwoOperationGroupClient("two-operation-group");
+  
+  client.group1.one();
+  client.group1.three();
+  client.group1.four();
+  
+  client.group2.two();
+  client.group2.five();
+  client.group2.six();
+  ```
+  """)
+@client({
+  name: "TwoOperationGroupClient",
+  service: Client.Structure.Service,
+})
+@scenario
+namespace Client.Structure.TwoOperationGroup;
+
+@operationGroup
+interface Group1 {
+  one is Client.Structure.Service.one;
+  three is Client.Structure.Service.Foo.three;
+  four is Client.Structure.Service.Foo.four;
+}
+
+@operationGroup
+interface Group2 {
+  two is Client.Structure.Service.two;
+  five is Client.Structure.Service.Bar.five;
+  six is Client.Structure.Service.Bar.six;
+}

--- a/packages/azure-http-specs/specs/client/structure/two-operation-group/main.tsp
+++ b/packages/azure-http-specs/specs/client/structure/two-operation-group/main.tsp
@@ -1,0 +1,5 @@
+/**
+ * DO NOT GENERATE FROM THIS FILE USE client.tsp
+ * This is just to simulate a service entrypoint
+ */
+import "../common/service.tsp";

--- a/packages/azure-http-specs/specs/client/structure/two-operation-group/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/structure/two-operation-group/mockapi.ts
@@ -1,0 +1,13 @@
+import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { createServerTests } from "../common/service.js";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Client_Structure_TwoOperationGroup = passOnSuccess([
+  createServerTests("/client/structure/two-operation-group/one"),
+  createServerTests("/client/structure/two-operation-group/two"),
+  createServerTests("/client/structure/two-operation-group/three"),
+  createServerTests("/client/structure/two-operation-group/four"),
+  createServerTests("/client/structure/two-operation-group/five"),
+  createServerTests("/client/structure/two-operation-group/six"),
+]);

--- a/packages/azure-http-specs/specs/payload/pageable/main.tsp
+++ b/packages/azure-http-specs/specs/payload/pageable/main.tsp
@@ -1,0 +1,63 @@
+import "@typespec/spec-lib";
+import "@azure-tools/typespec-azure-core";
+import "@typespec/versioning";
+
+using TypeSpec.Versioning;
+using Azure.Core;
+using SpecLib;
+
+@doc("Test describing pageable.")
+@scenarioService("/payload/pageable")
+@useDependency(global.Azure.Core.Versions.v1_0_Preview_2)
+namespace Payload.Pageable;
+
+@doc("User model")
+model User {
+  @doc("User name")
+  name: string;
+}
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "For testing pageable"
+@scenario
+@scenarioDoc("""
+  List users.
+  
+  SDK may hide the "maxpagesize" from API signature. The functionality of "maxpagesize" could be in related language Page model.
+  
+  Expected query parameter:
+  maxpagesize=3
+  
+  Expected response body:
+  ```json
+  {
+    "value":[
+      {
+        "name":"user5"
+      },
+      {
+        "name":"user6"
+      },
+      {
+        "name":"user7"
+      }
+    ],
+    "nextLink": "{endpoint}/payload/pageable?skipToken=name-user7&maxpagesize=3"
+  }
+  ```
+  
+  Expected query parameter:
+  skipToken=name-user7
+  maxpagesize=3
+  
+  ```json
+  {
+    "value":[
+      {
+        "name":"user8"
+      }
+    ]
+  }
+  ```
+  """)
+@doc("List users")
+op list(...MaxPageSizeQueryParameter): Page<User>;

--- a/packages/azure-http-specs/specs/payload/pageable/mockapi.ts
+++ b/packages/azure-http-specs/specs/payload/pageable/mockapi.ts
@@ -1,0 +1,73 @@
+import {
+  json,
+  MockRequest,
+  ScenarioMockApi,
+  ValidationError,
+  withServiceKeys,
+} from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+function pageableHandler(req: MockRequest) {
+  req.expect.containsQueryParam("maxpagesize", "3");
+  const skipToken = req.query["skipToken"];
+  if (skipToken === undefined) {
+    return {
+      pass: "firstPage",
+      status: 200,
+      body: json({
+        value: [{ name: "user5" }, { name: "user6" }, { name: "user7" }],
+        nextLink: `${req.baseUrl}/payload/pageable?skipToken=name-user7&maxpagesize=3`,
+      }),
+    } as const;
+  } else if (skipToken === "name-user7") {
+    return {
+      pass: "secondPage",
+      status: 200,
+      body: json({ value: [{ name: "user8" }] }),
+    } as const;
+  } else {
+    throw new ValidationError(
+      "Unsupported skipToken query parameter",
+      `Not provided for first page, "name-user7" for second page`,
+      req.query["skipToken"],
+    );
+  }
+}
+
+Scenarios.Payload_Pageable_list = withServiceKeys(["firstPage", "secondPage"]).pass([
+  {
+    uri: "/payload/pageable",
+    method: "get",
+    request: {
+      params: {
+        maxpagesize: "3",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({
+        value: [{ name: "user5" }, { name: "user6" }, { name: "user7" }],
+        nextLink: `/payload/pageable?skipToken=name-user7&maxpagesize=3`,
+      }),
+    },
+    handler: pageableHandler,
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/payload/pageable",
+    method: "get",
+    request: {
+      params: {
+        maxpagesize: "3",
+        skipToken: "name-user7",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({ value: [{ name: "user8" }] }),
+    },
+    handler: pageableHandler,
+    kind: "MockApiDefinition",
+  },
+]);

--- a/packages/azure-http-specs/specs/resiliency/srv-driven/main.tsp
+++ b/packages/azure-http-specs/specs/resiliency/srv-driven/main.tsp
@@ -1,0 +1,170 @@
+import "@typespec/http";
+import "@typespec/versioning";
+import "@typespec/spec-lib";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Versioning;
+using Azure.ClientGenerator.Core;
+using TypeSpec.Http;
+using SpecLib;
+
+@versioned(Versions)
+@doc("""
+  Test that we can grow up a service spec and service deployment into a multi-versioned service with full client support.
+  
+  There are three concepts that should be clarified:
+  1. Client spec version: refers to the spec that the client is generated from. 'v1' is a client generated from old.tsp and 'v2' is a client generated from main.tsp.
+  2. Service deployment version: refers to a deployment version of the service. 'v1' represents the initial deployment of the service with a single api version. 'v2' represents the new deployment of a service with multiple api versions
+  3. Api version: The initial deployment of the service only supports api version 'v1'. The new deployment of the service supports api versions 'v1' and 'v2'.
+  
+  We test the following configurations from this service spec:
+  - A client generated from the second service spec can call the second deployment of a service with api version v1
+  - A client generated from the second service spec can call the second deployment of a service with api version v2
+  """)
+@client({
+  name: "ResiliencyServiceDrivenClient",
+})
+@service
+@server(
+  "{endpoint}/resiliency/service-driven/client:v2/service:{serviceDeploymentVersion}/api-version:{apiVersion}",
+  "Testserver endpoint",
+  {
+    @doc("Need to be set as 'http://localhost:3000' in client.")
+    endpoint: url,
+
+    @doc("Pass in either 'v1' or 'v2'. This represents a version of the service deployment in history. 'v1' is for the deployment when the service had only one api version. 'v2' is for the deployment when the service had api-versions 'v1' and 'v2'.")
+    serviceDeploymentVersion: string,
+
+    @doc("Pass in either 'v1' or 'v2'. This represents the API version of a service.")
+    apiVersion: string,
+  }
+)
+namespace Resiliency.ServiceDriven;
+
+@doc("Service versions")
+enum Versions {
+  @doc("Version 1")
+  v1,
+
+  @doc("Version 2")
+  v2,
+}
+
+model PostInput {
+  url: string;
+}
+
+@route("/add-optional-param")
+interface AddOptionalParam {
+  @scenario
+  @scenarioDoc("""
+    Need the following two calls:
+    - Pass in `serviceDeploymentVersion="v2"` and `apiVersion="v1"` with no parameters.
+    - Pass in `serviceDeploymentVersion="v2"` and `apiVersion="v2"` with query parameter `new-parameter="new"`.
+    
+    There are three concepts that should be clarified:
+    1. Client spec version: refers to the spec that the client is generated from. 'v1' is a client generated from old.tsp and 'v2' is a client generated from main.tsp.
+    2. Service deployment version: refers to a deployment version of the service. 'v1' represents the initial deployment of the service with a single api version. 'v2' represents the new deployment of a service with multiple api versions
+    3. Api version: The initial deployment of the service only supports api version 'v1'. The new deployment of the service supports api versions 'v1' and 'v2'.
+    
+    With the above two calls, we test the following configurations from this service spec:
+    - A client generated from the second service spec can call the second deployment of a service with api version v1
+    - A client generated from the second service spec can call the second deployment of a service with api version v2 with the updated changes
+    
+    Tests that we can grow up an operation from accepting no parameters to accepting an optional input parameter.
+    """)
+  @route("/from-none")
+  @doc("Test that grew up from accepting no parameters to an optional input parameter")
+  @head
+  fromNone(
+    @added(Versions.v2)
+    @doc("I'm a new input optional parameter")
+    @query
+    `new-parameter`?: string,
+  ): NoContentResponse;
+
+  @scenario
+  @scenarioDoc("""
+    Need the following two calls:
+    - Pass in `serviceDeploymentVersion="v2"` and `apiVersion="v1"` with query parameter `parameter="required"`.
+    - Pass in `serviceDeploymentVersion="v2"` and `apiVersion="v2"` with query parameter `parameter="required"` and query parameter `new-parameter="new"`.
+    
+    There are three concepts that should be clarified:
+    1. Client spec version: refers to the spec that the client is generated from. 'v1' is a client generated from old.tsp and 'v2' is a client generated from main.tsp.
+    2. Service deployment version: refers to a deployment version of the service. 'v1' represents the initial deployment of the service with a single api version. 'v2' represents the new deployment of a service with multiple api versions
+    3. Api version: The initial deployment of the service only supports api version 'v1'. The new deployment of the service supports api versions 'v1' and 'v2'.
+    
+    With the above two calls, we test the following configurations from this service spec:
+    - A client generated from the second service spec can call the second deployment of a service with api version v1
+    - A client generated from the second service spec can call the second deployment of a service with api version v2 with the updated changes
+    
+    Tests that we can grow up an operation from accepting one required parameter to accepting a required parameter and an optional parameter.
+    """)
+  @route("/from-one-required")
+  @doc("Operation that grew up from accepting one required parameter to accepting a required parameter and an optional parameter.")
+  @get
+  fromOneRequired(
+    @doc("I am a required parameter")
+    @query
+    parameter: string,
+
+    @added(Versions.v2)
+    @doc("I'm a new input optional parameter")
+    @query
+    `new-parameter`?: string,
+  ): NoContentResponse;
+
+  @scenario
+  @scenarioDoc("""
+    Need the following two calls:
+    - Pass in `serviceDeploymentVersion="v2"` and `apiVersion="v1"` with query parameter `parameter="optional"`.
+    - Pass in `serviceDeploymentVersion="v2"` and `apiVersion="v2"` with query parameter `parameter="optional"` and query parameter `new-parameter="new"`.
+    
+    There are three concepts that should be clarified:
+    1. Client spec version: refers to the spec that the client is generated from. 'v1' is a client generated from old.tsp and 'v2' is a client generated from main.tsp.
+    2. Service deployment version: refers to a deployment version of the service. 'v1' represents the initial deployment of the service with a single api version. 'v2' represents the new deployment of a service with multiple api versions
+    3. Api version: The initial deployment of the service only supports api version 'v1'. The new deployment of the service supports api versions 'v1' and 'v2'.
+    
+    With the above two calls, we test the following configurations from this service spec:
+    - A client generated from the second service spec can call the second deployment of a service with api version v1
+    - A client generated from the second service spec can call the second deployment of a service with api version v2 with the updated changes
+    
+    Tests that we can grow up an operation from accepting one optional parameter to accepting two optional parameters.
+    """)
+  @route("/from-one-optional")
+  @doc("Tests that we can grow up an operation from accepting one optional parameter to accepting two optional parameters.")
+  @get
+  fromOneOptional(
+    @doc("I am an optional parameter")
+    @query
+    parameter?: string,
+
+    @added(Versions.v2)
+    @doc("I'm a new input optional parameter")
+    @query
+    `new-parameter`?: string,
+  ): NoContentResponse;
+}
+
+@scenario
+@scenarioDoc("""
+  Need the following two calls:
+  - Call with client spec version "v1" with `serviceDeploymentVersion="v2"` and `apiVersion="v2"`
+  - Call with client spec version "v2" with `serviceDeploymentVersion="v2"` and `apiVersion="v2"`
+  
+  There are three concepts that should be clarified:
+  1. Client spec version: refers to the spec that the client is generated from. 'v1' is a client generated from old.tsp and 'v2' is a client generated from main.tsp.
+  2. Service deployment version: refers to a deployment version of the service. 'v1' represents the initial deployment of the service with a single api version. 'v2' represents the new deployment of a service with multiple api versions
+  3. Api version: The initial deployment of the service only supports api version 'v1'. The new deployment of the service supports api versions 'v1' and 'v2'.
+  
+  With the above two calls, we test the following configurations from this service spec:
+  - A client generated from the first service spec can break the glass and call the second deployment of a service with api version v2
+  - A client generated from the second service spec can call the second deployment of a service with api version v2 with the updated changes
+  
+  Tests that we can grow up by adding an operation.
+  """)
+@added(Versions.v2)
+@route("/add-operation")
+@doc("Added operation")
+@delete
+op addOperation(): NoContentResponse;

--- a/packages/azure-http-specs/specs/resiliency/srv-driven/mockapi.ts
+++ b/packages/azure-http-specs/specs/resiliency/srv-driven/mockapi.ts
@@ -1,0 +1,282 @@
+import { MockRequest, ScenarioMockApi, ValidationError, passOnSuccess } from "@typespec/spec-api";
+
+export const commonBase = "/resiliency/service-driven";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Resiliency_ServiceDriven_AddOptionalParam_fromNone = passOnSuccess([
+  {
+    uri: `${commonBase}/client[:]v1/service[:]v1/api-version[:]v1/add-optional-param/from-none`,
+    method: "head",
+    request: {},
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      return {
+        status: 204,
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: `${commonBase}/client[:]v1/service[:]v2/api-version[:]v1/add-optional-param/from-none`,
+    method: "head",
+    request: {},
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      return {
+        status: 204,
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: `${commonBase}/client[:]v2/service[:]v2/api-version[:]v1/add-optional-param/from-none`,
+    method: "head",
+    request: {},
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      if (req.params["new-parameter"] !== undefined) {
+        throw new ValidationError(
+          "Did not expect 'new-parameter'",
+          undefined,
+          req.params["new-parameter"],
+        );
+      }
+      return {
+        status: 204,
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: `${commonBase}/client[:]v2/service[:]v2/api-version[:]v2/add-optional-param/from-none`,
+    method: "head",
+    request: {
+      params: {
+        "new-parameter": "new",
+      },
+    },
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("new-parameter", "new");
+      return {
+        status: 204,
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+]);
+
+Scenarios.Resiliency_ServiceDriven_AddOptionalParam_fromOneRequired = passOnSuccess([
+  {
+    uri: `${commonBase}/client[:]v1/service[:]v1/api-version[:]v1/add-optional-param/from-one-required`,
+    method: "get",
+    request: {
+      params: {
+        parameter: "required",
+      },
+    },
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("parameter", "required");
+      return {
+        status: 204,
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: `${commonBase}/client[:]v1/service[:]v2/api-version[:]v1/add-optional-param/from-one-required`,
+    method: "get",
+    request: {
+      params: {
+        parameter: "required",
+      },
+    },
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("parameter", "required");
+      return {
+        status: 204,
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: `${commonBase}/client[:]v2/service[:]v2/api-version[:]v1/add-optional-param/from-one-required`,
+    method: "get",
+    request: {
+      params: {
+        parameter: "required",
+      },
+    },
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("parameter", "required");
+      if (req.params["new-parameter"] !== undefined) {
+        throw new ValidationError(
+          "Did not expect 'new-parameter'",
+          undefined,
+          req.params["new-parameter"],
+        );
+      }
+      return {
+        status: 204,
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: `${commonBase}/client[:]v2/service[:]v2/api-version[:]v2/add-optional-param/from-one-required`,
+    method: "get",
+    request: {
+      params: {
+        parameter: "required",
+        "new-parameter": "new",
+      },
+    },
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("parameter", "required");
+      req.expect.containsQueryParam("new-parameter", "new");
+      return {
+        status: 204,
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+]);
+
+Scenarios.Resiliency_ServiceDriven_AddOptionalParam_fromOneOptional = passOnSuccess([
+  {
+    uri: `${commonBase}/client[:]v1/service[:]v1/api-version[:]v1/add-optional-param/from-one-optional`,
+    method: "get",
+    request: {
+      params: {
+        parameter: "optional",
+      },
+    },
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("parameter", "optional");
+      return {
+        status: 204,
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: `${commonBase}/client[:]v1/service[:]v2/api-version[:]v1/add-optional-param/from-one-optional`,
+    method: "get",
+    request: {
+      params: {
+        parameter: "optional",
+      },
+    },
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("parameter", "optional");
+      return {
+        status: 204,
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: `${commonBase}/client[:]v2/service[:]v2/api-version[:]v1/add-optional-param/from-one-optional`,
+    method: "get",
+    request: {
+      params: {
+        parameter: "optional",
+      },
+    },
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("parameter", "optional");
+      if (req.params["new-parameter"] !== undefined) {
+        throw new ValidationError(
+          "Did not expect 'new-parameter'",
+          undefined,
+          req.params["new-parameter"],
+        );
+      }
+      return {
+        status: 204,
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: `${commonBase}/client[:]v2/service[:]v2/api-version[:]v2/add-optional-param/from-one-optional`,
+    method: "get",
+    request: {
+      params: {
+        parameter: "optional",
+        "new-parameter": "new",
+      },
+    },
+    response: {
+      status: 204,
+    },
+    handler: (req: MockRequest) => {
+      req.expect.containsQueryParam("parameter", "optional");
+      req.expect.containsQueryParam("new-parameter", "new");
+      return {
+        status: 204,
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+]);
+
+Scenarios.Resiliency_ServiceDriven_breakTheGlass = passOnSuccess({
+  uri: `${commonBase}/client[:]v1/service[:]v2/api-version[:]v2/add-operation`,
+  method: "delete",
+  request: {},
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    return {
+      status: 204,
+    };
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Resiliency_ServiceDriven_addOperation = passOnSuccess({
+  uri: `${commonBase}/client[:]v2/service[:]v2/api-version[:]v2/add-operation`,
+  method: "delete",
+  request: {},
+  response: {
+    status: 204,
+  },
+  handler: (req: MockRequest) => {
+    return {
+      status: 204,
+    };
+  },
+  kind: "MockApiDefinition",
+});

--- a/packages/azure-http-specs/specs/resiliency/srv-driven/old.tsp
+++ b/packages/azure-http-specs/specs/resiliency/srv-driven/old.tsp
@@ -1,0 +1,120 @@
+import "@typespec/http";
+import "@typespec/versioning";
+import "@typespec/spec-lib";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+using TypeSpec.Versioning;
+using SpecLib;
+
+@versioned(Versions)
+@doc("""
+  Test that we can grow up a service spec and service deployment into a multi-versioned service with full client support.
+  """)
+@client({
+  name: "ResiliencyServiceDrivenClient",
+})
+@service
+@server(
+  "{endpoint}/resiliency/service-driven/client:v1/service:{serviceDeploymentVersion}/api-version:{apiVersion}",
+  "Testserver endpoint",
+  {
+    @doc("Need to be set as 'http://localhost:3000' in client.")
+    endpoint: url,
+
+    @doc("Pass in either 'v1' or 'v2'. This represents a version of the service deployment in history. 'v1' is for the deployment when the service had only one api version. 'v2' is for the deployment when the service had api-versions 'v1' and 'v2'.")
+    serviceDeploymentVersion: string,
+
+    @doc("Pass in 'v1'. This represents the API version of the service. Will grow up in the next deployment to be both 'v1' and 'v2'")
+    apiVersion: string,
+  }
+)
+namespace Resiliency.ServiceDriven;
+
+@doc("Service versions.")
+enum Versions {
+  @doc("Version 1")
+  v1,
+}
+
+model PostInput {
+  url: string;
+}
+
+@route("/add-optional-param")
+interface AddOptionalParam {
+  @scenario
+  @scenarioDoc("""
+      Need the following two calls:
+      - Pass in `serviceDeploymentVersion="v1"` and `apiVersion="v1"` with no parameters.
+      - Pass in `serviceDeploymentVersion="v2"` and `apiVersion="v1"` with no parameters.
+    
+      There are three concepts that should be clarified:
+      1. Client spec version: refers to the spec that the client is generated from. 'v1' is a client generated from old.tsp and 'v2' is a client generated from main.tsp.
+      2. Service deployment version: refers to a deployment version of the service. 'v1' represents the initial deployment of the service with a single api version. 'v2' represents the new deployment of a service with multiple api versions
+      3. Api version: The initial deployment of the service only supports api version 'v1'. The new deployment of the service supports api versions 'v1' and 'v2'.
+    
+      With the above two calls, we test the following configurations from this service spec:
+      - A client generated from the first service spec can call the first deployment of a service with api version v1
+      - A client generated from the first service spec can call the second deployment of a service with api version v1
+    
+      In the next service spec, we will test that we can grow this operation from accepting no parameters to accepting an optional parameter.
+    """)
+  @route("/from-none")
+  @doc("Test that currently accepts no parameters, will be updated in next spec to accept a new optional parameter as well")
+  @head
+  fromNone(): NoContentResponse;
+
+  @scenario
+  @scenarioDoc("""
+      Need the following two calls:
+      - Pass in `serviceDeploymentVersion="v1"` and `apiVersion="v1"` with query parameter `parameter="required"`.
+      - Pass in `serviceDeploymentVersion="v2"` and `apiVersion="v1"` with query parameter `parameter="required"`.
+    
+      There are three concepts that should be clarified:
+      1. Client spec version: refers to the spec that the client is generated from. 'v1' is a client generated from old.tsp and 'v2' is a client generated from main.tsp.
+      2. Service deployment version: refers to a deployment version of the service. 'v1' represents the initial deployment of the service with a single api version. 'v2' represents the new deployment of a service with multiple api versions
+      3. Api version: The initial deployment of the service only supports api version 'v1'. The new deployment of the service supports api versions 'v1' and 'v2'.
+    
+      With the above two calls, we test the following configurations from this service spec:
+      - A client generated from the first service spec can call the first deployment of a service with api version v1
+      - A client generated from the first service spec can call the second deployment of a service with api version v1
+    
+      In the next service spec, we will test that we can grow this operation from accepting one required parameter to accepting both a required and an optional parameter.
+    """)
+  @route("/from-one-required")
+  @doc("Test that currently accepts one required parameter, will be updated in next spec to accept a new optional parameter as well")
+  @get
+  fromOneRequired(
+    @doc("I am a required parameter")
+    @query
+    parameter: string,
+  ): NoContentResponse;
+
+  @scenario
+  @scenarioDoc("""
+      Need the following two calls:
+      - Pass in `serviceDeploymentVersion="v1"` and `apiVersion="v1"` with query parameter `parameter="optional"`.
+      - Pass in `serviceDeploymentVersion="v2"` and `apiVersion="v1"` with query parameter `parameter="optional"`.
+    
+      There are three concepts that should be clarified:
+      1. Client spec version: refers to the spec that the client is generated from. 'v1' is a client generated from old.tsp and 'v2' is a client generated from main.tsp.
+      2. Service deployment version: refers to a deployment version of the service. 'v1' represents the initial deployment of the service with a single api version. 'v2' represents the new deployment of a service with multiple api versions
+      3. Api version: The initial deployment of the service only supports api version 'v1'. The new deployment of the service supports api versions 'v1' and 'v2'.
+    
+      With the above two calls, we test the following configurations from this service spec:
+      - A client generated from the first service spec can call the first deployment of a service with api version v1
+      - A client generated from the first service spec can call the second deployment of a service with api version v1
+    
+      In the next service spec, we will test that we can grow this operation from accepting one optional parameter to accepting two optional parameters.
+    """)
+  @route("/from-one-optional")
+  @doc("Test that currently accepts one optional parameter, will be updated in next spec to accept a new optional parameter as well")
+  @get
+  fromOneOptional(
+    @doc("I am an optional parameter")
+    @query
+    parameter?: string,
+  ): NoContentResponse;
+}

--- a/packages/azure-http-specs/specs/scratch/.gitignore
+++ b/packages/azure-http-specs/specs/scratch/.gitignore
@@ -1,0 +1,3 @@
+# This directory reserved for creating scratch *.tsp for testing/experimentation
+**/*
+!.gitignore

--- a/packages/azure-http-specs/tsconfig.build.json
+++ b/packages/azure-http-specs/tsconfig.build.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "references": [
+    { "path": "../../core/packages/spec-api/tsconfig.build.json" },
+    { "path": "../../core/packages/spec-lib/tsconfig.build.json" },
+    { "path": "../../core/packages/spec-core/tsconfig.build.json" }
+  ],
+  "exclude": ["**/*.test.*", "test/**/*"]
+}

--- a/packages/azure-http-specs/tsconfig.json
+++ b/packages/azure-http-specs/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../core/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "tsBuildInfoFile": "temp/.tsbuildinfo",
+    "types": ["multer"],
+    "allowJs": true
+  },
+  "include": ["./specs/**/*.ts", "./specs/**/*.js"]
+}

--- a/packages/azure-http-specs/tspconfig.yaml
+++ b/packages/azure-http-specs/tspconfig.yaml
@@ -1,0 +1,2 @@
+emitters:
+  "@typespec/openapi3": true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2189,7 +2189,7 @@ importers:
         specifier: ^1.4.10
         version: 1.4.12
       '@types/node':
-        specifier: ^22.1.0
+        specifier: ~22.7.5
         version: 22.7.5
       '@typespec/openapi':
         specifier: workspace:~

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,7 +395,7 @@ importers:
         version: link:../tmlanguage-generator
       ts-node:
         specifier: ~10.9.2
-        version: 10.9.2(@swc/core@1.7.35)(@types/node@22.7.5)(typescript@5.6.3)
+        version: 10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.3)
       typescript:
         specifier: ~5.6.3
         version: 5.6.3
@@ -2145,6 +2145,67 @@ importers:
       vitest:
         specifier: ^2.1.2
         version: 2.1.2(@types/node@22.7.5)(@vitest/ui@2.1.2)(happy-dom@15.7.4)(jsdom@25.0.1)(terser@5.34.1)
+
+  packages/azure-http-specs:
+    dependencies:
+      '@azure-tools/typespec-azure-core':
+        specifier: workspace:~
+        version: link:../typespec-azure-core
+      '@typespec/compiler':
+        specifier: workspace:~
+        version: link:../../core/packages/compiler
+      '@typespec/http':
+        specifier: workspace:~
+        version: link:../../core/packages/http
+      '@typespec/rest':
+        specifier: workspace:~
+        version: link:../../core/packages/rest
+      '@typespec/spec-api':
+        specifier: workspace:~
+        version: link:../../core/packages/spec-api
+      '@typespec/spec-core':
+        specifier: workspace:~
+        version: link:../../core/packages/spec-core
+      '@typespec/spec-lib':
+        specifier: workspace:~
+        version: link:../../core/packages/spec-lib
+      '@typespec/versioning':
+        specifier: workspace:~
+        version: link:../../core/packages/versioning
+      '@typespec/xml':
+        specifier: workspace:~
+        version: link:../../core/packages/xml
+    devDependencies:
+      '@azure-tools/typespec-autorest':
+        specifier: workspace:~
+        version: link:../typespec-autorest
+      '@azure-tools/typespec-azure-resource-manager':
+        specifier: workspace:~
+        version: link:../typespec-azure-resource-manager
+      '@azure-tools/typespec-client-generator-core':
+        specifier: workspace:~
+        version: link:../typespec-client-generator-core
+      '@types/multer':
+        specifier: ^1.4.10
+        version: 1.4.12
+      '@types/node':
+        specifier: ^22.1.0
+        version: 22.7.5
+      '@typespec/openapi':
+        specifier: workspace:~
+        version: link:../../core/packages/openapi
+      '@typespec/openapi3':
+        specifier: workspace:~
+        version: link:../../core/packages/openapi3
+      concurrently:
+        specifier: ^9.0.1
+        version: 9.0.1
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
+      typescript:
+        specifier: ~5.6.2
+        version: 5.6.3
 
   packages/e2e-tests:
     devDependencies:
@@ -16357,7 +16418,7 @@ snapshots:
       terser-webpack-plugin: 5.3.10(webpack@5.94.0)
       tslib: 2.7.0
       update-notifier: 6.0.2
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.94.0))(webpack@5.94.0)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.95.0))(webpack@5.94.0)
       webpack: 5.94.0
       webpack-bundle-analyzer: 4.10.2
       webpack-dev-server: 4.15.2(webpack@5.94.0)
@@ -16456,7 +16517,7 @@ snapshots:
       tslib: 2.7.0
       unified: 11.0.5
       unist-util-visit: 5.0.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.94.0))(webpack@5.94.0)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.95.0))(webpack@5.94.0)
       vfile: 6.0.3
       webpack: 5.94.0
     transitivePeerDependencies:
@@ -17512,7 +17573,7 @@ snapshots:
       resolve-pathname: 3.0.0
       shelljs: 0.8.5
       tslib: 2.7.0
-      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.94.0))(webpack@5.94.0)
+      url-loader: 4.1.1(file-loader@6.2.0(webpack@5.95.0))(webpack@5.94.0)
       utility-types: 3.11.0
       webpack: 5.94.0
     optionalDependencies:
@@ -20523,7 +20584,7 @@ snapshots:
 
   '@types/multer@1.4.12':
     dependencies:
-      '@types/express': 4.17.21
+      '@types/express': 5.0.0
 
   '@types/mustache@4.2.5': {}
 
@@ -20613,7 +20674,7 @@ snapshots:
 
   '@types/serve-index@1.9.4':
     dependencies:
-      '@types/express': 4.17.21
+      '@types/express': 5.0.0
 
   '@types/serve-static@1.15.7':
     dependencies:
@@ -28499,7 +28560,7 @@ snapshots:
 
   ts-dedent@2.2.0: {}
 
-  ts-node@10.9.2(@swc/core@1.7.35)(@types/node@22.7.5)(typescript@5.6.3):
+  ts-node@10.9.2(@swc/core@1.7.35(@swc/helpers@0.5.13))(@types/node@22.7.5)(typescript@5.6.3):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -28809,14 +28870,14 @@ snapshots:
     optionalDependencies:
       file-loader: 6.2.0(webpack@5.94.0(@swc/core@1.7.35(@swc/helpers@0.5.13)))
 
-  url-loader@4.1.1(file-loader@6.2.0(webpack@5.94.0))(webpack@5.94.0):
+  url-loader@4.1.1(file-loader@6.2.0(webpack@5.95.0))(webpack@5.94.0):
     dependencies:
       loader-utils: 2.0.4
       mime-types: 2.1.35
       schema-utils: 3.3.0
       webpack: 5.94.0
     optionalDependencies:
-      file-loader: 6.2.0(webpack@5.94.0)
+      file-loader: 6.2.0(webpack@5.95.0)
 
   url-parse@1.5.10:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2201,10 +2201,10 @@ importers:
         specifier: ^9.0.1
         version: 9.0.1
       rimraf:
-        specifier: ^6.0.1
+        specifier: ~6.0.1
         version: 6.0.1
       typescript:
-        specifier: ~5.6.2
+        specifier: ~5.6.3
         version: 5.6.3
 
   packages/e2e-tests:


### PR DESCRIPTION
This is a spin-off of PR https://github.com/Azure/cadl-ranch/pull/741. A new package `@azure-tools/azure-http-specs` has been created to handle only the azure specific scenarios and the scenarios that are not included in the `@typespec/http-specs` package. 
Please review and approve the PR. 

Note:
1. The `test:e2e` script is working fine.
2. I have not deleted the `cadl-ranch-specs` folder under `e2e-tests` folder and not modified the `e2e-tests.mjs` script.