### PR TITLE
switch e2e tests from cadl-ranch to azure-http-specs

### DIFF
--- a/eng/pipelines/jobs/e2e-job.yml
+++ b/eng/pipelines/jobs/e2e-job.yml
@@ -21,7 +21,7 @@ jobs:
       - template: /eng/pipelines/templates/build.yml
 
       - script: node packages/e2e-tests/e2e-tests.mjs
-        displayName: Cadl Ranch e2e tests
+        displayName: Azure Http Specs e2e tests
 
       - script: pnpm test:e2e
         displayName: E2E Tests

--- a/packages/e2e-tests/azure-http-specs/package.json
+++ b/packages/e2e-tests/azure-http-specs/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "@azure-tools/typespec-e2e-azure-http-specs",
+  "type": "module",
+  "private": true
+}

--- a/packages/e2e-tests/cadl-ranch-specs/package.json
+++ b/packages/e2e-tests/cadl-ranch-specs/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "@azure-tools/typespec-e2e-cadl-ranch-specs",
-  "dependencies": {
-    "@azure-tools/cadl-ranch-specs": "0.39.6"
-  },
-  "type": "module",
-  "private": true
-}


### PR DESCRIPTION
cadl-ranch has been archived. This is also blocking core updates because we aren't updating the old cadl-ranch specs anymore:
https://github.com/Azure/typespec-azure/pull/2270