### PR TITLE
[@azure-tools/azure-http-specs] - Remove handler for majority of the Scenarios

### DIFF
--- a/packages/azure-http-specs/package.json
+++ b/packages/azure-http-specs/package.json
@@ -34,8 +34,7 @@
   "homepage": "https://azure.github.io/typespec-azure",
   "dependencies": {
     "@typespec/spector": "workspace:~",
-    "@typespec/spec-api": "workspace:~",
-    "@typespec/spector": "workspace:~"
+    "@typespec/spec-api": "workspace:~"
   },
   "devDependencies": {
     "@azure-tools/typespec-azure-resource-manager": "workspace:~",

--- a/packages/azure-http-specs/specs/azure/client-generator-core/access/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/access/mockapi.ts
@@ -1,11 +1,4 @@
-import {
-  json,
-  MockApiDefinition,
-  MockRequest,
-  passOnSuccess,
-  ScenarioMockApi,
-  ValidationError,
-} from "@typespec/spec-api";
+import { json, MockApiDefinition, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
@@ -21,15 +14,6 @@ function createMockApiDefinitions(route: string): MockApiDefinition {
     response: {
       status: 200,
       body: json({ name: "sample" }),
-    },
-    handler: (req: MockRequest) => {
-      if (!("name" in req.query)) {
-        throw new ValidationError("Should submit name query", "any string", undefined);
-      }
-      return {
-        status: 200,
-        body: json({ name: req.query["name"] }),
-      };
     },
     kind: "MockApiDefinition",
   };
@@ -64,15 +48,6 @@ Scenarios.Azure_ClientGenerator_Core_Access_RelativeModelInOperation = passOnSuc
       status: 200,
       body: json({ name: "Madge", inner: { name: "Madge" } }),
     },
-    handler: (req: MockRequest) => {
-      if (!("name" in req.query)) {
-        throw new ValidationError("Should submit name query", "any string", undefined);
-      }
-      return {
-        status: 200,
-        body: json({ name: "Madge", inner: { name: "Madge" } }),
-      };
-    },
     kind: "MockApiDefinition",
   },
   {
@@ -86,15 +61,6 @@ Scenarios.Azure_ClientGenerator_Core_Access_RelativeModelInOperation = passOnSuc
     response: {
       status: 200,
       body: json({ name: "Madge", kind: "real" }),
-    },
-    handler: (req: MockRequest) => {
-      if (!("kind" in req.query)) {
-        throw new ValidationError("Should submit name query", "any string", undefined);
-      }
-      return {
-        status: 200,
-        body: json({ name: "Madge", kind: "real" }),
-      };
     },
     kind: "MockApiDefinition",
   },

