### PR TITLE
[typespec-autorest] Fix logic around `canShare` and `@invisible`

### DIFF
--- a/.chronus/changes/witemple-msft-autorest-invisible-fix-2025-2-4-16-21-51.md
+++ b/.chronus/changes/witemple-msft-autorest-invisible-fix-2025-2-4-16-21-51.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-autorest"
 ---
 
-Fixed a bug causing properties marked `@invisble(Lifecycle)` to remain included in payloads."
+Fixed a bug causing properties marked `@invisible(Lifecycle)` to remain included in payloads."

--- a/.chronus/changes/witemple-msft-autorest-invisible-fix-2025-2-4-16-21-51.md
+++ b/.chronus/changes/witemple-msft-autorest-invisible-fix-2025-2-4-16-21-51.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Fixed a bug causing properties marked `@invisble(Lifecycle)` to remain included in payloads."

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -2084,6 +2084,10 @@ export async function getOpenAPIForService(
     const sharedVisibilities = ["Read", "Create", "Update"];
     const lifecycle = getLifecycleVisibilityEnum(program);
     const visibilities = getVisibilityForClass(program, prop, lifecycle);
+    // If the property does not have default visibility (all Lifecycle modifiers)
+    // then we have to look at the active modifiers to determine if it has any
+    // visibility other than read, create, or update, since those are compatible
+    // with x-ms-mutability.
     if (visibilities.size !== lifecycle.members.size) {
       for (const visibility of visibilities) {
         if (!sharedVisibilities.includes(visibility.name)) {
@@ -2091,7 +2095,10 @@ export async function getOpenAPIForService(
         }
       }
     }
-    return true;
+    // Otherwise, the property can be shared if it has default visibility or only
+    // shared visibilities, but not if it is _invisible_. The property is invisible
+    // if it has no active modifiers.
+    return visibilities.size !== 0;
   }
 
   function resolveProperty(prop: ModelProperty, context: SchemaContext): OpenAPI2SchemaProperty {


### PR DESCRIPTION
This PR fixes a bug with the handling of `@invisible(Lifecycle)` in typespec-autorest. Currently, it considers a property shareable if it either has default visibility (all modifiers), or if it does not contain any modifiers that cannot be expressed through x-ms-mutability. This was almost correct, except for the case where the property is _completely invisible_, in which case the property cannot be shared. This behavior was unique to typespec-autorest due to its logic around handling x-ms-mutability and the openapi3 emitter was not affected because it only attempts to share read-only properties.

In practice, `@invisible(Lifecycle)` is extremely rarely used because it means that the property would not be present in any operation payloads.

This PR adds a test against regressions ensuring that `@invisible(Lifecycle)` correctly hides properties.