### PR TITLE
Update the client generation document to provide valid typespec samples

### DIFF
--- a/website/src/content/docs/docs/howtos/Generate client libraries/06types.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/06types.mdx
@@ -707,14 +707,6 @@ public final class Animal implements JsonSerializable<Animal> {
 model Animal {
   name: string;
   kind: string;
-  ...Record<string | int32>;
-}
-```
-
-```typespec
-model Animal {
-  name: string;
-  kind: string;
   ...Record<string>;
   ...Record<int32>;
 }
@@ -963,7 +955,7 @@ TypeSpec uses `@discriminator` decorator to add a discriminator to a model.
 <ClientTabs>
 <ClientTabItem lang="typespec" >
 
-TypeSpec now has two ways to represent a discriminated set.
+Client emitters now only support a single way to represent a discriminated set in TypeSpec.
 
 1. Use model
 
@@ -1003,20 +995,6 @@ model Siamese extends Cat {
 model Ragdoll extends Cat {
   kind: CatKind.Ragdoll;
 }
-```
-
-2. Use union
-
-```typespec
-@discriminator("kind")
-union Cat {
-  Siamese,
-  Ragdoll,
-}
-
-model Siamese {}
-
-model Ragdoll {}
 ```
 
 </ClientTabItem>
@@ -1250,16 +1228,11 @@ about nullability by inspecting the type of a property.
 model Foo {
   basicNullableProperty: string | null;
   modelNullableProperty: Bar | null;
-  unionNullableProperty: Bar | Baz | null;
   enumNullableProperty: LR | null;
 }
 
 model Bar {
   prop: string;
-}
-
-model Baz {
-  prop: int32;
 }
 
 enum LR {
@@ -1318,52 +1291,6 @@ A nullable type has kind `nullable` and property `valueType`. The kind of the ty
     },
     {
       "kind": "property",
-      "name": "unionNullableProperty",
-      "serializedName": "unionNullableProperty",
-      "optional": false,
-      "type": {
-        "kind": "nullable",
-        "valueType": {
-          "kind": "union",
-          "values": [
-            {
-              "kind": "model",
-              "name": "Bar",
-              "properties": [
-                {
-                  "kind": "property",
-                  "name": "prop",
-                  "serializedName": "prop",
-                  "optional": false,
-                  "type": {
-                    "kind": "string",
-                    "encode": "string"
-                  }
-                }
-              ]
-            },
-            {
-              "kind": "model",
-              "name": "Baz",
-              "properties": [
-                {
-                  "kind": "property",
-                  "name": "prop",
-                  "serializedName": "prop",
-                  "optional": false,
-                  "type": {
-                    "kind": "int32",
-                    "encode": "int32"
-                  }
-                }
-              ]
-            }
-          ]
-        }
-      }
-    },
-    {
-      "kind": "property",
       "name": "enumNullableProperty",
       "serializedName": "enumNullableProperty",
       "optional": false,
@@ -1409,9 +1336,6 @@ from corehttp.utils import CaseInsensitiveEnumMeta
 class Bar(_model_base.Model):
   prop: Optional[str] = rest_field()
 
-class Baz(_model_base.Model):
-  prop: Optional[str] = rest_field()
-
 class LR(str, Enum, metaclass=CaseInsensitiveEnumMeta):
   LEFT = "left"
   RIGHT = "right"
@@ -1419,7 +1343,6 @@ class LR(str, Enum, metaclass=CaseInsensitiveEnumMeta):
 class Foo(_model_base.Model):
   basicNullableProperty: Optional[str] = rest_field()
   modelNullableProperty: Optional["_models.Bar"] = rest_field()
-  unionNullableProperty: Optional[Union["_models.Bar", "_models.Baz"]] = rest_field()
   enumNullableProperty: Optional["LR"] = rest_field()
 
 ```
@@ -2314,108 +2237,6 @@ public enum WidgetOrientation {
 </ClientTabItem>
 </ClientTabs>
 
-### Union with multiple types
-
-These are unions where the values don't share same type.
-
-<ClientTabs>
-<ClientTabItem lang="typespec" >
-
-```typespec
-model Shirt {
-  sizing: 32 | 34 | int32 | "small" | "medium" | string;
-}
-```
-
-</ClientTabItem>
-<ClientTabItem lang="tcgc">
-
-```json
-{
-  "kind": "union",
-  "name": "ShirtSizings",
-  "generatedName": true,
-  "values": [
-    {
-      "kind": "constant",
-      "value": 32,
-      "valueType": {
-        "kind": "int32"
-      }
-    },
-    {
-      "kind": "constant",
-      "value": 34,
-      "valueType": {
-        "kind": "int32"
-      }
-    },
-    {
-      "kind": "constant",
-      "value": "small",
-      "valueType": {
-        "kind": "string"
-      }
-    },
-    {
-      "kind": "constant",
-      "value": "medium",
-      "valueType": {
-        "kind": "string"
-      }
-    },
-    {
-      "kind": "string"
-    }
-  ]
-}
-```
-
-</ClientTabItem>
-<ClientTabItem lang="python">
-
-Python will generate this as a union since these entries don't share the same type
-
-```python
-from typing import Literal
-
-type ShirtSizing = Literal[32] | Literal[34] | int | Literal["small"] | Literal["medium"] | str
-
-model Shirt:
-  sizing: ShirtSizing
-```
-
-</ClientTabItem>
-<ClientTabItem lang="csharp" >
-
-```csharp
-public partial class Shirt
-{
-  public BinaryData Shirt;
-}
-```
-
-</ClientTabItem>
-<ClientTabItem lang="typescript" >
-
-```typescript
-export interface Shirt {
-  sizing: 32 | 34 | number | "small" | "medium" | string;
-}
-```
-
-</ClientTabItem>
-<ClientTabItem lang="java" >
-
-```java
-public final class Shirt {
-    private BinaryData sizing;
-}
-```
-
-</ClientTabItem>
-</ClientTabs>
-
 ## Enums
 
 ### Standard
@@ -2706,7 +2527,7 @@ We will take the `@encode` decorator into account, determining how we serialize 
 <ClientTabs>
 <ClientTabItem lang="typespec" >
 
-```tsp
+```typespec
 model Test {
   @encode(DateTimeKnownEncoding.rfc3339)
   prop: utcDateTime;
@@ -2769,7 +2590,7 @@ When you specify an encoding type, say that you want to encode an integer as a s
 <ClientTabs>
 <ClientTabItem lang="typespec" >
 
-```tsp
+```typespec
 model Test {
   @encode(string)
   prop: int64;

--- a/website/src/content/docs/docs/howtos/Generate client libraries/08methodInputs.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/08methodInputs.mdx
@@ -14,6 +14,11 @@ This document outlines the method input signatures that language emitters will g
 <ClientTabItem lang="typespec" >
 
 ```typespec
+model User {
+  firstName: string;
+  lastName: string;
+}
+
 @get
 op get(): User;
 ```
@@ -101,6 +106,11 @@ func (client *Client) Get(ctx context.Context, options *ClientGetOptions) (Clien
 <ClientTabItem lang="typespec" >
 
 ```typespec
+model User {
+  firstName: string;
+  lastName: string;
+}
+
 @post
 op post(@body body: User): void;
 ```
@@ -624,7 +634,8 @@ model BlobProperties {
   @path
   name: string;
 
-  @header testHeader: string;
+  @header
+  testHeader: string;
 }
 
 @route("blob_properties/{name}")


### PR DESCRIPTION
Update the below 2 documents to validate all existing typespec samples
1. Remove the pattern that we do not support.
2. Remove the TypeSpec code that would cause lint error.
3. Update the code to include model to make a valid sample
4. Update the related generated code.