--- a/packages/azure-http-specs/specs/azure/client-generator-core/flatten-property/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/flatten-property/mockapi.ts
@@ -1,10 +1,4 @@
-import {
-  json,
-  MockApiDefinition,
-  MockRequest,
-  passOnSuccess,
-  ScenarioMockApi,
-} from "@typespec/spec-api";
+import { json, MockApiDefinition, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 function createMockApiDefinitions(route: string, request: any, response: any): MockApiDefinition {
@@ -17,13 +11,6 @@ function createMockApiDefinitions(route: string, request: any, response: any): M
     response: {
       status: 200,
       body: json(response),
-    },
-    handler: (req: MockRequest) => {
-      req.expect.bodyEquals(request);
-      return {
-        status: 200,
-        body: json(response),
-      };
     },
     kind: "MockApiDefinition",
   };

--- a/packages/azure-http-specs/specs/azure/client-generator-core/usage/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/usage/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, MockRequest, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
@@ -14,11 +14,6 @@ Scenarios.Azure_ClientGenerator_Core_Usage_ModelInOperation = passOnSuccess([
     response: {
       status: 204,
     },
-    handler: (req: MockRequest) => {
-      const validBody = { name: "Madge" };
-      req.expect.bodyEquals(validBody);
-      return { status: 204 };
-    },
     kind: "MockApiDefinition",
   },
   {
@@ -29,12 +24,6 @@ Scenarios.Azure_ClientGenerator_Core_Usage_ModelInOperation = passOnSuccess([
       status: 200,
       body: json({ name: "Madge" }),
     },
-    handler: (req: MockRequest) => {
-      return {
-        status: 200,
-        body: json({ name: "Madge" }),
-      };
-    },
     kind: "MockApiDefinition",
   },
   {
@@ -44,12 +33,6 @@ Scenarios.Azure_ClientGenerator_Core_Usage_ModelInOperation = passOnSuccess([
     response: {
       status: 200,
       body: json({ result: { name: "Madge" } }),
-    },
-    handler: (req: MockRequest) => {
-      return {
-        status: 200,
-        body: json({ result: { name: "Madge" } }),
-      };
     },
     kind: "MockApiDefinition",
   },

--- a/packages/azure-http-specs/specs/azure/core/basic/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/basic/mockapi.ts
@@ -1,10 +1,4 @@
-import {
-  json,
-  MockRequest,
-  passOnSuccess,
-  ScenarioMockApi,
-  ValidationError,
-} from "@typespec/spec-api";
+import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 const validUser = { id: 1, name: "Madge", etag: "11bdc430-65e8-45ad-81d9-8ffa60d55b59" };
@@ -23,16 +17,6 @@ Scenarios.Azure_Core_Basic_createOrUpdate = passOnSuccess({
     body: { name: "Madge" },
   },
   response: { status: 200, body: json(validUser) },
-  handler: (req: MockRequest) => {
-    if (req.params.id !== "1") {
-      throw new ValidationError("Expected path param id=1", "1", req.params.id);
-    }
-    req.expect.containsHeader("content-type", "application/merge-patch+json");
-    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
-    const validBody = { name: "Madge" };
-    req.expect.bodyEquals(validBody);
-    return { status: 200, body: json(validUser) };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -47,16 +31,6 @@ Scenarios.Azure_Core_Basic_createOrReplace = passOnSuccess({
     body: { name: "Madge" },
   },
   response: { status: 200, body: json(validUser) },
-  handler: (req: MockRequest) => {
-    if (req.params.id !== "1") {
-      throw new ValidationError("Expected path param id=1", "1", req.params.id);
-    }
-    req.expect.containsHeader("content-type", "application/json");
-    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
-    const validBody = { name: "Madge" };
-    req.expect.bodyEquals(validBody);
-    return { status: 200, body: json(validUser) };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -70,13 +44,6 @@ Scenarios.Azure_Core_Basic_get = passOnSuccess({
     },
   },
   response: { status: 200, body: json(validUser) },
-  handler: (req: MockRequest) => {
-    if (req.params.id !== "1") {
-      throw new ValidationError("Expected path param id=1", "1", req.params.id);
-    }
-    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
-    return { status: 200, body: json(validUser) };
-  },
   kind: "MockApiDefinition",
 });
 const responseBody = {
@@ -110,22 +77,6 @@ Scenarios.Azure_Core_Basic_list = passOnSuccess({
     },
   },
   response: { status: 200, body: json(responseBody) },
-  handler: (req: MockRequest) => {
-    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
-    req.expect.containsQueryParam("top", "5");
-    req.expect.containsQueryParam("skip", "10");
-    req.expect.containsQueryParam("orderby", "id");
-    req.expect.containsQueryParam("filter", "id lt 10");
-    if (!req.originalRequest.originalUrl.includes("select[]=id&select[]=orders&select[]=etag")) {
-      throw new ValidationError(
-        "Expected query param select[]=id&select[]=orders&select[]=etag ",
-        "select[]=id&select[]=orders&select[]=etag",
-        req.originalRequest.originalUrl,
-      );
-    }
-    req.expect.containsQueryParam("expand", "orders");
-    return { status: 200, body: json(responseBody) };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -140,13 +91,6 @@ Scenarios.Azure_Core_Basic_delete = passOnSuccess({
   },
   response: {
     status: 204,
-  },
-  handler: (req: MockRequest) => {
-    if (req.params.id !== "1") {
-      throw new ValidationError("Expected path param id=1", "1", req.params.id);
-    }
-    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
-    return { status: 204 };
   },
   kind: "MockApiDefinition",
 });
@@ -165,14 +109,6 @@ Scenarios.Azure_Core_Basic_export = passOnSuccess({
     status: 200,
     body: json(validUser),
   },
-  handler: (req: MockRequest) => {
-    if (req.params.id !== "1") {
-      throw new ValidationError("Expected path param id=1", "1", req.params.id);
-    }
-    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
-    req.expect.containsQueryParam("format", "json");
-    return { status: 200, body: json(validUser) };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -187,10 +123,5 @@ Scenarios.Azure_Core_Basic_exportAllUsers = passOnSuccess({
     },
   },
   response: { status: 200, body: json(expectBody) },
-  handler: (req: MockRequest) => {
-    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
-    req.expect.containsQueryParam("format", "json");
-    return { status: 200, body: json(expectBody) };
-  },
   kind: "MockApiDefinition",
 });

--- a/packages/azure-http-specs/specs/azure/core/lro/standard/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/lro/standard/mockapi.ts
@@ -110,9 +110,6 @@ Scenarios.Azure_Core_Lro_Standard_createOrReplace = passOnSuccess([
       status: 200,
       body: json(validUser),
     },
-    handler: (req: MockRequest) => {
-      return { status: 200, body: json(validUser) };
-    },
     kind: "MockApiDefinition",
   },
 ]);

--- a/packages/azure-http-specs/specs/azure/core/model/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/model/mockapi.ts
@@ -7,9 +7,6 @@ Scenarios.Azure_Core_Model_AzureCoreEmbeddingVector_get = passOnSuccess({
   method: "get",
   request: {},
   response: { status: 200, body: json([0, 1, 2, 3, 4]) },
-  handler: (req) => {
-    return { status: 200, body: json([0, 1, 2, 3, 4]) };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -20,10 +17,6 @@ Scenarios.Azure_Core_Model_AzureCoreEmbeddingVector_put = passOnSuccess({
     body: [0, 1, 2, 3, 4],
   },
   response: { status: 204 },
-  handler: (req) => {
-    req.expect.bodyEquals([0, 1, 2, 3, 4]);
-    return { status: 204 };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -33,12 +26,5 @@ Scenarios.Azure_Core_Model_AzureCoreEmbeddingVector_post = passOnSuccess({
   method: "post",
   request: { body: { embedding: [0, 1, 2, 3, 4] } },
   response: { status: 200, body: json(responseBody) },
-  handler: (req) => {
-    req.expect.bodyEquals({ embedding: [0, 1, 2, 3, 4] });
-    return {
-      status: 200,
-      body: json(responseBody),
-    };
-  },
   kind: "MockApiDefinition",
 });

--- a/packages/azure-http-specs/specs/azure/core/page/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/page/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, MockRequest, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 const validUser = { id: 1, name: "Madge", etag: "11bdc430-65e8-45ad-81d9-8ffa60d55b59" };
@@ -8,12 +8,6 @@ Scenarios.Azure_Core_Page_listWithPage = passOnSuccess({
   method: "get",
   request: {},
   response: { status: 200, body: json({ value: [validUser] }) },
-  handler: (req: MockRequest) => {
-    const responseBody = {
-      value: [validUser],
-    };
-    return { status: 200, body: json(responseBody) };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -27,17 +21,6 @@ Scenarios.Azure_Core_Page_listWithParameters = passOnSuccess({
     body: { inputName: "Madge" },
   },
   response: { status: 200, body: json({ value: [validUser] }) },
-  handler: (req: MockRequest) => {
-    req.expect.containsQueryParam("another", "Second");
-
-    const validBody = { inputName: "Madge" };
-    req.expect.bodyEquals(validBody);
-
-    const responseBody = {
-      value: [validUser],
-    };
-    return { status: 200, body: json(responseBody) };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -47,12 +30,6 @@ Scenarios.Azure_Core_Page_TwoModelsAsPageItem = passOnSuccess([
     method: "get",
     request: {},
     response: { status: 200, body: json({ value: [{ id: 1 }] }) },
-    handler: (req: MockRequest) => {
-      const responseBody = {
-        value: [{ id: 1 }],
-      };
-      return { status: 200, body: json(responseBody) };
-    },
     kind: "MockApiDefinition",
   },
   {
@@ -60,12 +37,6 @@ Scenarios.Azure_Core_Page_TwoModelsAsPageItem = passOnSuccess([
     method: "get",
     request: {},
     response: { status: 200, body: json({ value: [{ name: "Madge" }] }) },
-    handler: (req: MockRequest) => {
-      const responseBody = {
-        value: [{ name: "Madge" }],
-      };
-      return { status: 200, body: json(responseBody) };
-    },
     kind: "MockApiDefinition",
   },
 ]);
@@ -75,11 +46,5 @@ Scenarios.Azure_Core_Page_listWithCustomPageModel = passOnSuccess({
   method: "get",
   request: {},
   response: { status: 200, body: json({ items: [validUser] }) },
-  handler: (req: MockRequest) => {
-    const responseBody = {
-      items: [validUser],
-    };
-    return { status: 200, body: json(responseBody) };
-  },
   kind: "MockApiDefinition",
 });

--- a/packages/azure-http-specs/specs/azure/core/scalar/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/scalar/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, MockRequest, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
@@ -8,9 +8,6 @@ Scenarios.Azure_Core_Scalar_AzureLocationScalar_get = passOnSuccess({
   method: "get",
   request: {},
   response: { status: 200, body: json("eastus") },
-  handler: (req: MockRequest) => {
-    return { status: 200, body: json("eastus") };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -24,10 +21,6 @@ Scenarios.Azure_Core_Scalar_AzureLocationScalar_put = passOnSuccess({
     },
   },
   response: { status: 204 },
-  handler: (req: MockRequest) => {
-    req.expect.bodyEquals("eastus");
-    return { status: 204 };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -37,13 +30,6 @@ Scenarios.Azure_Core_Scalar_AzureLocationScalar_post = passOnSuccess({
   method: "post",
   request: { body: azureLocation },
   response: { status: 200, body: json(azureLocation) },
-  handler: (req: MockRequest) => {
-    req.expect.bodyEquals({ location: "eastus" });
-    return {
-      status: 200,
-      body: json(azureLocation),
-    };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -56,10 +42,6 @@ Scenarios.Azure_Core_Scalar_AzureLocationScalar_header = passOnSuccess({
     },
   },
   response: { status: 204 },
-  handler: (req: MockRequest) => {
-    req.expect.containsHeader("region", "eastus");
-    return { status: 204 };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -72,9 +54,5 @@ Scenarios.Azure_Core_Scalar_AzureLocationScalar_query = passOnSuccess({
     },
   },
   response: { status: 204 },
-  handler: (req: MockRequest) => {
-    req.expect.containsQueryParam("region", "eastus");
-    return { status: 204 };
-  },
   kind: "MockApiDefinition",
 });

--- a/packages/azure-http-specs/specs/azure/core/traits/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/traits/mockapi.ts
@@ -1,11 +1,4 @@
-import {
-  json,
-  MockRequest,
-  passOnSuccess,
-  ScenarioMockApi,
-  validateValueFormat,
-  ValidationError,
-} from "@typespec/spec-api";
+import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
@@ -39,39 +32,6 @@ Scenarios.Azure_Core_Traits_smokeTest = passOnSuccess({
       "x-ms-client-request-id": "86aede1f-96fa-4e7f-b1e1-bf8a947cb804",
     },
   },
-  handler: (req: MockRequest) => {
-    if (!("x-ms-client-request-id" in req.headers)) {
-      throw new ValidationError(
-        "Should submit header x-ms-client-request-id",
-        "any uuid",
-        undefined,
-      );
-    }
-    if (req.params.id !== "1") {
-      throw new ValidationError("Expected path param id=1", "1", req.params.id);
-    }
-    req.expect.containsHeader("foo", "123");
-    const if_none_match = req.headers["if-none-match"];
-    const if_match = req.headers["if-match"];
-    if (if_none_match !== '"invalid"' && if_match !== '"valid"') {
-      throw new ValidationError(
-        `Expected header "if-none-match" equals "invalid" but got ${if_none_match} or "if-match" equals "valid" but got ${if_match}`,
-        `"if-match": "valid" or "if-none-match": "invalid"`,
-        `"if-match": ${if_match} or "if-none-match": ${if_none_match}`,
-      );
-    }
-    req.expect.containsHeader("if-unmodified-since", "Fri, 26 Aug 2022 14:38:00 GMT");
-    req.expect.containsHeader("if-modified-since", "Thu, 26 Aug 2021 14:38:00 GMT");
-    return {
-      status: 200,
-      body: json(validUser),
-      headers: {
-        bar: "456",
-        etag: "11bdc430-65e8-45ad-81d9-8ffa60d55b59",
-        "x-ms-client-request-id": req.headers["x-ms-client-request-id"],
-      },
-    };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -96,36 +56,6 @@ Scenarios.Azure_Core_Traits_repeatableAction = passOnSuccess({
     headers: {
       "repeatability-result": "accepted",
     },
-  },
-  handler: (req: MockRequest) => {
-    if (req.params.id !== "1") {
-      throw new ValidationError("Expected path param id=1", "1", req.params.id);
-    }
-
-    if (!("repeatability-request-id" in req.headers)) {
-      throw new ValidationError("Repeatability-Request-ID is missing", "A UUID string", undefined);
-    }
-    if (!("repeatability-first-sent" in req.headers)) {
-      throw new ValidationError(
-        "Repeatability-First-Sent is missing",
-        "A date-time in headers format",
-        undefined,
-      );
-    }
-
-    validateValueFormat(req.headers["repeatability-request-id"], "uuid");
-    validateValueFormat(req.headers["repeatability-first-sent"], "rfc7231");
-
-    const validBody = { userActionValue: "test" };
-    req.expect.bodyEquals(validBody);
-
-    return {
-      status: 200,
-      body: json({ userActionResult: "test" }),
-      headers: {
-        "repeatability-result": "accepted",
-      },
-    };
   },
   kind: "MockApiDefinition",
 });

--- a/packages/azure-http-specs/specs/azure/example/basic/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/example/basic/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, MockRequest, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
@@ -31,30 +31,6 @@ Scenarios.Client_AzureExampleClient_basicAction = passOnSuccess({
     body: json({
       stringProperty: "text",
     }),
-  },
-  handler: (req: MockRequest) => {
-    req.expect.containsQueryParam("api-version", "2022-12-01-preview");
-    req.expect.containsQueryParam("query-param", "query");
-    req.expect.containsHeader("header-param", "header");
-    const validBody = {
-      stringProperty: "text",
-      modelProperty: {
-        int32Property: 1,
-        float32Property: 1.5,
-        enumProperty: "EnumValue1",
-      },
-      arrayProperty: ["item"],
-      recordProperty: {
-        record: "value",
-      },
-    };
-    req.expect.bodyEquals(validBody);
-    return {
-      status: 200,
-      body: json({
-        stringProperty: "text",
-      }),
-    };
   },
   kind: "MockApiDefinition",
 });

--- a/packages/azure-http-specs/specs/azure/resource-manager/models/common-types/managed-identity/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/models/common-types/managed-identity/mockapi.ts
@@ -1,10 +1,4 @@
-import {
-  json,
-  MockRequest,
-  passOnSuccess,
-  ScenarioMockApi,
-  ValidationError,
-} from "@typespec/spec-api";
+import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
@@ -84,34 +78,6 @@ Scenarios.Azure_ResourceManager_Models_CommonTypes_ManagedIdentity_ManagedIdenti
       status: 200,
       body: json(validSystemAssignedManagedIdentityResource),
     },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected subscriptionId",
-          SUBSCRIPTION_ID_EXPECTED,
-          req.params.subscriptionId,
-        );
-      }
-      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected resourceGroup",
-          RESOURCE_GROUP_EXPECTED,
-          req.params.resourceGroup,
-        );
-      }
-      if (req.params.managedIdentityResourceName.toLowerCase() !== "identity") {
-        throw new ValidationError(
-          "Unexpected managed identity resource name",
-          "identity",
-          req.params.managedIdentityResourceName,
-        );
-      }
-      return {
-        status: 200,
-        body: json(validSystemAssignedManagedIdentityResource),
-      };
-    },
     kind: "MockApiDefinition",
   });
 
@@ -133,35 +99,6 @@ Scenarios.Azure_ResourceManager_Models_CommonTypes_ManagedIdentity_ManagedIdenti
     response: {
       status: 200,
       body: json(validSystemAssignedManagedIdentityResource),
-    },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected subscriptionId",
-          SUBSCRIPTION_ID_EXPECTED,
-          req.params.subscriptionId,
-        );
-      }
-      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected resourceGroup",
-          RESOURCE_GROUP_EXPECTED,
-          req.params.resourceGroup,
-        );
-      }
-      if (req.params.managedIdentityResourceName.toLowerCase() !== "identity") {
-        throw new ValidationError(
-          "Unexpected managed identity resource name",
-          "identity",
-          req.params.managedIdentityResourceName,
-        );
-      }
-      req.expect.deepEqual(req.body["identity"], createExpectedIdentity);
-      return {
-        status: 200,
-        body: json(validSystemAssignedManagedIdentityResource),
-      };
     },
     kind: "MockApiDefinition",
   });
@@ -187,35 +124,6 @@ Scenarios.Azure_ResourceManager_Models_CommonTypes_ManagedIdentity_ManagedIdenti
     response: {
       status: 200,
       body: json(validUserAssignedAndSystemAssignedManagedIdentityResource),
-    },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected subscriptionId",
-          SUBSCRIPTION_ID_EXPECTED,
-          req.params.subscriptionId,
-        );
-      }
-      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected resourceGroup",
-          RESOURCE_GROUP_EXPECTED,
-          req.params.resourceGroup,
-        );
-      }
-      if (req.params.managedIdentityResourceName.toLowerCase() !== "identity") {
-        throw new ValidationError(
-          "Unexpected managed identity resource name",
-          "identity",
-          req.params.managedIdentityResourceName,
-        );
-      }
-      req.expect.deepEqual(req.body["identity"], updateExpectedIdentity);
-      return {
-        status: 200,
-        body: json(validUserAssignedAndSystemAssignedManagedIdentityResource),
-      };
     },
     kind: "MockApiDefinition",
   });

