### PR TITLE
[common-types] Fix difference on privateEndpointConnectionName for common-types

### DIFF
--- a/packages/samples/common-types/openapi/v3/privatelinks.json
+++ b/packages/samples/common-types/openapi/v3/privatelinks.json
@@ -211,8 +211,8 @@
     }
   },
   "parameters": {
-    "PrivateEndpointConnectionParameter": {
-      "name": "name",
+    "PrivateEndpointConnectionName": {
+      "name": "privateEndpointConnectionName",
       "in": "path",
       "description": "The name of the private endpoint connection associated with the Azure resource.",
       "required": true,

--- a/packages/samples/common-types/openapi/v4/privatelinks.json
+++ b/packages/samples/common-types/openapi/v4/privatelinks.json
@@ -220,8 +220,8 @@
     }
   },
   "parameters": {
-    "PrivateEndpointConnectionParameter": {
-      "name": "name",
+    "PrivateEndpointConnectionName": {
+      "name": "privateEndpointConnectionName",
       "in": "path",
       "description": "The name of the private endpoint connection associated with the Azure resource.",
       "required": true,

--- a/packages/samples/common-types/openapi/v5/privatelinks.json
+++ b/packages/samples/common-types/openapi/v5/privatelinks.json
@@ -220,8 +220,8 @@
     }
   },
   "parameters": {
-    "PrivateEndpointConnectionParameter": {
-      "name": "name",
+    "PrivateEndpointConnectionName": {
+      "name": "privateEndpointConnectionName",
       "in": "path",
       "description": "The name of the private endpoint connection associated with the Azure resource.",
       "required": true,

--- a/packages/samples/common-types/openapi/v6/privatelinks.json
+++ b/packages/samples/common-types/openapi/v6/privatelinks.json
@@ -230,8 +230,8 @@
     }
   },
   "parameters": {
-    "PrivateEndpointConnectionParameter": {
-      "name": "name",
+    "PrivateEndpointConnectionName": {
+      "name": "privateEndpointConnectionName",
       "in": "path",
       "description": "The name of the private endpoint connection associated with the Azure resource.",
       "required": true,

--- a/packages/samples/common-types/src/private-links.tsp
+++ b/packages/samples/common-types/src/private-links.tsp
@@ -14,5 +14,5 @@ model Resource {}
 @@OpenAPI.extension(PrivateLinkResource.properties, "x-ms-client-flatten", true);
 
 interface RegisterParams {
-  v3(...PrivateEndpointConnectionParameter): void;
+  v3(...PrivateEndpointConnectionName): void;
 }

--- a/packages/samples/specs/resource-manager/resource-common-properties/private-links/main.tsp
+++ b/packages/samples/specs/resource-manager/resource-common-properties/private-links/main.tsp
@@ -63,7 +63,7 @@ model TestTrackedProperties {
 /** Holder for private endpoint connections */
 @parentResource(TestTrackedResource)
 model PrivateEndpointConnectionResource is ProxyResource<PrivateEndpointConnectionProperties> {
-  ...PrivateEndpointConnectionParameter;
+  ...PrivateEndpointConnectionName;
 }
 
 /** Private connection operations */

--- a/packages/typespec-azure-resource-manager/lib/common-types/private-links.tsp
+++ b/packages/typespec-azure-resource-manager/lib/common-types/private-links.tsp
@@ -128,12 +128,12 @@ union PrivateEndpointServiceConnectionStatus {
 /**
  * The name of the private endpoint connection associated with the Azure resource.
  */
-model PrivateEndpointConnectionParameter {
+model PrivateEndpointConnectionName {
   /** The name of the private endpoint connection associated with the Azure resource. */
   @path
   @key("privateEndpointConnectionName")
   @TypeSpec.Rest.segment("privateEndpointConnections")
-  name: string;
+  privateEndpointConnectionName: string;
 }
 
 /**


### PR DESCRIPTION
Closing final gaps on common types.

Fixing this current difference 
![image](https://github.com/user-attachments/assets/035ef2a3-f26d-43ae-b196-8b0155709dda)
