### PR TITLE
[tcgc] fix regression of 0.50.1

### DIFF
--- a/.chronus/changes/fix_regression-2025-0-22-14-2-17.md
+++ b/.chronus/changes/fix_regression-2025-0-22-14-2-17.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-client-generator-core"
 ---
 
-Deprecate `serializedName` property of `SdkEndpointParameter`. Use `type.templateArguments[x].serializedName` or `type.variantTypes[x].templateArguments[x].serializedName` instead.
+Deprecate `serializedName` property of `SdkEndpointParameter`. Use `type.templateArguments[x].serializedName` or `type.variantTypes[x].templateArguments[x].serializedName` instead.

--- a/.chronus/changes/fix_regression-2025-0-22-14-2-17.md
+++ b/.chronus/changes/fix_regression-2025-0-22-14-2-17.md
@@ -1,0 +1,7 @@
+---
+changeKind: deprecation
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Deprecate `serializedName` property of `SdkEndpointParameter`. Use `type.templateArguments[x].serializedName` or `type.variantTypes[x].templateArguments[x].serializedName` instead.

--- a/.chronus/changes/fix_regression-2025-0-22-14-2-45.md
+++ b/.chronus/changes/fix_regression-2025-0-22-14-2-45.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Fix regression of example mapping for model with parameters.

--- a/packages/typespec-client-generator-core/src/example.ts
+++ b/packages/typespec-client-generator-core/src/example.ts
@@ -13,7 +13,6 @@ import { getOperationId } from "@typespec/openapi";
 import {
   SdkArrayExampleValue,
   SdkArrayType,
-  SdkBodyModelPropertyType,
   SdkClientType,
   SdkDictionaryExampleValue,
   SdkDictionaryType,
@@ -612,13 +611,14 @@ function getSdkModelExample(
     const modelQueue = [type];
     while (modelQueue.length > 0) {
       const model = modelQueue.pop()!;
-      for (let property of model.properties) {
-        property = property as SdkBodyModelPropertyType;
+      for (const property of model.properties) {
+        // for query/path/cookie/header parameters, they should have been handled in parameters.
         if (
+          property.kind === "property" &&
           property.serializationOptions.json?.name &&
-          !properties.has(property.serializationOptions.json?.name)
+          !properties.has(property.serializationOptions.json.name)
         ) {
-          properties.set(property.serializationOptions.json?.name, property);
+          properties.set(property.serializationOptions.json.name, property);
         }
       }
       if (model.additionalProperties && additionalPropertiesType === undefined) {

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -459,6 +459,10 @@ export interface SdkEndpointParameter extends SdkModelPropertyTypeBase {
   urlEncode: boolean;
   onClient: true;
   type: SdkEndpointType | SdkUnionType<SdkEndpointType>;
+  /**
+   * @deprecated This property is deprecated. Use `type.templateArguments[x].serializedName` or `type.variantTypes[x].templateArguments[x].serializedName` instead.
+   */
+  serializedName?: string;
 }
 
 export interface SdkCredentialParameter extends SdkModelPropertyTypeBase {

--- a/packages/typespec-client-generator-core/test/examples/example-types/getModelWithExtraParamter.json
+++ b/packages/typespec-client-generator-core/test/examples/example-types/getModelWithExtraParamter.json
@@ -1,0 +1,16 @@
+{
+  "operationId": "getModelWithExtraParamter",
+  "title": "getModelWithExtraParamter",
+  "parameters": {},
+  "responses": {
+    "200": {
+      "headers": {
+        "x-ms-prop": "test"
+      },
+      "body": {
+        "a": "a",
+        "b": 2
+      }
+    }
+  }
+}

--- a/packages/typespec-client-generator-core/test/types/serialization-options.test.ts
+++ b/packages/typespec-client-generator-core/test/types/serialization-options.test.ts
@@ -586,4 +586,25 @@ describe("typespec-client-generator-core: serialization options", () => {
     strictEqual(model.properties[0].kind, "property");
     strictEqual(model.properties[0].serializationOptions.json?.name, "rename");
   });
+
+  it("@unwrapped for string property", async function () {
+    runner = await createSdkTestRunner({
+      librariesToAdd: [XmlTestLibrary],
+      autoUsings: ["TypeSpec.Xml"],
+    });
+
+    await runner.compileWithBuiltInService(`
+      @usage(Usage.input | Usage.output)
+      model BlobName {
+        @unwrapped content: string;
+      }
+    `);
+
+    const models = runner.context.sdkPackage.models;
+    strictEqual(models.length, 1);
+    const model = models[0];
+    strictEqual(model.properties[0].kind, "property");
+    strictEqual(model.properties[0].serializationOptions.xml?.name, "content");
+    strictEqual(model.properties[0].serializationOptions.xml?.unwrapped, true);
+  });
 });


### PR DESCRIPTION
1. Deprecate `serializedName` property of `SdkEndpointParameter`. Use `type.templateArguments[x].serializedName` or `type.variantTypes[x].templateArguments[x].serializedName` instead.
2. Fix regression of example mapping for model with parameters.