--- a/packages/azure-http-specs/specs/azure/resource-manager/models/resources/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/models/resources/mockapi.ts
@@ -1,10 +1,4 @@
-import {
-  json,
-  MockRequest,
-  passOnSuccess,
-  ScenarioMockApi,
-  ValidationError,
-} from "@typespec/spec-api";
+import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
@@ -82,27 +76,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_SingletonTrackedResources_getBy
       status: 200,
       body: json(validSingletonResource),
     },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected subscriptionId",
-          SUBSCRIPTION_ID_EXPECTED,
-          req.params.subscriptionId,
-        );
-      }
-      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected resourceGroup",
-          RESOURCE_GROUP_EXPECTED,
-          req.params.resourceGroup,
-        );
-      }
-      return {
-        status: 200,
-        body: json(validSingletonResource),
-      };
-    },
     kind: "MockApiDefinition",
   });
 
@@ -126,33 +99,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_SingletonTrackedResources_creat
     response: {
       status: 200,
       body: json(validSingletonResource),
-    },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected subscriptionId",
-          SUBSCRIPTION_ID_EXPECTED,
-          req.params.subscriptionId,
-        );
-      }
-      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected resourceGroup",
-          RESOURCE_GROUP_EXPECTED,
-          req.params.resourceGroup,
-        );
-      }
-      req.expect.bodyEquals({
-        location: "eastus",
-        properties: {
-          description: "valid",
-        },
-      });
-      return {
-        status: 200,
-        body: json(validSingletonResource),
-      };
     },
     kind: "MockApiDefinition",
   });
