### PR TITLE
Add flavor in Azure tutorial

### DIFF
--- a/website/src/content/docs/docs/howtos/Generate client libraries/00howtogen.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/00howtogen.mdx
@@ -55,7 +55,13 @@ emit:
   - "@azure-tools/typespec-ts"
 options:
   "@azure-tools/typespec-python":
-    package-name: azure-service-template
+    flavor: azure
+  "@azure-tools/typespec-java":
+    flavor: azure
+  "@azure-tools/typespec-csharp":
+    flavor: azure
+  "@azure-tools/typespec-ts":
+    flavor: azure
 ```
 
 Several language repositories utilize the `tsp-client` tool to simplify generating client libraries. For more information on the tool, see [Getting started with `tsp-client`](<./../Generating with tsp-client/tsp_client.md>).


### PR DESCRIPTION
While we have issues to remove `flavor` for `azure-tools` emitters, matter of fact is that today it's needed, and people got confused following the tutorial today (for good reasons).
I'll do a PR once we change the default, it may be in several months given this is not a priority.