### PR TITLE
azure-http-specs, update azure example scenario name

### DIFF
--- a/.chronus/changes/azure-http-specs_update-azure-example-2024-10-29-12-14-37.md
+++ b/.chronus/changes/azure-http-specs_update-azure-example-2024-10-29-12-14-37.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Update scenario name on azure example scenario

--- a/packages/azure-http-specs/spec-summary.md
+++ b/packages/azure-http-specs/spec-summary.md
@@ -720,6 +720,42 @@ Expected response body:
 }
 ```
 
+### Azure_Example_Basic
+
+- Endpoint: `post /azure/example/basic/basic`
+
+Expected request and response is same as the JSON example at examples/2022-12-01-preview/basic.json
+
+When generate the code, one need to set the "examples-directory" option.
+
+Expected query parameter: query-param=query&api-version=2022-12-01-preview
+Expected header parameter: header-param=header
+
+Expected input body:
+
+```json
+{
+  "stringProperty": "text",
+  "modelProperty": {
+    "int32Property": 1,
+    "float32Property": 1.5,
+    "enumProperty": "EnumValue1"
+  },
+  "arrayProperty": ["item"],
+  "recordProperty": {
+    "record": "value"
+  }
+}
+```
+
+Expected response body:
+
+```json
+{
+  "stringProperty": "text"
+}
+```
+
 ### Azure_ResourceManager_CommonProperties_ManagedIdentity_createWithSystemAssigned
 
 - Endpoint: `put https://management.azure.com`
@@ -1344,42 +1380,6 @@ Expected header parameters:
 - x-ms-client-request-id=<any uuid string>
   Expected response header:
 - x-ms-client-request-id=<uuid string same with request header>
-
-### Client_AzureExampleClient_basicAction
-
-- Endpoint: `post /azure/example/basic/basic`
-
-Expected request and response is same as the JSON example at examples/2022-12-01-preview/basic.json
-
-When generate the code, one need to set the "examples-directory" option.
-
-Expected query parameter: query-param=query&api-version=2022-12-01-preview
-Expected header parameter: header-param=header
-
-Expected input body:
-
-```json
-{
-  "stringProperty": "text",
-  "modelProperty": {
-    "int32Property": 1,
-    "float32Property": 1.5,
-    "enumProperty": "EnumValue1"
-  },
-  "arrayProperty": ["item"],
-  "recordProperty": {
-    "record": "value"
-  }
-}
-```
-
-Expected response body:
-
-```json
-{
-  "stringProperty": "text"
-}
-```
 
 ### Client_Naming_Header_request
 

--- a/packages/azure-http-specs/specs/azure/example/basic/client.tsp
+++ b/packages/azure-http-specs/specs/azure/example/basic/client.tsp
@@ -8,9 +8,9 @@ using Spector;
 
 @TypeSpec.Versioning.useDependency(_Specs_.Azure.Example.Basic.Versions.v2022_12_01_preview)
 @route("/azure/example/basic")
-namespace Client;
+namespace AzureExampleBasicClient;
 
-@@clientNamespace(Client, "azure.example.basic", "java");
+@@clientNamespace(AzureExampleBasicClient, "azure.example.basic", "java");
 @@clientNamespace(_Specs_.Azure.Example.Basic, "azure.example.basic", "java");
 
 @client({
@@ -18,39 +18,5 @@ namespace Client;
   service: _Specs_.Azure.Example.Basic,
 })
 interface AzureExampleClient {
-  @scenario
-  @scenarioDoc("""
-    Expected request and response is same as the JSON example at examples/2022-12-01-preview/basic.json
-    
-    When generate the code, one need to set the "examples-directory" option.
-    
-    Expected query parameter: query-param=query&api-version=2022-12-01-preview
-    Expected header parameter: header-param=header
-    
-    Expected input body:
-    ```json
-    {
-      "stringProperty": "text",
-      "modelProperty": {
-        "int32Property": 1,
-        "float32Property": 1.5,
-        "enumProperty": "EnumValue1"
-      },
-      "arrayProperty": [
-        "item"
-      ],
-      "recordProperty": {
-        "record": "value"
-      }
-    }
-    ```
-    
-    Expected response body:
-    ```json
-    {
-      "stringProperty": "text"
-    }
-    ```
-    """)
   basicAction is _Specs_.Azure.Example.Basic.ServiceOperationGroup.basic;
 }

--- a/packages/azure-http-specs/specs/azure/example/basic/main.tsp
+++ b/packages/azure-http-specs/specs/azure/example/basic/main.tsp
@@ -15,6 +15,40 @@ using Spector;
     versioned: Versions,
   }
 )
+@scenario
+@scenarioDoc("""
+  Expected request and response is same as the JSON example at examples/2022-12-01-preview/basic.json
+  
+  When generate the code, one need to set the "examples-directory" option.
+  
+  Expected query parameter: query-param=query&api-version=2022-12-01-preview
+  Expected header parameter: header-param=header
+  
+  Expected input body:
+  ```json
+  {
+    "stringProperty": "text",
+    "modelProperty": {
+      "int32Property": 1,
+      "float32Property": 1.5,
+      "enumProperty": "EnumValue1"
+    },
+    "arrayProperty": [
+      "item"
+    ],
+    "recordProperty": {
+      "record": "value"
+    }
+  }
+  ```
+  
+  Expected response body:
+  ```json
+  {
+    "stringProperty": "text"
+  }
+  ```
+  """)
 namespace _Specs_.Azure.Example.Basic;
 
 enum Versions {

--- a/packages/azure-http-specs/specs/azure/example/basic/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/example/basic/mockapi.ts
@@ -2,7 +2,7 @@ import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 
-Scenarios.Client_AzureExampleClient_basicAction = passOnSuccess({
+Scenarios.Azure_Example_Basic = passOnSuccess({
   uri: "/azure/example/basic/basic",
   method: "post",
   request: {


### PR DESCRIPTION
Move `@scenario` from client.tsp to main.tsp

When in client.tsp, the namespace there would be the scenario name of this test, which appears not correct.
![image](https://github.com/user-attachments/assets/dbdb394b-425a-4a61-af59-0f48a15f0932)

This should not affect code generated by emitters.