@@ -187,36 +133,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_SingletonTrackedResources_updat
       },
     }),
   },
-  handler: (req: MockRequest) => {
-    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-    if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-      throw new ValidationError(
-        "Unexpected subscriptionId",
-        SUBSCRIPTION_ID_EXPECTED,
-        req.params.subscriptionId,
-      );
-    }
-    if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-      throw new ValidationError(
-        "Unexpected resourceGroup",
-        RESOURCE_GROUP_EXPECTED,
-        req.params.resourceGroup,
-      );
-    }
-    req.expect.bodyEquals({
-      location: "eastus2",
-      properties: {
-        description: "valid2",
-      },
-    });
-    const resource = JSON.parse(JSON.stringify(validSingletonResource));
-    resource.location = "eastus2";
-    resource.properties.description = "valid2";
-    return {
-      status: 200,
-      body: json(resource),
-    };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -236,29 +152,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_SingletonTrackedResources_listB
       body: json({
         value: [validSingletonResource],
       }),
-    },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected subscriptionId",
-          SUBSCRIPTION_ID_EXPECTED,
-          req.params.subscriptionId,
-        );
-      }
-      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected resourceGroup",
-          RESOURCE_GROUP_EXPECTED,
-          req.params.resourceGroup,
-        );
-      }
-      return {
-        status: 200,
-        body: json({
-          value: [validSingletonResource],
-        }),
-      };
     },
     kind: "MockApiDefinition",
   });
