### PR TITLE
[tcgc[ export `listAllServiceNamespaces`

### DIFF
--- a/.chronus/changes/export_list_service-2025-2-13-10-47-21.md
+++ b/.chronus/changes/export_list_service-2025-2-13-10-47-21.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Provide `listAllServiceNamespaces` to list service namespaces with versioning support.

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -58,13 +58,12 @@ import {
   clientNamespaceKey,
   findRootSourceProperty,
   listAllNamespaces,
-  listAllServiceNamespaces,
   listAllUserDefinedNamespaces,
   negationScopesKey,
   scopeKey,
 } from "./internal-utils.js";
 import { createStateSymbol, reportDiagnostic } from "./lib.js";
-import { getLibraryName } from "./public-utils.js";
+import { getLibraryName, listAllServiceNamespaces } from "./public-utils.js";
 import { getSdkEnum, getSdkModel, getSdkUnion } from "./types.js";
 
 export const namespace = "Azure.ClientGenerator.Core";

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -10,7 +10,6 @@ import {
   Interface,
   isNeverType,
   isNullType,
-  isService,
   isVoidType,
   listServices,
   Model,
@@ -671,26 +670,6 @@ export function handleVersioningMutationForGlobalNamespace(context: TCGCContext)
   const subgraph = unsafe_mutateSubgraphWithNamespace(context.program, [mutator], globalNamespace);
   compilerAssert(subgraph.type.kind === "Namespace", "Should not have mutated to another type");
   return subgraph.type;
-}
-
-/**
- * Currently, listServices can only be called from a program instance. This doesn't work well if we're doing mutation,
- * because we want to just mutate the global namespace once, then find all of the services in the program, since we aren't
- * able to explicitly tell listServices to iterate over our specific mutated global namespace. We're going to use this function
- * instead to list all of the services in the global namespace.
- *
- * See https://github.com/microsoft/typespec/issues/6247
- *
- * @param context
- */
-export function listAllServiceNamespaces(context: TCGCContext): Namespace[] {
-  const serviceNamespaces: Namespace[] = [];
-  for (const ns of listAllUserDefinedNamespaces(context)) {
-    if (isService(context.program, ns)) {
-      serviceNamespaces.push(ns);
-    }
-  }
-  return serviceNamespaces;
 }
 
 export function listRawSubClients(

--- a/packages/typespec-client-generator-core/src/package.ts
+++ b/packages/typespec-client-generator-core/src/package.ts
@@ -74,7 +74,6 @@ import {
   getValueTypeValue,
   isNeverOrVoidType,
   isSubscriptionId,
-  listAllServiceNamespaces,
   listRawSubClients,
   updateWithApiVersionInformation,
 } from "./internal-utils.js";
@@ -87,6 +86,7 @@ import {
   getHttpOperationWithCache,
   getLibraryName,
   isApiVersion,
+  listAllServiceNamespaces,
 } from "./public-utils.js";
 import {
   getAllReferencedTypes,

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -14,6 +14,7 @@ import {
   getFriendlyName,
   getNamespaceFullName,
   ignoreDiagnostics,
+  isService,
   resolveEncodedName,
 } from "@typespec/compiler";
 import { HttpOperation, getHttpOperation, getHttpPart, isMetadata } from "@typespec/http";
@@ -49,7 +50,6 @@ import {
   hasNoneVisibility,
   isAzureCoreTspModel,
   isHttpBodySpread,
-  listAllServiceNamespaces,
   listAllUserDefinedNamespaces,
   listRawSubClients,
   removeVersionsLargerThanExplicitlySpecified,
@@ -716,4 +716,24 @@ export function getHttpOperationParameter(
     }
   }
   return undefined;
+}
+
+/**
+ * Currently, listServices can only be called from a program instance. This doesn't work well if we're doing mutation,
+ * because we want to just mutate the global namespace once, then find all of the services in the program, since we aren't
+ * able to explicitly tell listServices to iterate over our specific mutated global namespace. We're going to use this function
+ * instead to list all of the services in the global namespace.
+ *
+ * See https://github.com/microsoft/typespec/issues/6247
+ *
+ * @param context
+ */
+export function listAllServiceNamespaces(context: TCGCContext): Namespace[] {
+  const serviceNamespaces: Namespace[] = [];
+  for (const ns of listAllUserDefinedNamespaces(context)) {
+    if (isService(context.program, ns)) {
+      serviceNamespaces.push(ns);
+    }
+  }
+  return serviceNamespaces;
 }

--- a/packages/typespec-client-generator-core/test/utils.ts
+++ b/packages/typespec-client-generator-core/test/utils.ts
@@ -5,7 +5,7 @@ import {
   SdkPackage,
   SdkServiceMethod,
 } from "../src/interfaces.js";
-import { listAllServiceNamespaces } from "../src/internal-utils.js";
+import { listAllServiceNamespaces } from "../src/public-utils.js";
 import { SdkTestRunner } from "./test-host.js";
 
 export function hasFlag<T extends number>(value: T, flag: T): boolean {


### PR DESCRIPTION
the exported `listAllServiceNamespaces` function will help to list all namespaces with `@service` decorator with latest api version for versioning service by default. mainly for rlc usage.