### PR TITLE
Add Codegen owners to spector specs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,6 @@
 * @bterlson @markcowl @allenjzhang @timotheeguerin
 
 /packages/typespec-client-generator-core @lmazuel @m-nash @iscai-msft @srnagar @joheredi
+/packages/azure-http-specs/specs/ @iscai-msft @lmazuel @m-nash @joheredi @srnagar @weidongxu-microsoft @tadelesh @jhendrixMSFT 
 
 /docs/howtos/DataPlane*/ @lmazuel @m-nash @iscai-msft @srnagar @joheredi


### PR DESCRIPTION
Porting the cadl-ranch owners, so Codegen team can approve new tests autonomously
https://github.com/Azure/cadl-ranch/blob/30c3d78c3672c3dd2f81d6d91380e177f0566b44/.github/CODEOWNERS#L2C34-L2C112