### PR TITLE
[tcgc] use the right path parameter name when filtering method parameter

### DIFF
--- a/.chronus/changes/fix_path_param_filtering-2024-10-25-14-34-24.md
+++ b/.chronus/changes/fix_path_param_filtering-2024-10-25-14-34-24.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+use the right path parameter name when filtering method parameter

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -412,12 +412,12 @@ function getSdkHttpResponseAndExceptions(
   context: TCGCContext,
   httpOperation: HttpOperation,
 ): [
-  {
-    responses: SdkHttpResponse[];
-    exceptions: SdkHttpErrorResponse[];
-  },
-  readonly Diagnostic[],
-] {
+    {
+      responses: SdkHttpResponse[];
+      exceptions: SdkHttpErrorResponse[];
+    },
+    readonly Diagnostic[],
+  ] {
   const diagnostics = createDiagnosticCollector();
   const responses: SdkHttpResponse[] = [];
   const exceptions: SdkHttpErrorResponse[] = [];
@@ -655,7 +655,7 @@ function filterOutUselessPathParameters(
       param.__raw &&
       isPathParam(context.program, param.__raw) &&
       httpOperation.parameters.parameters.filter(
-        (p) => p.type === "path" && p.name === getWireName(context, param.__raw!),
+        (p) => p.type === "path" && p.name === (getPathParamName(context.program, param.__raw!) ?? param.name),
       ).length === 0
     ) {
       methodParameters.splice(i, 1);

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -412,12 +412,12 @@ function getSdkHttpResponseAndExceptions(
   context: TCGCContext,
   httpOperation: HttpOperation,
 ): [
-    {
-      responses: SdkHttpResponse[];
-      exceptions: SdkHttpErrorResponse[];
-    },
-    readonly Diagnostic[],
-  ] {
+  {
+    responses: SdkHttpResponse[];
+    exceptions: SdkHttpErrorResponse[];
+  },
+  readonly Diagnostic[],
+] {
   const diagnostics = createDiagnosticCollector();
   const responses: SdkHttpResponse[] = [];
   const exceptions: SdkHttpErrorResponse[] = [];
@@ -655,7 +655,9 @@ function filterOutUselessPathParameters(
       param.__raw &&
       isPathParam(context.program, param.__raw) &&
       httpOperation.parameters.parameters.filter(
-        (p) => p.type === "path" && p.name === (getPathParamName(context.program, param.__raw!) ?? param.name),
+        (p) =>
+          p.type === "path" &&
+          p.name === (getPathParamName(context.program, param.__raw!) ?? param.name),
       ).length === 0
     ) {
       methodParameters.splice(i, 1);

--- a/packages/typespec-client-generator-core/test/packages/parameters.test.ts
+++ b/packages/typespec-client-generator-core/test/packages/parameters.test.ts
@@ -1103,6 +1103,17 @@ describe("typespec-client-generator-core: parameters", () => {
       strictEqual(method.operation.uriTemplate, "/test");
     });
 
+    it("normal case with different wire name", async () => {
+      await runner.compileWithBuiltInService(`
+          @autoRoute
+          op test(@path("param-wire") param: string): void;
+        `);
+      const sdkPackage = runner.context.sdkPackage;
+      const method = getServiceMethodOfClient(sdkPackage);
+      strictEqual(method.parameters.length, 1);
+      strictEqual(method.operation.parameters.length, 1);
+    });
+
     it("singleton resource", async () => {
       const runnerWithArm = await createSdkTestRunner({
         librariesToAdd: [AzureResourceManagerTestLibrary, AzureCoreTestLibrary, OpenAPITestLibrary],


### PR DESCRIPTION
fix: https://github.com/Azure/typespec-azure/issues/1905