### PR TITLE
azure-http-specs, config java namespace, avoid _Specs_ appear in SDK namespace

### DIFF
--- a/.chronus/changes/azure-http-specs_config-java-namespace-2025-1-8-11-59-45.md
+++ b/.chronus/changes/azure-http-specs_config-java-namespace-2025-1-8-11-59-45.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Update SDK namespace for Java, avoid _Specs_ appears in SDK namespace.

--- a/packages/azure-http-specs/specs/azure/client-generator-core/access/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/access/main.tsp
@@ -8,6 +8,7 @@ using Spector;
 
 @doc("Test for internal decorator.")
 @scenarioService("/azure/client-generator-core/access")
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.access", "java")
 namespace _Specs_.Azure.ClientGenerator.Core.Access;
 
 @route("/publicOperation")

--- a/packages/azure-http-specs/specs/azure/client-generator-core/api-version/header/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/api-version/header/client.tsp
@@ -11,3 +11,8 @@ using Spector;
 namespace Customizations;
 
 @@apiVersion(HeaderApiVersionParam.version);
+
+@@clientNamespace(Client.AlternateApiVersion.Service.Header,
+  "azure.clientgenerator.core.apiversion.header",
+  "java"
+);

--- a/packages/azure-http-specs/specs/azure/client-generator-core/api-version/path/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/api-version/path/client.tsp
@@ -11,3 +11,8 @@ using Spector;
 namespace Customizations;
 
 @@apiVersion(PathApiVersionParam.version);
+
+@@clientNamespace(Client.AlternateApiVersion.Service.Path,
+  "azure.clientgenerator.core.apiversion.path",
+  "java"
+);

--- a/packages/azure-http-specs/specs/azure/client-generator-core/api-version/query/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/api-version/query/client.tsp
@@ -11,3 +11,8 @@ using Spector;
 namespace Customizations;
 
 @@apiVersion(QueryApiVersionParam.version);
+
+@@clientNamespace(Client.AlternateApiVersion.Service.Query,
+  "azure.clientgenerator.core.apiversion.query",
+  "java"
+);

--- a/packages/azure-http-specs/specs/azure/client-generator-core/flatten-property/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/flatten-property/main.tsp
@@ -8,6 +8,10 @@ using Spector;
 
 @doc("Illustrates the model flatten cases.")
 @scenarioService("/azure/client-generator-core/flatten-property")
+@global.Azure.ClientGenerator.Core.clientNamespace(
+  "azure.clientgenerator.core.flattenproperty",
+  "java"
+)
 namespace _Specs_.Azure.ClientGenerator.Core.FlattenProperty;
 
 @doc("This is the model with one level of flattening.")

--- a/packages/azure-http-specs/specs/azure/client-generator-core/usage/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/usage/main.tsp
@@ -8,6 +8,7 @@ using Spector;
 
 @doc("Test for internal decorator.")
 @scenarioService("/azure/client-generator-core/usage")
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.usage", "java")
 namespace _Specs_.Azure.ClientGenerator.Core.Usage;
 
 @scenario
@@ -15,6 +16,7 @@ namespace _Specs_.Azure.ClientGenerator.Core.Usage;
   This scenario contains two public operations. Both should be generated and exported.
   The models are override to roundtrip, so they should be generated and exported as well.
   """)
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.usage", "java")
 namespace ModelInOperation {
   @doc("Usage override to roundtrip.")
   @global.Azure.ClientGenerator.Core.usage(

--- a/packages/azure-http-specs/specs/azure/core/basic/client.tsp
+++ b/packages/azure-http-specs/specs/azure/core/basic/client.tsp
@@ -4,3 +4,5 @@ import "./main.tsp";
 using Azure.ClientGenerator.Core;
 
 @@convenientAPI(_Specs_.Azure.Core.Basic.createOrUpdate, false, "csharp");
+
+@@clientNamespace(_Specs_.Azure.Core.Basic, "azure.core.basic", "java");

--- a/packages/azure-http-specs/specs/azure/core/lro/rpc/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/lro/rpc/main.tsp
@@ -2,6 +2,7 @@ import "@azure-tools/typespec-azure-core";
 import "@typespec/spector";
 import "@typespec/rest";
 import "@typespec/versioning";
+import "@azure-tools/typespec-client-generator-core";
 
 using Azure.Core;
 using global.Azure.Core.Traits;
@@ -18,6 +19,7 @@ using Spector;
     versioned: Versions,
   }
 )
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.lro.rpc", "java")
 namespace _Specs_.Azure.Core.Lro.Rpc;
 
 @doc("The API version.")

--- a/packages/azure-http-specs/specs/azure/core/lro/standard/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/lro/standard/main.tsp
@@ -2,6 +2,7 @@ import "@azure-tools/typespec-azure-core";
 import "@typespec/spector";
 import "@typespec/rest";
 import "@typespec/versioning";
+import "@azure-tools/typespec-client-generator-core";
 
 using Azure.Core;
 using global.Azure.Core.Traits;
@@ -18,6 +19,7 @@ using Spector;
     versioned: Versions,
   }
 )
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.lro.standard", "java")
 namespace _Specs_.Azure.Core.Lro.Standard;
 
 @doc("The API version.")

--- a/packages/azure-http-specs/specs/azure/core/model/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/model/main.tsp
@@ -16,6 +16,7 @@ using Spector;
     versioned: Versions,
   }
 )
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.model", "java")
 namespace _Specs_.Azure.Core.Model;
 @doc("The version of the API.")
 enum Versions {

--- a/packages/azure-http-specs/specs/azure/core/page/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/page/main.tsp
@@ -3,6 +3,7 @@ import "@typespec/spector";
 import "@typespec/http";
 import "@typespec/rest";
 import "@typespec/versioning";
+import "@azure-tools/typespec-client-generator-core";
 
 using Azure.Core;
 using TypeSpec.Http;
@@ -18,6 +19,7 @@ using Spector;
     versioned: Versions,
   }
 )
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.page", "java")
 namespace _Specs_.Azure.Core.Page;
 
 @doc("The version of the API.")

--- a/packages/azure-http-specs/specs/azure/core/scalar/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/scalar/main.tsp
@@ -16,6 +16,7 @@ using Spector;
     versioned: Versions,
   }
 )
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.scalar", "java")
 namespace _Specs_.Azure.Core.Scalar;
 @doc("The version of the API.")
 enum Versions {

--- a/packages/azure-http-specs/specs/azure/core/traits/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/traits/main.tsp
@@ -3,6 +3,7 @@ import "@typespec/spector";
 import "@typespec/http";
 import "@typespec/rest";
 import "@typespec/versioning";
+import "@azure-tools/typespec-client-generator-core";
 
 using global.Azure.Core;
 using global.Azure.Core.Traits;
@@ -20,6 +21,7 @@ using Spector;
   }
 )
 @versioned(Versions)
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.trait", "java")
 namespace _Specs_.Azure.Core.Traits;
 
 @doc("Service versions")


### PR DESCRIPTION
context: Java does not want to see the default `_specs_` in its namespace https://github.com/Azure/autorest.java/tree/main/typespec-tests/src/main/java/_specs_