### PR TITLE
Add `@scope` decorator

### DIFF
--- a/.chronus/changes/scope-decorator-2024-11-18-12-59-12.md
+++ b/.chronus/changes/scope-decorator-2024-11-18-12-59-12.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Add `@scope` decorator to define the language scope for operation

--- a/packages/typespec-client-generator-core/README.md
+++ b/packages/typespec-client-generator-core/README.md
@@ -654,6 +654,7 @@ To define the client scope of an operation.
 ##### Examples
 
 ```typespec
+@scope("!csharp")
 op test: void;
 ```
 

--- a/packages/typespec-client-generator-core/README.md
+++ b/packages/typespec-client-generator-core/README.md
@@ -82,6 +82,7 @@ options:
 - [`@override`](#@override)
 - [`@paramAlias`](#@paramalias)
 - [`@protocolAPI`](#@protocolapi)
+- [`@scope`](#@scope)
 - [`@usage`](#@usage)
 - [`@useSystemTextJsonConverter`](#@usesystemtextjsonconverter)
 
@@ -590,6 +591,30 @@ Whether you want to generate an operation as a protocol operation.
 
 ```typespec
 @protocolAPI(false)
+op test: void;
+```
+
+#### `@scope`
+
+To define the client scope of an operation.
+
+```typespec
+@Azure.ClientGenerator.Core.scope(scope?: valueof string)
+```
+
+##### Target
+
+`Operation`
+
+##### Parameters
+
+| Name  | Type             | Description                                                                                                                                                                                           |
+| ----- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| scope | `valueof string` | The language scope you want this decorator to apply to. If not specified, will apply to all language emitters<br />You can use "!" to specify negation such as "!(java, python)" or "!java, !python". |
+
+##### Examples
+
+```typespec
 op test: void;
 ```
 

--- a/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.ts
+++ b/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.ts
@@ -533,6 +533,18 @@ export type ClientNamespaceDecorator = (
   scope?: string,
 ) => void;
 
+/**
+ * To define the client scope of an operation.
+ *
+ * @param scope The language scope you want this decorator to apply to. If not specified, will apply to all language emitters
+ * You can use "!" to specify negation such as "!(java, python)" or "!java, !python".
+ * @example
+ * ```typespec
+ * op test: void;
+ * ```
+ */
+export type ScopeDecorator = (context: DecoratorContext, target: Operation, scope?: string) => void;
+
 export type AzureClientGeneratorCoreDecorators = {
   clientName: ClientNameDecorator;
   convenientAPI: ConvenientAPIDecorator;
@@ -547,4 +559,5 @@ export type AzureClientGeneratorCoreDecorators = {
   clientInitialization: ClientInitializationDecorator;
   paramAlias: ParamAliasDecorator;
   clientNamespace: ClientNamespaceDecorator;
+  scope: ScopeDecorator;
 };

--- a/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.ts
+++ b/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.ts
@@ -572,6 +572,7 @@ export type AlternateTypeDecorator = (
  * You can use "!" to specify negation such as "!(java, python)" or "!java, !python".
  * @example
  * ```typespec
+ * @scope("!csharp")
  * op test: void;
  * ```
  */

--- a/packages/typespec-client-generator-core/lib/decorators.tsp
+++ b/packages/typespec-client-generator-core/lib/decorators.tsp
@@ -547,6 +547,7 @@ extern dec alternateType(source: ModelProperty | Scalar, alternate: Scalar, scop
  *
  * @example
  * ```typespec
+ * @scope("!csharp")
  * op test: void;
  * ```
  */

--- a/packages/typespec-client-generator-core/lib/decorators.tsp
+++ b/packages/typespec-client-generator-core/lib/decorators.tsp
@@ -513,3 +513,15 @@ extern dec clientNamespace(
   rename: valueof string,
   scope?: valueof string
 );
+
+/**
+ * To define the client scope of an operation.
+ * @param scope The language scope you want this decorator to apply to. If not specified, will apply to all language emitters
+ * You can use "!" to specify negation such as "!(java, python)" or "!java, !python".
+ *
+ * @example
+ * ```typespec
+ * op test: void;
+ * ```
+ */
+extern dec scope(target: Operation, scope?: valueof string);

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -38,6 +38,7 @@ import {
   OperationGroupDecorator,
   ParamAliasDecorator,
   ProtocolAPIDecorator,
+  ScopeDecorator,
   UsageDecorator,
 } from "../generated-defs/Azure.ClientGenerator.Core.js";
 import {
@@ -58,6 +59,7 @@ import {
   getValidApiVersion,
   isAzureCoreTspModel,
   negationScopesKey,
+  scopeKey,
 } from "./internal-utils.js";
 import { createStateSymbol, reportDiagnostic } from "./lib.js";
 import { getLibraryName } from "./public-utils.js";
@@ -1070,4 +1072,18 @@ function getNamespaceFullNameWithOverride(context: TCGCContext, namespace: Names
     current = current.namespace;
   }
   return segments.join(".");
+}
+
+export const $scope: ScopeDecorator = (
+  context: DecoratorContext,
+  entity: Operation,
+  scope?: LanguageScopes,
+) => {
+  setScopedDecoratorData(context, $scope, negationScopesKey, entity, undefined, scope);
+};
+
+export function IsInScope(context: TCGCContext, entity: Operation): boolean {
+  var scopes = getScopedDecoratorData(context, scopeKey, entity);
+  if (scopes === undefined) return true;
+  return scopes.includes(context.emitterName);
 }

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -1082,11 +1082,23 @@ export const $scope: ScopeDecorator = (
   const [negationScopes, scopes] = parseScopes(context, scope);
   if (negationScopes !== undefined && negationScopes.length > 0) {
     const targetEntry = context.program.stateMap(negationScopesKey).get(entity);
-    setScopedDecoratorData(context, $scope, negationScopesKey, entity, !targetEntry ? negationScopes : [...Object.values(targetEntry), ...negationScopes]);
+    setScopedDecoratorData(
+      context,
+      $scope,
+      negationScopesKey,
+      entity,
+      !targetEntry ? negationScopes : [...Object.values(targetEntry), ...negationScopes],
+    );
   }
   if (scopes !== undefined && scopes.length > 0) {
     const targetEntry = context.program.stateMap(scopeKey).get(entity);
-    setScopedDecoratorData(context, $scope, scopeKey, entity, !targetEntry ? scopes : [...Object.values(targetEntry), ...scopes]);
+    setScopedDecoratorData(
+      context,
+      $scope,
+      scopeKey,
+      entity,
+      !targetEntry ? scopes : [...Object.values(targetEntry), ...scopes],
+    );
   }
 };
 

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -1079,11 +1079,9 @@ export const $scope: ScopeDecorator = (
   entity: Operation,
   scope?: LanguageScopes,
 ) => {
-  setScopedDecoratorData(context, $scope, negationScopesKey, entity, undefined, scope);
+  setScopedDecoratorData(context, $scope, scopeKey, entity, true, scope);
 };
 
 export function IsInScope(context: TCGCContext, entity: Operation): boolean {
-  const scopes = getScopedDecoratorData(context, scopeKey, entity);
-  if (scopes === undefined) return true;
-  return scopes.includes(context.emitterName);
+  return getScopedDecoratorData(context, scopeKey, entity) === true;
 }

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -1081,16 +1081,11 @@ export const $scope: ScopeDecorator = (
 ) => {
   const [negationScopes, scopes] = parseScopes(context, scope);
   if (negationScopes !== undefined && negationScopes.length > 0) {
-    const targetEntry = context.program.stateMap(negationScopesKey).get(entity);
-    setScopedDecoratorData(
-      context,
-      $scope,
-      negationScopesKey,
-      entity,
-      !targetEntry ? negationScopes : [...Object.values(targetEntry), ...negationScopes],
-    );
+    // for negation scope, override the previous value
+    setScopedDecoratorData(context, $scope, negationScopesKey, entity, negationScopes);
   }
   if (scopes !== undefined && scopes.length > 0) {
+    // for normal scope, add them incrementally
     const targetEntry = context.program.stateMap(scopeKey).get(entity);
     setScopedDecoratorData(
       context,

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -626,6 +626,10 @@ export function listOperationsInOperationGroup(
     }
 
     for (const op of current.operations.values()) {
+      if (!IsInScope(context, op)) {
+        continue;
+      }
+
       // Skip templated operations and omit operations
       if (
         !isTemplateDeclarationOrInstance(op) &&
@@ -1141,7 +1145,7 @@ export const $scope: ScopeDecorator = (
   }
 };
 
-export function IsInScope(context: TCGCContext, entity: Operation): boolean {
+function IsInScope(context: TCGCContext, entity: Operation): boolean {
   const scopes = getScopedDecoratorData(context, scopeKey, entity);
   if (scopes !== undefined && scopes.includes(context.emitterName)) {
     return true;

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -1083,7 +1083,7 @@ export const $scope: ScopeDecorator = (
 };
 
 export function IsInScope(context: TCGCContext, entity: Operation): boolean {
-  var scopes = getScopedDecoratorData(context, scopeKey, entity);
+  const scopes = getScopedDecoratorData(context, scopeKey, entity);
   if (scopes === undefined) return true;
   return scopes.includes(context.emitterName);
 }

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -1079,9 +1079,26 @@ export const $scope: ScopeDecorator = (
   entity: Operation,
   scope?: LanguageScopes,
 ) => {
-  setScopedDecoratorData(context, $scope, scopeKey, entity, true, scope);
+  const [negationScopes, scopes] = parseScopes(context, scope);
+  if (negationScopes !== undefined && negationScopes.length > 0) {
+    const targetEntry = context.program.stateMap(negationScopesKey).get(entity);
+    setScopedDecoratorData(context, $scope, negationScopesKey, entity, !targetEntry ? negationScopes : [...Object.values(targetEntry), ...negationScopes]);
+  }
+  if (scopes !== undefined && scopes.length > 0) {
+    const targetEntry = context.program.stateMap(scopeKey).get(entity);
+    setScopedDecoratorData(context, $scope, scopeKey, entity, !targetEntry ? scopes : [...Object.values(targetEntry), ...scopes]);
+  }
 };
 
 export function IsInScope(context: TCGCContext, entity: Operation): boolean {
-  return getScopedDecoratorData(context, scopeKey, entity) === true;
+  const scopes = getScopedDecoratorData(context, scopeKey, entity);
+  if (scopes !== undefined && scopes.includes(context.emitterName)) {
+    return true;
+  }
+
+  const negationScopes = getScopedDecoratorData(context, negationScopesKey, entity);
+  if (negationScopes !== undefined && negationScopes.includes(context.emitterName)) {
+    return false;
+  }
+  return true;
 }

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -52,6 +52,7 @@ export const AllScopes = Symbol.for("@azure-core/typespec-client-generator-core/
 export const clientNameKey = createStateSymbol("clientName");
 export const clientNamespaceKey = createStateSymbol("clientNamespace");
 export const negationScopesKey = createStateSymbol("negationScopes");
+export const scopeKey = createStateSymbol("scope");
 
 /**
  *

--- a/packages/typespec-client-generator-core/src/package.ts
+++ b/packages/typespec-client-generator-core/src/package.ts
@@ -22,6 +22,7 @@ import {
   getClientNameOverride,
   getClientNamespace,
   getOverriddenClientMethod,
+  IsInScope,
   listClients,
   listOperationGroups,
   listOperationsInOperationGroup,
@@ -606,9 +607,11 @@ function getSdkMethods<TServiceOperation extends SdkServiceOperation>(
   const diagnostics = createDiagnosticCollector();
   const retval: SdkMethod<TServiceOperation>[] = [];
   for (const operation of listOperationsInOperationGroup(context, client)) {
-    retval.push(
-      diagnostics.pipe(getSdkServiceMethod<TServiceOperation>(context, operation, sdkClientType)),
-    );
+    if (IsInScope(context, operation)) {
+      retval.push(
+        diagnostics.pipe(getSdkServiceMethod<TServiceOperation>(context, operation, sdkClientType)),
+      );
+    }
   }
   for (const operationGroup of listOperationGroups(context, client)) {
     // We create a client accessor for each operation group

--- a/packages/typespec-client-generator-core/src/package.ts
+++ b/packages/typespec-client-generator-core/src/package.ts
@@ -22,7 +22,6 @@ import {
   getClientNameOverride,
   getClientNamespace,
   getOverriddenClientMethod,
-  IsInScope,
   listClients,
   listOperationGroups,
   listOperationsInOperationGroup,
@@ -607,11 +606,9 @@ function getSdkMethods<TServiceOperation extends SdkServiceOperation>(
   const diagnostics = createDiagnosticCollector();
   const retval: SdkMethod<TServiceOperation>[] = [];
   for (const operation of listOperationsInOperationGroup(context, client)) {
-    if (IsInScope(context, operation)) {
-      retval.push(
-        diagnostics.pipe(getSdkServiceMethod<TServiceOperation>(context, operation, sdkClientType)),
-      );
-    }
+    retval.push(
+      diagnostics.pipe(getSdkServiceMethod<TServiceOperation>(context, operation, sdkClientType)),
+    );
   }
   for (const operationGroup of listOperationGroups(context, client)) {
     // We create a client accessor for each operation group

--- a/packages/typespec-client-generator-core/src/tsp-index.ts
+++ b/packages/typespec-client-generator-core/src/tsp-index.ts
@@ -10,10 +10,10 @@ import {
   $operationGroup,
   $override,
   $protocolAPI,
+  $scope,
   $usage,
   $useSystemTextJsonConverter,
   paramAliasDecorator,
-  $scope,
 } from "./decorators.js";
 
 export { $lib } from "./lib.js";

--- a/packages/typespec-client-generator-core/src/tsp-index.ts
+++ b/packages/typespec-client-generator-core/src/tsp-index.ts
@@ -13,6 +13,7 @@ import {
   $usage,
   $useSystemTextJsonConverter,
   paramAliasDecorator,
+  $scope,
 } from "./decorators.js";
 
 export { $lib } from "./lib.js";
@@ -34,5 +35,6 @@ export const $decorators = {
     clientInitialization: $clientInitialization,
     paramAlias: paramAliasDecorator,
     clientNamespace: $clientNamespace,
+    scope: $scope,
   } as AzureClientGeneratorCoreDecorators,
 };

--- a/packages/typespec-client-generator-core/test/decorators.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators.test.ts
@@ -3017,7 +3017,7 @@ describe("typespec-client-generator-core: decorators", () => {
       ok(sdkClient === undefined);
     });
 
-    it("define scope for operation incrementally", async () => {
+    it("negation scope override", async () => {
       const runnerWithCSharp = await createSdkTestRunner({
         emitterName: "@azure-tools/typespec-csharp",
       });
@@ -3033,7 +3033,6 @@ describe("typespec-client-generator-core: decorators", () => {
           }
           @scope("!java")
           @scope("!csharp")
-          @scope("csharp")
           op func(
             @body body: Test
           ): void;
@@ -3065,6 +3064,30 @@ describe("typespec-client-generator-core: decorators", () => {
           model Test {
             prop: string;
           }
+          op func(
+            @body body: Test
+          ): void;
+        }
+      `);
+
+      const sdkPackage = runnerWithCSharp.context.sdkPackage;
+      const sdkClient = sdkPackage.clients.find((x) => x.methods.find((m) => m.name === "func"));
+      ok(sdkClient);
+    });
+
+    it("negation scope override normal scope", async () => {
+      const runnerWithCSharp = await createSdkTestRunner({
+        emitterName: "@azure-tools/typespec-csharp",
+      });
+      await runnerWithCSharp.compile(`
+        @service
+        namespace MyService {
+          @clientName("TestRenamed", "csharp")
+          model Test {
+            prop: string;
+          }
+          @scope("!csharp")
+          @scope("csharp")
           op func(
             @body body: Test
           ): void;

--- a/packages/typespec-client-generator-core/test/decorators.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators.test.ts
@@ -2990,7 +2990,7 @@ describe("typespec-client-generator-core: decorators", () => {
       `);
 
       const sdkPackage = runnerWithCSharp.context.sdkPackage;
-      const sdkClient = sdkPackage.clients.find((x) => x.methods.find(m => m.name === "func"));
+      const sdkClient = sdkPackage.clients.find((x) => x.methods.find((m) => m.name === "func"));
       ok(sdkClient);
     });
 
@@ -3013,7 +3013,7 @@ describe("typespec-client-generator-core: decorators", () => {
       `);
 
       const sdkPackage = runnerWithCSharp.context.sdkPackage;
-      const sdkClient = sdkPackage.clients.find(x => x.methods.find(m => m.name === "func"));
+      const sdkClient = sdkPackage.clients.find((x) => x.methods.find((m) => m.name === "func"));
       ok(sdkClient === undefined);
     });
 
@@ -3041,12 +3041,16 @@ describe("typespec-client-generator-core: decorators", () => {
       `;
       await runnerWithCSharp.compile(spec);
       const csharpSdkPackage = runnerWithCSharp.context.sdkPackage;
-      const csharpSdkClient = csharpSdkPackage.clients.find(x => x.methods.find(m => m.name === "func"));
+      const csharpSdkClient = csharpSdkPackage.clients.find((x) =>
+        x.methods.find((m) => m.name === "func"),
+      );
       ok(csharpSdkClient);
 
       await runnerWithJava.compile(spec);
       const javaSdkPackage = runnerWithJava.context.sdkPackage;
-      const javaSdkClient = javaSdkPackage.clients.find(x => x.methods.find(m => m.name === "func"));
+      const javaSdkClient = javaSdkPackage.clients.find((x) =>
+        x.methods.find((m) => m.name === "func"),
+      );
       ok(javaSdkClient === undefined);
     });
 
@@ -3065,10 +3069,10 @@ describe("typespec-client-generator-core: decorators", () => {
             @body body: Test
           ): void;
         }
-      `); 
+      `);
 
       const sdkPackage = runnerWithCSharp.context.sdkPackage;
-      const sdkClient = sdkPackage.clients.find((x) => x.methods.find(m => m.name === "func"));
+      const sdkClient = sdkPackage.clients.find((x) => x.methods.find((m) => m.name === "func"));
       ok(sdkClient);
     });
   });

--- a/packages/typespec-client-generator-core/test/decorators.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators.test.ts
@@ -3049,5 +3049,27 @@ describe("typespec-client-generator-core: decorators", () => {
       const javaSdkClient = javaSdkPackage.clients.find(x => x.methods.find(m => m.name === "func"));
       ok(javaSdkClient === undefined);
     });
+
+    it("no scope decorator", async () => {
+      const runnerWithCSharp = await createSdkTestRunner({
+        emitterName: "@azure-tools/typespec-csharp",
+      });
+      await runnerWithCSharp.compile(`
+        @service
+        namespace MyService {
+          @clientName("TestRenamed", "csharp")
+          model Test {
+            prop: string;
+          }
+          op func(
+            @body body: Test
+          ): void;
+        }
+      `); 
+
+      const sdkPackage = runnerWithCSharp.context.sdkPackage;
+      const sdkClient = sdkPackage.clients.find((x) => x.methods.find(m => m.name === "func"));
+      ok(sdkClient);
+    });
   });
 });

--- a/packages/typespec-client-generator-core/test/decorators.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators.test.ts
@@ -2969,4 +2969,29 @@ describe("typespec-client-generator-core: decorators", () => {
       ok(testModel);
     });
   });
+
+  describe("scope decorator", () => {
+    it("remove operation from csharp client", async () => {
+      const runnerWithCSharp = await createSdkTestRunner({
+        emitterName: "@azure-tools/typespec-csharp",
+      });
+      await runnerWithCSharp.compile(`
+        @service
+        namespace MyService {
+          @clientName("TestRenamed", "csharp")
+          model Test {
+            prop: string;
+          }
+          @scope("!csharp")
+          op func(
+            @body body: Test
+          ): void;
+        }
+      `);
+
+      const sdkPackage = runnerWithCSharp.context.sdkPackage;
+      const testModel = sdkPackage.models.find((x) => x.name === "TestRenamed");
+      ok(testModel);
+    });
+  });
 });

--- a/packages/typespec-client-generator-core/test/decorators.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators.test.ts
@@ -2978,7 +2978,6 @@ describe("typespec-client-generator-core: decorators", () => {
       await runnerWithCSharp.compile(`
         @service
         namespace MyService {
-          @clientName("TestRenamed", "csharp")
           model Test {
             prop: string;
           }
@@ -2990,8 +2989,10 @@ describe("typespec-client-generator-core: decorators", () => {
       `);
 
       const sdkPackage = runnerWithCSharp.context.sdkPackage;
-      const sdkClient = sdkPackage.clients.find((x) => x.methods.find((m) => m.name === "func"));
-      ok(sdkClient);
+      const client = sdkPackage.clients.find((x) => x.methods.find((m) => m.name === "func"));
+      const model = sdkPackage.models.find((x) => x.name === "Test");
+      ok(client);
+      ok(model);
     });
 
     it("exclude operation from csharp client", async () => {
@@ -3001,7 +3002,6 @@ describe("typespec-client-generator-core: decorators", () => {
       await runnerWithCSharp.compile(`
         @service
         namespace MyService {
-          @clientName("TestRenamed", "csharp")
           model Test {
             prop: string;
           }
@@ -3013,8 +3013,10 @@ describe("typespec-client-generator-core: decorators", () => {
       `);
 
       const sdkPackage = runnerWithCSharp.context.sdkPackage;
-      const sdkClient = sdkPackage.clients.find((x) => x.methods.find((m) => m.name === "func"));
-      ok(sdkClient === undefined);
+      const client = sdkPackage.clients.find((x) => x.methods.find((m) => m.name === "func"));
+      const model = sdkPackage.models.find((x) => x.name === "Test");
+      strictEqual(client, undefined);
+      strictEqual(model, undefined);
     });
 
     it("negation scope override", async () => {
@@ -3027,7 +3029,6 @@ describe("typespec-client-generator-core: decorators", () => {
       const spec = `
         @service
         namespace MyService {
-          @clientName("TestRenamed", "csharp")
           model Test {
             prop: string;
           }
@@ -3043,14 +3044,18 @@ describe("typespec-client-generator-core: decorators", () => {
       const csharpSdkClient = csharpSdkPackage.clients.find((x) =>
         x.methods.find((m) => m.name === "func"),
       );
+      const csharpSdkModel = csharpSdkPackage.models.find((x) => x.name === "Test");
       ok(csharpSdkClient);
+      ok(csharpSdkModel);
 
       await runnerWithJava.compile(spec);
       const javaSdkPackage = runnerWithJava.context.sdkPackage;
       const javaSdkClient = javaSdkPackage.clients.find((x) =>
         x.methods.find((m) => m.name === "func"),
       );
-      ok(javaSdkClient === undefined);
+      const javaSdkModel = javaSdkPackage.models.find((x) => x.name === "Test");
+      strictEqual(javaSdkClient, undefined);
+      strictEqual(javaSdkModel, undefined);
     });
 
     it("no scope decorator", async () => {
@@ -3060,7 +3065,6 @@ describe("typespec-client-generator-core: decorators", () => {
       await runnerWithCSharp.compile(`
         @service
         namespace MyService {
-          @clientName("TestRenamed", "csharp")
           model Test {
             prop: string;
           }
@@ -3071,8 +3075,10 @@ describe("typespec-client-generator-core: decorators", () => {
       `);
 
       const sdkPackage = runnerWithCSharp.context.sdkPackage;
-      const sdkClient = sdkPackage.clients.find((x) => x.methods.find((m) => m.name === "func"));
-      ok(sdkClient);
+      const client = sdkPackage.clients.find((x) => x.methods.find((m) => m.name === "func"));
+      const model = sdkPackage.models.find((x) => x.name === "Test");
+      ok(client);
+      ok(model);
     });
 
     it("negation scope override normal scope", async () => {
@@ -3082,7 +3088,6 @@ describe("typespec-client-generator-core: decorators", () => {
       await runnerWithCSharp.compile(`
         @service
         namespace MyService {
-          @clientName("TestRenamed", "csharp")
           model Test {
             prop: string;
           }
@@ -3095,8 +3100,10 @@ describe("typespec-client-generator-core: decorators", () => {
       `);
 
       const sdkPackage = runnerWithCSharp.context.sdkPackage;
-      const sdkClient = sdkPackage.clients.find((x) => x.methods.find((m) => m.name === "func"));
-      ok(sdkClient);
+      const client = sdkPackage.clients.find((x) => x.methods.find((m) => m.name === "func"));
+      const model = sdkPackage.models.find((x) => x.name === "Test");
+      ok(client);
+      ok(model);
     });
   });
 });

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/decorators.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/decorators.md
@@ -516,6 +516,30 @@ Whether you want to generate an operation as a protocol operation.
 op test: void;
 ```
 
+### `@scope` {#@Azure.ClientGenerator.Core.scope}
+
+To define the client scope of an operation.
+
+```typespec
+@Azure.ClientGenerator.Core.scope(scope?: valueof string)
+```
+
+#### Target
+
+`Operation`
+
+#### Parameters
+
+| Name  | Type             | Description                                                                                                                                                                                           |
+| ----- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| scope | `valueof string` | The language scope you want this decorator to apply to. If not specified, will apply to all language emitters<br />You can use "!" to specify negation such as "!(java, python)" or "!java, !python". |
+
+#### Examples
+
+```typespec
+op test: void;
+```
+
 ### `@usage` {#@Azure.ClientGenerator.Core.usage}
 
 Override usage for models/enums.

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/decorators.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/decorators.md
@@ -575,6 +575,7 @@ To define the client scope of an operation.
 #### Examples
 
 ```typespec
+@scope("!csharp")
 op test: void;
 ```
 

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/index.mdx
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/index.mdx
@@ -51,5 +51,6 @@ npm install --save-peer @azure-tools/typespec-client-generator-core
 - [`@override`](./decorators.md#@Azure.ClientGenerator.Core.override)
 - [`@paramAlias`](./decorators.md#@Azure.ClientGenerator.Core.paramAlias)
 - [`@protocolAPI`](./decorators.md#@Azure.ClientGenerator.Core.protocolAPI)
+- [`@scope`](./decorators.md#@Azure.ClientGenerator.Core.scope)
 - [`@usage`](./decorators.md#@Azure.ClientGenerator.Core.usage)
 - [`@useSystemTextJsonConverter`](./decorators.md#@Azure.ClientGenerator.Core.useSystemTextJsonConverter)


### PR DESCRIPTION
Resolves #964

The scope parameter of `@scope` decorator is not working as the normal decorator.
For a normal decorator, we need to get the decorator value from state map based on the scope and the current emitter name. If the value hit from the state map with current emitter name, it's a positive case, if not hit, it's a negative case.
```
@clientName("Renamed", csharp)
model A;
```
With the normal decorator scope handling, if the decorator is absent it is a negative case. For the case below, we don't need to handle `@clientname` decorator, it is a negative case.
```
model A;
```


But for `@scope` decorator, when it is absent, it means `AllScopes`, which is also a positive case. For below two cases, python emitter should include this operation, both of them are positive case.
```
op func: void
```
and 
```
@scope("!csharp")
op func: void
```

For incremental applying, the mechanism should be similar to the normal decorator scope handling.
- for the same scope, the later decorator value wins regardless it's defined with normal scope or scope negation