### PR TITLE
Add ide label for azure specific ide requests

### DIFF
--- a/.github/policies/issues.triage.generated.yml
+++ b/.github/policies/issues.triage.generated.yml
@@ -27,6 +27,8 @@ configuration:
                     label: emitter:autorest
                 - hasLabel:
                     label: eng
+                - hasLabel:
+                    label: ide
         then:
           - addLabel:
               label: needs-area
@@ -47,6 +49,8 @@ configuration:
                   label: emitter:autorest
               - labelAdded:
                   label: eng
+              - labelAdded:
+                  label: ide
         then:
           - removeLabel:
               label: needs-area
@@ -68,6 +72,8 @@ configuration:
                   label: emitter:autorest
               - labelRemoved:
                   label: eng
+              - labelRemoved:
+                  label: ide
           - not:
               or:
                 - hasLabel:
@@ -80,6 +86,8 @@ configuration:
                     label: emitter:autorest
                 - hasLabel:
                     label: eng
+                - hasLabel:
+                    label: ide
         then:
           - addLabel:
               label: needs-area

--- a/.github/policies/prs.triage.generated.yml
+++ b/.github/policies/prs.triage.generated.yml
@@ -46,3 +46,9 @@ configuration:
             then:
               - addLabel:
                   label: lib:tcgc
+          - if:
+              - includesModifiedFiles:
+                  files: []
+            then:
+              - addLabel:
+                  label: ide

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -313,6 +313,7 @@ Area of the codebase
 | `lib:azure-resource-manager` | #957300 | Issues for @azure-tools/typespec-azure-core library            |
 | `emitter:autorest`           | #957300 | Issues for @azure-tools/typespec-autorest emitter              |
 | `eng`                        | #65bfff |                                                                |
+| `ide`                        | #846da1 | Issues for Azure specific ide features                         |
 
 #### issue_kinds
 

--- a/eng/config/labels.ts
+++ b/eng/config/labels.ts
@@ -43,6 +43,7 @@ export const AreaPaths: Record<keyof typeof AreaLabels, string[]> = {
   "lib:azure-resource-manager": ["packages/typespec-azure-resource-manager/"],
   "emitter:autorest": ["packages/typespec-autorest/"],
   "lib:tcgc": ["packages/typespec-client-generator-core/"],
+  ide: [],
 };
 
 export default defineConfig({

--- a/eng/config/labels.ts
+++ b/eng/config/labels.ts
@@ -28,6 +28,10 @@ export const AreaLabels = defineLabels({
     color: "65bfff",
     description: "",
   },
+  "ide": {
+    color: "846da1",
+    description: "Issues for Azure specific ide features",
+  },
 });
 
 /**

--- a/eng/config/labels.ts
+++ b/eng/config/labels.ts
@@ -28,7 +28,7 @@ export const AreaLabels = defineLabels({
     color: "65bfff",
     description: "",
   },
-  "ide": {
+  ide: {
     color: "846da1",
     description: "Issues for Azure specific ide features",
   },


### PR DESCRIPTION
Label was added and is now making the CI fail for every PR as there is one issue assigned to it so we don't auto delete 