@@ -282,37 +175,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_action
     response: {
       status: 204,
     },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected subscriptionId",
-          SUBSCRIPTION_ID_EXPECTED,
-          req.params.subscriptionId,
-        );
-      }
-      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected resourceGroup",
-          RESOURCE_GROUP_EXPECTED,
-          req.params.resourceGroup,
-        );
-      }
-      if (req.params.topLevelResourceName.toLowerCase() !== "top") {
-        throw new ValidationError(
-          "Unexpected top level resource name",
-          "top",
-          req.params.topLevelResourceName,
-        );
-      }
-      req.expect.bodyEquals({
-        message: "Resource action at top level.",
-        urgent: true,
-      });
-      return {
-        status: 204,
-      };
-    },
     kind: "MockApiDefinition",
   });
 
@@ -331,34 +193,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_get = 
   response: {
     status: 200,
     body: json(validTopLevelResource),
-  },
-  handler: (req: MockRequest) => {
-    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-    if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-      throw new ValidationError(
-        "Unexpected subscriptionId",
-        SUBSCRIPTION_ID_EXPECTED,
-        req.params.subscriptionId,
-      );
-    }
-    if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-      throw new ValidationError(
-        "Unexpected resourceGroup",
-        RESOURCE_GROUP_EXPECTED,
-        req.params.resourceGroup,
-      );
-    }
-    if (req.params.topLevelResourceName.toLowerCase() !== "top") {
-      throw new ValidationError(
-        "Unexpected top level resource name",
-        "top",
-        req.params.topLevelResourceName,
-      );
-    }
-    return {
-      status: 200,
-      body: json(validTopLevelResource),
-    };
   },
   kind: "MockApiDefinition",
 });
