### PR TITLE
Add legacy operations for multi-path scenario

### DIFF
--- a/.chronus/changes/legacyOperations-2025-0-17-19-14-32.md
+++ b/.chronus/changes/legacyOperations-2025-0-17-19-14-32.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Add legacy operations for multi-path scenario

--- a/packages/typespec-azure-resource-manager/lib/Legacy/arm.legacy.tsp
+++ b/packages/typespec-azure-resource-manager/lib/Legacy/arm.legacy.tsp
@@ -1,2 +1,3 @@
 import "./managed-identity.tsp";
 import "./decorator.tsp";
+import "./operations.tsp";

--- a/packages/typespec-azure-resource-manager/lib/Legacy/operations.tsp
+++ b/packages/typespec-azure-resource-manager/lib/Legacy/operations.tsp
@@ -27,10 +27,7 @@ namespace Azure.ResourceManager.Legacy {
     @autoRoute
     @doc("Create a {name}", Resource)
     @armResourceCreateOrUpdate(Resource)
-    @Azure.Core.Foundations.Private.defaultFinalStateVia(#[
-      "location",
-      "azure-async-operation"
-    ])
+    @Azure.Core.Foundations.Private.defaultFinalStateVia(#["location", "azure-async-operation"])
     @put
     CreateOrUpdateAsync<
       Resource extends Azure.ResourceManager.CommonTypes.Resource,
@@ -145,11 +142,7 @@ namespace Azure.ResourceManager.Legacy {
         Azure.Core.Foundations.RetryAfterHeader,
       Parameters extends {} = {},
       Response extends {} = ArmDeletedResponse | ArmDeleteAcceptedLroResponse<LroHeaders> | ArmDeletedNoContentResponse
-    >(
-      ...ParentParameters,
-      ...ResourceTypeParameter,
-      ...Parameters,
-    ): Response | ErrorType;
+    >(...ParentParameters, ...ResourceTypeParameter, ...Parameters): Response | ErrorType;
 
     /**
      * @dev Delete a resource synchronously
@@ -167,11 +160,7 @@ namespace Azure.ResourceManager.Legacy {
       Resource extends Azure.ResourceManager.CommonTypes.Resource,
       Parameters extends {} = {},
       Response extends {} = ArmDeletedResponse | ArmDeletedNoContentResponse
-    >(
-      ...ParentParameters,
-      ...ResourceTypeParameter,
-      ...Parameters,
-    ): Response | ErrorType;
+    >(...ParentParameters, ...ResourceTypeParameter, ...Parameters): Response | ErrorType;
 
     /**
      * @dev Get a resource
@@ -188,11 +177,7 @@ namespace Azure.ResourceManager.Legacy {
       Resource extends Azure.ResourceManager.CommonTypes.Resource,
       Parameters extends {} = {},
       Response extends {} = ArmResponse<Resource>
-    >(
-      ...ParentParameters,
-      ...ResourceTypeParameter,
-      ...Parameters,
-    ): Response | ErrorType;
+    >(...ParentParameters, ...ResourceTypeParameter, ...Parameters): Response | ErrorType;
 
     /**
      * @dev List a resource

--- a/packages/typespec-azure-resource-manager/lib/Legacy/operations.tsp
+++ b/packages/typespec-azure-resource-manager/lib/Legacy/operations.tsp
@@ -130,7 +130,6 @@ namespace Azure.ResourceManager.Legacy {
      * @template Parameters Optional. Additional parameters after the path parameters
      * @template Response Optional. The success response(s) for the delete operation
      */
-    #suppress "@azure-tools/typespec-azure-core/no-response-body" "Valid"
     @autoRoute
     @doc("Delete a {name}", Resource)
     @delete
@@ -150,7 +149,6 @@ namespace Azure.ResourceManager.Legacy {
      * @template Parameters Optional. Additional parameters after the path parameters
      * @template Response Optional. The success response(s) for the delete operation
      */
-    #suppress "@azure-tools/typespec-azure-core/no-response-body" "Valid"
     @autoRoute
     @doc("Delete a {name}", Resource)
     @delete
@@ -233,7 +231,6 @@ namespace Azure.ResourceManager.Legacy {
      * @template Response The response model for the action
      * @template Parameters Optional. Additional parameters after the path parameters
      */
-    #suppress "@azure-tools/typespec-azure-core/no-response-body" "ARM"
     #suppress "@azure-tools/typespec-azure-core/no-private-usage" "template"
     @autoRoute
     @armResourceAction(Resource)

--- a/packages/typespec-azure-resource-manager/lib/Legacy/operations.tsp
+++ b/packages/typespec-azure-resource-manager/lib/Legacy/operations.tsp
@@ -1,0 +1,290 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.Core;
+using Azure.ResourceManager;
+
+namespace Azure.ResourceManager.Legacy {
+  interface LegacyOperations<
+    ParentParameters extends {},
+    ResourceTypeParameter extends {},
+    ErrorType extends {} = ErrorResponse
+  > {
+    /**
+     * @dev A long-running resource CreateOrUpdate (PUT)
+     * @template Resource the resource being created or updated
+     * @template LroHeaders Optional.  Allows overriding the lro headers returned on resource create
+     * @template Parameters Optional. Additional parameters after the path parameters
+     * @template Response Optional. The success response(s) for the PUT operation
+     */
+    #suppress "@azure-tools/typespec-azure-core/no-private-usage"
+    @autoRoute
+    @doc("Create a {name}", Resource)
+    @armResourceCreateOrUpdate(Resource)
+    @Azure.Core.Foundations.Private.defaultFinalStateVia(#[
+      "location",
+      "azure-async-operation"
+    ])
+    @put
+    CreateOrUpdateAsync<
+      Resource extends Azure.ResourceManager.CommonTypes.Resource,
+      LroHeaders extends TypeSpec.Reflection.Model = ArmAsyncOperationHeader<FinalResult = Resource> &
+        Azure.Core.Foundations.RetryAfterHeader,
+      Parameters extends {} = {},
+      Response extends {} = ArmResourceUpdatedResponse<Resource> | ArmResourceCreatedResponse<
+        Resource,
+        LroHeaders
+      >
+    >(
+      ...ParentParameters,
+      ...ResourceTypeParameter,
+      ...Parameters,
+      @doc("Resource create parameters.") @bodyRoot resource: Resource,
+    ): Response | ErrorType;
+
+    /**
+     * @dev A synchronous resource CreateOrUpdate (PUT)
+     * @template Resource the resource being created or updated
+     * @template Parameters Optional. Additional parameters after the path parameters
+     * @template Response Optional. The success response(s) for the PUT operation
+     */
+    #suppress "@azure-tools/typespec-azure-core/no-private-usage"
+    @autoRoute
+    @doc("Create a {name}", Resource)
+    @armResourceCreateOrUpdate(Resource)
+    @put
+    CreateOrUpdateSync<
+      Resource extends Azure.ResourceManager.CommonTypes.Resource,
+      Parameters extends {} = {},
+      Response extends {} = ArmResourceUpdatedResponse<Resource> | ArmResourceCreatedSyncResponse<Resource>
+    >(
+      ...ParentParameters,
+      ...ResourceTypeParameter,
+      ...Parameters,
+      @doc("Resource create parameters.") @bodyRoot resource: Resource,
+    ): Response | ErrorType;
+
+    /**
+     * @dev A long-running resource Update (PATCH)
+     * @template Resource the resource being created or updated
+     * @template PatchModel the PATCH request model
+     * @template LroHeaders Optional.  Allows overriding the lro headers returned on resource create
+     * @template Parameters Optional. Additional parameters after the path parameters
+     * @template Response Optional. The success response(s) for the PATCH operation
+     */
+    @autoRoute
+    @doc("Update a {name}", Resource)
+    @armResourceUpdate(Resource)
+    @patch
+    CustomPatchAsync<
+      Resource extends Azure.ResourceManager.CommonTypes.Resource,
+      PatchModel extends {} = Azure.ResourceManager.Foundations.TagsUpdateModel<Resource>,
+      LroHeaders extends TypeSpec.Reflection.Model = ArmLroLocationHeader<
+        Azure.Core.StatusMonitorPollingOptions<ArmOperationStatus>,
+        Resource,
+        string
+      > &
+        Azure.Core.Foundations.RetryAfterHeader,
+      Parameters extends {} = {},
+      Response extends {} = ArmResponse<Resource> | ArmAcceptedLroResponse<
+        "Resource update request accepted.",
+        LroHeaders
+      >
+    >(
+      ...ParentParameters,
+      ...ResourceTypeParameter,
+      ...Parameters,
+      @doc("The resource properties to be updated.") @bodyRoot properties: PatchModel,
+    ): Response | ErrorType;
+
+    /**
+     * @dev A synchronous resource Update (PATCH)
+     * @template Resource the resource being created or updated
+     * @template PatchModel the PATCH request model
+     * @template Parameters Optional. Additional parameters after the path parameters
+     * @template Response Optional. The success response(s) for the PATCH operation
+     */
+    @autoRoute
+    @doc("Update a {name}", Resource)
+    @armResourceUpdate(Resource)
+    @patch
+    CustomPatchSync<
+      Resource extends Azure.ResourceManager.CommonTypes.Resource,
+      PatchModel extends {} = Azure.ResourceManager.Foundations.TagsUpdateModel<Resource>,
+      Parameters extends {} = {},
+      Response extends {} = ArmResponse<Resource>
+    >(
+      ...ParentParameters,
+      ...ResourceTypeParameter,
+      ...Parameters,
+      @doc("The resource properties to be updated.") @bodyRoot properties: PatchModel,
+    ): Response | ErrorType;
+
+    /**
+     * @dev Delete a resource asynchronously
+     * @template Resource The resource being deleted
+     * @template LroHeaders The lro headers for the operation
+     * @template Parameters Optional. Additional parameters after the path parameters
+     * @template Response Optional. The success response(s) for the delete operation
+     */
+    #suppress "@azure-tools/typespec-azure-core/no-response-body" "Valid"
+    @autoRoute
+    @doc("Delete a {name}", Resource)
+    @delete
+    @deletesResource(Resource)
+    @armResourceDelete(Resource)
+    DeleteWithoutOkAsync<
+      Resource extends Azure.ResourceManager.CommonTypes.Resource,
+      LroHeaders extends TypeSpec.Reflection.Model = ArmLroLocationHeader &
+        Azure.Core.Foundations.RetryAfterHeader,
+      Parameters extends {} = {},
+      Response extends {} = ArmDeletedResponse | ArmDeleteAcceptedLroResponse<LroHeaders> | ArmDeletedNoContentResponse
+    >(
+      ...ParentParameters,
+      ...ResourceTypeParameter,
+      ...Parameters,
+    ): Response | ErrorType;
+
+    /**
+     * @dev Delete a resource synchronously
+     * @template Resource The resource being deleted
+     * @template Parameters Optional. Additional parameters after the path parameters
+     * @template Response Optional. The success response(s) for the delete operation
+     */
+    #suppress "@azure-tools/typespec-azure-core/no-response-body" "Valid"
+    @autoRoute
+    @doc("Delete a {name}", Resource)
+    @delete
+    @deletesResource(Resource)
+    @armResourceDelete(Resource)
+    DeleteSync<
+      Resource extends Azure.ResourceManager.CommonTypes.Resource,
+      Parameters extends {} = {},
+      Response extends {} = ArmDeletedResponse | ArmDeletedNoContentResponse
+    >(
+      ...ParentParameters,
+      ...ResourceTypeParameter,
+      ...Parameters,
+    ): Response | ErrorType;
+
+    /**
+     * @dev Get a resource
+     * @template Resource The resource being read
+     * @template Parameters Optional. Additional parameters after the path parameters
+     * @template Response Optional. The success response for a get operation.
+     */
+    @autoRoute
+    @doc("Get a {name}", Resource)
+    @get
+    @readsResource(Resource)
+    @armResourceRead(Resource)
+    Read<
+      Resource extends Azure.ResourceManager.CommonTypes.Resource,
+      Parameters extends {} = {},
+      Response extends {} = ArmResponse<Resource>
+    >(
+      ...ParentParameters,
+      ...ResourceTypeParameter,
+      ...Parameters,
+    ): Response | ErrorType;
+
+    /**
+     * @dev List a resource
+     * @template Resource The resource being listed
+     * @template Parameters Optional. Additional parameters after the path parameters
+     * @template Response Optional. The response returned by the list
+     */
+    @autoRoute
+    @doc("List {name} resources", Resource)
+    @get
+    @listsResource(Resource)
+    @segmentOf(Resource)
+    @armResourceList(Resource)
+    List<
+      Resource extends Azure.ResourceManager.CommonTypes.Resource,
+      Parameters extends {} = {},
+      Response extends {} = ArmResponse<ResourceListResult<Resource>>
+    >(...ParentParameters, ...Parameters): Response | ErrorType;
+
+    /**
+     * A synchronous resource action.
+     * @template Resource The resource being acted upon
+     * @template Request The request model for the action
+     * @template Response The response model for the action
+     * @template Parameters Optional. Additional parameters after the path parameters
+     */
+    #suppress "@azure-tools/typespec-azure-core/no-private-usage"
+    @autoRoute
+    @armResourceAction(Resource)
+    @Private.enforceConstraint(Resource, Foundations.Resource)
+    @post
+    @returnsDoc("Azure operation completed successfully.")
+    ActionSync<
+      Resource extends Foundations.Resource,
+      Request extends TypeSpec.Reflection.Model | void,
+      Response extends TypeSpec.Reflection.Model | void,
+      Parameters extends {} = {}
+    >(
+      ...ParentParameters,
+      ...ResourceTypeParameter,
+      ...Parameters,
+
+      @doc("The content of the action request")
+      @bodyRoot
+      body: Request,
+    ): Response | ErrorType;
+
+    /**
+     * A long-running resource action.
+     * @template Resource The resource being acted upon
+     * @template Request The request model for the action
+     * @template LroHeaders Optional. Allows overriding the headers returned in the Accepted response
+     * @template Response The response model for the action
+     * @template Parameters Optional. Additional parameters after the path parameters
+     */
+    #suppress "@azure-tools/typespec-azure-core/no-response-body" "ARM"
+    #suppress "@azure-tools/typespec-azure-core/no-private-usage" "template"
+    @autoRoute
+    @armResourceAction(Resource)
+    @Private.enforceConstraint(Resource, Foundations.Resource)
+    @post
+    @returnsDoc("Azure operation completed successfully.")
+    ActionAsync<
+      Resource extends Foundations.Resource,
+      Request extends TypeSpec.Reflection.Model | void,
+      Result extends TypeSpec.Reflection.Model | void,
+      LroHeaders extends TypeSpec.Reflection.Model = ArmLroLocationHeader<
+        Azure.Core.StatusMonitorPollingOptions<ArmOperationStatus>,
+        Result,
+        string
+      > &
+        Azure.Core.Foundations.RetryAfterHeader,
+      Parameters extends {} = {},
+      Response extends {} | void = ArmAcceptedLroResponse<
+        "Resource operation accepted.",
+        LroHeaders
+      > | Result
+    >(
+      ...ParentParameters,
+      ...ResourceTypeParameter,
+      ...Parameters,
+
+      @doc("The content of the action request")
+      @bodyRoot
+      body: Request,
+    ): Response | ErrorType;
+  }
+  /**
+   * @dev Get the provider namespace key-value pair
+   * @template Resource Optional.  The resource to get the provider namespace for.
+   */
+  model Provider<Resource extends {} = TenantActionScope> {
+    ...ProviderNamespace<Resource>;
+  }
+}

--- a/website/src/content/docs/docs/libraries/azure-resource-manager/reference/data-types.md
+++ b/website/src/content/docs/docs/libraries/azure-resource-manager/reference/data-types.md
@@ -2688,6 +2688,24 @@ model Foo is TrackedResource<FooProperties> {
 | --------- | --------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
 | identity? | [`ManagedServiceIdentityV4`](./data-types.md#Azure.ResourceManager.Legacy.ManagedServiceIdentityV4) | The managed service identities assigned to this resource. |
 
+### `Provider` {#Azure.ResourceManager.Legacy.Provider}
+
+```typespec
+model Azure.ResourceManager.Legacy.Provider<Resource>
+```
+
+#### Template Parameters
+
+| Name     | Description                                               |
+| -------- | --------------------------------------------------------- |
+| Resource | Optional. The resource to get the provider namespace for. |
+
+#### Properties
+
+| Name     | Type                             | Description |
+| -------- | -------------------------------- | ----------- |
+| provider | `"Microsoft.ThisWillBeReplaced"` |             |
+
 ### `ManagedServiceIdentityType` {#Azure.ResourceManager.Legacy.ManagedServiceIdentityType}
 
 Type of managed service identity (where both SystemAssigned and UserAssigned types are allowed).

--- a/website/src/content/docs/docs/libraries/azure-resource-manager/reference/index.mdx
+++ b/website/src/content/docs/docs/libraries/azure-resource-manager/reference/index.mdx
@@ -270,7 +270,12 @@ npm install --save-peer @azure-tools/typespec-azure-resource-manager
 
 - [`@customAzureResource`](./decorators.md#@Azure.ResourceManager.Legacy.customAzureResource)
 
+### Interfaces
+
+- [`LegacyOperations`](./interfaces.md#Azure.ResourceManager.Legacy.LegacyOperations)
+
 ### Models
 
 - [`ManagedServiceIdentityV4`](./data-types.md#Azure.ResourceManager.Legacy.ManagedServiceIdentityV4)
 - [`ManagedServiceIdentityV4Property`](./data-types.md#Azure.ResourceManager.Legacy.ManagedServiceIdentityV4Property)
+- [`Provider`](./data-types.md#Azure.ResourceManager.Legacy.Provider)

--- a/website/src/content/docs/docs/libraries/azure-resource-manager/reference/interfaces.md
+++ b/website/src/content/docs/docs/libraries/azure-resource-manager/reference/interfaces.md
@@ -1183,3 +1183,172 @@ op Azure.ResourceManager.Foundations.checkNameAvailability(apiVersion: string, b
 | Request          | The operation request body                                               |
 | Response         | The operation response                                                   |
 | AdditionalParams | A parameter model with properties representing non-path parameters       |
+
+## Azure.ResourceManager.Legacy
+
+### `LegacyOperations` {#Azure.ResourceManager.Legacy.LegacyOperations}
+
+```typespec
+interface Azure.ResourceManager.Legacy.LegacyOperations<ParentParameters, ResourceTypeParameter, ErrorType>
+```
+
+#### Template Parameters
+
+| Name                  | Description |
+| --------------------- | ----------- |
+| ParentParameters      |             |
+| ResourceTypeParameter |             |
+| ErrorType             |             |
+
+#### `LegacyOperations.CreateOrUpdateAsync` {#Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateAsync}
+
+```typespec
+op Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateAsync(resource: Resource): Response | ErrorType
+```
+
+##### Template Parameters
+
+| Name       | Description                                                             |
+| ---------- | ----------------------------------------------------------------------- |
+| Resource   | the resource being created or updated                                   |
+| LroHeaders | Optional. Allows overriding the lro headers returned on resource create |
+| Parameters | Optional. Additional parameters after the path parameters               |
+| Response   | Optional. The success response(s) for the PUT operation                 |
+
+#### `LegacyOperations.CreateOrUpdateSync` {#Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateSync}
+
+```typespec
+op Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateSync(resource: Resource): Response | ErrorType
+```
+
+##### Template Parameters
+
+| Name       | Description                                               |
+| ---------- | --------------------------------------------------------- |
+| Resource   | the resource being created or updated                     |
+| Parameters | Optional. Additional parameters after the path parameters |
+| Response   | Optional. The success response(s) for the PUT operation   |
+
+#### `LegacyOperations.CustomPatchAsync` {#Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchAsync}
+
+```typespec
+op Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchAsync(properties: PatchModel): Response | ErrorType
+```
+
+##### Template Parameters
+
+| Name       | Description                                                             |
+| ---------- | ----------------------------------------------------------------------- |
+| Resource   | the resource being created or updated                                   |
+| PatchModel | the PATCH request model                                                 |
+| LroHeaders | Optional. Allows overriding the lro headers returned on resource create |
+| Parameters | Optional. Additional parameters after the path parameters               |
+| Response   | Optional. The success response(s) for the PATCH operation               |
+
+#### `LegacyOperations.CustomPatchSync` {#Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchSync}
+
+```typespec
+op Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchSync(properties: PatchModel): Response | ErrorType
+```
+
+##### Template Parameters
+
+| Name       | Description                                               |
+| ---------- | --------------------------------------------------------- |
+| Resource   | the resource being created or updated                     |
+| PatchModel | the PATCH request model                                   |
+| Parameters | Optional. Additional parameters after the path parameters |
+| Response   | Optional. The success response(s) for the PATCH operation |
+
+#### `LegacyOperations.DeleteWithoutOkAsync` {#Azure.ResourceManager.Legacy.LegacyOperations.DeleteWithoutOkAsync}
+
+```typespec
+op Azure.ResourceManager.Legacy.LegacyOperations.DeleteWithoutOkAsync(): Response | ErrorType
+```
+
+##### Template Parameters
+
+| Name       | Description                                                |
+| ---------- | ---------------------------------------------------------- |
+| Resource   | The resource being deleted                                 |
+| LroHeaders | The lro headers for the operation                          |
+| Parameters | Optional. Additional parameters after the path parameters  |
+| Response   | Optional. The success response(s) for the delete operation |
+
+#### `LegacyOperations.DeleteSync` {#Azure.ResourceManager.Legacy.LegacyOperations.DeleteSync}
+
+```typespec
+op Azure.ResourceManager.Legacy.LegacyOperations.DeleteSync(): Response | ErrorType
+```
+
+##### Template Parameters
+
+| Name       | Description                                                |
+| ---------- | ---------------------------------------------------------- |
+| Resource   | The resource being deleted                                 |
+| Parameters | Optional. Additional parameters after the path parameters  |
+| Response   | Optional. The success response(s) for the delete operation |
+
+#### `LegacyOperations.Read` {#Azure.ResourceManager.Legacy.LegacyOperations.Read}
+
+```typespec
+op Azure.ResourceManager.Legacy.LegacyOperations.Read(): Response | ErrorType
+```
+
+##### Template Parameters
+
+| Name       | Description                                               |
+| ---------- | --------------------------------------------------------- |
+| Resource   | The resource being read                                   |
+| Parameters | Optional. Additional parameters after the path parameters |
+| Response   | Optional. The success response for a get operation.       |
+
+#### `LegacyOperations.List` {#Azure.ResourceManager.Legacy.LegacyOperations.List}
+
+```typespec
+op Azure.ResourceManager.Legacy.LegacyOperations.List(): Response | ErrorType
+```
+
+##### Template Parameters
+
+| Name       | Description                                               |
+| ---------- | --------------------------------------------------------- |
+| Resource   | The resource being listed                                 |
+| Parameters | Optional. Additional parameters after the path parameters |
+| Response   | Optional. The response returned by the list               |
+
+#### `LegacyOperations.ActionSync` {#Azure.ResourceManager.Legacy.LegacyOperations.ActionSync}
+
+A synchronous resource action.
+
+```typespec
+op Azure.ResourceManager.Legacy.LegacyOperations.ActionSync(body: Request): Response | ErrorType
+```
+
+##### Template Parameters
+
+| Name       | Description                                               |
+| ---------- | --------------------------------------------------------- |
+| Resource   | The resource being acted upon                             |
+| Request    | The request model for the action                          |
+| Response   | The response model for the action                         |
+| Parameters | Optional. Additional parameters after the path parameters |
+
+#### `LegacyOperations.ActionAsync` {#Azure.ResourceManager.Legacy.LegacyOperations.ActionAsync}
+
+A long-running resource action.
+
+```typespec
+op Azure.ResourceManager.Legacy.LegacyOperations.ActionAsync(body: Request): Response | ErrorType
+```
+
+##### Template Parameters
+
+| Name       | Description                                                               |
+| ---------- | ------------------------------------------------------------------------- |
+| Resource   | The resource being acted upon                                             |
+| Request    | The request model for the action                                          |
+| Result     |                                                                           |
+| LroHeaders | Optional. Allows overriding the headers returned in the Accepted response |
+| Parameters | Optional. Additional parameters after the path parameters                 |
+| Response   | The response model for the action                                         |


### PR DESCRIPTION
To proceed https://github.com/Azure/typespec-azure/issues/234, add the legacy operation template into the library according to this [design](https://gist.github.com/markcowl/825f8827d1e280a1c5ffeb57eb968677). It's almost the same as @markcowl 's design, except:
1. Change the body name and doc for CustomPatchSync/CustomPatchAsync to align with those of ArmCustomPatchSync/ArmCustomPatchAsync.
2. Change the DeleteAsync to DeleteWithoutOkAsync because its corresponding ArmResourceDeleteAsync is deprecated.