### PR TITLE
[tcgc] refine cross language definition id logic

### DIFF
--- a/.chronus/changes/tcgc-crxlangdefid-2025-0-3-16-45-47.md
+++ b/.chronus/changes/tcgc-crxlangdefid-2025-0-3-16-45-47.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+refine cross language definition id logic

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -230,20 +230,27 @@ export function getCrossLanguageDefinitionId(
   appendNamespace: boolean = true,
 ): string {
   let retval = type.name || "anonymous";
-  const namespace = type.kind === "ModelProperty" ? type.model?.namespace : type.namespace;
+  let namespace = type.kind === "ModelProperty" ? type.model?.namespace : type.namespace;
   switch (type.kind) {
+    // Enum and Scalar will always have a name
     case "Union":
     case "Model":
-      // Enum and Scalar will always have a name
       if (type.name) {
         break;
       }
       const contextPath = operation
         ? getContextPath(context, operation, type)
         : findContextPath(context, type);
+      const namingPart = contextPath.slice(findLastNonAnonymousNode(contextPath));
+      if (
+        namingPart[0]?.type?.kind === "Model" ||
+        namingPart[0]?.type?.kind === "Union" ||
+        namingPart[0]?.type?.kind === "Operation"
+      ) {
+        namespace = namingPart[0]?.type?.namespace;
+      }
       retval =
-        contextPath
-          .slice(findLastNonAnonymousModelNode(contextPath))
+        namingPart
           .map((x) =>
             x.type?.kind === "Model" || x.type?.kind === "Union"
               ? x.type.name || x.name
@@ -255,7 +262,12 @@ export function getCrossLanguageDefinitionId(
       break;
     case "ModelProperty":
       if (type.model) {
-        retval = `${getCrossLanguageDefinitionId(context, type.model, undefined, false)}.${retval}`;
+        // operation parameter case
+        if (type.model === operation?.parameters) {
+          retval = `${getCrossLanguageDefinitionId(context, operation, undefined, false)}.${retval}`;
+        } else {
+          retval = `${getCrossLanguageDefinitionId(context, type.model, operation, false)}.${retval}`;
+        }
       }
       break;
     case "Operation":
@@ -364,7 +376,7 @@ function findContextPath(
 
 interface ContextNode {
   name: string;
-  type?: Model | Union | TspLiteralType;
+  type: Model | Union | TspLiteralType | Operation;
 }
 
 /**
@@ -388,7 +400,7 @@ function getContextPath(
 
     if (httpOperation.parameters.body) {
       visited.clear();
-      result = [{ name: root.name }];
+      result = [{ name: root.name, type: root }];
       let bodyType: Type;
       if (isHttpBodySpread(httpOperation.parameters.body)) {
         bodyType = getHttpBodySpreadModel(httpOperation.parameters.body.type as Model);
@@ -402,7 +414,7 @@ function getContextPath(
 
     for (const parameter of Object.values(httpOperation.parameters.parameters)) {
       visited.clear();
-      result = [{ name: root.name }];
+      result = [{ name: root.name, type: root }];
       if (
         dfsModelProperties(typeToFind, parameter.param.type, `Request${pascalCase(parameter.name)}`)
       ) {
@@ -414,7 +426,7 @@ function getContextPath(
       for (const innerResponse of response.responses) {
         if (innerResponse.body?.type) {
           visited.clear();
-          result = [{ name: root.name }];
+          result = [{ name: root.name, type: root }];
           if (dfsModelProperties(typeToFind, innerResponse.body.type, "Response", true)) {
             return result;
           }
@@ -424,7 +436,7 @@ function getContextPath(
         if (headers) {
           for (const header of Object.values(headers)) {
             visited.clear();
-            result = [{ name: root.name }];
+            result = [{ name: root.name, type: root }];
             if (dfsModelProperties(typeToFind, header.type, `Response${pascalCase(header.name)}`)) {
               return result;
             }
@@ -566,15 +578,15 @@ function getContextPath(
   }
 }
 
-function findLastNonAnonymousModelNode(contextPath: ContextNode[]): number {
+function findLastNonAnonymousNode(contextPath: ContextNode[]): number {
   let lastNonAnonymousModelNodeIndex = contextPath.length - 1;
   while (lastNonAnonymousModelNodeIndex >= 0) {
     const currType = contextPath[lastNonAnonymousModelNodeIndex].type;
     if (
-      !contextPath[lastNonAnonymousModelNodeIndex].type ||
-      (currType?.kind === "Model" && currType.name)
+      (currType.kind === "Model" || currType.kind === "Union" || currType.kind === "Operation") &&
+      currType.name
     ) {
-      // it's nonanonymous model node (if no type defined, it's the operation node)
+      // it's non anonymous node
       break;
     } else {
       --lastNonAnonymousModelNodeIndex;
@@ -601,11 +613,11 @@ function buildNameFromContextPaths(
     return "";
   }
 
-  // 1. find the last nonanonymous model node
-  const lastNonAnonymousModelNodeIndex = findLastNonAnonymousModelNode(contextPath);
+  // 1. find the last non-anonymous model node
+  const lastNonAnonymousNodeIndex = findLastNonAnonymousNode(contextPath);
   // 2. build name
   let createName: string = "";
-  for (let j = lastNonAnonymousModelNodeIndex; j < contextPath.length; j++) {
+  for (let j = lastNonAnonymousNodeIndex; j < contextPath.length; j++) {
     const currContextPathType = contextPath[j]?.type;
     if (
       currContextPathType?.kind === "String" ||
@@ -614,11 +626,11 @@ function buildNameFromContextPaths(
     ) {
       // constant type
       createName = `${createName}${pascalCase(contextPath[j].name)}`;
-    } else if (!currContextPathType?.name) {
-      // is anonymous model node
+    } else if (!currContextPathType?.name || currContextPathType.kind === "Operation") {
+      // is anonymous node or operation node
       createName = `${createName}${pascalCase(contextPath[j].name)}`;
     } else {
-      // is non-anonymous model, use type name
+      // is non-anonymous node, use type name
       createName = `${createName}${currContextPathType!.name!}`;
     }
   }

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1084,7 +1084,7 @@ function getSdkCredentialType(
       name: createGeneratedName(context, client.service, "CredentialUnion"),
       isGeneratedName: true,
       clientNamespace: getClientNamespace(context, client.service),
-      crossLanguageDefinitionId: getCrossLanguageDefinitionId(context, client.service),
+      crossLanguageDefinitionId: `${getCrossLanguageDefinitionId(context, client.service)}.CredentialUnion`,
       decorators: [],
       access: "public",
       usage: UsageFlags.None,
@@ -1099,11 +1099,10 @@ export function getSdkCredentialParameter(
 ): SdkCredentialParameter | undefined {
   const auth = getAuthentication(context.program, client.service);
   if (!auth) return undefined;
-  const name = "credential";
   return {
     type: getSdkCredentialType(context, client, auth),
     kind: "credential",
-    name,
+    name: "credential",
     isGeneratedName: true,
     doc: "Credential used to authenticate requests to the service.",
     apiVersions: getAvailableApiVersions(context, client.service, client.type),

--- a/packages/typespec-client-generator-core/test/packages/client.test.ts
+++ b/packages/typespec-client-generator-core/test/packages/client.test.ts
@@ -682,7 +682,10 @@ describe("typespec-client-generator-core: client", () => {
     strictEqual(clientAccessor.name, "getMyOperationGroup");
     strictEqual(clientAccessor.parameters.length, 0);
     strictEqual(clientAccessor.response, operationGroup);
-    strictEqual(clientAccessor.crossLanguageDefinitionId, "TestService.MyOperationGroup");
+    strictEqual(
+      clientAccessor.crossLanguageDefinitionId,
+      "TestService.MyOperationGroup.getMyOperationGroup",
+    );
 
     strictEqual(operationGroup.initialization.properties.length, 1);
     strictEqual(operationGroup.initialization.access, "internal");
@@ -733,7 +736,7 @@ describe("typespec-client-generator-core: client", () => {
 
     const fooAccessor = mainClient.methods[0];
     strictEqual(fooAccessor.kind, "clientaccessor");
-    strictEqual(fooAccessor.crossLanguageDefinitionId, "TestService.Foo");
+    strictEqual(fooAccessor.crossLanguageDefinitionId, "TestService.Foo.getFoo");
     strictEqual(fooAccessor.access, "internal");
     strictEqual(fooAccessor.name, "getFoo");
     strictEqual(fooAccessor.parameters.length, 0);
@@ -743,7 +746,7 @@ describe("typespec-client-generator-core: client", () => {
     strictEqual(barAccessor.kind, "clientaccessor");
     strictEqual(barAccessor.access, "internal");
     strictEqual(barAccessor.name, "getBar");
-    strictEqual(barAccessor.crossLanguageDefinitionId, "TestService.Bar");
+    strictEqual(barAccessor.crossLanguageDefinitionId, "TestService.Bar.getBar");
     strictEqual(barAccessor.parameters.length, 0);
     strictEqual(barAccessor.response, barClient);
 
@@ -754,7 +757,7 @@ describe("typespec-client-generator-core: client", () => {
 
     const fooBarAccessor = fooClient.methods[0];
     strictEqual(fooBarAccessor.kind, "clientaccessor");
-    strictEqual(fooBarAccessor.crossLanguageDefinitionId, "TestService.Foo.Bar");
+    strictEqual(fooBarAccessor.crossLanguageDefinitionId, "TestService.Foo.Bar.getBar");
     strictEqual(fooBarAccessor.access, "internal");
     strictEqual(fooBarAccessor.name, "getBar");
     strictEqual(fooBarAccessor.parameters.length, 0);

--- a/packages/typespec-client-generator-core/test/public-utils.test.ts
+++ b/packages/typespec-client-generator-core/test/public-utils.test.ts
@@ -1393,7 +1393,7 @@ describe("typespec-client-generator-core: public-utils", () => {
         strictEqual(unionEnum.kind, "enum");
         strictEqual(unionEnum.name, "AStatus");
         ok(unionEnum.isGeneratedName);
-        strictEqual(unionEnum.crossLanguageDefinitionId, "A.status.anonymous");
+        strictEqual(unionEnum.crossLanguageDefinitionId, "TestService.A.status.anonymous");
         strictEqual(models[0].kind, "model");
         const statusProp = models[0].properties[0];
         strictEqual(statusProp.kind, "property");
@@ -1465,7 +1465,7 @@ describe("typespec-client-generator-core: public-utils", () => {
         const unionEnum = test1.properties[0].type;
         strictEqual(unionEnum.name, "AChoiceStatus");
         ok(unionEnum.isGeneratedName);
-        strictEqual(unionEnum.crossLanguageDefinitionId, "A.choice.status.anonymous");
+        strictEqual(unionEnum.crossLanguageDefinitionId, "TestService.A.choice.status.anonymous");
       });
     });
 
@@ -1552,7 +1552,7 @@ describe("typespec-client-generator-core: public-utils", () => {
         strictEqual(unionEnum.name, "AStatus");
         ok(unionEnum.isGeneratedName);
         // not a defined type in tsp, so no crossLanguageDefinitionId
-        strictEqual(unionEnum.crossLanguageDefinitionId, "A.status.anonymous");
+        strictEqual(unionEnum.crossLanguageDefinitionId, "TestService.A.status.anonymous");
       });
     });
 
@@ -1611,7 +1611,7 @@ describe("typespec-client-generator-core: public-utils", () => {
         // not a defined type in tsp, so no crossLanguageDefinitionId
         strictEqual(
           unionEnum.crossLanguageDefinitionId,
-          "test.ResponseRepeatabilityResult.anonymous",
+          "MyService.test.ResponseRepeatabilityResult.anonymous",
         );
         ok(unionEnum.isGeneratedName);
       });
@@ -1639,7 +1639,7 @@ describe("typespec-client-generator-core: public-utils", () => {
         // not a defined type in tsp, so no crossLanguageDefinitionId
         strictEqual(
           unionEnum.crossLanguageDefinitionId,
-          "test.RequestRepeatabilityResult.anonymous",
+          "MyService.test.RequestRepeatabilityResult.anonymous",
         );
         ok(unionEnum.isGeneratedName);
       });
@@ -1673,7 +1673,7 @@ describe("typespec-client-generator-core: public-utils", () => {
         strictEqual(stringType.isGeneratedName, true);
         strictEqual(
           stringType.crossLanguageDefinitionId,
-          "test.RequestRepeatabilityResult.anonymous",
+          "MyService.test.RequestRepeatabilityResult.anonymous",
         );
       });
 

--- a/packages/typespec-client-generator-core/test/public-utils/get-cross-language-definition-id.test.ts
+++ b/packages/typespec-client-generator-core/test/public-utils/get-cross-language-definition-id.test.ts
@@ -1,0 +1,109 @@
+import { AzureCoreTestLibrary } from "@azure-tools/typespec-azure-core/testing";
+import { strictEqual } from "assert";
+import { beforeEach, describe, it } from "vitest";
+import { createSdkTestRunner, SdkTestRunner } from "../test-host.js";
+
+describe("typespec-client-generator-core: getCrossLanguageDefinitionId", () => {
+  let runner: SdkTestRunner;
+
+  beforeEach(async () => {
+    runner = await createSdkTestRunner({ emitterName: "@azure-tools/typespec-python" });
+  });
+
+  it("parameter's crossLanguageDefinitionId", async () => {
+    runner = await createSdkTestRunner({
+      librariesToAdd: [AzureCoreTestLibrary],
+      autoUsings: ["Azure.Core", "Azure.Core.Traits"],
+      emitterName: "@azure-tools/typespec-java",
+    });
+    await runner.compileWithBuiltInAzureCoreService(`
+      alias ServiceTraits = SupportsRepeatableRequests &
+      SupportsConditionalRequests &
+      SupportsClientRequestId;
+      
+      @route("service-status")
+      op getServiceStatus is RpcOperation<
+        {},
+        {
+          statusString: string;
+        },
+        ServiceTraits
+      >;
+    `);
+
+    const sdkPackage = runner.context.sdkPackage;
+    strictEqual(
+      sdkPackage.clients[0].initialization.properties[1].crossLanguageDefinitionId,
+      "My.Service.getServiceStatus.apiVersion",
+    );
+    const getServiceStatus = sdkPackage.clients[0].methods[0];
+    strictEqual(getServiceStatus.kind, "basic");
+    strictEqual(
+      getServiceStatus.parameters[0].crossLanguageDefinitionId,
+      "My.Service.getServiceStatus.clientRequestId",
+    );
+    strictEqual(
+      getServiceStatus.parameters[1].crossLanguageDefinitionId,
+      "My.Service.getServiceStatus.accept",
+    );
+    const operation = getServiceStatus.operation;
+    strictEqual(
+      operation.parameters[0].crossLanguageDefinitionId,
+      "My.Service.getServiceStatus.apiVersion",
+    );
+    strictEqual(
+      operation.parameters[1].crossLanguageDefinitionId,
+      "My.Service.getServiceStatus.clientRequestId",
+    );
+    strictEqual(
+      operation.parameters[2].crossLanguageDefinitionId,
+      "My.Service.getServiceStatus.accept",
+    );
+  });
+
+  it("endpoint's crossLanguageDefinitionId", async () => {
+    runner = await createSdkTestRunner({
+      librariesToAdd: [AzureCoreTestLibrary],
+      autoUsings: ["Azure.Core", "Azure.Core.Traits"],
+      emitterName: "@azure-tools/typespec-java",
+    });
+    await runner.compile(`
+      @service({
+        title: "Contoso Widget Manager",
+      })
+      @server(
+        "{url}/widget",
+        "Contoso Widget APIs",
+        {
+          url: string,
+        }
+      )
+      @versioned(Contoso.WidgetManager.Versions)
+      namespace Contoso.WidgetManager;
+
+      enum Versions {
+        @useDependency(Azure.Core.Versions.v1_0_Preview_2)
+        "2022-08-30",
+      }
+
+      op test(): void;
+    `);
+
+    const sdkPackage = runner.context.sdkPackage;
+    const initialization = sdkPackage.clients[0].initialization;
+    const endpoint = initialization.properties[0];
+    strictEqual(endpoint.crossLanguageDefinitionId, "Contoso.WidgetManager.endpoint");
+    strictEqual(endpoint.type.kind, "union");
+    strictEqual(endpoint.type.crossLanguageDefinitionId, "Contoso.WidgetManager.Endpoint");
+    strictEqual(endpoint.type.variantTypes[0].kind, "endpoint");
+    strictEqual(
+      endpoint.type.variantTypes[0].templateArguments[0].crossLanguageDefinitionId,
+      "Contoso.WidgetManager.url",
+    );
+    strictEqual(endpoint.type.variantTypes[1].kind, "endpoint");
+    strictEqual(
+      endpoint.type.variantTypes[1].templateArguments[0].crossLanguageDefinitionId,
+      "Contoso.WidgetManager.endpoint",
+    );
+  });
+});

--- a/packages/typespec-client-generator-core/test/types/enum-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/enum-types.test.ts
@@ -559,11 +559,11 @@ describe("typespec-client-generator-core: enum types", () => {
     const modelType = getClientType(runner.context, Test) as SdkModelType;
     const enumType = modelType.properties[0].type as SdkEnumType;
     strictEqual(enumType.name, "TestColor");
-    strictEqual(enumType.crossLanguageDefinitionId, "Test.color.anonymous");
+    strictEqual(enumType.crossLanguageDefinitionId, "N.Test.color.anonymous");
     strictEqual(enumType.isGeneratedName, true);
     strictEqual(enumType.isUnionAsEnum, true);
     // no cross language def id bc it's not a defined object in tsp
-    strictEqual(enumType.crossLanguageDefinitionId, "Test.color.anonymous");
+    strictEqual(enumType.crossLanguageDefinitionId, "N.Test.color.anonymous");
     const values = enumType.values;
     strictEqual(values[0].name, "left");
     strictEqual(values[0].value, "left");
@@ -609,7 +609,7 @@ describe("typespec-client-generator-core: enum types", () => {
     const modelType = getClientType(runner.context, Test) as SdkModelType;
     const unionType = modelType.properties[0].type as SdkUnionType;
     strictEqual(unionType.name, "TestColor");
-    strictEqual(unionType.crossLanguageDefinitionId, "Test.color.anonymous");
+    strictEqual(unionType.crossLanguageDefinitionId, "N.Test.color.anonymous");
     strictEqual(unionType.isGeneratedName, true);
     const variants = unionType.variantTypes;
     const lr = variants[0] as SdkEnumType;


### PR DESCRIPTION
1. refine all generated type's cross language definition id
2. for parameters, use the operation name as the prefix of cross language definition id
3. for anonymous model, add namespace for first section of the cross language definition id

fix: https://github.com/Azure/typespec-azure/issues/2031