@@ -384,40 +218,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_create
     response: {
       status: 200,
       body: json(validTopLevelResource),
-    },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected subscriptionId",
-          SUBSCRIPTION_ID_EXPECTED,
-          req.params.subscriptionId,
-        );
-      }
-      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected resourceGroup",
-          RESOURCE_GROUP_EXPECTED,
-          req.params.resourceGroup,
-        );
-      }
-      if (req.params.topLevelResourceName.toLowerCase() !== "top") {
-        throw new ValidationError(
-          "Unexpected top level resource name",
-          "top",
-          req.params.topLevelResourceName,
-        );
-      }
-      req.expect.bodyEquals({
-        location: "eastus",
-        properties: {
-          description: "valid",
-        },
-      });
-      return {
-        status: 200,
-        body: json(validTopLevelResource),
-      };
     },
     kind: "MockApiDefinition",
   });
@@ -451,39 +251,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_update
       },
     }),
   },
-  handler: (req: MockRequest) => {
-    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-    if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-      throw new ValidationError(
-        "Unexpected subscriptionId",
-        SUBSCRIPTION_ID_EXPECTED,
-        req.params.subscriptionId,
-      );
-    }
-    if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-      throw new ValidationError(
-        "Unexpected resourceGroup",
-        RESOURCE_GROUP_EXPECTED,
-        req.params.resourceGroup,
-      );
-    }
-    if (req.params.topLevelResourceName.toLowerCase() !== "top") {
-      throw new ValidationError(
-        "Unexpected top level resource name",
-        "top",
-        req.params.topLevelResourceName,
-      );
-    }
-    req.expect.deepEqual(req.body.properties, {
-      description: "valid2",
-    });
-    const resource = JSON.parse(JSON.stringify(validTopLevelResource));
-    resource.properties.description = "valid2";
-    return {
-      status: 200,
-      body: json(resource),
-    };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -500,33 +267,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_delete
   },
   response: {
     status: 204,
-  },
-  handler: (req: MockRequest) => {
-    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-    if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-      throw new ValidationError(
-        "Unexpected subscriptionId",
-        SUBSCRIPTION_ID_EXPECTED,
-        req.params.subscriptionId,
-      );
-    }
-    if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-      throw new ValidationError(
-        "Unexpected resourceGroup",
-        RESOURCE_GROUP_EXPECTED,
-        req.params.resourceGroup,
-      );
-    }
-    if (req.params.topLevelResourceName.toLowerCase() !== "top") {
-      throw new ValidationError(
-        "Unexpected top level resource name",
-        "top",
-        req.params.topLevelResourceName,
-      );
-    }
-    return {
-      status: 204,
-    };
   },
   kind: "MockApiDefinition",
 });
@@ -548,29 +288,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_listBy
         value: [validTopLevelResource],
       }),
     },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected subscriptionId",
-          SUBSCRIPTION_ID_EXPECTED,
-          req.params.subscriptionId,
-        );
-      }
-      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected resourceGroup",
-          RESOURCE_GROUP_EXPECTED,
-          req.params.resourceGroup,
-        );
-      }
-      return {
-        status: 200,
-        body: json({
-          value: [validTopLevelResource],
-        }),
-      };
-    },
     kind: "MockApiDefinition",
   });
 
@@ -589,22 +306,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_TopLevelTrackedResources_listBy
       body: json({
         value: [validTopLevelResource],
       }),
-    },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected subscriptionId",
-          SUBSCRIPTION_ID_EXPECTED,
-          req.params.subscriptionId,
-        );
-      }
-      return {
-        status: 200,
-        body: json({
-          value: [validTopLevelResource],
-        }),
-      };
     },
     kind: "MockApiDefinition",
   });
@@ -625,41 +326,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_get = pass
   response: {
     status: 200,
     body: json(validNestedResource),
-  },
-  handler: (req: MockRequest) => {
-    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-    if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-      throw new ValidationError(
-        "Unexpected subscriptionId",
-        SUBSCRIPTION_ID_EXPECTED,
-        req.params.subscriptionId,
-      );
-    }
-    if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-      throw new ValidationError(
-        "Unexpected resourceGroup",
-        RESOURCE_GROUP_EXPECTED,
-        req.params.resourceGroup,
-      );
-    }
-    if (req.params.topLevelResourceName.toLowerCase() !== "top") {
-      throw new ValidationError(
-        "Unexpected top level resource name",
-        "top",
-        req.params.topLevelResourceName,
-      );
-    }
-    if (req.params.nestedResourceName.toLowerCase() !== "nested") {
-      throw new ValidationError(
-        "Unexpected nested resource name",
-        "nested",
-        req.params.nestedResourceName,
-      );
-    }
-    return {
-      status: 200,
-      body: json(validNestedResource),
-    };
   },
   kind: "MockApiDefinition",
 });
@@ -685,46 +351,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_createOrRe
     response: {
       status: 200,
       body: json(validNestedResource),
-    },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected subscriptionId",
-          SUBSCRIPTION_ID_EXPECTED,
-          req.params.subscriptionId,
-        );
-      }
-      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected resourceGroup",
-          RESOURCE_GROUP_EXPECTED,
-          req.params.resourceGroup,
-        );
-      }
-      if (req.params.topLevelResourceName.toLowerCase() !== "top") {
-        throw new ValidationError(
-          "Unexpected top level resource name",
-          "top",
-          req.params.topLevelResourceName,
-        );
-      }
-      if (req.params.nestedResourceName.toLowerCase() !== "nested") {
-        throw new ValidationError(
-          "Unexpected nested resource name",
-          "nested",
-          req.params.nestedResourceName,
-        );
-      }
-      req.expect.bodyEquals({
-        properties: {
-          description: "valid",
-        },
-      });
-      return {
-        status: 200,
-        body: json(validNestedResource),
-      };
     },
     kind: "MockApiDefinition",
   });
