### PR TITLE
[tcgc] fix regression of 0.51.2

### DIFF
--- a/.chronus/changes/fix_property-2025-1-24-11-55-32.md
+++ b/.chronus/changes/fix_property-2025-1-24-11-55-32.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+`isGeneratedName` always set to true only when it is the inner type of nullable union.

--- a/.chronus/changes/fix_property-2025-1-24-11-56-21.md
+++ b/.chronus/changes/fix_property-2025-1-24-11-56-21.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Remove parameter cache to retain HTTP metadata info for model property.

--- a/packages/typespec-client-generator-core/src/context.ts
+++ b/packages/typespec-client-generator-core/src/context.ts
@@ -17,8 +17,6 @@ import {
   SdkEmitterOptions,
   SdkEnumType,
   SdkHttpOperation,
-  SdkHttpParameter,
-  SdkMethodParameter,
   SdkModelPropertyType,
   SdkModelType,
   SdkNullableType,
@@ -50,8 +48,6 @@ export function createTCGCContext(program: Program, emitterName?: string): TCGCC
     >(),
     __httpOperationCache: new Map<Operation, HttpOperation>(),
     __modelPropertyCache: new Map<ModelProperty, SdkModelPropertyType>(),
-    __methodParameterCache: new Map<ModelProperty, SdkMethodParameter>(),
-    __httpParameterCache: new Map<ModelProperty, SdkHttpParameter>(),
   };
 }
 

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -338,88 +338,84 @@ export function getSdkHttpParameter(
   location?: "path" | "query" | "header" | "body" | "cookie",
 ): [SdkHttpParameter, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
-  let parameter = context.__httpParameterCache?.get(param);
-
-  if (!parameter) {
-    const base = diagnostics.pipe(getSdkModelPropertyTypeBase(context, param, operation));
-    const program = context.program;
-    const correspondingMethodParams: SdkParameter[] = []; // we set it later in the operation
-    if (isPathParam(context.program, param) || location === "path") {
-      // we don't url encode if the type can be assigned to url
-      const urlEncode = !ignoreDiagnostics(
-        program.checker.isTypeAssignableTo(
-          // TODO: THIS NEED TO BE MIGRATED BY MARCH 2024 release.
-          // eslint-disable-next-line @typescript-eslint/no-deprecated
-          param.type.projectionBase ?? param.type,
-          program.checker.getStdType("url"),
-          param.type,
-        ),
-      );
-      parameter = {
-        ...base,
-        kind: "path",
-        urlEncode,
-        explode: (httpParam as HttpOperationPathParameter)?.explode ?? false,
-        style: (httpParam as HttpOperationPathParameter)?.style ?? "simple",
-        allowReserved: (httpParam as HttpOperationPathParameter)?.allowReserved ?? false,
-        serializedName: getPathParamName(program, param) ?? base.name,
-        correspondingMethodParams,
-        optional: false,
-      };
-    } else if (isCookieParam(context.program, param) || location === "cookie") {
-      parameter = {
-        ...base,
-        kind: "cookie",
-        serializedName: getCookieParamOptions(program, param)?.name ?? base.name,
-        correspondingMethodParams,
-        optional: param.optional,
-      };
-    } else if (isBody(context.program, param) || location === "body") {
-      parameter = {
-        ...base,
-        kind: "body",
-        serializedName: param.name === "" ? "body" : getWireName(context, param),
-        contentTypes: ["application/json"], // will update when we get to the operation level
-        defaultContentType: "application/json", // will update when we get to the operation level
-        optional: param.optional,
-        correspondingMethodParams,
-      };
-    } else if (isQueryParam(context.program, param) || location === "query") {
-      parameter = {
-        ...base,
-        optional: param.optional,
-        collectionFormat: getCollectionFormat(context, param),
-        correspondingMethodParams,
-        kind: "query",
-        serializedName: getQueryParamName(program, param) ?? base.name,
-        explode: (httpParam as HttpOperationQueryParameter)?.explode,
-      };
-    } else {
-      if (!(isHeader(context.program, param) || location === "header")) {
-        diagnostics.add(
-          createDiagnostic({
-            code: "unexpected-http-param-type",
-            target: param,
-            format: {
-              paramName: param.name,
-              expectedType: "path, query, header, or body",
-              actualType: param.kind,
-            },
-          }),
-        );
-      }
-      parameter = {
-        ...base,
-        optional: param.optional,
-        collectionFormat: getCollectionFormat(context, param),
-        correspondingMethodParams,
-        kind: "header",
-        serializedName: getHeaderFieldName(program, param) ?? base.name,
-      };
-    }
-    context.__httpParameterCache.set(param, parameter);
+  const base = diagnostics.pipe(getSdkModelPropertyTypeBase(context, param, operation));
+  const program = context.program;
+  const correspondingMethodParams: SdkParameter[] = []; // we set it later in the operation
+  if (isPathParam(context.program, param) || location === "path") {
+    // we don't url encode if the type can be assigned to url
+    const urlEncode = !ignoreDiagnostics(
+      program.checker.isTypeAssignableTo(
+        // TODO: THIS NEED TO BE MIGRATED BY MARCH 2024 release.
+        // eslint-disable-next-line @typescript-eslint/no-deprecated
+        param.type.projectionBase ?? param.type,
+        program.checker.getStdType("url"),
+        param.type,
+      ),
+    );
+    return diagnostics.wrap({
+      ...base,
+      kind: "path",
+      urlEncode,
+      explode: (httpParam as HttpOperationPathParameter)?.explode ?? false,
+      style: (httpParam as HttpOperationPathParameter)?.style ?? "simple",
+      allowReserved: (httpParam as HttpOperationPathParameter)?.allowReserved ?? false,
+      serializedName: getPathParamName(program, param) ?? base.name,
+      correspondingMethodParams,
+      optional: false,
+    });
   }
-  return diagnostics.wrap(parameter);
+  if (isCookieParam(context.program, param) || location === "cookie") {
+    return diagnostics.wrap({
+      ...base,
+      kind: "cookie",
+      serializedName: getCookieParamOptions(program, param)?.name ?? base.name,
+      correspondingMethodParams,
+      optional: param.optional,
+    });
+  }
+  if (isBody(context.program, param) || location === "body") {
+    return diagnostics.wrap({
+      ...base,
+      kind: "body",
+      serializedName: param.name === "" ? "body" : getWireName(context, param),
+      contentTypes: ["application/json"], // will update when we get to the operation level
+      defaultContentType: "application/json", // will update when we get to the operation level
+      optional: param.optional,
+      correspondingMethodParams,
+    });
+  }
+  const headerQueryBase = {
+    ...base,
+    optional: param.optional,
+    collectionFormat: getCollectionFormat(context, param),
+    correspondingMethodParams,
+  };
+  if (isQueryParam(context.program, param) || location === "query") {
+    return diagnostics.wrap({
+      ...headerQueryBase,
+      kind: "query",
+      serializedName: getQueryParamName(program, param) ?? base.name,
+      explode: (httpParam as HttpOperationQueryParameter)?.explode,
+    });
+  }
+  if (!(isHeader(context.program, param) || location === "header")) {
+    diagnostics.add(
+      createDiagnostic({
+        code: "unexpected-http-param-type",
+        target: param,
+        format: {
+          paramName: param.name,
+          expectedType: "path, query, header, or body",
+          actualType: param.kind,
+        },
+      }),
+    );
+  }
+  return diagnostics.wrap({
+    ...headerQueryBase,
+    kind: "header",
+    serializedName: getHeaderFieldName(program, param) ?? base.name,
+  });
 }
 
 function getSdkHttpResponseAndExceptions(

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -51,8 +51,6 @@ export interface TCGCContext {
 
   __referencedTypeCache: Map<Type, SdkModelType | SdkEnumType | SdkUnionType | SdkNullableType>;
   __modelPropertyCache: Map<ModelProperty, SdkModelPropertyType>;
-  __methodParameterCache: Map<ModelProperty, SdkMethodParameter>;
-  __httpParameterCache: Map<ModelProperty, SdkHttpParameter>;
   __generatedNames?: Map<Union | Model | TspLiteralType, string>;
   __httpOperationCache: Map<Operation, HttpOperation>;
   __clientToParameters: Map<Interface | Namespace, SdkParameter[]>;

--- a/packages/typespec-client-generator-core/src/package.ts
+++ b/packages/typespec-client-generator-core/src/package.ts
@@ -832,15 +832,10 @@ function getSdkMethodParameter(
   operation: Operation,
 ): [SdkMethodParameter, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
-  let parameter = context.__methodParameterCache.get(type);
-  if (!parameter) {
-    parameter = {
-      ...diagnostics.pipe(getSdkModelPropertyType(context, type, operation)),
-      kind: "method",
-    };
-    context.__methodParameterCache.set(type, parameter);
-  }
-  return diagnostics.wrap(parameter as SdkMethodParameter);
+  return diagnostics.wrap({
+    ...diagnostics.pipe(getSdkModelPropertyType(context, type, operation)),
+    kind: "method",
+  });
 }
 
 function getSdkMethods<TServiceOperation extends SdkServiceOperation>(

--- a/packages/typespec-client-generator-core/test/package.test.ts
+++ b/packages/typespec-client-generator-core/test/package.test.ts
@@ -953,7 +953,7 @@ describe("typespec-client-generator-core: package", () => {
         (x) => x.name === "clientRequestId",
       );
       ok(clientRequestIdProperty);
-      strictEqual(clientRequestIdProperty.kind, "property");
+      strictEqual(clientRequestIdProperty.kind, "header");
     });
 
     it("azure widget getWidgetAnalytics", async () => {

--- a/packages/typespec-client-generator-core/test/packages/parameters.test.ts
+++ b/packages/typespec-client-generator-core/test/packages/parameters.test.ts
@@ -499,21 +499,21 @@ describe("typespec-client-generator-core: parameters", () => {
     strictEqual(methodParam.type.properties.length, 3);
 
     const model = methodParam.type;
-    strictEqual(model.properties[0].kind, "property");
+    strictEqual(model.properties[0].kind, "header");
     strictEqual(model.properties[0].name, "header");
     strictEqual(model.properties[0].optional, false);
     strictEqual(model.properties[0].onClient, false);
     strictEqual(model.properties[0].isApiVersionParam, false);
     strictEqual(model.properties[0].type.kind, "string");
 
-    strictEqual(model.properties[1].kind, "property");
+    strictEqual(model.properties[1].kind, "query");
     strictEqual(model.properties[1].name, "query");
     strictEqual(model.properties[1].optional, false);
     strictEqual(model.properties[1].onClient, false);
     strictEqual(model.properties[1].isApiVersionParam, false);
     strictEqual(model.properties[1].type.kind, "string");
 
-    strictEqual(model.properties[2].kind, "property");
+    strictEqual(model.properties[2].kind, "body");
     strictEqual(model.properties[2].name, "body");
     strictEqual(model.properties[2].optional, false);
     strictEqual(model.properties[2].onClient, false);

--- a/packages/typespec-client-generator-core/test/types/enum-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/enum-types.test.ts
@@ -466,6 +466,40 @@ describe("typespec-client-generator-core: enum types", () => {
       emitterName: "@azure-tools/typespec-python",
       "flatten-union-as-enum": false,
     });
+    const { Foo } = (await runner.compile(
+      `
+        @service({})
+        namespace N {
+          @test
+          union Foo {
+            "bar",
+            Baz,
+            string,
+          }
+
+          enum Baz {
+            test,
+            foo,
+          }
+
+          op test(@body test: Foo): void;
+        }
+      `,
+    )) as { Foo: Union };
+
+    const unionType = getClientType(runner.context, Foo);
+
+    strictEqual(unionType.kind, "union");
+    strictEqual(unionType.name, "Foo");
+    strictEqual(unionType.isGeneratedName, false);
+    strictEqual(unionType.crossLanguageDefinitionId, "N.Foo");
+  });
+
+  it("nullable union as enum with hierarchy without flatten", async () => {
+    runner = await createSdkTestRunner({
+      emitterName: "@azure-tools/typespec-python",
+      "flatten-union-as-enum": false,
+    });
     const { Test } = (await runner.compile(
       `
         @service({})
@@ -502,6 +536,7 @@ describe("typespec-client-generator-core: enum types", () => {
 
     strictEqual(unionType.kind, "union");
     strictEqual(unionType.name, "Test");
+    strictEqual(unionType.isGeneratedName, true);
     strictEqual(unionType.crossLanguageDefinitionId, "N.Test");
 
     const variants = unionType.variantTypes;
@@ -509,6 +544,7 @@ describe("typespec-client-generator-core: enum types", () => {
     const a = variants[0] as SdkEnumType;
     strictEqual(a.kind, "enum");
     strictEqual(a.name, "A");
+    strictEqual(a.isGeneratedName, false);
     strictEqual(a.crossLanguageDefinitionId, "N.A");
     strictEqual(a.isUnionAsEnum, true);
     strictEqual(a.values[0].name, "A1");
@@ -519,6 +555,7 @@ describe("typespec-client-generator-core: enum types", () => {
     const b = variants[1] as SdkEnumType;
     strictEqual(b.kind, "enum");
     strictEqual(b.name, "B");
+    strictEqual(b.isGeneratedName, false);
     strictEqual(b.crossLanguageDefinitionId, "N.B");
     strictEqual(b.isUnionAsEnum, true);
     strictEqual(b.values[0].name, "B");
@@ -527,6 +564,7 @@ describe("typespec-client-generator-core: enum types", () => {
     const c = variants[2] as SdkEnumType;
     strictEqual(c.kind, "enum");
     strictEqual(c.name, "C");
+    strictEqual(c.isGeneratedName, false);
     strictEqual(c.crossLanguageDefinitionId, "N.C");
     strictEqual(c.isUnionAsEnum, false);
     strictEqual(c.values[0].name, "C");

--- a/packages/typespec-client-generator-core/test/types/model-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/model-types.test.ts
@@ -1805,7 +1805,7 @@ describe("typespec-client-generator-core: model types", () => {
     strictEqual(inputModel.properties.length, 1);
     const nameProperty = inputModel.properties[0];
     strictEqual(nameProperty.name, "name");
-    strictEqual(nameProperty.kind, "property");
+    strictEqual(nameProperty.kind, "header");
     ok(nameProperty.visibility);
     strictEqual(nameProperty.visibility.length, 1);
     strictEqual(nameProperty.visibility[0], Visibility.Read);

--- a/packages/typespec-client-generator-core/test/types/union-types.test.ts
+++ b/packages/typespec-client-generator-core/test/types/union-types.test.ts
@@ -424,7 +424,7 @@ describe("typespec-client-generator-core: union types", () => {
     const sdkType = property.type;
     strictEqual(sdkType.kind, "union");
     strictEqual(sdkType.name, "MyNamedUnion");
-    strictEqual(sdkType.isGeneratedName, true);
+    strictEqual(sdkType.isGeneratedName, false);
     strictEqual(sdkType.usage, UsageFlags.Input | UsageFlags.Output);
     strictEqual(sdkType.access, "public");
     const variants = sdkType.variantTypes;


### PR DESCRIPTION
fix: https://github.com/Azure/typespec-azure/issues/2251
`isGeneratedName` always set to true only when it is the inner type of nullable union.
Remove parameter cache to retain HTTP metadata info for model property.