### PR TITLE
Fix: Target param property when error on invalid type

### DIFF
--- a/.chronus/changes/fix-unsupported-param-target-2025-1-24-23-11-54.md
+++ b/.chronus/changes/fix-unsupported-param-target-2025-1-24-23-11-54.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Target param property when warn on unsupported parameter type

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -1253,6 +1253,7 @@ export async function getOpenAPIForService(
     type: Type,
     schemaContext: SchemaContext,
     paramName: string,
+    target: DiagnosticTarget,
     multipart?: boolean,
   ): PrimitiveItems | undefined {
     const fullSchema = getSchemaForType(type, schemaContext);
@@ -1285,7 +1286,7 @@ export async function getOpenAPIForService(
       if (isBytes(elementType)) {
         return { type: "array", items: { type: "string", format: "binary" } };
       }
-      const schema = getSchemaForPrimitiveItems(elementType, schemaContext, paramName, true);
+      const schema = getSchemaForPrimitiveItems(elementType, schemaContext, paramName, type, true);
       if (schema === undefined) {
         return undefined;
       }
@@ -1297,7 +1298,7 @@ export async function getOpenAPIForService(
         items: schema,
       };
     } else {
-      const schema = getSchemaForPrimitiveItems(type, schemaContext, paramName, true);
+      const schema = getSchemaForPrimitiveItems(type, schemaContext, paramName, type, true);
 
       if (schema === undefined) {
         return undefined;
@@ -1392,14 +1393,19 @@ export async function getOpenAPIForService(
     "type" | "items"
   > {
     if (param.type.kind === "Model" && isArrayModelType(program, param.type)) {
-      const itemSchema = getSchemaForPrimitiveItems(param.type.indexer.value, schemaContext, name);
+      const itemSchema = getSchemaForPrimitiveItems(
+        param.type.indexer.value,
+        schemaContext,
+        name,
+        param,
+      );
       const schema = itemSchema && {
         ...itemSchema,
       };
       delete (schema as any).description;
       return { type: "array", items: schema };
     } else {
-      return getSchemaForPrimitiveItems(param.type, schemaContext, name) as any;
+      return getSchemaForPrimitiveItems(param.type, schemaContext, name, param) as any;
     }
   }
 

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -1201,6 +1201,7 @@ export async function getOpenAPIForService(
         part.body.type,
         { visibility, ignoreMetadataAnnotations: false },
         partName,
+        part.body.type,
       );
       if (schema) {
         if (part.multi) {
@@ -1276,6 +1277,7 @@ export async function getOpenAPIForService(
     type: Type,
     schemaContext: SchemaContext,
     paramName: string,
+    target: DiagnosticTarget,
   ): PrimitiveItems | undefined {
     if (isBytes(type)) {
       return { type: "file" };
@@ -1286,7 +1288,13 @@ export async function getOpenAPIForService(
       if (isBytes(elementType)) {
         return { type: "array", items: { type: "string", format: "binary" } };
       }
-      const schema = getSchemaForPrimitiveItems(elementType, schemaContext, paramName, type, true);
+      const schema = getSchemaForPrimitiveItems(
+        elementType,
+        schemaContext,
+        paramName,
+        target,
+        true,
+      );
       if (schema === undefined) {
         return undefined;
       }
@@ -1298,7 +1306,7 @@ export async function getOpenAPIForService(
         items: schema,
       };
     } else {
-      const schema = getSchemaForPrimitiveItems(type, schemaContext, paramName, type, true);
+      const schema = getSchemaForPrimitiveItems(type, schemaContext, paramName, target, true);
 
       if (schema === undefined) {
         return undefined;
@@ -1369,7 +1377,7 @@ export async function getOpenAPIForService(
     const result = {
       in: "formData",
       ...base,
-      ...(getFormDataSchema(param.type, schemaContext, base.name) as any),
+      ...(getFormDataSchema(param.type, schemaContext, base.name, param) as any),
       default: param.defaultValue && getDefaultValue(param.defaultValue, param),
     };
 


### PR DESCRIPTION
This allows suppressing the error message

unblock https://github.com/microsoft/typespec/issues/6110