### PR TITLE
[tcgc] use array instead of set to make the types ordered by typespec definition

### DIFF
--- a/.chronus/changes/types_order-2024-9-31-14-3-9.md
+++ b/.chronus/changes/types_order-2024-9-31-14-3-9.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+use array instead of set to make the types ordered by typespec definition

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1753,7 +1753,7 @@ function filterOutTypes(
   context: TCGCContext,
   filter: number,
 ): (SdkModelType | SdkEnumType | SdkUnionType | SdkNullableType)[] {
-  const result = new Set<SdkModelType | SdkEnumType | SdkUnionType | SdkNullableType>();
+  const result = new Array<SdkModelType | SdkEnumType | SdkUnionType | SdkNullableType>();
   for (const [type, sdkType] of context.referencedTypeMap?.entries() ?? []) {
     // filter models/enums/union of Core
     if (
@@ -1767,9 +1767,11 @@ function filterOutTypes(
     if ((sdkType.usage & filter) === 0) {
       continue;
     }
-    result.add(sdkType);
+    if (!result.includes(sdkType)) {
+      result.push(sdkType);
+    }
   }
-  return [...result];
+  return result;
 }
 
 export function getAllModelsWithDiagnostics(


### PR DESCRIPTION
fix: https://github.com/Azure/typespec-azure/issues/1394