### PR TITLE
Openapi extension emit schema

### DIFF
--- a/.chronus/changes/openapi-extension-emit-schema-2025-2-4-10-35-45.md
+++ b/.chronus/changes/openapi-extension-emit-schema-2025-2-4-10-35-45.md
@@ -1,0 +1,24 @@
+---
+changeKind: breaking
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Updates the `@extension` behavior to emit schemas for passed in Types. Values will continue to be emitted as raw data. Model and Tuple expressions that were previously treated as Values are now treated as Types.
+
+Now the following TypeSpec:
+```tsp
+@OpenAPI.extension("x-value", "custom value")
+@OpenAPI.extension("x-schema", typeof "custom value")
+model Foo {}
+```
+emits the following schema:
+```yaml
+Foo:
+  type: object
+  x-value: custom value
+  x-schema:
+    type: string
+    enum:
+      - custom value
+```

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -94,6 +94,7 @@ import {
   isStringType,
   isTemplateDeclaration,
   isTemplateDeclarationOrInstance,
+  isType,
   isVoidType,
   joinPaths,
   navigateTypesInNamespace,
@@ -2133,7 +2134,15 @@ export async function getOpenAPIForService(
     }
     if (extensions) {
       for (const key of extensions.keys()) {
-        emitObject[key] = extensions.get(key);
+        const value = extensions.get(key);
+        if (isType(value)) {
+          emitObject[key] = getSchemaForType(value, {
+            ignoreMetadataAnnotations: false,
+            visibility: Visibility.All,
+          });
+        } else {
+          emitObject[key] = extensions.get(key);
+        }
       }
     }
   }


### PR DESCRIPTION
Depends on https://github.com/microsoft/typespec/pull/6229
Fixes https://github.com/microsoft/typespec/issues/6077

This PR updates `@azure-tools/typespec-autorest` to support emitting schemas for Types passed into the `@OpenAPI.extension` decorator.