### PR TITLE
[tcgc] rename `clientNamespace` into `namespace` directly

### DIFF
--- a/.chronus/changes/rename_namespace-2025-1-14-17-4-43.md
+++ b/.chronus/changes/rename_namespace-2025-1-14-17-4-43.md
@@ -1,0 +1,7 @@
+---
+changeKind: deprecation
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Deprecate `clientNamespace` property in `SdkClientType`, `SdkNullableType`, `SdkEnumType`, `SdkUnionType` and `SdkModelType`. Use `namespace` instead.

--- a/.chronus/changes/rename_namespace-2025-1-14-17-4-43.md
+++ b/.chronus/changes/rename_namespace-2025-1-14-17-4-43.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-client-generator-core"
 ---
 
-Deprecate `clientNamespace` property in `SdkClientType`, `SdkNullableType`, `SdkEnumType`, `SdkUnionType` and `SdkModelType`. Use `namespace` instead.
+Deprecate `clientNamespace` property in `SdkClientType`, `SdkNullableType`, `SdkEnumType`, `SdkUnionType` and `SdkModelType`. Use `namespace` instead.

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -177,7 +177,14 @@ export interface SdkClientType<TServiceOperation extends SdkServiceOperation>
   __raw: SdkClient | SdkOperationGroup;
   kind: "client";
   name: string;
