### PR TITLE
[tcgc] fix api version nested client default value

### DIFF
--- a/.chronus/changes/tcgc-fixApiVersionNestedClientDefaultValue-2025-2-10-15-42-42.md
+++ b/.chronus/changes/tcgc-fixApiVersionNestedClientDefaultValue-2025-2-10-15-42-42.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Set `.clientDefaultValue` for api-versions in triple-nested clients

--- a/.chronus/changes/tcgc-fixApiVersionNestedClientDefaultValue-2025-2-10-15-44-40.md
+++ b/.chronus/changes/tcgc-fixApiVersionNestedClientDefaultValue-2025-2-10-15-44-40.md
@@ -1,0 +1,7 @@
+---
+changeKind: deprecation
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Remove unused public `listSubClients` to avoid confusion with new internal utils function

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -41,7 +41,7 @@ import {
   getVersioningMutators,
   getVersions,
 } from "@typespec/versioning";
-import { getParamAlias } from "./decorators.js";
+import { getParamAlias, listOperationGroups } from "./decorators.js";
 import {
   DecoratorInfo,
   SdkBuiltInType,
@@ -49,6 +49,7 @@ import {
   SdkEnumType,
   SdkHttpResponse,
   SdkModelPropertyType,
+  SdkOperationGroup,
   SdkType,
   TCGCContext,
 } from "./interfaces.js";
@@ -700,4 +701,23 @@ export function listAllServiceNamespaces(context: TCGCContext): Namespace[] {
     }
   }
   return serviceNamespaces;
+}
+
+export function listRawSubClients(
+  context: TCGCContext,
+  client: SdkOperationGroup | SdkClient,
+  retval?: (SdkOperationGroup | SdkClient)[],
+): (SdkOperationGroup | SdkClient)[] {
+  if (retval === undefined) {
+    retval = [];
+  }
+  if (retval.includes(client)) return retval;
+  if (client.kind === "SdkOperationGroup") {
+    retval.push(client);
+  }
+
+  for (const operationGroup of listOperationGroups(context, client)) {
+    listRawSubClients(context, operationGroup, retval);
+  }
+  return retval;
 }

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -24,13 +24,11 @@ import {
   getClientNameOverride,
   getIsApiVersion,
   listClients,
-  listOperationGroups,
   listOperationsInOperationGroup,
 } from "./decorators.js";
 import {
   SdkBodyModelPropertyType,
   SdkBodyParameter,
-  SdkClientType,
   SdkCookieParameter,
   SdkHeaderParameter,
   SdkHttpOperation,
@@ -39,7 +37,6 @@ import {
   SdkPathParameter,
   SdkQueryParameter,
   SdkServiceMethod,
-  SdkServiceOperation,
   SdkType,
   TCGCContext,
 } from "./interfaces.js";
@@ -54,6 +51,7 @@ import {
   isHttpBodySpread,
   listAllServiceNamespaces,
   listAllUserDefinedNamespaces,
+  listRawSubClients,
   removeVersionsLargerThanExplicitlySpecified,
 } from "./internal-utils.js";
 import { createDiagnostic } from "./lib.js";
@@ -358,17 +356,12 @@ function findContextPath(
         return result;
       }
     }
