### PR TITLE
Update converter document

### DIFF
--- a/website/src/content/docs/docs/migrate-swagger/01-get-started.md
+++ b/website/src/content/docs/docs/migrate-swagger/01-get-started.md
@@ -26,9 +26,21 @@ We have created a swagger to TypeSpec conversion tool to help take on the bulk o
 
 ### Generate TypeSpec with converter
 
-```shell
-npm install -g @azure-tools/typespec-client-generator-cli
-```
+- Install dependencies
+  - If you are starting from a scratch folder:
+    ```shell
+    npm install @azure-tools/typespec-client-generator-cli
+    ```
+
+    **_Important!_** If it's not your first time install `@azure-tools/typespec-client-generator-cli`, update by 
+
+    ```shell
+    npm update @autorest/openapi-to-typespec
+    ```
+  - If you are starting from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs):
+    ```shell
+    npm install # Run at root
+    ```
 
 - Run the tool from the directory you would like to output your files.
 

--- a/website/src/content/docs/docs/migrate-swagger/01-get-started.md
+++ b/website/src/content/docs/docs/migrate-swagger/01-get-started.md
@@ -27,16 +27,19 @@ We have created a swagger to TypeSpec conversion tool to help take on the bulk o
 ### Generate TypeSpec with converter
 
 - Install dependencies
+
   - If you are starting from a scratch folder:
+
     ```shell
     npm install @azure-tools/typespec-client-generator-cli
     ```
 
-    **_Important!_** If it's not your first time install `@azure-tools/typespec-client-generator-cli`, update by 
+    **_Important!_** If it's not your first time install `@azure-tools/typespec-client-generator-cli`, update by
 
     ```shell
     npm update @autorest/openapi-to-typespec
     ```
+
   - If you are starting from [azure-rest-api-specs](https://github.com/Azure/azure-rest-api-specs):
     ```shell
     npm install # Run at root


### PR DESCRIPTION
After this PR https://github.com/Azure/azure-sdk-tools/pull/9602, `@autorest/openapi-to-typespec` no longer updated with tsp-client. Customers need to update themselves every time when `@autorest/openapi-to-typespec` release. This document update is to guide customers how to updadte.