-  clientNamespace: string; // fully qualified namespace
+  /**
+   * @deprecated Use `namespace` instead.
+   */
+  clientNamespace: string;
+  /**
+   * Full qualified namespace.
+   */
+  namespace: string;
   doc?: string;
   summary?: string;
   /**
@@ -385,14 +392,28 @@ export interface SdkNullableType extends SdkTypeBase {
   type: SdkType;
   usage: UsageFlags;
   access: AccessFlags;
-  clientNamespace: string; // fully qualified namespace
+  /**
+   * @deprecated Use `namespace` instead.
+   */
+  clientNamespace: string;
+  /**
+   * Full qualified namespace.
+   */
+  namespace: string;
 }
 
 export interface SdkEnumType extends SdkTypeBase {
   kind: "enum";
   name: string;
   isGeneratedName: boolean;
-  clientNamespace: string; // fully qualified namespace
+  /**
+   * @deprecated Use `namespace` instead.
+   */
+  clientNamespace: string;
+  /**
+   * Full qualified namespace.
+   */
+  namespace: string;
   valueType: SdkBuiltInType;
   values: SdkEnumValueType[];
   isFixed: boolean;
@@ -423,7 +444,14 @@ export interface SdkConstantType extends SdkTypeBase {
 export interface SdkUnionType<TValueType extends SdkTypeBase = SdkType> extends SdkTypeBase {
   name: string;
   isGeneratedName: boolean;
-  clientNamespace: string; // fully qualified namespace
+  /**
+   * @deprecated Use `namespace` instead.
+   */
+  clientNamespace: string;
+  /**
+   * Full qualified namespace.
+   */
+  namespace: string;
   kind: "union";
   variantTypes: TValueType[];
   crossLanguageDefinitionId: string;
@@ -436,7 +464,14 @@ export interface SdkModelType extends SdkTypeBase {
   properties: SdkModelPropertyType[];
   name: string;
   isGeneratedName: boolean;
-  clientNamespace: string; // fully qualified namespace
+  /**
+   * @deprecated Use `namespace` instead.
+   */
+  clientNamespace: string;
+  /**
+   * Full qualified namespace.
+   */
+  namespace: string;
   access: AccessFlags;
   usage: UsageFlags;
   additionalProperties?: SdkType;

--- a/packages/typespec-client-generator-core/src/package.ts
+++ b/packages/typespec-client-generator-core/src/package.ts
@@ -420,7 +420,8 @@ function getSdkMethodResponse(
       variantTypes: allResponseBodies,
       name: createGeneratedName(context, operation, "UnionResponse"),
       isGeneratedName: true,
-      clientNamespace: client.clientNamespace,
+      namespace: client.namespace,
+      clientNamespace: client.namespace,
       crossLanguageDefinitionId: `${getCrossLanguageDefinitionId(context, operation)}.UnionResponse`,
       decorators: [],
     };
@@ -436,7 +437,8 @@ function getSdkMethodResponse(
       decorators: [],
       access: "public",
       usage: UsageFlags.Output,
-      clientNamespace: client.clientNamespace,
+      namespace: client.namespace,
+      clientNamespace: client.namespace,
     };
   }
   return {
@@ -572,6 +574,7 @@ function getSdkInitializationType(
   } else {
     const namePrefix = client.kind === "SdkClient" ? client.name : client.groupPath;
     const name = `${namePrefix.split(".").at(-1)}Options`;
+    const namespace = getClientNamespace(context, client.type);
     initializationModel = {
       __raw: client.service,
       doc: "Initialization class for the client",
@@ -582,7 +585,8 @@ function getSdkInitializationType(
       access,
       usage: UsageFlags.Input,
       crossLanguageDefinitionId: `${getNamespaceFullName(client.service.namespace!)}.${name}`,
-      clientNamespace: getClientNamespace(context, client.type),
+      namespace,
+      clientNamespace: namespace,
       apiVersions: context.__tspTypeToApiVersions.get(client.type)!,
       decorators: [],
       serializationOptions: {},
@@ -842,6 +846,7 @@ function getSdkEndpointParameter<TServiceOperation extends SdkServiceOperation =
   }
   let type: SdkEndpointType | SdkUnionType<SdkEndpointType>;
   if (types.length > 1) {
+    const namespace = getClientNamespace(context, rawClient.service);
     type = {
       kind: "union",
       access: "public",
@@ -850,7 +855,8 @@ function getSdkEndpointParameter<TServiceOperation extends SdkServiceOperation =
       name: createGeneratedName(context, rawClient.service, "Endpoint"),
       isGeneratedName: true,
       crossLanguageDefinitionId: `${getCrossLanguageDefinitionId(context, rawClient.service)}.Endpoint`,
-      clientNamespace: getClientNamespace(context, rawClient.service),
+      namespace,
+      clientNamespace: namespace,
       decorators: [],
     } as SdkUnionType<SdkEndpointType>;
   } else {
@@ -878,6 +884,7 @@ function createSdkClientType<TServiceOperation extends SdkServiceOperation>(
   parent?: SdkClientType<TServiceOperation>,
 ): [SdkClientType<TServiceOperation>, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
+  const namespace = getClientNamespace(context, client.type);
   const sdkClientType: SdkClientType<TServiceOperation> = {
     __raw: client,
     kind: "client",
@@ -887,7 +894,8 @@ function createSdkClientType<TServiceOperation extends SdkServiceOperation>(
     methods: [],
     apiVersions: context.__tspTypeToApiVersions.get(client.type)!,
     nameSpace: getClientNamespaceStringHelper(context, client.service)!,
-    clientNamespace: getClientNamespace(context, client.type),
+    namespace: namespace,
+    clientNamespace: namespace,
     initialization: diagnostics.pipe(getSdkInitializationType(context, client)),
     clientInitialization: diagnostics.pipe(createSdkClientInitializationType(context, client)),
     decorators: diagnostics.pipe(getTypeDecorators(context, client.type)),
@@ -1015,20 +1023,20 @@ function organizeNamespaces<TServiceOperation extends SdkServiceOperation>(
   const clients = [...sdkPackage.clients];
   while (clients.length > 0) {
     const client = clients.shift()!;
-    getSdkNamespace(sdkPackage, client.clientNamespace).clients.push(client);
+    getSdkNamespace(sdkPackage, client.namespace).clients.push(client);
     client.methods
       .filter((m) => m.kind === "clientaccessor")
       .map((m) => m.response)
       .map((c) => clients.push(c));
   }
   for (const model of sdkPackage.models) {
-    getSdkNamespace(sdkPackage, model.clientNamespace).models.push(model);
+    getSdkNamespace(sdkPackage, model.namespace).models.push(model);
   }
   for (const enumType of sdkPackage.enums) {
-    getSdkNamespace(sdkPackage, enumType.clientNamespace).enums.push(enumType);
+    getSdkNamespace(sdkPackage, enumType.namespace).enums.push(enumType);
   }
   for (const unionType of sdkPackage.unions) {
-    getSdkNamespace(sdkPackage, unionType.clientNamespace).unions.push(unionType);
+    getSdkNamespace(sdkPackage, unionType.namespace).unions.push(unionType);
   }
 }
 

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -517,6 +517,7 @@ export function getSdkUnionWithDiagnostics(
       retval = diagnostics.pipe(getEmptyUnionType(context, type, operation));
       updateReferencedTypeMap(context, type, retval);
     } else {
+      const namespace = getClientNamespace(context, type);
       // if a union is `type | null`, then we will return a nullable wrapper type of the type
       if (nonNullOptions.length === 1 && nullOption !== undefined) {
         retval = {
@@ -526,7 +527,8 @@ export function getSdkUnionWithDiagnostics(
           type: diagnostics.pipe(getUnknownType(context, type)),
           access: "public",
           usage: UsageFlags.None,
-          clientNamespace: getClientNamespace(context, type),
+          namespace,
+          clientNamespace: namespace,
         };
         updateReferencedTypeMap(context, type, retval);
         retval.type = diagnostics.pipe(
@@ -554,7 +556,8 @@ export function getSdkUnionWithDiagnostics(
               type: retval,
               access: "public",
               usage: UsageFlags.None,
-              clientNamespace: getClientNamespace(context, type),
+              namespace,
+              clientNamespace: namespace,
             };
           }
           updateReferencedTypeMap(context, type, retval);
@@ -567,7 +570,8 @@ export function getSdkUnionWithDiagnostics(
           ...diagnostics.pipe(getSdkTypeBaseHelper(context, type, "union")),
           name: getLibraryName(context, type) || getGeneratedName(context, type, operation),
           isGeneratedName: true, // always set inner union type as generated name
-          clientNamespace: getClientNamespace(context, type),
+          namespace,
+          clientNamespace: namespace,
           variantTypes: [],
           crossLanguageDefinitionId: getCrossLanguageDefinitionId(context, type, operation),
           access: "public",
@@ -581,7 +585,8 @@ export function getSdkUnionWithDiagnostics(
             type: retval,
             access: "public",
             usage: UsageFlags.None,
-            clientNamespace: getClientNamespace(context, type),
+            namespace,
+            clientNamespace: namespace,
           };
         }
         updateReferencedTypeMap(context, type, retval);
@@ -606,12 +611,14 @@ function getEmptyUnionType(
   operation?: Operation,
 ): [SdkUnionType, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
+  const namespace = getClientNamespace(context, type);
 
   return diagnostics.wrap({
     ...diagnostics.pipe(getSdkTypeBaseHelper(context, type, "union")),
     name: getLibraryName(context, type) || getGeneratedName(context, type, operation),
     isGeneratedName: !type.name,
-    clientNamespace: getClientNamespace(context, type),
+    namespace,
+    clientNamespace: namespace,
     variantTypes: [],
     crossLanguageDefinitionId: getCrossLanguageDefinitionId(context, type, operation),
     access: "public",
@@ -804,11 +811,13 @@ export function getSdkModelWithDiagnostics(
   if (!sdkType) {
     const name = getLibraryName(context, type) || getGeneratedName(context, type, operation);
     const usage = isErrorModel(context.program, type) ? UsageFlags.Error : UsageFlags.None; // eslint-disable-line @typescript-eslint/no-deprecated
+    const namespace = getClientNamespace(context, type);
     sdkType = {
       ...diagnostics.pipe(getSdkTypeBaseHelper(context, type, "model")),
       name: name,
       isGeneratedName: !type.name,
-      clientNamespace: getClientNamespace(context, type),
+      namespace,
+      clientNamespace: namespace,
       doc: getDoc(context.program, type),
       summary: getSummary(context.program, type),
       properties: [],
@@ -935,11 +944,13 @@ function getSdkEnumWithDiagnostics(
   const diagnostics = createDiagnosticCollector();
   let sdkType = context.referencedTypeMap?.get(type) as SdkEnumType | undefined;
   if (!sdkType) {
+    const namespace = getClientNamespace(context, type);
     sdkType = {
       ...diagnostics.pipe(getSdkTypeBaseHelper(context, type, "enum")),
       name: getLibraryName(context, type),
       isGeneratedName: false,
-      clientNamespace: getClientNamespace(context, type),
+      namespace,
+      clientNamespace: namespace,
       doc: getDoc(context.program, type),
       summary: getSummary(context.program, type),
       valueType: diagnostics.pipe(
@@ -1001,11 +1012,13 @@ export function getSdkUnionEnumWithDiagnostics(
   const diagnostics = createDiagnosticCollector();
   const union = type.union;
   const name = getLibraryName(context, type.union) || getGeneratedName(context, union, operation);
+  const namespace = getClientNamespace(context, type.union);
   const sdkType: SdkEnumType = {
     ...diagnostics.pipe(getSdkTypeBaseHelper(context, type.union, "enum")),
     name,
     isGeneratedName: !type.union.name,
-    clientNamespace: getClientNamespace(context, type.union),
+    namespace,
+    clientNamespace: namespace,
     doc: getDoc(context.program, union),
     summary: getSummary(context.program, union),
     valueType:
@@ -1162,13 +1175,15 @@ function getSdkCredentialType(
     }
   }
   if (credentialTypes.length > 1) {
+    const namespace = getClientNamespace(context, client.service);
     return {
       __raw: client.service,
       kind: "union",
       variantTypes: credentialTypes,
       name: createGeneratedName(context, client.service, "CredentialUnion"),
       isGeneratedName: true,
-      clientNamespace: getClientNamespace(context, client.service),
+      namespace,
+      clientNamespace: namespace,
       crossLanguageDefinitionId: `${getCrossLanguageDefinitionId(context, client.service)}.CredentialUnion`,
       decorators: [],
       access: "public",

--- a/packages/typespec-client-generator-core/test/decorators/client-namespace.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/client-namespace.test.ts
@@ -21,7 +21,7 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
       op test(): Test;
       `,
       );
-      strictEqual(runner.context.sdkPackage.models[0].clientNamespace, "TestService");
+      strictEqual(runner.context.sdkPackage.models[0].namespace, "TestService");
     });
 
     it("namespace on enum", async () => {
@@ -34,7 +34,7 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
       op test(): Test;
       `,
       );
-      strictEqual(runner.context.sdkPackage.enums[0].clientNamespace, "TestService");
+      strictEqual(runner.context.sdkPackage.enums[0].namespace, "TestService");
     });
 
     it("namespace on union", async () => {
@@ -47,7 +47,7 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
       op test(param: Test): void;
       `,
       );
-      strictEqual(runner.context.sdkPackage.unions[0].clientNamespace, "TestService");
+      strictEqual(runner.context.sdkPackage.unions[0].namespace, "TestService");
     });
 
     it("namespace on union as enum", async () => {
@@ -60,7 +60,7 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
       op test(param: Test): void;
       `,
       );
-      strictEqual(runner.context.sdkPackage.enums[0].clientNamespace, "TestService");
+      strictEqual(runner.context.sdkPackage.enums[0].namespace, "TestService");
     });
 
     it("namespace on union with null", async () => {
@@ -73,7 +73,7 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
       op test(param: Test): void;
       `,
       );
-      strictEqual(runner.context.sdkPackage.unions[0].clientNamespace, "TestService");
+      strictEqual(runner.context.sdkPackage.unions[0].namespace, "TestService");
     });
 
     it("namespace on namespace", async () => {
@@ -87,7 +87,7 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
         (
           runner.context.sdkPackage.clients[0].methods[0]
             .response as SdkClientType<SdkServiceOperation>
-        ).clientNamespace,
+        ).namespace,
         "TestService.Inner",
       );
     });
@@ -103,7 +103,7 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
         (
           runner.context.sdkPackage.clients[0].methods[0]
             .response as SdkClientType<SdkServiceOperation>
-        ).clientNamespace,
+        ).namespace,
         "TestService",
       );
     });
@@ -121,7 +121,7 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
       op test(): Test;
       `,
       );
-      strictEqual(runner.context.sdkPackage.models[0].clientNamespace, "MyNamespace");
+      strictEqual(runner.context.sdkPackage.models[0].namespace, "MyNamespace");
     });
 
     it("namespace override on enum", async () => {
@@ -135,7 +135,7 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
       op test(): Test;
       `,
       );
-      strictEqual(runner.context.sdkPackage.enums[0].clientNamespace, "MyNamespace");
+      strictEqual(runner.context.sdkPackage.enums[0].namespace, "MyNamespace");
     });
 
     it("namespace override on union", async () => {
@@ -149,7 +149,7 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
       op test(param: Test): void;
       `,
       );
-      strictEqual(runner.context.sdkPackage.unions[0].clientNamespace, "MyNamespace");
+      strictEqual(runner.context.sdkPackage.unions[0].namespace, "MyNamespace");
     });
 
     it("namespace override on union as enum", async () => {
@@ -163,7 +163,7 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
       op test(param: Test): void;
       `,
       );
-      strictEqual(runner.context.sdkPackage.enums[0].clientNamespace, "MyNamespace");
+      strictEqual(runner.context.sdkPackage.enums[0].namespace, "MyNamespace");
     });
 
     it("namespace override on union with null", async () => {
@@ -177,7 +177,7 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
       op test(param: Test): void;
       `,
       );
-      strictEqual(runner.context.sdkPackage.unions[0].clientNamespace, "MyNamespace");
+      strictEqual(runner.context.sdkPackage.unions[0].namespace, "MyNamespace");
     });
 
     it("namespace override on namespace", async () => {
@@ -193,7 +193,7 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
         (
           runner.context.sdkPackage.clients[0].methods[0]
             .response as SdkClientType<SdkServiceOperation>
-        ).clientNamespace,
+        ).namespace,
         "MyNamespace",
       );
     });
@@ -211,7 +211,7 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
         (
           runner.context.sdkPackage.clients[0].methods[0]
             .response as SdkClientType<SdkServiceOperation>
-        ).clientNamespace,
+        ).namespace,
         "MyNamespace",
       );
     });
@@ -236,12 +236,12 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
       @@clientNamespace(Inner, "MyNamespace");
       `,
       );
-      strictEqual(runner.context.sdkPackage.clients[0].clientNamespace, "TestService"); // root namespace
+      strictEqual(runner.context.sdkPackage.clients[0].namespace, "TestService"); // root namespace
       strictEqual(
         (
           runner.context.sdkPackage.clients[0].methods[0]
             .response as SdkClientType<SdkServiceOperation>
-        ).clientNamespace,
+        ).namespace,
         "MyNamespace",
       ); // Inner namespace with override
       strictEqual(
@@ -250,11 +250,11 @@ describe("typespec-client-generator-core: @clientNamespace", () => {
             runner.context.sdkPackage.clients[0].methods[0]
               .response as SdkClientType<SdkServiceOperation>
           ).methods[0].response as SdkClientType<SdkServiceOperation>
-        ).clientNamespace,
+        ).namespace,
         "MyNamespace.Test",
       ); // Test namespace affected by Inner namespace override
-      strictEqual(runner.context.sdkPackage.models[0].clientNamespace, "MyNamespace");
-      strictEqual(runner.context.sdkPackage.models[1].clientNamespace, "MyNamespace.Test");
+      strictEqual(runner.context.sdkPackage.models[0].namespace, "MyNamespace");
+      strictEqual(runner.context.sdkPackage.models[1].namespace, "MyNamespace.Test");
     });
   });
 });

--- a/packages/typespec-client-generator-core/test/packages/namespaces.test.ts
+++ b/packages/typespec-client-generator-core/test/packages/namespaces.test.ts
@@ -233,9 +233,9 @@ describe("typespec-client-generator-core: namespaces", () => {
     const sdkPackage = runner.context.sdkPackage;
     const foodClient = sdkPackage.clients.find((x) => x.name === "FoodClient");
     ok(foodClient);
-    strictEqual(foodClient.clientNamespace, "PetStoreRenamed");
+    strictEqual(foodClient.namespace, "PetStoreRenamed");
     const petActionClient = sdkPackage.clients.find((x) => x.name === "PetActionClient");
     ok(petActionClient);
-    strictEqual(petActionClient.clientNamespace, "PetStoreRenamed.SubNamespace");
+    strictEqual(petActionClient.namespace, "PetStoreRenamed.SubNamespace");
   });
 });


### PR DESCRIPTION
Deprecate `clientNamespace` property in `SdkClientType`, `SdkNullableType`, `SdkEnumType`, `SdkUnionType` and `SdkModelType`. Use `namespace` instead.

fix: https://github.com/Azure/typespec-azure/issues/2123