### PR TITLE
Validate and update sample output for media type hint change

### DIFF
--- a/.chronus/changes/witemple-msft-media-type-hint-2025-2-14-16-25-14.md
+++ b/.chronus/changes/witemple-msft-media-type-hint-2025-2-14-16-25-14.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Update some tests and logic around constant/string content-type parameters.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "core"]
 	path = core
-	url = https://github.com/microsoft/typespec
-	branch = main
+	url = https://github.com/witemple-msft/typespec
+	branch = witemple-msft/media-type-hint

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "core"]
 	path = core
-	url = https://github.com/witemple-msft/typespec
-	branch = witemple-msft/media-type-hint
+	url = https://github.com/microsoft/typespec
+	branch = main

--- a/packages/samples/test/output/core/grpc-library-example/@azure-tools/typespec-autorest/openapi.json
+++ b/packages/samples/test/output/core/grpc-library-example/@azure-tools/typespec-autorest/openapi.json
@@ -139,6 +139,9 @@
           "LibraryService"
         ],
         "description": "Merges two shelves by adding all books from the shelf named\n`other_shelf_name` to shelf `name`, and deletes\n`other_shelf_name`. Returns the updated shelf.\nThe book ids of the moved books may not be the same as the original books.\nReturns NOT_FOUND if either shelf does not exist.\nThis call is a no-op if the specified shelves are the same.",
