### PR TITLE
Fix Typo mistake in @key("privateLinkResourcenName"). Change from privateLinkResourcenName to privateLinkResourceName 

### DIFF
--- a/.chronus/changes/fix-typo-in-privateLinkResourcenName-2025-1-7-11-23-20.md
+++ b/.chronus/changes/fix-typo-in-privateLinkResourcenName-2025-1-7-11-23-20.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Fix common-types privatelink typo in `@key("privateLinkResourcenName") from privateLinkResourcenName to privateLinkResourceName`

--- a/packages/typespec-azure-resource-manager/lib/common-types/private-links.tsp
+++ b/packages/typespec-azure-resource-manager/lib/common-types/private-links.tsp
@@ -144,7 +144,7 @@ model PrivateLinkResourceParameter<Segment extends valueof string = "privateLink
   /** The name of the private link associated with the Azure resource. */
   @path
   @TypeSpec.Rest.segment(Segment)
-  @key("privateLinkResourcenName")
+  @key("privateLinkResourceName")
   name: string;
 }
 


### PR DESCRIPTION
Bug reported in: https://github.com/Azure/typespec-azure/issues/2183