@@ -759,48 +385,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_update = p
       },
     }),
   },
-  handler: (req: MockRequest) => {
-    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-    if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-      throw new ValidationError(
-        "Unexpected subscriptionId",
-        SUBSCRIPTION_ID_EXPECTED,
-        req.params.subscriptionId,
-      );
-    }
-    if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-      throw new ValidationError(
-        "Unexpected resourceGroup",
-        RESOURCE_GROUP_EXPECTED,
-        req.params.resourceGroup,
-      );
-    }
-    if (req.params.topLevelResourceName.toLowerCase() !== "top") {
-      throw new ValidationError(
-        "Unexpected top level resource name",
-        "top",
-        req.params.topLevelResourceName,
-      );
-    }
-    if (req.params.nestedResourceName.toLowerCase() !== "nested") {
-      throw new ValidationError(
-        "Unexpected nested resource name",
-        "nested",
-        req.params.nestedResourceName,
-      );
-    }
-    req.expect.bodyEquals({
-      properties: {
-        description: "valid2",
-      },
-    });
-    const resource = JSON.parse(JSON.stringify(validNestedResource));
-    resource.properties.description = "valid2";
-    return {
-      status: 200,
-      body: json(resource),
-    };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -818,12 +402,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_delete = p
   },
   response: {
     status: 204,
-  },
-  handler: (req: MockRequest) => {
-    req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-    return {
-      status: 204,
-    };
   },
   kind: "MockApiDefinition",
 });
@@ -845,36 +423,6 @@ Scenarios.Azure_ResourceManager_Models_Resources_NestedProxyResources_listByTopL
       body: json({
         value: [validNestedResource],
       }),
-    },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("api-version", "2023-12-01-preview");
-      if (req.params.subscriptionId !== SUBSCRIPTION_ID_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected subscriptionId",
-          SUBSCRIPTION_ID_EXPECTED,
-          req.params.subscriptionId,
-        );
-      }
-      if (req.params.resourceGroup.toLowerCase() !== RESOURCE_GROUP_EXPECTED) {
-        throw new ValidationError(
-          "Unexpected resourceGroup",
-          RESOURCE_GROUP_EXPECTED,
-          req.params.resourceGroup,
-        );
-      }
-      if (req.params.topLevelResourceName.toLowerCase() !== "top") {
-        throw new ValidationError(
-          "Unexpected top level resource name",
-          "top",
-          req.params.topLevelResourceName,
-        );
-      }
-      return {
-        status: 200,
-        body: json({
-          value: [validNestedResource],
-        }),
-      };
     },
     kind: "MockApiDefinition",
   });

--- a/packages/azure-http-specs/specs/client/naming/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/naming/mockapi.ts
@@ -1,4 +1,4 @@
-import { MockRequest, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
@@ -10,12 +10,6 @@ Scenarios.Client_Naming_Property_client = passOnSuccess({
   },
   response: {
     status: 204,
-  },
-  handler: (req: MockRequest) => {
-    req.expect.bodyEquals({ defaultName: true });
-    return {
-      status: 204,
-    };
   },
   kind: "MockApiDefinition",
 });
