### PR TITLE
specs, clientNamespace for Java

### DIFF
--- a/.chronus/changes/specs_clientNamespace-for-java-2024-10-22-10-38-54.md
+++ b/.chronus/changes/specs_clientNamespace-for-java-2024-10-22-10-38-54.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Update clientNamespace for Java.

--- a/packages/azure-http-specs/specs/azure/example/basic/client.tsp
+++ b/packages/azure-http-specs/specs/azure/example/basic/client.tsp
@@ -10,6 +10,9 @@ using Spector;
 @route("/azure/example/basic")
 namespace Client;
 
+@@clientNamespace(Client, "azure.example.basic", "java");
+@@clientNamespace(_Specs_.Azure.Example.Basic, "azure.example.basic", "java");
+
 @client({
   name: "AzureExampleClient",
   service: _Specs_.Azure.Example.Basic,


### PR DESCRIPTION
backport https://github.com/Azure/cadl-ranch/pull/771

After this, Java would start the migration to http-specs/azure-http-specs and no longer update cadl-ranch