-    const ogs = listOperationGroups(context, client);
-    while (ogs.length) {
-      const operationGroup = ogs.pop();
-      for (const operation of listOperationsInOperationGroup(context, operationGroup!)) {
+    for (const og of listRawSubClients(context, client)) {
+      for (const operation of listOperationsInOperationGroup(context, og)) {
         const result = getContextPath(context, operation, type);
         if (result.length > 0) {
           return result;
         }
-      }
-      if (operationGroup?.subOperationGroups) {
-        ogs.push(...operationGroup.subOperationGroups);
       }
     }
   }
@@ -672,28 +665,6 @@ export function getHttpOperationExamples(
   operation: HttpOperation,
 ): SdkHttpOperationExample[] {
   return context.__httpOperationExamples?.get(operation) ?? [];
-}
-
-/**
- * Get all the sub clients from current client.
- *
- * @param client
- * @param listNestedClients determine if nested clients should be listed
- * @returns
- */
-export function listSubClients<TServiceOperation extends SdkServiceOperation>(
-  client: SdkClientType<TServiceOperation>,
-  listNestedClients: boolean = false,
-): SdkClientType<TServiceOperation>[] {
-  const subClients: SdkClientType<TServiceOperation>[] = client.methods
-    .filter((c) => c.kind === "clientaccessor")
-    .map((c) => c.response as SdkClientType<TServiceOperation>);
-  if (listNestedClients) {
-    for (const subClient of [...subClients]) {
-      subClients.push(...listSubClients(subClient, listNestedClients));
-    }
-  }
-  return subClients;
 }
 
 export function isAzureCoreModel(t: SdkType): boolean {

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -53,7 +53,6 @@ import {
   getOverriddenClientMethod,
   getUsageOverride,
   listClients,
-  listOperationGroups,
   listOperationsInOperationGroup,
   shouldFlattenProperty,
   shouldGenerateConvenient,
@@ -105,6 +104,7 @@ import {
   isNeverOrVoidType,
   isOnClient,
   listAllUserDefinedNamespaces,
+  listRawSubClients,
   twoParamsEquivalent,
   updateWithApiVersionInformation,
 } from "./internal-utils.js";
@@ -1941,15 +1941,10 @@ export function handleAllTypes(context: TCGCContext): [void, readonly Diagnostic
       // operations on a client
       diagnostics.pipe(updateTypesFromOperation(context, operation));
     }
-    const ogs = listOperationGroups(context, client);
-    while (ogs.length) {
-      const operationGroup = ogs.pop();
-      for (const operation of listOperationsInOperationGroup(context, operationGroup!)) {
+    for (const sc of listRawSubClients(context, client)) {
+      for (const operation of listOperationsInOperationGroup(context, sc)) {
         // operations on operation groups
         diagnostics.pipe(updateTypesFromOperation(context, operation));
-      }
-      if (operationGroup?.subOperationGroups) {
-        ogs.push(...operationGroup.subOperationGroups);
       }
     }
     // server parameters

--- a/packages/typespec-client-generator-core/test/internal-utils.test.ts
+++ b/packages/typespec-client-generator-core/test/internal-utils.test.ts
@@ -1,8 +1,7 @@
 import { Model } from "@typespec/compiler";
-import { deepStrictEqual, ok, strictEqual } from "assert";
+import { deepStrictEqual, strictEqual } from "assert";
 import { beforeEach, describe, it } from "vitest";
 import { getValueTypeValue } from "../src/internal-utils.js";
-import { listSubClients } from "../src/public-utils.js";
 import { SdkTestRunner, createSdkTestRunner } from "./test-host.js";
 
 describe("typespec-client-generator-core: internal-utils", () => {
@@ -23,139 +22,6 @@ describe("typespec-client-generator-core: internal-utils", () => {
       const runner = await createSdkTestRunner({ emitterName: "@typespec/http-client-csharp" });
       await runner.compile("");
       strictEqual(runner.context.emitterName, "csharp");
-    });
-  });
-
-  describe("listSubClients", () => {
-    it("no sub clients", async () => {
-      await runner.compile(`
-        @service
-        namespace MyClient;
-      `);
-
-      const rootClient = runner.context.sdkPackage.clients[0];
-      ok(rootClient);
-      strictEqual(listSubClients(rootClient).length, 0);
-    });
-
-    it("one sub client", async () => {
-      await runner.compile(`
-        @service
-        namespace MyClient {
-          namespace SubClient {}
-        }
-      `);
-
-      const rootClient = runner.context.sdkPackage.clients[0];
-      ok(rootClient);
-      const subClients = listSubClients(rootClient);
-      strictEqual(subClients.length, 1);
-      strictEqual(subClients[0].name, "SubClient");
-    });
-
-    it("namespace and interface hierarchy", async () => {
-      await runner.compile(`
-        @service
-        @route("/a")
-        namespace A {
-          @route("/o1") op a_o1(): void;
-          @route("/o2") op a_o2(): void;
-
-          @route("/g")
-          interface AG {
-            @route("/o1") a_g_o1(): void;
-            @route("/o2") a_g_o2(): void;
-          }
-
-          @route("/a")
-          namespace AA {
-            @route("/o1") op aa_o1(): void;
-            @route("/o2") op aa_o2(): void;
-
-            @route("/g")
-            interface AAG {
-              @route("/o1") aa_g_o1(): void;
-              @route("/o2") aa_g_o2(): void;
-            }
-
-            @route("/a")
-            namespace AAA{};
-
-            @route("/b")
-            namespace AAB{
-              @route("/o1") op aab_o1(): void;
-              @route("/o2") op aab_o2(): void;
-
-              @route("/g1")
-              interface AABGroup1 {
-                @route("/o1") aab_g1_o1(): void;
-                @route("/o2") aab_g1_o2(): void;
-              }
-
-              @route("/g2")
-              interface AABGroup2 {
-              }
-            };
-          }
-        };
-      `);
-
-      const rootClient = runner.context.sdkPackage.clients[0];
-      ok(rootClient);
-      let subClients = listSubClients(rootClient);
-      strictEqual(subClients.length, 2);
-
-      const agClient = subClients[1];
-      strictEqual(agClient.name, "AG");
-
-      const aaClient = subClients[0];
-      strictEqual(aaClient.name, "AA");
-
-      subClients = listSubClients(agClient);
-      strictEqual(subClients.length, 0);
-
-      subClients = listSubClients(aaClient);
-      strictEqual(subClients.length, 3);
-
-      const aagClient = subClients[2];
-      strictEqual(aagClient.name, "AAG");
-
-      const aaaClient = subClients[0];
-      strictEqual(aaaClient.name, "AAA");
-
-      const aabClient = subClients[1];
-      strictEqual(aabClient.name, "AAB");
-
-      subClients = listSubClients(aagClient);
-      strictEqual(subClients.length, 0);
-
-      subClients = listSubClients(aaaClient);
-      strictEqual(subClients.length, 0);
-
-      subClients = listSubClients(aabClient);
-      strictEqual(subClients.length, 2);
-
-      const aabGroup1Client = subClients[0];
-      strictEqual(aabGroup1Client.name, "AABGroup1");
-
-      const aabGroup2Client = subClients[1];
-      strictEqual(aabGroup2Client.name, "AABGroup2");
-
-      subClients = listSubClients(aabGroup1Client);
-      strictEqual(subClients.length, 0);
-
-      subClients = listSubClients(aabGroup2Client);
-      strictEqual(subClients.length, 0);
-
-      subClients = listSubClients(rootClient, true);
-      strictEqual(subClients.length, 7);
-      strictEqual(subClients[0].name, "AA");
-      strictEqual(subClients[1].name, "AG");
-      strictEqual(subClients[2].name, "AAA");
-      strictEqual(subClients[3].name, "AAB");
-      strictEqual(subClients[4].name, "AAG");
-      strictEqual(subClients[5].name, "AABGroup1");
-      strictEqual(subClients[6].name, "AABGroup2");
     });
   });
 


### PR DESCRIPTION
fixes #2313

The issue was that previously we only went down one-level of subclients: we didn't recurse to go through all subclients when setting `.clientDefaultValue` for api versions and others.

This PR adds deeper recursion, updates other places in code where we run into this issue, and removes an unused public-utils function to avoid confusion