@@ -29,12 +23,6 @@ Scenarios.Client_Naming_Property_language = passOnSuccess({
   response: {
     status: 204,
   },
-  handler: (req: MockRequest) => {
-    req.expect.bodyEquals({ defaultName: true });
-    return {
-      status: 204,
-    };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -47,12 +35,6 @@ Scenarios.Client_Naming_Property_compatibleWithEncodedName = passOnSuccess({
   response: {
     status: 204,
   },
-  handler: (req: MockRequest) => {
-    req.expect.bodyEquals({ wireName: true });
-    return {
-      status: 204,
-    };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -62,11 +44,6 @@ Scenarios.Client_Naming_operation = passOnSuccess({
   request: {},
   response: {
     status: 204,
-  },
-  handler: (req: MockRequest) => {
-    return {
-      status: 204,
-    };
   },
   kind: "MockApiDefinition",
 });
@@ -80,12 +57,6 @@ Scenarios.Client_Naming_parameter = passOnSuccess({
   response: {
     status: 204,
   },
-  handler: (req: MockRequest) => {
-    req.expect.containsQueryParam("defaultName", "true");
-    return {
-      status: 204,
-    };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -97,12 +68,6 @@ Scenarios.Client_Naming_Header_request = passOnSuccess({
   },
   response: {
     status: 204,
-  },
-  handler: (req: MockRequest) => {
-    req.expect.containsHeader("default-name", "true");
-    return {
-      status: 204,
-    };
   },
   kind: "MockApiDefinition",
 });
@@ -117,14 +82,6 @@ Scenarios.Client_Naming_Header_response = passOnSuccess({
       "default-name": "true",
     },
   },
-  handler: (req: MockRequest) => {
-    return {
-      status: 204,
-      headers: {
-        "default-name": "true",
-      },
-    };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -137,12 +94,6 @@ Scenarios.Client_Naming_Model_client = passOnSuccess({
   response: {
     status: 204,
   },
-  handler: (req: MockRequest) => {
-    req.expect.bodyEquals({ defaultName: true });
-    return {
-      status: 204,
-    };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -154,12 +105,6 @@ Scenarios.Client_Naming_Model_language = passOnSuccess({
   },
   response: {
     status: 204,
-  },
-  handler: (req: MockRequest) => {
-    req.expect.bodyEquals({ defaultName: true });
-    return {
-      status: 204,
-    };
   },
   kind: "MockApiDefinition",
 });
@@ -176,12 +121,6 @@ Scenarios.Client_Naming_UnionEnum_unionEnumName = passOnSuccess({
   response: {
     status: 204,
   },
-  handler: (req: MockRequest) => {
-    req.expect.bodyEquals("value1");
-    return {
-      status: 204,
-    };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -196,12 +135,6 @@ Scenarios.Client_Naming_UnionEnum_unionEnumMemberName = passOnSuccess({
   },
   response: {
     status: 204,
-  },
-  handler: (req: MockRequest) => {
-    req.expect.bodyEquals("value1");
-    return {
-      status: 204,
-    };
   },
   kind: "MockApiDefinition",
 });

--- a/packages/azure-http-specs/specs/client/structure/common/service.ts
+++ b/packages/azure-http-specs/specs/client/structure/common/service.ts
@@ -1,4 +1,4 @@
-import { MockApiDefinition, MockRequest } from "@typespec/spec-api";
+import { MockApiDefinition } from "@typespec/spec-api";
 
 export function createServerTests(uri: string): MockApiDefinition {
   return {
@@ -6,9 +6,6 @@ export function createServerTests(uri: string): MockApiDefinition {
     method: "post",
     request: {},
     response: { status: 204 },
-    handler: (req: MockRequest) => {
-      return { status: 204 };
-    },
     kind: "MockApiDefinition",
   };
 }

--- a/packages/azure-http-specs/specs/resiliency/srv-driven/mockapi.ts
+++ b/packages/azure-http-specs/specs/resiliency/srv-driven/mockapi.ts
@@ -12,11 +12,6 @@ Scenarios.Resiliency_ServiceDriven_AddOptionalParam_fromNone = passOnSuccess([
     response: {
       status: 204,
     },
-    handler: (req: MockRequest) => {
-      return {
-        status: 204,
-      };
-    },
     kind: "MockApiDefinition",
   },
   {
@@ -25,11 +20,6 @@ Scenarios.Resiliency_ServiceDriven_AddOptionalParam_fromNone = passOnSuccess([
     request: {},
     response: {
       status: 204,
-    },
-    handler: (req: MockRequest) => {
-      return {
-        status: 204,
-      };
     },
     kind: "MockApiDefinition",
   },
@@ -65,12 +55,6 @@ Scenarios.Resiliency_ServiceDriven_AddOptionalParam_fromNone = passOnSuccess([
     response: {
       status: 204,
     },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("new-parameter", "new");
-      return {
-        status: 204,
-      };
-    },
     kind: "MockApiDefinition",
   },
 ]);
@@ -87,12 +71,6 @@ Scenarios.Resiliency_ServiceDriven_AddOptionalParam_fromOneRequired = passOnSucc
     response: {
       status: 204,
     },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("parameter", "required");
-      return {
-        status: 204,
-      };
-    },
     kind: "MockApiDefinition",
   },
   {
@@ -105,12 +83,6 @@ Scenarios.Resiliency_ServiceDriven_AddOptionalParam_fromOneRequired = passOnSucc
     },
     response: {
       status: 204,
-    },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("parameter", "required");
-      return {
-        status: 204,
-      };
     },
     kind: "MockApiDefinition",
   },
@@ -152,13 +124,6 @@ Scenarios.Resiliency_ServiceDriven_AddOptionalParam_fromOneRequired = passOnSucc
     response: {
       status: 204,
     },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("parameter", "required");
-      req.expect.containsQueryParam("new-parameter", "new");
-      return {
-        status: 204,
-      };
-    },
     kind: "MockApiDefinition",
   },
 ]);
@@ -175,12 +140,6 @@ Scenarios.Resiliency_ServiceDriven_AddOptionalParam_fromOneOptional = passOnSucc
     response: {
       status: 204,
     },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("parameter", "optional");
-      return {
-        status: 204,
-      };
-    },
     kind: "MockApiDefinition",
   },
   {
@@ -193,12 +152,6 @@ Scenarios.Resiliency_ServiceDriven_AddOptionalParam_fromOneOptional = passOnSucc
     },
     response: {
       status: 204,
-    },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("parameter", "optional");
-      return {
-        status: 204,
-      };
     },
     kind: "MockApiDefinition",
   },
@@ -240,13 +193,6 @@ Scenarios.Resiliency_ServiceDriven_AddOptionalParam_fromOneOptional = passOnSucc
     response: {
       status: 204,
     },
-    handler: (req: MockRequest) => {
-      req.expect.containsQueryParam("parameter", "optional");
-      req.expect.containsQueryParam("new-parameter", "new");
-      return {
-        status: 204,
-      };
-    },
     kind: "MockApiDefinition",
   },
 ]);
@@ -258,11 +204,6 @@ Scenarios.Resiliency_ServiceDriven_breakTheGlass = passOnSuccess({
   response: {
     status: 204,
   },
-  handler: (req: MockRequest) => {
-    return {
-      status: 204,
-    };
-  },
   kind: "MockApiDefinition",
 });
 
@@ -272,11 +213,6 @@ Scenarios.Resiliency_ServiceDriven_addOperation = passOnSuccess({
   request: {},
   response: {
     status: 204,
-  },
-  handler: (req: MockRequest) => {
-    return {
-      status: 204,
-    };
   },
   kind: "MockApiDefinition",
 });


### PR DESCRIPTION
This is the continuation of the PR https://github.com/microsoft/typespec/pull/4725. This PR handles the removal of handler property in majority of the Scenarios (Except ones related to LRO and that checks the absence of a parameter). All Scenarios are validated and tested. Please review and approve the PR. Thanks