### PR TITLE
 Exclude template instances from the `no-response-body` rule.

### DIFF
--- a/.chronus/changes/fix-duplicate-warning-2025-0-15-11-39-29.md
+++ b/.chronus/changes/fix-duplicate-warning-2025-0-15-11-39-29.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Exclude template instances from the `no-response-body` rule.

--- a/packages/typespec-azure-resource-manager/src/rules/no-response-body.ts
+++ b/packages/typespec-azure-resource-manager/src/rules/no-response-body.ts
@@ -1,4 +1,4 @@
-import { createRule, Operation } from "@typespec/compiler";
+import { createRule, isTemplateInstance, Operation } from "@typespec/compiler";
 import { getHttpOperation, getResponsesForOperation, HttpOperationResponse } from "@typespec/http";
 import { isTemplatedInterfaceOperation } from "./utils.js";
 /**
@@ -20,7 +20,12 @@ export const noResponseBodyRule = createRule({
     return {
       operation: (op: Operation) => {
         const [httpOperation] = getHttpOperation(context.program, op);
-        if (isTemplatedInterfaceOperation(op) || httpOperation.verb === "head") return;
+        if (
+          isTemplateInstance(op) ||
+          isTemplatedInterfaceOperation(op) ||
+          httpOperation.verb === "head"
+        )
+          return;
 
         const responses = getResponsesForOperation(context.program, op)[0].find(
           (v) => v.statusCodes !== 204 && v.statusCodes !== 202,


### PR DESCRIPTION
issue: https://github.com/Azure/typespec-azure/issues/1785