### PR TITLE
[tcgc] fix missing result segments of anonymous paged response with header

### DIFF
--- a/.chronus/changes/fix_result_path-2025-1-19-14-38-26.md
+++ b/.chronus/changes/fix_result_path-2025-1-19-14-38-26.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Fix missing result segments of anonymous paged response with header.

--- a/packages/typespec-client-generator-core/src/package.ts
+++ b/packages/typespec-client-generator-core/src/package.ts
@@ -178,11 +178,17 @@ function getSdkPagingServiceMethod<TServiceOperation extends SdkServiceOperation
     baseServiceMethod.response.resultPath = getPropertyPathFromModel(
       context,
       responseType?.__raw,
-      (p) => p === pagingOperation.output.pageItems.property,
+      (p) =>
+        p.kind === "ModelProperty" &&
+        findRootSourceProperty(p) ===
+          findRootSourceProperty(pagingOperation.output.pageItems.property),
     );
     baseServiceMethod.response.resultSegments = getPropertySegmentsFromModelOrParameters(
       responseType,
-      (p) => p.__raw === pagingOperation.output.pageItems.property,
+      (p) =>
+        p.__raw?.kind === "ModelProperty" &&
+        findRootSourceProperty(p.__raw) ===
+          findRootSourceProperty(pagingOperation.output.pageItems.property),
     );
 
     let nextLinkPath = undefined;
@@ -191,11 +197,17 @@ function getSdkPagingServiceMethod<TServiceOperation extends SdkServiceOperation
       nextLinkPath = getPropertyPathFromModel(
         context,
         responseType?.__raw,
-        (p) => p === pagingOperation.output.nextLink!.property,
+        (p) =>
+          p.kind === "ModelProperty" &&
+          findRootSourceProperty(p) ===
+            findRootSourceProperty(pagingOperation.output.nextLink!.property),
       );
       nextLinkSegments = getPropertySegmentsFromModelOrParameters(
         responseType,
-        (p) => p.__raw === pagingOperation.output.nextLink?.property,
+        (p) =>
+          p.__raw?.kind === "ModelProperty" &&
+          findRootSourceProperty(p.__raw) ===
+            findRootSourceProperty(pagingOperation.output.nextLink!.property),
       );
     }
 
@@ -215,11 +227,19 @@ function getSdkPagingServiceMethod<TServiceOperation extends SdkServiceOperation
         continuationTokenResponseSegments = baseServiceMethod.operation.responses
           .map((r) => r.headers)
           .flat()
-          .filter((h) => h.__raw === pagingOperation.output.continuationToken!.property);
+          .filter(
+            (h) =>
+              h.__raw?.kind === "ModelProperty" &&
+              findRootSourceProperty(h.__raw) ===
+                findRootSourceProperty(pagingOperation.output.continuationToken!.property),
+          );
       } else {
         continuationTokenResponseSegments = getPropertySegmentsFromModelOrParameters(
           responseType,
-          (p) => p.__raw === pagingOperation.output.continuationToken!.property,
+          (p) =>
+            p.__raw?.kind === "ModelProperty" &&
+            findRootSourceProperty(p.__raw) ===
+              findRootSourceProperty(pagingOperation.output.continuationToken!.property),
         );
       }
     }

--- a/packages/typespec-client-generator-core/test/packages/paged-operation.test.ts
+++ b/packages/typespec-client-generator-core/test/packages/paged-operation.test.ts
@@ -81,6 +81,31 @@ describe("typespec-client-generator-core: paged operation", () => {
     strictEqual(response.resultSegments[0], sdkPackage.models[0].properties[0]);
   });
 
+  it("normal paged result in anonymous model with header", async () => {
+    await runner.compileWithBuiltInService(`
+      @list
+      op test(): {
+        @pageItems
+        tests: Test[];
+        @header
+        h: string;
+      };
+      model Test {
+        id: string;
+      }
+    `);
+    const sdkPackage = runner.context.sdkPackage;
+    const method = getServiceMethodOfClient(sdkPackage);
+    strictEqual(method.name, "test");
+    strictEqual(method.kind, "paging");
+
+    const response = method.response;
+    strictEqual(response.kind, "method");
+    strictEqual(response.resultPath, "tests");
+    strictEqual(response.resultSegments?.length, 1);
+    strictEqual(response.resultSegments[0], sdkPackage.models[0].properties[0]);
+  });
+
   it("nullable paged result", async () => {
     await runner.compileWithBuiltInService(`
       @list


### PR DESCRIPTION
for any spread cases, we need to use root source property to do the comparison. 