### PR TITLE
azure-http-specs, validate orphan model serializable

### DIFF
--- a/.chronus/changes/azure-http-specs_validate-orphan-model-serializable-2025-2-6-14-48-18.md
+++ b/.chronus/changes/azure-http-specs_validate-orphan-model-serializable-2025-2-6-14-48-18.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Add orphanModelSerializable operation to verify the JSON serialization of an orphan model

--- a/packages/azure-http-specs/spec-summary.md
+++ b/packages/azure-http-specs/spec-summary.md
@@ -127,9 +127,11 @@ Expected response body:
   - `post /azure/client-generator-core/usage/inputToInputOutput`
   - `post /azure/client-generator-core/usage/outputToInputOutput`
   - `post /azure/client-generator-core/usage/modelInReadOnlyProperty`
+  - `post /azure/client-generator-core/usage/orphanModelSerializable`
 
-This scenario contains two public operations. Both should be generated and exported.
-The models are override to roundtrip, so they should be generated and exported as well.
+This scenario contains 4 public operations. All should be generated and exported.
+'OrphanModel' is not used but specified as 'public' and 'input', so it should be generated in SDK. The 'orphanModelSerializable' operation verifies that the model can be serialized to JSON.
+The other models are override to roundtrip, so they should be generated and exported as well.
 
 ### Azure_Core_Basic_createOrReplace
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/usage/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/usage/main.tsp
@@ -13,8 +13,9 @@ namespace _Specs_.Azure.ClientGenerator.Core.Usage;
 
 @scenario
 @scenarioDoc("""
-  This scenario contains two public operations. Both should be generated and exported.
-  The models are override to roundtrip, so they should be generated and exported as well.
+  This scenario contains 4 public operations. All should be generated and exported.
+  'OrphanModel' is not used but specified as 'public' and 'input', so it should be generated in SDK. The 'orphanModelSerializable' operation verifies that the model can be serialized to JSON.
+  The other models are override to roundtrip, so they should be generated and exported as well.
   """)
 @global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.usage", "java")
 namespace ModelInOperation {
@@ -90,11 +91,31 @@ namespace ModelInOperation {
   op modelInReadOnlyProperty(@body body: RoundTripModel): {
     @body body: RoundTripModel;
   };
+
+  @doc("""
+    Serialize the 'OrphanModel' as request body.
+    
+    Expected body parameter: 
+    ```json
+    {
+      "name": "name",
+      "desc": "desc"
+    }
+    ```
+    """)
+  @global.Azure.ClientGenerator.Core.convenientAPI(false)
+  @route("/orphanModelSerializable")
+  @put
+  op orphanModelSerializable(@body body: unknown): NoContentResponse;
 }
 
 @doc("Not used anywhere, but access is override to public so still need to be generated and exported with serialization.")
 @global.Azure.ClientGenerator.Core.usage(global.Azure.ClientGenerator.Core.Usage.input)
 @global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.public)
 model OrphanModel {
+  @global.Azure.ClientGenerator.Core.clientName("modelName")
   name: string;
+
+  @encodedName("application/json", "desc")
+  description: string;
 }

--- a/packages/azure-http-specs/specs/azure/client-generator-core/usage/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/usage/mockapi.ts
@@ -36,4 +36,18 @@ Scenarios.Azure_ClientGenerator_Core_Usage_ModelInOperation = passOnSuccess([
     },
     kind: "MockApiDefinition",
   },
+  {
+    uri: "/azure/client-generator-core/usage/orphanModelSerializable",
+    method: "put",
+    request: {
+      body: {
+        name: "name",
+        desc: "desc",
+      },
+    },
+    response: {
+      status: 204,
+    },
+    kind: "MockApiDefinition",
+  },
 ]);

--- a/packages/azure-http-specs/specs/azure/core/traits/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/traits/main.tsp
@@ -21,7 +21,7 @@ using Spector;
   }
 )
 @versioned(Versions)
-@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.trait", "java")
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.traits", "java")
 namespace _Specs_.Azure.Core.Traits;
 
 @doc("Service versions")


### PR DESCRIPTION
As discussed, we want to verify that an orphan model is by default serializable as JSON.

Since there were an existing test on orphan model, I just enhanced it and added an operation to verify the serialization.