### PR TITLE
[tcgc] try to migrate to mutator

### DIFF
--- a/.chronus/changes/migrate_mutator-2025-2-4-10-44-16.md
+++ b/.chronus/changes/migrate_mutator-2025-2-4-10-44-16.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Switch from deprecated projection libraries to mutators

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -111,7 +111,7 @@ function listScopedDecoratorData(context: TCGCContext, key: symbol): any[] {
 }
 
 function setScopedDecoratorData(
-  context: DecoratorContext,
+  context: DecoratorContext | TCGCContext,
   decorator: DecoratorFunction,
   key: symbol,
   target: Type,
@@ -154,7 +154,10 @@ function setScopedDecoratorData(
   }
 }
 
-function parseScopes(context: DecoratorContext, scope?: LanguageScopes): [string[]?, string[]?] {
+function parseScopes(
+  context: DecoratorContext | TCGCContext,
+  scope?: LanguageScopes,
+): [string[]?, string[]?] {
   if (scope === undefined) {
     return [undefined, undefined];
   }
@@ -321,6 +324,8 @@ function updateClientWithVersioning(context: TCGCContext, client: SdkClient) {
       context.__versioning_client_type_cache.set(client.type, subgraph.type);
       client.type = subgraph.type;
     }
+    // clear `@client` set on copy of the client when mutate sub graph
+    setScopedDecoratorData(context, $client, clientKey, client.type, undefined);
   }
 }
 

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -353,9 +353,7 @@ export function getSdkHttpParameter(
     // we don't url encode if the type can be assigned to url
     const urlEncode = !ignoreDiagnostics(
       program.checker.isTypeAssignableTo(
-        // TODO: THIS NEED TO BE MIGRATED BY MARCH 2024 release.
-        // eslint-disable-next-line @typescript-eslint/no-deprecated
-        param.type.projectionBase ?? param.type,
+        param.type,
         program.checker.getStdType("url"),
         param.type,
       ),

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -16,7 +16,6 @@ import {
   Operation,
   PagingOperation,
   Program,
-  ProjectedProgram,
   Type,
   Union,
 } from "@typespec/compiler";
@@ -58,9 +57,7 @@ export interface TCGCContext {
   __clientToApiVersionClientDefaultValue: Map<Interface | Namespace, string | undefined>;
   __knownScalars?: Record<string, SdkBuiltInKinds>;
   __rawClients?: SdkClient[];
-  // TODO: THIS NEED TO BE MIGRATED BY MARCH 2024 release.
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
-  __service_projection?: Map<Namespace, [Namespace, ProjectedProgram | undefined]>;
+  __versioning_client_type_cache?: Map<Namespace | Interface, Namespace | Interface>;
   __httpOperationExamples?: Map<HttpOperation, SdkHttpOperationExample[]>;
   __originalProgram: Program;
   __pagedResultSet: Set<SdkType>;

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -36,6 +36,7 @@ export interface TCGCContext {
   diagnostics: readonly Diagnostic[];
   emitterName: string;
   arm?: boolean;
+  globalNamespace?: Namespace; // the root of all tsp namespaces for this instance. Starting point for traversal
 
   generateProtocolMethods?: boolean;
   generateConvenienceMethods?: boolean;
@@ -57,7 +58,6 @@ export interface TCGCContext {
   __clientToApiVersionClientDefaultValue: Map<Interface | Namespace, string | undefined>;
   __knownScalars?: Record<string, SdkBuiltInKinds>;
   __rawClients?: SdkClient[];
-  __versioning_client_type_cache?: Map<Namespace | Interface, Namespace | Interface>;
   __httpOperationExamples?: Map<HttpOperation, SdkHttpOperationExample[]>;
   __originalProgram: Program;
   __pagedResultSet: Set<SdkType>;

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -1,14 +1,17 @@
 import {
   BooleanLiteral,
+  compilerAssert,
   createDiagnosticCollector,
   Diagnostic,
   getDeprecationDetails,
   getLifecycleVisibilityEnum,
+  getLocationContext,
   getNamespaceFullName,
   getVisibilityForClass,
   Interface,
   isNeverType,
   isNullType,
+  isService,
   isVoidType,
   Model,
   ModelProperty,
@@ -23,12 +26,21 @@ import {
   Value,
 } from "@typespec/compiler";
 import {
+  unsafe_mutateSubgraphWithNamespace,
+  unsafe_MutatorWithNamespace,
+} from "@typespec/compiler/experimental";
+import {
   HttpOperation,
   HttpOperationBody,
   HttpOperationMultipartBody,
   HttpOperationResponseContent,
 } from "@typespec/http";
-import { getAddedOnVersions, getRemovedOnVersions, getVersions } from "@typespec/versioning";
+import {
+  getAddedOnVersions,
+  getRemovedOnVersions,
+  getVersioningMutators,
+  getVersions,
+} from "@typespec/versioning";
 import { getParamAlias } from "./decorators.js";
 import {
   DecoratorInfo,
@@ -608,4 +620,81 @@ export function getStreamAsBytes(
     crossLanguageDefinitionId: "",
   };
   return diagnostics.wrap(unknownType);
+}
+
+function getVersioningMutator(
+  context: TCGCContext,
+  service: Namespace,
+  apiVersion: string,
+): unsafe_MutatorWithNamespace {
+  const versionMutator = getVersioningMutators(context.program, service);
+  compilerAssert(
+    versionMutator !== undefined && versionMutator.kind !== "transient",
+    "Versioning service should not get undefined or transient versioning mutator",
+  );
+
+  const mutators = versionMutator.snapshots
+    .filter((snapshot) => apiVersion === snapshot.version.value)
+    .map((x) => x.mutator);
+  compilerAssert(mutators.length === 1, "One api version should not get multiple mutators");
+
+  return mutators[0];
+}
+
+function handleVersioningMutationForGlobalNamespace(context: TCGCContext): Namespace {
+  const globalNamespace = context.program.getGlobalNamespaceType();
+  const allApiVersions = getVersions(context.program, globalNamespace)[1]
+    ?.getVersions()
+    .map((x) => x.value);
+  if (!allApiVersions) return globalNamespace;
+
+  const apiVersion = getValidApiVersion(context, allApiVersions);
+  if (apiVersion === undefined) return globalNamespace;
+
+  const mutator = getVersioningMutator(context, globalNamespace, apiVersion);
+  const subgraph = unsafe_mutateSubgraphWithNamespace(context.program, [mutator], globalNamespace);
+  compilerAssert(subgraph.type.kind === "Namespace", "Should not have mutated to another type");
+  return subgraph.type;
+}
+
+function listAllUserDefinedNamespaces(
+  context: TCGCContext,
+  namespace: Namespace,
+  retval?: Namespace[],
+): Namespace[] {
+  if (!retval) {
+    retval = [];
+  }
+  if (retval.includes(namespace)) return retval;
+  if (getLocationContext(context.program, namespace).type === "project") {
+    retval.push(namespace);
+  }
+  for (const ns of namespace.namespaces.values()) {
+    retval = retval.concat(listAllUserDefinedNamespaces(context, ns, retval));
+  }
+  return retval;
+}
+
+/**
+ * Currently, listServices can only be called from a program instance. This doesn't work well if we're doing mutation,
+ * because we want to just mutate the global namespace once, then find all of the services in the program, since we aren't
+ * able to explicitly tell listServices to iterate over our specific mutated global namespace. We're going to use this function
+ * instead to list all of the services in the global namespace.
+ *
+ * See https://github.com/microsoft/typespec/issues/6247
+ *
+ * @param context
+ */
+export function listAllServiceNamespaces(context: TCGCContext): Namespace[] {
+  const serviceNamespaces: Namespace[] = [];
+  let globalNamespace = context.globalNamespace;
+  if (!globalNamespace) {
+    globalNamespace = handleVersioningMutationForGlobalNamespace(context);
+  }
+  for (const ns of listAllUserDefinedNamespaces(context, globalNamespace)) {
+    if (isService(context.program, ns)) {
+      serviceNamespaces.push(ns);
+    }
+  }
+  return serviceNamespaces;
 }

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -15,7 +15,6 @@ import {
   getNamespaceFullName,
   getProjectedName,
   ignoreDiagnostics,
-  listServices,
   resolveEncodedName,
 } from "@typespec/compiler";
 import { HttpOperation, getHttpOperation, getHttpPart, isMetadata } from "@typespec/http";
@@ -53,6 +52,7 @@ import {
   hasNoneVisibility,
   isAzureCoreTspModel,
   isHttpBodySpread,
+  listAllServiceNamespaces,
   removeVersionsLargerThanExplicitlySpecified,
 } from "./internal-utils.js";
 import { createDiagnostic } from "./lib.js";
@@ -108,7 +108,7 @@ export function isApiVersion(context: TCGCContext, type: { name: string }): bool
  * @returns
  */
 export function getClientNamespaceString(context: TCGCContext): string | undefined {
-  return getClientNamespaceStringHelper(context, listServices(context.program)[0]?.type);
+  return getClientNamespaceStringHelper(context, listAllServiceNamespaces(context)[0]);
 }
 
 /**
@@ -295,14 +295,14 @@ export function getCrossLanguageDefinitionId(
  */
 export function getCrossLanguagePackageId(context: TCGCContext): [string, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
-  const services = listServices(context.program);
-  if (services.length === 0) return diagnostics.wrap("");
-  const serviceNamespace = getNamespaceFullName(services[0].type);
-  if (services.length > 1) {
+  const serviceNamespaces = listAllServiceNamespaces(context);
+  if (serviceNamespaces.length === 0) return diagnostics.wrap("");
+  const serviceNamespace = getNamespaceFullName(serviceNamespaces[0]);
+  if (serviceNamespaces.length > 1) {
     diagnostics.add(
       createDiagnostic({
         code: "multiple-services",
-        target: services[0].type,
+        target: serviceNamespaces[0],
         format: {
           service: serviceNamespace,
         },

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1894,6 +1894,7 @@ function filterOutTypes(
       result.push(sdkType);
     }
   }
+  const refTypes = Array.from(context.__referencedTypeCache?.entries() ?? []);
   return result;
 }
 

--- a/packages/typespec-client-generator-core/test/public-utils.test.ts
+++ b/packages/typespec-client-generator-core/test/public-utils.test.ts
@@ -5,7 +5,6 @@ import {
   Namespace,
   Operation,
   ignoreDiagnostics,
-  listServices,
 } from "@typespec/compiler";
 import { expectDiagnostics } from "@typespec/compiler/testing";
 import { getHttpOperation, getServers } from "@typespec/http";
@@ -25,6 +24,7 @@ import {
 } from "../src/public-utils.js";
 import { getAllModels, getSdkUnion } from "../src/types.js";
 import { SdkTestRunner, createSdkContextTestHelper, createSdkTestRunner } from "./test-host.js";
+import { listAllServiceNamespaces } from "../src/internal-utils.js";
 
 describe("typespec-client-generator-core: public-utils", () => {
   let runner: SdkTestRunner;
@@ -34,7 +34,7 @@ describe("typespec-client-generator-core: public-utils", () => {
   });
 
   function getServiceNamespace() {
-    return listServices(runner.context.program)[0].type;
+    return listAllServiceNamespaces(runner.context)[0];
   }
   describe("getDefaultApiVersion", () => {
     it("get single", async () => {


### PR DESCRIPTION
find two issues:
~1. when doing mutator, it seems the decorator data will be set again: https://github.com/microsoft/typespec/issues/6180~
2. for spread case, the model property will not be consistent: https://github.com/microsoft/typespec/issues/6181

resolve: https://github.com/Azure/typespec-azure/issues/2215