### PR TITLE
typespec-autorest - remove usage of deprecated isContentTypeHeader

### DIFF
--- a/.chronus/changes/rm-is-content-type-header-2025-2-7-10-57-21.md
+++ b/.chronus/changes/rm-is-content-type-header-2025-2-7-10-57-21.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Removes usage of isContentTypeHeader

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -109,11 +109,9 @@ import {
   HttpOperation,
   HttpOperationBody,
   HttpOperationMultipartBody,
-  HttpOperationParameter,
   HttpOperationParameters,
-  HttpOperationPathParameter,
-  HttpOperationQueryParameter,
   HttpOperationResponse,
+  HttpProperty,
   HttpStatusCodeRange,
   HttpStatusCodesEntry,
   MetadataInfo,
@@ -126,7 +124,6 @@ import {
   getServers,
   getStatusCodeDescription,
   getVisibilitySuffix,
-  isContentTypeHeader,
   isSharedRoute,
   reportIfNoRoutes,
   resolveRequestVisibility,
@@ -279,6 +276,11 @@ interface PendingSchema {
 interface ProcessedSchema extends PendingSchema {
   schema: OpenAPI2Schema | undefined;
 }
+
+type HttpParameterProperties = Extract<
+  HttpProperty,
+  { kind: "header" | "query" | "path" | "cookie" }
+>;
 
 export async function getOpenAPIForService(
   context: AutorestEmitterContext,
@@ -444,12 +446,16 @@ export async function getOpenAPIForService(
     for (const prop of server.parameters.values()) {
       const param = getOpenAPI2Parameter(
         {
-          param: prop,
-          type: "path",
-          name: prop.name,
-          explode: false,
-          style: "simple",
-          allowReserved: false,
+          kind: "path",
+          path: [],
+          property: prop,
+          options: {
+            allowReserved: false,
+            explode: false,
+            style: "simple",
+            name: prop.name,
+            type: "path",
+          },
         },
         {
           visibility: Visibility.Read,
@@ -1108,23 +1114,22 @@ export async function getOpenAPIForService(
   function emitEndpointParameters(methodParams: HttpOperationParameters, visibility: Visibility) {
     const consumes: string[] = methodParams.body?.contentTypes ?? [];
 
-    for (const httpOpParam of methodParams.parameters) {
-      const shared = params.get(httpOpParam.param);
+    for (const httpProperty of methodParams.properties) {
+      const shared = params.get(httpProperty.property);
       if (shared) {
         currentEndpoint.parameters.push(shared);
         continue;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-deprecated
-      if (httpOpParam.type === "header" && isContentTypeHeader(program, httpOpParam.param)) {
+      if (!isHttpParameterProperty(httpProperty)) {
         continue;
       }
-      if (httpOpParam.type === "cookie") {
-        reportDiagnostic(program, { code: "cookies-unsupported", target: httpOpParam.param });
+      if (httpProperty.kind === "cookie") {
+        reportDiagnostic(program, { code: "cookies-unsupported", target: httpProperty.property });
         continue;
       }
-      emitParameter(httpOpParam.param, () =>
-        getOpenAPI2Parameter(httpOpParam, { visibility, ignoreMetadataAnnotations: false }),
+      emitParameter(httpProperty.property, () =>
+        getOpenAPI2Parameter(httpProperty, { visibility, ignoreMetadataAnnotations: false }),
       );
     }
 
@@ -1401,52 +1406,59 @@ export async function getOpenAPIForService(
     }
   }
 
-  function getQueryCollectionFormat(param: HttpOperationQueryParameter): string | undefined {
-    if (param.explode) {
+  function getQueryCollectionFormat(
+    httpProp: HttpProperty & { kind: "query" },
+  ): string | undefined {
+    if (httpProp.options.explode) {
       return "multi";
     }
     // eslint-disable-next-line @typescript-eslint/no-deprecated
-    let collectionFormat = param.format;
+    let collectionFormat = httpProp.options.format;
     if (collectionFormat && !["csv", "ssv", "tsv", "pipes", "multi"].includes(collectionFormat)) {
       collectionFormat = undefined;
-      reportDiagnostic(program, { code: "invalid-multi-collection-format", target: param.param });
+      reportDiagnostic(program, {
+        code: "invalid-multi-collection-format",
+        target: httpProp.property,
+      });
     }
 
     return collectionFormat;
   }
   function getOpenAPI2QueryParameter(
-    param: HttpOperationQueryParameter,
+    httpProp: HttpProperty & { kind: "query" },
     schemaContext: SchemaContext,
   ): OpenAPI2QueryParameter {
-    const base = getOpenAPI2ParameterBase(param.param, param.name);
-    const collectionFormat = getQueryCollectionFormat(param);
-    const schema = getSimpleParameterSchema(param.param, schemaContext, base.name);
+    const property = httpProp.property;
+    const base = getOpenAPI2ParameterBase(property, httpProp.options.name);
+    const collectionFormat = getQueryCollectionFormat(httpProp);
+    const schema = getSimpleParameterSchema(property, schemaContext, base.name);
     return {
       in: "query",
       collectionFormat:
         collectionFormat === "csv" && schema.items === undefined // If csv
           ? undefined
           : (collectionFormat as any),
-      default: param.param.defaultValue && getDefaultValue(param.param.defaultValue, param.param),
+      default: property.defaultValue && getDefaultValue(property.defaultValue, property),
       ...base,
       ...schema,
     };
   }
 
   function getOpenAPI2PathParameter(
-    param: HttpOperationPathParameter,
+    httpProp: HttpProperty & { kind: "path" },
     schemaContext: SchemaContext,
   ): OpenAPI2PathParameter {
-    const base = getOpenAPI2ParameterBase(param.param, param.name);
+    const property = httpProp.property;
+    const base = getOpenAPI2ParameterBase(property, httpProp.options.name);
 
     const result: OpenAPI2PathParameter = {
       in: "path",
-      default: param.param.defaultValue && getDefaultValue(param.param.defaultValue, param.param),
+      default: property.defaultValue && getDefaultValue(property.defaultValue, property),
       ...base,
-      ...getSimpleParameterSchema(param.param, schemaContext, base.name),
+      ...getSimpleParameterSchema(property, schemaContext, base.name),
     };
 
-    if (param.allowReserved) {
+    if (httpProp.options.allowReserved) {
       result["x-ms-skip-url-encoding"] = true;
     }
 
@@ -1454,65 +1466,69 @@ export async function getOpenAPIForService(
   }
 
   function getOpenAPI2HeaderParameter(
-    param: ModelProperty,
+    prop: ModelProperty,
     schemaContext: SchemaContext,
     name?: string,
   ): OpenAPI2HeaderParameter {
-    const base = getOpenAPI2ParameterBase(param, name);
-    const headerOptions = getHeaderFieldOptions(program, param);
+    const base = getOpenAPI2ParameterBase(prop, name);
+    const headerOptions = getHeaderFieldOptions(program, prop);
     // eslint-disable-next-line @typescript-eslint/no-deprecated
     let collectionFormat = headerOptions.format;
     if (
       !collectionFormat &&
-      (typeof headerOptions.explode === "boolean" || $.array.is(param.type))
+      (typeof headerOptions.explode === "boolean" || $.array.is(prop.type))
     ) {
       collectionFormat = headerOptions.explode ? "multi" : "csv";
     }
     if (collectionFormat && !["csv", "ssv", "tsv", "pipes"].includes(collectionFormat)) {
       collectionFormat = undefined;
-      reportDiagnostic(program, { code: "invalid-multi-collection-format", target: param });
+      reportDiagnostic(program, { code: "invalid-multi-collection-format", target: prop });
     }
     return {
       in: "header",
-      default: param.defaultValue && getDefaultValue(param.defaultValue, param),
+      default: prop.defaultValue && getDefaultValue(prop.defaultValue, prop),
       ...base,
       collectionFormat: collectionFormat as any,
-      ...getSimpleParameterSchema(param, schemaContext, base.name),
+      ...getSimpleParameterSchema(prop, schemaContext, base.name),
     };
   }
 
   function getOpenAPI2ParameterInternal(
-    param: HttpOperationParameter,
+    httpProperty: HttpParameterProperties,
     schemaContext: SchemaContext,
   ): OpenAPI2Parameter & { in: "query" | "path" | "header" } {
-    switch (param.type) {
+    switch (httpProperty.kind) {
       case "query":
-        return getOpenAPI2QueryParameter(param, schemaContext);
+        return getOpenAPI2QueryParameter(httpProperty, schemaContext);
       case "path":
-        return getOpenAPI2PathParameter(param, schemaContext);
+        return getOpenAPI2PathParameter(httpProperty, schemaContext);
       case "header":
-        return getOpenAPI2HeaderParameter(param.param, schemaContext, param.name);
+        return getOpenAPI2HeaderParameter(
+          httpProperty.property,
+          schemaContext,
+          httpProperty.options.name,
+        );
       case "cookie":
         compilerAssert(false, "Should verify cookies before");
         break;
       default:
-        const _assertNever: never = param;
+        const _assertNever: never = httpProperty;
         compilerAssert(false, "Unreachable");
     }
   }
 
   function getOpenAPI2Parameter<T extends OpenAPI2Parameter["in"]>(
-    param: HttpOperationParameter & { type: T },
+    httpProp: HttpParameterProperties & { kind: T },
     schemaContext: SchemaContext,
   ): OpenAPI2Parameter & { in: T } {
-    const value = getOpenAPI2ParameterInternal(param, schemaContext);
+    const value = getOpenAPI2ParameterInternal(httpProp, schemaContext);
     // Apply decorators to a copy of the parameter definition.  We use
     // Object.assign here because applyIntrinsicDecorators returns a new object
     // based on the target object and we need to apply its changes back to the
     // original parameter.
     Object.assign(
       value,
-      applyIntrinsicDecorators(param.param, {
+      applyIntrinsicDecorators(httpProp.property, {
         type: (value as any).type,
         format: (value as any).format,
       }),
@@ -2759,4 +2775,10 @@ async function loadExamples(
     }
   }
   return diagnostics.wrap(map);
+}
+
+function isHttpParameterProperty(
+  httpProperty: HttpProperty,
+): httpProperty is HttpParameterProperties {
+  return ["header", "query", "path", "cookie"].includes(httpProperty.kind);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,9 +87,6 @@ importers:
 
   core:
     devDependencies:
-      '@alloy-js/prettier-plugin-alloy':
-        specifier: ^0.1.0
-        version: 0.1.0
       '@chronus/chronus':
         specifier: ^0.17.0
         version: 0.17.0
@@ -378,15 +375,15 @@ importers:
       '@inquirer/prompts':
         specifier: ^7.3.1
         version: 7.3.2(@types/node@22.13.9)
-      '@npmcli/arborist':
-        specifier: ^8.0.0
-        version: 8.0.0
       ajv:
         specifier: ~8.17.1
         version: 8.17.1
       change-case:
         specifier: ~5.4.4
         version: 5.4.4
+      env-paths:
+        specifier: ^3.0.0
+        version: 3.0.0
       globby:
         specifier: ~14.1.0
         version: 14.1.0
@@ -405,6 +402,9 @@ importers:
       semver:
         specifier: ^7.7.1
         version: 7.7.1
+      tar:
+        specifier: ^7.4.3
+        version: 7.4.3
       temporal-polyfill:
         specifier: ^0.2.5
         version: 0.2.5
@@ -430,9 +430,6 @@ importers:
       '@types/node':
         specifier: ~22.13.9
         version: 22.13.9
-      '@types/npmcli__arborist':
-        specifier: ^6.3.0
-        version: 6.3.0
       '@types/semver':
         specifier: ^7.5.8
         version: 7.5.8
@@ -482,11 +479,11 @@ importers:
   core/packages/emitter-framework:
     dependencies:
       '@alloy-js/core':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@alloy-js/typescript':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@typespec/compiler':
         specifier: workspace:^
         version: link:../compiler
@@ -498,8 +495,8 @@ importers:
         version: link:../rest
     devDependencies:
       '@alloy-js/babel-preset':
-        specifier: ^0.1.1
-        version: 0.1.1(@babel/core@7.26.9)
+        specifier: ^0.2.0
+        version: 0.2.0(@babel/core@7.26.9)
       '@babel/cli':
         specifier: ^7.24.8
         version: 7.26.4(@babel/core@7.26.9)
@@ -740,8 +737,8 @@ importers:
   core/packages/http-client:
     dependencies:
       '@alloy-js/core':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@typespec/compiler':
         specifier: workspace:^
         version: link:../compiler
@@ -750,8 +747,8 @@ importers:
         version: link:../http
     devDependencies:
       '@alloy-js/babel-preset':
-        specifier: ^0.1.1
-        version: 0.1.1(@babel/core@7.26.9)
+        specifier: ^0.2.0
+        version: 0.2.0(@babel/core@7.26.9)
       '@babel/cli':
         specifier: ^7.24.8
         version: 7.26.4(@babel/core@7.26.9)
@@ -780,11 +777,11 @@ importers:
   core/packages/http-client-js:
     dependencies:
       '@alloy-js/core':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@alloy-js/typescript':
-        specifier: ^0.5.0
-        version: 0.5.0
+        specifier: ^0.6.0
+        version: 0.6.0
       '@typespec/compiler':
         specifier: workspace:^
         version: link:../compiler
@@ -805,8 +802,8 @@ importers:
         version: 3.5.3
     devDependencies:
       '@alloy-js/babel-preset':
-        specifier: ^0.1.1
-        version: 0.1.1(@babel/core@7.26.9)
+        specifier: ^0.2.0
+        version: 0.2.0(@babel/core@7.26.9)
       '@babel/cli':
         specifier: ^7.24.8
         version: 7.26.4(@babel/core@7.26.9)
@@ -3304,28 +3301,24 @@ packages:
   '@algolia/transporter@4.24.0':
     resolution: {integrity: sha512-86nI7w6NzWxd1Zp9q3413dRshDqAzSbsQjhcDhPIatEFiZrL1/TjnHL8S7jVKFePlIMzDsZWXAXwXzcok9c5oA==}
 
-  '@alloy-js/babel-plugin-jsx-dom-expressions@0.37.21':
-    resolution: {integrity: sha512-1ULoB6jxSgeRBnR9ktOqj6jewUc3zNRzx4sk8shyqwaD9kLKJ03cObmTFn0xDR3Y3JOP3TmhobL4/niycPyWYA==}
+  '@alloy-js/babel-plugin-jsx-dom-expressions@0.38.0':
+    resolution: {integrity: sha512-iq6Pndj40y/ehBuAxxYT7l8HfagXpiKKz2yrZnbog1jJFIY1Fjnvzkl5dLYAQIUk1t28wj4tiLi+D6A/sqwggA==}
     peerDependencies:
       '@babel/core': ^7.24.7
 
-  '@alloy-js/babel-plugin@0.1.0':
-    resolution: {integrity: sha512-G4Is8ZECXVkbbSXvitMqJOfWeWYmd+ZRdnLxk9MGOrw/N2Sh/d8QXx9rI1DNJuMNf3wi3iE60p5srhtUGNLt8g==}
+  '@alloy-js/babel-plugin@0.2.0':
+    resolution: {integrity: sha512-cTcRePmUWU5rQtXp89XQsyggWX72SjfWADoz3meieuvgPE/BOMXC7QU9VHscZCXyRbJKRX/S4fnRiO34fe1N4w==}
     peerDependencies:
       '@babel/core': ^7.24.7
 
-  '@alloy-js/babel-preset@0.1.1':
-    resolution: {integrity: sha512-sX3nb9+qciBXTaafIYYa/aW3FFZPcSIWm7VFwz134nFJu79jMS+JgsBgcL+md6zH4Vf9WPE/8V1E4LX9WdxS1A==}
+  '@alloy-js/babel-preset@0.2.0':
+    resolution: {integrity: sha512-EbIQiXyRa2Osd5iBwFT2C7s8IBKhQlgMaGA9sasFTo31KGYa5Tim51on8tjdlvGUEWUmJz7KlKA/hjWpchTgDQ==}
 
-  '@alloy-js/core@0.5.0':
-    resolution: {integrity: sha512-EGmjQ8f02xeKPchq3fLlRhK5mt1acce9x0eG1MLOGidNY/PNPlwm6McgT4kSlTIvqGB1R8S64MQQIh86fOpDhQ==}
+  '@alloy-js/core@0.6.0':
+    resolution: {integrity: sha512-t11kEP2lyD5eYk17rcgcFerZIHQwRuEJW3vnKxTTXWCZPcknKyV8STDtqx9B1G0rE01E8tz1cYFpCTiWXIv/Kg==}
 
-  '@alloy-js/prettier-plugin-alloy@0.1.0':
-    resolution: {integrity: sha512-mFfag8sQm5gPJMoGvJNc1fx66Z3X3nxCeoiitBeFnd5nkBMsMnvVw6LZSrVyybt2qTzY+G/9Qvz3ULkW7RB15Q==}
-    engines: {node: '>=18.0.0'}
-
-  '@alloy-js/typescript@0.5.0':
-    resolution: {integrity: sha512-asIUIxqCJDBw3HINDdy+mj5vWm3FUCLlXxfSuydyCzmFvVIfMz2TLQGa660CNx98KLsNzCWegmXnsC5QYH3rbg==}
+  '@alloy-js/typescript@0.6.0':
+    resolution: {integrity: sha512-vGhBm9Vr90uwtsGeeA/89EKxBUe/p/+hZ3ozLO6jm72Ph1nJZbd5+spFs9V/CPfDt0KaR6jruwcJaqHO08AEBw==}
 
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
@@ -5502,9 +5495,6 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
-  '@npm/types@1.0.2':
-    resolution: {integrity: sha512-KXZccTDEnWqNrrx6JjpJKU/wJvNeg9BDgjS0XhmlZab7br921HtyVbsYzJr4L+xIvjdJ20Wh9dgxgCI2a5CEQw==}
-
   '@npmcli/agent@3.0.0':
     resolution: {integrity: sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q==}
     engines: {node: ^18.17.0 || >=20.5.0}
@@ -6343,9 +6333,6 @@ packages:
   '@types/braces@3.0.5':
     resolution: {integrity: sha512-SQFof9H+LXeWNz8wDe7oN5zu7ket0qwMu5vZubW4GCJ8Kkeh6nBWUz87+KTz/G3Kqsrp0j/W253XJb3KMEeg3w==}
 
-  '@types/cacache@17.0.2':
-    resolution: {integrity: sha512-IrqHzVX2VRMDQQKa7CtKRnuoCLdRJiLW6hWU+w7i7+AaQ0Ii5bKwJxd5uRK4zBCyrHd3tG6G8zOm2LplxbSfQg==}
-
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
@@ -6459,24 +6446,6 @@ packages:
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
-
-  '@types/npm-package-arg@6.1.4':
-    resolution: {integrity: sha512-vDgdbMy2QXHnAruzlv68pUtXCjmqUk3WrBAsRboRovsOmxbfn/WiYCjmecyKjGztnMps5dWp4Uq2prp+Ilo17Q==}
-
-  '@types/npm-registry-fetch@8.0.7':
-    resolution: {integrity: sha512-db9iBh7kDDg4lRT4k4XZ6IiecTEgFCID4qk+VDVPbtzU855q3KZLCn08ATr4H27ntRJVhulQ7GWjl24H42x96w==}
-
-  '@types/npmcli__arborist@6.3.0':
-    resolution: {integrity: sha512-CXkuOBZDlcb+r0UMlmEAq3XOUZrL9XfZ2MXIwCSo726OBkkg+UIWlZ9h3n6To9w1WqMEIOZT2LkerhLgnsPV+Q==}
-
-  '@types/npmcli__package-json@4.0.4':
-    resolution: {integrity: sha512-6QjlFUSHBmZJWuC08bz1ZCx6tm4t+7+OJXAdvM6tL2pI7n6Bh5SIp/YxQvnOLFf8MzCXs2ijyFgrzaiu1UFBGA==}
-
-  '@types/npmlog@7.0.0':
-    resolution: {integrity: sha512-hJWbrKFvxKyWwSUXjZMYTINsSOY6IclhvGOZ97M8ac2tmR9hMwmTnYaMdpGhvju9ctWLTPhCS+eLfQNluiEjQQ==}
-
-  '@types/pacote@11.1.8':
-    resolution: {integrity: sha512-/XLR0VoTh2JEO0jJg1q/e6Rh9bxjBq9vorJuQmtT7rRrXSiWz7e7NsvXVYJQ0i8JxMlBMPPYDTnrRe7MZRFA8Q==}
 
   '@types/parse-json@4.0.2':
     resolution: {integrity: sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw==}
@@ -13416,7 +13385,7 @@ snapshots:
       '@algolia/logger-common': 4.24.0
       '@algolia/requester-common': 4.24.0
 
-  '@alloy-js/babel-plugin-jsx-dom-expressions@0.37.21(@babel/core@7.26.9)':
+  '@alloy-js/babel-plugin-jsx-dom-expressions@0.38.0(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/helper-module-imports': 7.18.6
@@ -13425,7 +13394,7 @@ snapshots:
       html-entities: 2.3.3
       validate-html-nesting: 1.2.2
 
-  '@alloy-js/babel-plugin@0.1.0(@babel/core@7.26.9)':
+  '@alloy-js/babel-plugin@0.2.0(@babel/core@7.26.9)':
     dependencies:
       '@babel/core': 7.26.9
       '@babel/generator': 7.26.9
@@ -13433,30 +13402,29 @@ snapshots:
       '@babel/plugin-syntax-jsx': 7.25.9(@babel/core@7.26.9)
       '@babel/types': 7.26.9
 
-  '@alloy-js/babel-preset@0.1.1(@babel/core@7.26.9)':
+  '@alloy-js/babel-preset@0.2.0(@babel/core@7.26.9)':
     dependencies:
-      '@alloy-js/babel-plugin': 0.1.0(@babel/core@7.26.9)
-      '@alloy-js/babel-plugin-jsx-dom-expressions': 0.37.21(@babel/core@7.26.9)
+      '@alloy-js/babel-plugin': 0.2.0(@babel/core@7.26.9)
+      '@alloy-js/babel-plugin-jsx-dom-expressions': 0.38.0(@babel/core@7.26.9)
     transitivePeerDependencies:
       - '@babel/core'
 
-  '@alloy-js/core@0.5.0':
+  '@alloy-js/core@0.6.0':
     dependencies:
-      '@alloy-js/babel-preset': 0.1.1(@babel/core@7.26.9)
+      '@alloy-js/babel-preset': 0.2.0(@babel/core@7.26.9)
       '@babel/core': 7.26.9
       '@babel/preset-typescript': 7.26.0(@babel/core@7.26.9)
       '@vue/reactivity': 3.5.13
       chalk: 5.4.1
       cli-table3: 0.6.5
       pathe: 1.1.2
+      prettier: 3.5.3
     transitivePeerDependencies:
       - supports-color
 
-  '@alloy-js/prettier-plugin-alloy@0.1.0': {}
-
-  '@alloy-js/typescript@0.5.0':
+  '@alloy-js/typescript@0.6.0':
     dependencies:
-      '@alloy-js/core': 0.5.0
+      '@alloy-js/core': 0.6.0
       change-case: 5.4.4
       pathe: 1.1.2
     transitivePeerDependencies:
@@ -16610,8 +16578,6 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
-  '@npm/types@1.0.2': {}
-
   '@npmcli/agent@3.0.0':
     dependencies:
       agent-base: 7.1.3
@@ -17689,10 +17655,6 @@ snapshots:
 
   '@types/braces@3.0.5': {}
 
-  '@types/cacache@17.0.2':
-    dependencies:
-      '@types/node': 22.13.9
-
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.0.4
@@ -17814,37 +17776,6 @@ snapshots:
       undici-types: 6.20.0
 
   '@types/normalize-package-data@2.4.4': {}
-
-  '@types/npm-package-arg@6.1.4': {}
-
-  '@types/npm-registry-fetch@8.0.7':
-    dependencies:
-      '@types/node': 22.13.9
-      '@types/node-fetch': 2.6.12
-      '@types/npm-package-arg': 6.1.4
-      '@types/npmlog': 7.0.0
-      '@types/ssri': 7.1.5
-
-  '@types/npmcli__arborist@6.3.0':
-    dependencies:
-      '@npm/types': 1.0.2
-      '@types/cacache': 17.0.2
-      '@types/node': 22.13.9
-      '@types/npmcli__package-json': 4.0.4
-      '@types/pacote': 11.1.8
-
-  '@types/npmcli__package-json@4.0.4': {}
-
-  '@types/npmlog@7.0.0':
-    dependencies:
-      '@types/node': 22.13.9
-
-  '@types/pacote@11.1.8':
-    dependencies:
-      '@types/node': 22.13.9
-      '@types/npm-registry-fetch': 8.0.7
-      '@types/npmlog': 7.0.0
-      '@types/ssri': 7.1.5
 
   '@types/parse-json@4.0.2': {}
 


### PR DESCRIPTION
Similar to OpenAPI3 changes in https://github.com/microsoft/typespec/pull/6311