### PR TITLE
[tcgc] fix wrong `unexpected-pageable-operation-return-type` because of nullable type

### DIFF
--- a/.chronus/changes/fix_unbranded_page_issue-2024-10-29-17-58-58.md
+++ b/.chronus/changes/fix_unbranded_page_issue-2024-10-29-17-58-58.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+fix wrong `unexpected-pageable-operation-return-type` because of nullable type

--- a/packages/typespec-client-generator-core/test/packages/paged-operation.test.ts
+++ b/packages/typespec-client-generator-core/test/packages/paged-operation.test.ts
@@ -69,6 +69,31 @@ describe("typespec-client-generator-core: paged operation", () => {
     strictEqual(response.resultPath, "tests");
   });
 
+  it("nullable paged result", async () => {
+    await runner.compileWithBuiltInService(`
+      @list
+      op test(): ListTestResult | NotFoundResponse;
+      model ListTestResult {
+        @pageItems
+        tests: Test[];
+        @TypeSpec.nextLink
+        next: string;
+      }
+      model Test {
+        id: string;
+      }
+    `);
+    const sdkPackage = runner.context.sdkPackage;
+    const method = getServiceMethodOfClient(sdkPackage);
+    strictEqual(method.name, "test");
+    strictEqual(method.kind, "paging");
+    strictEqual(method.nextLinkPath, "next");
+
+    const response = method.response;
+    strictEqual(response.kind, "method");
+    strictEqual(response.resultPath, "tests");
+  });
+
   it("normal paged result with encoded name", async () => {
     await runner.compileWithBuiltInService(`
       @list


### PR DESCRIPTION
when a method has several responses and only one of them has pageable body. tcgc's method return type will be a wrapped nullable type which real type is that response with body. so, when trying to find property, we need to peel off the wrapped nullable.