### PR TITLE
update common-types to use `@identifiers` instead of `@extension`

### DIFF
--- a/packages/samples/common-types/src/mobo.tsp
+++ b/packages/samples/common-types/src/mobo.tsp
@@ -1,4 +1,5 @@
 import "./base.tsp";
+import "@azure-tools/typespec-azure-resource-manager";
 
 import "../../node_modules/@azure-tools/typespec-azure-resource-manager/lib/common-types/mobo.tsp";
 
@@ -6,4 +7,4 @@ using OpenAPI;
 
 namespace Azure.ResourceManager.CommonTypes;
 
-@@extension(ManagedOnBehalfOfConfiguration.moboBrokerResources, "x-ms-identifiers", ["id"]);
+@@Azure.ResourceManager.identifiers(ManagedOnBehalfOfConfiguration.moboBrokerResources, #["id"]);

--- a/packages/samples/common-types/src/mobo.tsp
+++ b/packages/samples/common-types/src/mobo.tsp
@@ -1,5 +1,4 @@
 import "./base.tsp";
-import "@azure-tools/typespec-azure-resource-manager";
 
 import "../../node_modules/@azure-tools/typespec-azure-resource-manager/lib/common-types/mobo.tsp";
 
@@ -7,4 +6,4 @@ using OpenAPI;
 
 namespace Azure.ResourceManager.CommonTypes;
 
-@@Azure.ResourceManager.identifiers(ManagedOnBehalfOfConfiguration.moboBrokerResources, #["id"]);
+@@extension(ManagedOnBehalfOfConfiguration.moboBrokerResources, "x-ms-identifiers", ["id"]);

--- a/packages/typespec-azure-resource-manager/lib/common-types/network-security-perimeter.tsp
+++ b/packages/typespec-azure-resource-manager/lib/common-types/network-security-perimeter.tsp
@@ -156,8 +156,9 @@ model NetworkSecurityPerimeterConfigurationProperties {
   provisioningState?: NetworkSecurityPerimeterConfigurationProvisioningState;
 
   /** List of provisioning issues, if any */
+  #suppress "deprecated" "Update to @identifiers in next release"
   @visibility("read")
-  @Azure.ResourceManager.identifiers(#[])
+  @OpenAPI.extension("x-ms-identifiers", [])
   provisioningIssues?: ProvisioningIssue[];
 
   networkSecurityPerimeter?: NetworkSecurityPerimeter;
@@ -196,8 +197,9 @@ model ProvisioningIssueProperties {
   suggestedResourceIds?: Azure.Core.armResourceIdentifier[];
 
   /** Access rules that can be added to the network security profile (NSP) to remediate the issue. */
+  #suppress "deprecated" "Update to @identifiers in next release"
   @visibility("read")
-  @Azure.ResourceManager.identifiers(#[])
+  @OpenAPI.extension("x-ms-identifiers", [])
   suggestedAccessRules?: AccessRule[];
 }
 
@@ -220,7 +222,8 @@ model NetworkSecurityProfile {
   accessRulesVersion?: int32;
 
   /** List of Access Rules */
-  @Azure.ResourceManager.identifiers(#["name"])
+  #suppress "deprecated" "Update to @identifiers in next release"
+  @OpenAPI.extension("x-ms-identifiers", ["name"])
   accessRules?: AccessRule[];
 
   /** Current diagnostic settings version */

--- a/packages/typespec-azure-resource-manager/lib/common-types/network-security-perimeter.tsp
+++ b/packages/typespec-azure-resource-manager/lib/common-types/network-security-perimeter.tsp
@@ -157,7 +157,7 @@ model NetworkSecurityPerimeterConfigurationProperties {
 
   /** List of provisioning issues, if any */
   @visibility("read")
-  @OpenAPI.extension("x-ms-identifiers", [])
+  @Azure.ResourceManager.identifiers(#[])
   provisioningIssues?: ProvisioningIssue[];
 
   networkSecurityPerimeter?: NetworkSecurityPerimeter;
@@ -197,7 +197,7 @@ model ProvisioningIssueProperties {
 
   /** Access rules that can be added to the network security profile (NSP) to remediate the issue. */
   @visibility("read")
-  @OpenAPI.extension("x-ms-identifiers", [])
+  @Azure.ResourceManager.identifiers(#[])
   suggestedAccessRules?: AccessRule[];
 }
 
@@ -220,7 +220,7 @@ model NetworkSecurityProfile {
   accessRulesVersion?: int32;
 
   /** List of Access Rules */
-  @OpenAPI.extension("x-ms-identifiers", ["name"])
+  @Azure.ResourceManager.identifiers(#["name"])
   accessRules?: AccessRule[];
 
   /** Current diagnostic settings version */


### PR DESCRIPTION
Helps unblock testing of https://github.com/microsoft/typespec/pull/6078