### PR TITLE
[tcgc] add `disableUsageAccessPropagationToBase` flag and separate exception usage from output usage

### DIFF
--- a/.chronus/changes/add_usage_helper-2024-10-11-17-1-36.md
+++ b/.chronus/changes/add_usage_helper-2024-10-11-17-1-36.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+add `disableUsageAccessPropagationToBase` to support language that does not generate base model

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -615,6 +615,7 @@ export function createTCGCContext(program: Program, emitterName: string): TCGCCo
     __tspTypeToApiVersions: new Map(),
     __clientToApiVersionClientDefaultValue: new Map(),
     previewStringRegex: /-preview$/,
+    disableUsageAccessPropagationToBase: false,
   };
 }
 
@@ -626,6 +627,7 @@ interface VersioningStrategy {
 export interface CreateSdkContextOptions {
   readonly versioning?: VersioningStrategy;
   additionalDecorators?: string[];
+  disableUsageAccessPropagationToBase?: boolean; // this flag is for some languages that has no need to generate base model, but generate model with composition
 }
 
 export async function createSdkContext<
@@ -658,6 +660,7 @@ export async function createSdkContext<
     examplesDir: context.options["examples-dir"] ?? context.options["examples-directory"],
     decoratorsAllowList: [...defaultDecoratorsAllowList, ...(options?.additionalDecorators ?? [])],
     previewStringRegex: options?.versioning?.previewStringRegex || tcgcContext.previewStringRegex,
+    disableUsageAccessPropagationToBase: options?.disableUsageAccessPropagationToBase ?? false,
   };
   sdkContext.sdkPackage = diagnostics.pipe(getSdkPackage(sdkContext));
   for (const client of sdkContext.sdkPackage.clients) {

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -53,6 +53,7 @@ export interface TCGCContext {
   examplesDir?: string;
   decoratorsAllowList?: string[];
   previewStringRegex: RegExp;
+  disableUsageAccessPropagationToBase: boolean;
 }
 
 export interface SdkContext<

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -732,12 +732,10 @@ export enum UsageFlags {
   Spread = 1 << 6,
   // Output will also be set when Error is set.
   Error = 1 << 7,
-  // Set when type is used in conjunction with an application/json content type.
+  // Set when model is used in conjunction with an application/json content type.
   Json = 1 << 8,
-  // Set when type is used in conjunction with an application/xml content type.
+  // Set when model is used in conjunction with an application/xml content type.
   Xml = 1 << 9,
-  // Set when type is used for exception output
-  Exception = 1 << 10,
 }
 
 interface SdkExampleBase {

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -732,10 +732,12 @@ export enum UsageFlags {
   Spread = 1 << 6,
   // Output will also be set when Error is set.
   Error = 1 << 7,
-  // Set when model is used in conjunction with an application/json content type.
+  // Set when type is used in conjunction with an application/json content type.
   Json = 1 << 8,
-  // Set when model is used in conjunction with an application/xml content type.
+  // Set when type is used in conjunction with an application/xml content type.
   Xml = 1 << 9,
+  // Set when type is used for exception output
+  Exception = 1 << 10,
 }
 
 interface SdkExampleBase {

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1608,7 +1608,7 @@ function updateTypesFromOperation(
           } else {
             diagnostics.pipe(updateUsageOrAccess(context, UsageFlags.Output, sdkType));
           }
-          
+
           if (innerResponse.body.contentTypes.some((x) => isJsonContentType(x))) {
             diagnostics.pipe(updateUsageOrAccess(context, UsageFlags.Json, sdkType));
           }

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1458,8 +1458,11 @@ function updateUsageOrAccess(
   }
 
   if (!options.propagation) return diagnostics.wrap(undefined);
-  if (type.baseModel && !context.disableUsageAccessPropagationToBase) {
+  if (type.baseModel) {
     options.ignoreSubTypeStack.push(true);
+    if (context.disableUsageAccessPropagationToBase) {
+      options.skipFirst = true;
+    }
     diagnostics.pipe(updateUsageOrAccess(context, value, type.baseModel, options));
     options.ignoreSubTypeStack.pop();
   }

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1608,7 +1608,7 @@ function updateTypesFromOperation(
           } else {
             diagnostics.pipe(updateUsageOrAccess(context, UsageFlags.Output, sdkType));
           }
-
+          
           if (innerResponse.body.contentTypes.some((x) => isJsonContentType(x))) {
             diagnostics.pipe(updateUsageOrAccess(context, UsageFlags.Json, sdkType));
           }

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1603,8 +1603,12 @@ function updateTypesFromOperation(
             : innerResponse.body.type;
         const sdkType = diagnostics.pipe(getClientTypeWithDiagnostics(context, body, operation));
         if (generateConvenient) {
-          diagnostics.pipe(updateUsageOrAccess(context, UsageFlags.Output, sdkType));
-
+          if (response.statusCodes === "*" || isErrorModel(context.program, body)) {
+            diagnostics.pipe(updateUsageOrAccess(context, UsageFlags.Exception, sdkType));
+          } else {
+            diagnostics.pipe(updateUsageOrAccess(context, UsageFlags.Output, sdkType));
+          }
+          
           if (innerResponse.body.contentTypes.some((x) => isJsonContentType(x))) {
             diagnostics.pipe(updateUsageOrAccess(context, UsageFlags.Json, sdkType));
           }

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1234,8 +1234,8 @@ function updateMultiPartInfo(
         : undefined,
       contentType: httpOperationPart.body.contentTypeProperty
         ? diagnostics.pipe(
-            getSdkModelPropertyType(context, httpOperationPart.body.contentTypeProperty, operation),
-          )
+          getSdkModelPropertyType(context, httpOperationPart.body.contentTypeProperty, operation),
+        )
         : undefined,
       defaultContentTypes: httpOperationPart.body.contentTypes,
     };
@@ -1383,7 +1383,10 @@ function updateUsageOrAccess(
   if (options?.seenTypes === undefined) {
     options.seenTypes = new Set<SdkType>();
   }
-  if (options.seenTypes.has(type)) return diagnostics.wrap(undefined); // avoid circular references
+  if (options.seenTypes.has(type)) {
+    options.skipFirst = false;
+    return diagnostics.wrap(undefined); // avoid circular references
+  }
   if (type.kind === "array" || type.kind === "dict") {
     diagnostics.pipe(updateUsageOrAccess(context, value, type.valueType, options));
     return diagnostics.wrap(undefined);
@@ -1443,6 +1446,9 @@ function updateUsageOrAccess(
     }
   } else {
     options.skipFirst = false;
+    if (typeof value !== "number") {
+      type.__accessSet = true;
+    }
   }
 
   if (type.kind === "enum") return diagnostics.wrap(undefined);

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1603,12 +1603,8 @@ function updateTypesFromOperation(
             : innerResponse.body.type;
         const sdkType = diagnostics.pipe(getClientTypeWithDiagnostics(context, body, operation));
         if (generateConvenient) {
-          if (response.statusCodes === "*" || isErrorModel(context.program, body)) {
-            diagnostics.pipe(updateUsageOrAccess(context, UsageFlags.Exception, sdkType));
-          } else {
-            diagnostics.pipe(updateUsageOrAccess(context, UsageFlags.Output, sdkType));
-          }
-          
+          diagnostics.pipe(updateUsageOrAccess(context, UsageFlags.Output, sdkType));
+
           if (innerResponse.body.contentTypes.some((x) => isJsonContentType(x))) {
             diagnostics.pipe(updateUsageOrAccess(context, UsageFlags.Json, sdkType));
           }

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1234,8 +1234,8 @@ function updateMultiPartInfo(
         : undefined,
       contentType: httpOperationPart.body.contentTypeProperty
         ? diagnostics.pipe(
-            getSdkModelPropertyType(context, httpOperationPart.body.contentTypeProperty, operation),
-          )
+          getSdkModelPropertyType(context, httpOperationPart.body.contentTypeProperty, operation),
+        )
         : undefined,
       defaultContentTypes: httpOperationPart.body.contentTypes,
     };
@@ -1446,7 +1446,6 @@ function updateUsageOrAccess(
   }
 
   if (type.kind === "enum") return diagnostics.wrap(undefined);
-  if (!options.propagation) return diagnostics.wrap(undefined);
   if (type.kind === "union") {
     for (const unionType of type.variantTypes) {
       diagnostics.pipe(updateUsageOrAccess(context, value, unionType, options));
@@ -1457,7 +1456,9 @@ function updateUsageOrAccess(
     diagnostics.pipe(updateUsageOrAccess(context, value, type.type, options));
     return diagnostics.wrap(undefined);
   }
-  if (type.baseModel) {
+
+  if (!options.propagation) return diagnostics.wrap(undefined);
+  if (type.baseModel && !context.disableUsageAccessPropagationToBase) {
     options.ignoreSubTypeStack.push(true);
     diagnostics.pipe(updateUsageOrAccess(context, value, type.baseModel, options));
     options.ignoreSubTypeStack.pop();

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1234,8 +1234,8 @@ function updateMultiPartInfo(
         : undefined,
       contentType: httpOperationPart.body.contentTypeProperty
         ? diagnostics.pipe(
-          getSdkModelPropertyType(context, httpOperationPart.body.contentTypeProperty, operation),
-        )
+            getSdkModelPropertyType(context, httpOperationPart.body.contentTypeProperty, operation),
+          )
         : undefined,
       defaultContentTypes: httpOperationPart.body.contentTypes,
     };

--- a/packages/typespec-client-generator-core/test/decorators/access.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/access.test.ts
@@ -732,7 +732,10 @@ describe("typespec-client-generator-core: @access", () => {
   });
 
   it("disableUsageAccessPropagationToBase true with override", async () => {
-    runner = await createSdkTestRunner({ emitterName: "@azure-tools/typespec-python" }, { disableUsageAccessPropagationToBase: true });
+    runner = await createSdkTestRunner(
+      { emitterName: "@azure-tools/typespec-python" },
+      { disableUsageAccessPropagationToBase: true },
+    );
     await runner.compileWithBuiltInService(
       `
         model BaseClassThatsPruned {
@@ -758,7 +761,10 @@ describe("typespec-client-generator-core: @access", () => {
   });
 
   it("disableUsageAccessPropagationToBase true", async () => {
-    runner = await createSdkTestRunner({ emitterName: "@azure-tools/typespec-python" }, { disableUsageAccessPropagationToBase: true });
+    runner = await createSdkTestRunner(
+      { emitterName: "@azure-tools/typespec-python" },
+      { disableUsageAccessPropagationToBase: true },
+    );
     await runner.compileWithBuiltInService(
       `
         model BaseClassThatsPruned {

--- a/packages/typespec-client-generator-core/test/decorators/access.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/access.test.ts
@@ -730,4 +730,56 @@ describe("typespec-client-generator-core: @access", () => {
       code: "@azure-tools/typespec-client-generator-core/conflict-access-override",
     });
   });
+
+  it("disableUsageAccessPropagationToBase true with override", async () => {
+    runner = await createSdkTestRunner({ emitterName: "@azure-tools/typespec-python" }, { disableUsageAccessPropagationToBase: true });
+    await runner.compileWithBuiltInService(
+      `
+        model BaseClassThatsPruned {
+          id: int32;
+        }
+        model DerivedOne extends BaseClassThatsPruned {
+          name: string;
+          prop: UsedByProperty;
+        }
+        model UsedByProperty {
+          prop: string;
+        }
+        @@usage(DerivedOne, Usage.output);
+        @@access(DerivedOne, Access.public);
+      `,
+    );
+    const models = runner.context.sdkPackage.models;
+    strictEqual(models.length, 2);
+    strictEqual(models[0].access, "public");
+    strictEqual(models[0].name, "DerivedOne");
+    strictEqual(models[1].access, "public");
+    strictEqual(models[1].name, "UsedByProperty");
+  });
+
+  it("disableUsageAccessPropagationToBase true", async () => {
+    runner = await createSdkTestRunner({ emitterName: "@azure-tools/typespec-python" }, { disableUsageAccessPropagationToBase: true });
+    await runner.compileWithBuiltInService(
+      `
+        model BaseClassThatsPruned {
+          id: int32;
+        }
+        model DerivedOne extends BaseClassThatsPruned {
+          name: string;
+          prop: UsedByProperty;
+        }
+        model UsedByProperty {
+          prop: string;
+        }
+
+        op test(): DerivedOne;
+      `,
+    );
+    const models = runner.context.sdkPackage.models;
+    strictEqual(models.length, 2);
+    strictEqual(models[0].access, "public");
+    strictEqual(models[0].name, "DerivedOne");
+    strictEqual(models[1].access, "public");
+    strictEqual(models[1].name, "UsedByProperty");
+  });
 });

--- a/packages/typespec-client-generator-core/test/decorators/access.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/access.test.ts
@@ -788,4 +788,39 @@ describe("typespec-client-generator-core: @access", () => {
     strictEqual(models[1].access, "public");
     strictEqual(models[1].name, "UsedByProperty");
   });
+
+  it("disableUsageAccessPropagationToBase true complicated scenario", async () => {
+    runner = await createSdkTestRunner(
+      { emitterName: "@azure-tools/typespec-python" },
+      { disableUsageAccessPropagationToBase: true },
+    );
+    await runner.compileWithBuiltInService(
+      `
+        model BaseClassThatsPruned {
+          id: int32;
+          foo: UsedByBaseProperty;
+        }
+        model DerivedOne extends BaseClassThatsPruned {
+          name: string;
+          prop: UsedByProperty;
+        }
+        model UsedByProperty {
+          prop: string;
+        }
+        model UsedByBaseProperty {
+          prop: string;
+        }
+
+        op test(): DerivedOne;
+      `,
+    );
+    const models = runner.context.sdkPackage.models;
+    strictEqual(models.length, 3);
+    strictEqual(models[0].access, "public");
+    strictEqual(models[0].name, "DerivedOne");
+    strictEqual(models[1].access, "public");
+    strictEqual(models[1].name, "UsedByProperty");
+    strictEqual(models[2].access, "public");
+    strictEqual(models[2].name, "UsedByBaseProperty");
+  });
 });

--- a/packages/typespec-client-generator-core/test/decorators/usage.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/usage.test.ts
@@ -516,4 +516,39 @@ describe("typespec-client-generator-core: @usage", () => {
     strictEqual(models[1].usage, UsageFlags.Output | UsageFlags.Json);
     strictEqual(models[1].name, "UsedByProperty");
   });
+
+  it("disableUsageAccessPropagationToBase true complicated scenario", async () => {
+    runner = await createSdkTestRunner(
+      { emitterName: "@azure-tools/typespec-python" },
+      { disableUsageAccessPropagationToBase: true },
+    );
+    await runner.compileWithBuiltInService(
+      `
+        model BaseClassThatsPruned {
+          id: int32;
+          foo: UsedByBaseProperty;
+        }
+        model DerivedOne extends BaseClassThatsPruned {
+          name: string;
+          prop: UsedByProperty;
+        }
+        model UsedByProperty {
+          prop: string;
+        }
+        model UsedByBaseProperty {
+          prop: string;
+        }
+
+        op test(): DerivedOne;
+      `,
+    );
+    const models = runner.context.sdkPackage.models;
+    strictEqual(models.length, 3);
+    strictEqual(models[0].usage, UsageFlags.Output | UsageFlags.Json);
+    strictEqual(models[0].name, "DerivedOne");
+    strictEqual(models[1].usage, UsageFlags.Output | UsageFlags.Json);
+    strictEqual(models[1].name, "UsedByProperty");
+    strictEqual(models[2].usage, UsageFlags.Output | UsageFlags.Json);
+    strictEqual(models[2].name, "UsedByBaseProperty");
+  });
 });

--- a/packages/typespec-client-generator-core/test/decorators/usage.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/usage.test.ts
@@ -461,7 +461,10 @@ describe("typespec-client-generator-core: @usage", () => {
   });
 
   it("disableUsageAccessPropagationToBase true with override", async () => {
-    runner = await createSdkTestRunner({ emitterName: "@azure-tools/typespec-python" }, { disableUsageAccessPropagationToBase: true });
+    runner = await createSdkTestRunner(
+      { emitterName: "@azure-tools/typespec-python" },
+      { disableUsageAccessPropagationToBase: true },
+    );
     await runner.compileWithBuiltInService(
       `
         model BaseClassThatsPruned {
@@ -486,7 +489,10 @@ describe("typespec-client-generator-core: @usage", () => {
   });
 
   it("disableUsageAccessPropagationToBase true", async () => {
-    runner = await createSdkTestRunner({ emitterName: "@azure-tools/typespec-python" }, { disableUsageAccessPropagationToBase: true });
+    runner = await createSdkTestRunner(
+      { emitterName: "@azure-tools/typespec-python" },
+      { disableUsageAccessPropagationToBase: true },
+    );
     await runner.compileWithBuiltInService(
       `
         model BaseClassThatsPruned {

--- a/packages/typespec-client-generator-core/test/decorators/usage.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/usage.test.ts
@@ -517,7 +517,7 @@ describe("typespec-client-generator-core: @usage", () => {
     strictEqual(models[1].name, "UsedByProperty");
   });
 
-  it("disableUsageAccessPropagationToBase true complicated scenario", async () => {
+  it("disableUsageAccessPropagationToBase true property propagation", async () => {
     runner = await createSdkTestRunner(
       { emitterName: "@azure-tools/typespec-python" },
       { disableUsageAccessPropagationToBase: true },
@@ -550,5 +550,55 @@ describe("typespec-client-generator-core: @usage", () => {
     strictEqual(models[1].name, "UsedByProperty");
     strictEqual(models[2].usage, UsageFlags.Output | UsageFlags.Json);
     strictEqual(models[2].name, "UsedByBaseProperty");
+  });
+
+  it("disableUsageAccessPropagationToBase true discriminator propagation", async () => {
+    runner = await createSdkTestRunner(
+      { emitterName: "@azure-tools/typespec-python" },
+      { disableUsageAccessPropagationToBase: true },
+    );
+    await runner.compileWithBuiltInService(
+      `
+        @discriminator("kind")
+        model Fish {
+          age: int32;
+        }
+
+        @discriminator("sharktype")
+        model Shark extends Fish {
+          kind: "shark";
+          origin: Origin;
+        }
+
+        model Salmon extends Fish {
+          kind: "salmon";
+        }
+
+        model SawShark extends Shark {
+          sharktype: "saw";
+        }
+
+        model Origin {
+          country: string;
+          city: string;
+          manufacture: string;
+        }
+
+        @get
+        op getModel(): Fish;
+      `,
+    );
+    const models = runner.context.sdkPackage.models;
+    strictEqual(models.length, 5);
+    strictEqual(models[0].usage, UsageFlags.Output | UsageFlags.Json);
+    strictEqual(models[0].name, "Fish");
+    strictEqual(models[1].usage, UsageFlags.Output | UsageFlags.Json);
+    strictEqual(models[1].name, "Shark");
+    strictEqual(models[2].usage, UsageFlags.Output | UsageFlags.Json);
+    strictEqual(models[2].name, "Origin");
+    strictEqual(models[3].usage, UsageFlags.Output | UsageFlags.Json);
+    strictEqual(models[3].name, "SawShark");
+    strictEqual(models[4].usage, UsageFlags.Output | UsageFlags.Json);
+    strictEqual(models[4].name, "Salmon");
   });
 });

--- a/packages/typespec-client-generator-core/test/types/model-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/model-types.test.ts
@@ -1428,7 +1428,7 @@ describe("typespec-client-generator-core: model types", () => {
     ok(rawModel);
     strictEqual(rawModel.kind, "Model");
     strictEqual(isErrorModel(runner.context.program, rawModel), true);
-    ok(model.usage & UsageFlags.Exception);
+    ok(model.usage & UsageFlags.Output);
     ok(model.usage & UsageFlags.Error);
   });
 

--- a/packages/typespec-client-generator-core/test/types/model-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/model-types.test.ts
@@ -1428,7 +1428,7 @@ describe("typespec-client-generator-core: model types", () => {
     ok(rawModel);
     strictEqual(rawModel.kind, "Model");
     strictEqual(isErrorModel(runner.context.program, rawModel), true);
-    ok(model.usage & UsageFlags.Output);
+    ok(model.usage & UsageFlags.Exception);
     ok(model.usage & UsageFlags.Error);
   });
 


### PR DESCRIPTION
resolve: https://github.com/Azure/typespec-azure/issues/1827

add `disableUsageAccessPropagationToBase` flag: this flag aims to support language that does not generate base model, it will skip the base model's propagation but will not skip the property or subtype of the base model.