+        "consumes": [
+          "text/plain"
+        ],
         "parameters": [
           {
             "$ref": "#/parameters/MergeShelvesRequest.name"

--- a/packages/samples/test/output/core/init/@azure-tools/typespec-autorest/openapi.json
+++ b/packages/samples/test/output/core/init/@azure-tools/typespec-autorest/openapi.json
@@ -180,6 +180,10 @@
           "Widgets"
         ],
         "description": "Analyze a widget",
+        "produces": [
+          "text/plain",
+          "application/json"
+        ],
         "parameters": [
           {
             "name": "id",

--- a/packages/samples/test/output/core/nested/@azure-tools/typespec-autorest/openapi.json
+++ b/packages/samples/test/output/core/nested/@azure-tools/typespec-autorest/openapi.json
@@ -23,6 +23,9 @@
     "/": {
       "post": {
         "operationId": "SubC_AnotherOp",
+        "produces": [
+          "text/plain"
+        ],
         "parameters": [
           {
             "name": "body",
@@ -58,6 +61,9 @@
     "/sub/a/subsub": {
       "post": {
         "operationId": "SubSubA_DoSomething",
+        "produces": [
+          "text/plain"
+        ],
         "parameters": [
           {
             "name": "thing",
@@ -81,6 +87,9 @@
     "/sub/b": {
       "post": {
         "operationId": "SubB_DoSomething",
+        "produces": [
+          "text/plain"
+        ],
         "parameters": [
           {
             "name": "thing",

--- a/packages/samples/test/output/core/optional/@azure-tools/typespec-autorest/openapi.json
+++ b/packages/samples/test/output/core/optional/@azure-tools/typespec-autorest/openapi.json
@@ -23,6 +23,9 @@
     "/test": {
       "get": {
         "operationId": "OptionalMethods_Read",
+        "consumes": [
+          "text/plain"
+        ],
         "parameters": [
           {
             "name": "queryString",

--- a/packages/samples/test/output/core/simple/@azure-tools/typespec-autorest/openapi.json
+++ b/packages/samples/test/output/core/simple/@azure-tools/typespec-autorest/openapi.json
@@ -23,6 +23,9 @@
     "/alpha/{id}": {
       "get": {
         "operationId": "DoAlpha",
+        "produces": [
+          "text/plain"
+        ],
         "parameters": [
           {
             "name": "id",
@@ -44,6 +47,9 @@
     "/beta/{id}": {
       "get": {
         "operationId": "DoBeta",
+        "produces": [
+          "text/plain"
+        ],
         "parameters": [
           {
             "name": "id",

--- a/packages/samples/test/output/core/testserver/body-boolean/@azure-tools/typespec-autorest/openapi.json
+++ b/packages/samples/test/output/core/testserver/body-boolean/@azure-tools/typespec-autorest/openapi.json
@@ -46,6 +46,10 @@
       "put": {
         "operationId": "bool_putFalse",
         "description": "Set Boolean value false",
+        "produces": [
+          "text/plain",
+          "application/json"
+        ],
         "parameters": [
           {
             "name": "value",
@@ -79,6 +83,10 @@
       "get": {
         "operationId": "bool_getInvalid",
         "description": "Get invalid Boolean value",
+        "produces": [
+          "text/plain",
+          "application/json"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -100,6 +108,10 @@
       "get": {
         "operationId": "bool_getNull",
         "description": "Get null Boolean value",
+        "produces": [
+          "text/plain",
+          "application/json"
+        ],
         "parameters": [],
         "responses": {
           "200": {

--- a/packages/samples/test/output/core/testserver/body-string/@azure-tools/typespec-autorest/openapi.json
+++ b/packages/samples/test/output/core/testserver/body-string/@azure-tools/typespec-autorest/openapi.json
@@ -31,13 +31,16 @@
           "String Operations"
         ],
         "description": "Get value that is base64 encoded",
+        "produces": [
+          "application/octet-stream",
+          "application/json"
+        ],
         "parameters": [],
         "responses": {
           "200": {
             "description": "The request has succeeded.",
             "schema": {
-              "type": "string",
-              "format": "byte"
+              "type": "file"
             }
           },
           "default": {
@@ -54,6 +57,9 @@
           "String Operations"
         ],
         "description": "Put value that is base64 encoded",
+        "consumes": [
+          "application/octet-stream"
+        ],
         "parameters": [
           {
             "name": "value",
@@ -61,7 +67,7 @@
             "required": true,
             "schema": {
               "type": "string",
-              "format": "byte"
+              "format": "binary"
             }
           }
         ],

--- a/packages/samples/test/output/core/testserver/body-time/@azure-tools/typespec-autorest/openapi.json
+++ b/packages/samples/test/output/core/testserver/body-time/@azure-tools/typespec-autorest/openapi.json
@@ -24,6 +24,10 @@
       "get": {
         "operationId": "Time_Get",
         "description": "Get time value \"11:34:56\"",
+        "produces": [
+          "text/plain",
+          "application/json"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -44,6 +48,9 @@
       "put": {
         "operationId": "Time_Put",
         "description": "Put time value \"08:07:56\"",
+        "consumes": [
+          "text/plain"
+        ],
         "parameters": [
           {
             "name": "value",

--- a/packages/samples/test/output/core/testserver/media-types/@azure-tools/typespec-autorest/openapi.json
+++ b/packages/samples/test/output/core/testserver/media-types/@azure-tools/typespec-autorest/openapi.json
@@ -24,6 +24,9 @@
       "post": {
         "operationId": "AnalyzeBody",
         "description": "Analyze body, that could be different media types.",
+        "produces": [
+          "text/plain"
+        ],
         "consumes": [
           "application/pdf",
           "application/json",
@@ -50,6 +53,9 @@
       "post": {
         "operationId": "contentTypeWithEncoding",
         "description": "Pass in contentType 'text/plain; encoding=UTF-8' to pass test. Value for input does not matter",
+        "produces": [
+          "text/plain"
+        ],
         "consumes": [
           "text/plain"
         ],

--- a/packages/samples/test/output/core/testserver/multiple-inheritance/@azure-tools/typespec-autorest/openapi.json
+++ b/packages/samples/test/output/core/testserver/multiple-inheritance/@azure-tools/typespec-autorest/openapi.json
@@ -24,6 +24,10 @@
       "get": {
         "operationId": "MultipleInheritance_GetCat",
         "description": "Get a cat with name 'Whiskers' where likesMilk, meows, and hisses is true",
+        "produces": [
+          "application/json",
+          "text/plain"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -43,6 +47,9 @@
       "put": {
         "operationId": "MultipleInheritance_PutCat",
         "description": "Put a cat with name 'Boots' where likesMilk and hisses is false, meows is true",
+        "produces": [
+          "text/plain"
+        ],
         "parameters": [
           {
             "name": "cat",
@@ -73,6 +80,10 @@
       "get": {
         "operationId": "MultipleInheritance_GetFeline",
         "description": "Get a feline where meows and hisses are true",
+        "produces": [
+          "application/json",
+          "text/plain"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -92,6 +103,9 @@
       "put": {
         "operationId": "MultipleInheritance_PutFeline",
         "description": "Put a feline who hisses and doesn't meow",
+        "produces": [
+          "text/plain"
+        ],
         "parameters": [
           {
             "name": "feline",
@@ -122,6 +136,10 @@
       "get": {
         "operationId": "MultipleInheritance_GetHorse",
         "description": "Get a horse with name 'Fred' and isAShowHorse true",
+        "produces": [
+          "application/json",
+          "text/plain"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -141,6 +159,9 @@
       "put": {
         "operationId": "MultipleInheritance_PutHorse",
         "description": "Put a horse with name 'General' and isAShowHorse false",
+        "produces": [
+          "text/plain"
+        ],
         "parameters": [
           {
             "name": "horse",
@@ -171,6 +192,10 @@
       "get": {
         "operationId": "MultipleInheritance_GetKitten",
         "description": "Get a kitten with name 'Gatito' where likesMilk and meows is true, and hisses and eatsMiceYet is false",
+        "produces": [
+          "application/json",
+          "text/plain"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -190,6 +215,9 @@
       "put": {
         "operationId": "MultipleInheritance_PutKitten",
         "description": "Put a kitten with name 'Kitty' where likesMilk and hisses is false, meows and eatsMiceYet is true",
+        "produces": [
+          "text/plain"
+        ],
         "parameters": [
           {
             "name": "kitten",
@@ -220,6 +248,10 @@
       "get": {
         "operationId": "MultipleInheritance_GetPet",
         "description": "Get a pet with name 'Peanut'",
+        "produces": [
+          "application/json",
+          "text/plain"
+        ],
         "parameters": [],
         "responses": {
           "200": {
@@ -239,6 +271,9 @@
       "put": {
         "operationId": "MultipleInheritance_PutPet",
         "description": "Put a pet with name 'Butter'",
+        "produces": [
+          "text/plain"
+        ],
         "parameters": [
           {
             "name": "horse",

--- a/packages/typespec-autorest-canonical/test/return-types.test.ts
+++ b/packages/typespec-autorest-canonical/test/return-types.test.ts
@@ -545,9 +545,8 @@ describe("binary responses", () => {
       @get op read(): bytes;
     `);
     const operation = res.paths["/"].get;
-    deepStrictEqual(operation.produces, undefined);
-    strictEqual(operation.responses["200"].schema.type, "string");
-    strictEqual(operation.responses["200"].schema.format, "byte");
+    deepStrictEqual(operation.produces, ["application/octet-stream"]);
+    strictEqual(operation.responses["200"].schema.type, "file");
   });
 
   it("@body body: bytes responses should produce application/json with byte schema", async () => {
@@ -556,9 +555,8 @@ describe("binary responses", () => {
     `);
 
     const operation = res.paths["/"].get;
-    deepStrictEqual(operation.produces, undefined);
-    strictEqual(operation.responses["200"].schema.type, "string");
-    strictEqual(operation.responses["200"].schema.format, "byte");
+    deepStrictEqual(operation.produces, ["application/octet-stream"]);
+    strictEqual(operation.responses["200"].schema.type, "file");
   });
 
   it("@header contentType should override content type and set type to file", async () => {

--- a/packages/typespec-autorest/test/metadata.test.ts
+++ b/packages/typespec-autorest/test/metadata.test.ts
@@ -341,6 +341,7 @@ describe("typespec-autorest: metadata", () => {
       "/single/{p}": {
         get: {
           operationId: "Single",
+          produces: ["text/plain"],
           parameters: [
             { $ref: "#/parameters/Parameters.q" },
             { $ref: "#/parameters/Parameters.p" },
@@ -357,6 +358,7 @@ describe("typespec-autorest: metadata", () => {
       "/batch": {
         get: {
           operationId: "Batch",
+          produces: ["text/plain"],
           responses: {
             "200": {
               description: "The request has succeeded.",

--- a/packages/typespec-autorest/test/openapi-output.test.ts
+++ b/packages/typespec-autorest/test/openapi-output.test.ts
@@ -587,11 +587,11 @@ describe("typespec-autorest: request", () => {
         @post op read(@body body: bytes): {};
       `);
       const operation = res.paths["/"].post;
-      deepStrictEqual(operation.consumes, undefined);
+      deepStrictEqual(operation.consumes, ["application/octet-stream"]);
       const requestBody = operation.parameters[0];
       ok(requestBody);
       strictEqual(requestBody.schema.type, "string");
-      strictEqual(requestBody.schema.format, "byte");
+      strictEqual(requestBody.schema.format, "binary");
     });
 
     it("bytes request should respect @header contentType", async () => {

--- a/packages/typespec-autorest/test/parameters.test.ts
+++ b/packages/typespec-autorest/test/parameters.test.ts
@@ -478,7 +478,7 @@ describe("content type parameter", () => {
       ): void;
       `,
     );
-    strictEqual(res.paths["/"].post.consumes, undefined);
+    deepStrictEqual(res.paths["/"].post.consumes, ["text/plain"]);
   });
 });
 

--- a/packages/typespec-autorest/test/return-types.test.ts
+++ b/packages/typespec-autorest/test/return-types.test.ts
@@ -543,9 +543,8 @@ describe("typespec-autorest: return types", () => {
         @get op read(): bytes;
       `);
       const operation = res.paths["/"].get;
-      deepStrictEqual(operation.produces, undefined);
-      strictEqual(operation.responses["200"].schema.type, "string");
-      strictEqual(operation.responses["200"].schema.format, "byte");
+      deepStrictEqual(operation.produces, ["application/octet-stream"]);
+      strictEqual(operation.responses["200"].schema.type, "file");
     });
 
     it("@body body: bytes responses should produce application/json with byte schema", async () => {
@@ -554,9 +553,8 @@ describe("typespec-autorest: return types", () => {
       `);
 
       const operation = res.paths["/"].get;
-      deepStrictEqual(operation.produces, undefined);
-      strictEqual(operation.responses["200"].schema.type, "string");
-      strictEqual(operation.responses["200"].schema.format, "byte");
+      deepStrictEqual(operation.produces, ["application/octet-stream"]);
+      strictEqual(operation.responses["200"].schema.type, "file");
     });
 
     it("@header contentType should override content type and set type to file", async () => {

--- a/packages/typespec-autorest/test/services.test.ts
+++ b/packages/typespec-autorest/test/services.test.ts
@@ -23,6 +23,7 @@ it("supports emitting multiple services", async () => {
       get: {
         operationId: "Get",
         parameters: [],
+        produces: ["text/plain"],
         responses: {
           200: {
             description: "The request has succeeded.",
@@ -38,6 +39,7 @@ it("supports emitting multiple services", async () => {
       get: {
         operationId: "Other",
         parameters: [],
+        produces: ["text/plain"],
         responses: {
           200: {
             description: "The request has succeeded.",

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -68,7 +68,7 @@ import {
   twoParamsEquivalent,
 } from "./internal-utils.js";
 import { createDiagnostic } from "./lib.js";
-import { isMediaTypeJson } from "./media-types.js";
+import { isMediaTypeJson, isMediaTypeOctetStream, isMediaTypeTextPlain } from "./media-types.js";
 import {
   getCrossLanguageDefinitionId,
   getEffectivePayloadType,
@@ -277,7 +277,10 @@ function createContentTypeOrAcceptHeader(
 ): Omit<SdkMethodParameter, "kind"> {
   const name = bodyObject.kind === "body" ? "contentType" : "accept";
   let type: SdkType = getTypeSpecBuiltInType(context, "string");
-  // for contentType, we treat it as a constant IFF there's one value and it's application/json.
+  // for contentType, we treat it as a constant IFF there's one value and it's one of:
+  //  - application/json
+  //  - text/plain
+  //  - application/octet-stream
   // this is to prevent a breaking change when a service adds more content types in the future.
   // e.g. the service accepting image/png then later image/jpeg should _not_ be a breaking change.
   //
@@ -287,7 +290,10 @@ function createContentTypeOrAcceptHeader(
   if (
     bodyObject.contentTypes &&
     bodyObject.contentTypes.length === 1 &&
-    (isMediaTypeJson(bodyObject.contentTypes[0]) || name === "accept")
+    (isMediaTypeJson(bodyObject.contentTypes[0]) ||
+      isMediaTypeTextPlain(bodyObject.contentTypes[0]) ||
+      isMediaTypeOctetStream(bodyObject.contentTypes[0]) ||
+      name === "accept")
   ) {
     // in this case, we just want a content type of application/json
     type = {

--- a/packages/typespec-client-generator-core/src/media-types.ts
+++ b/packages/typespec-client-generator-core/src/media-types.ts
@@ -21,6 +21,18 @@ export function parseMediaType(mediaType: string) {
   return undefined;
 }
 
+export function isMediaTypeTextPlain(mediaType: string): boolean {
+  const mt = parseMediaType(mediaType);
+
+  return mt ? mt.type === text && mt.subtype === "plain" : false;
+}
+
+export function isMediaTypeOctetStream(mediaType: string): boolean {
+  const mt = parseMediaType(mediaType);
+
+  return mt ? mt.type === application && mt.subtype === "octet-stream" : false;
+}
+
 export function isMediaTypeJson(mediaType: string): boolean {
   const mt = parseMediaType(mediaType);
   return mt

--- a/packages/typespec-client-generator-core/test/methods/parameters.test.ts
+++ b/packages/typespec-client-generator-core/test/methods/parameters.test.ts
@@ -744,7 +744,7 @@ describe("content type", () => {
     strictEqual(methodParam.onClient, false);
     strictEqual(methodParam.isApiVersionParam, false);
     strictEqual(methodParam.type.kind, "constant");
-    strictEqual(methodParam.type.value, "application/json");
+    strictEqual(methodParam.type.value, "text/plain");
 
     const serviceOperation = method.operation;
     strictEqual(serviceOperation.parameters.length, 1);
@@ -824,7 +824,7 @@ describe("content type", () => {
     strictEqual(methodParam.onClient, false);
     strictEqual(methodParam.isApiVersionParam, false);
     strictEqual(methodParam.type.kind, "constant");
-    strictEqual(methodParam.type.value, "application/json");
+    strictEqual(methodParam.type.value, "text/plain");
 
     const serviceOperation = method.operation;
     strictEqual(serviceOperation.parameters.length, 1);


### PR DESCRIPTION
This is the Azure companion of https://github.com/microsoft/typespec/pull/6357

This PR updates the recorded sample output to account for changes to the default content types of scalars.