### PR TITLE
Uptake cleanup of http library

### DIFF
--- a/.chronus/changes/uptake-cleanup-http-2025-2-13-16-39-43.md
+++ b/.chronus/changes/uptake-cleanup-http-2025-2-13-16-39-43.md
@@ -1,0 +1,9 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-azure-core"
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Uptake cleanup of http library

--- a/packages/typespec-azure-core/test/test-host.ts
+++ b/packages/typespec-azure-core/test/test-host.ts
@@ -6,7 +6,6 @@ import {
   HttpOperation,
   HttpOperationParameter,
   HttpVerb,
-  RouteResolutionOptions,
 } from "@typespec/http";
 import { HttpTestLibrary } from "@typespec/http/testing";
 import { OpenAPITestLibrary } from "@typespec/openapi/testing";
@@ -61,11 +60,10 @@ export async function createAzureCoreTestRunner(
 
 export async function getOperations(
   code: string,
-  routeOptions?: RouteResolutionOptions,
 ): Promise<[HttpOperation[], readonly Diagnostic[], BasicTestRunner]> {
   const runner = await createAzureCoreTestRunner();
   await runner.compileAndDiagnose(code, { noEmit: true });
-  const [services] = getAllHttpServices(runner.program, routeOptions);
+  const [services] = getAllHttpServices(runner.program);
   return [services[0].operations, runner.program.diagnostics, runner];
 }
 
@@ -85,9 +83,8 @@ export interface SimpleHttpOperation {
 
 export async function getSimplifiedOperations(
   code: string,
-  routeOptions?: RouteResolutionOptions,
 ): Promise<[SimpleHttpOperation[], readonly Diagnostic[]]> {
-  const [routes, diagnostics] = await getOperations(code, routeOptions);
+  const [routes, diagnostics] = await getOperations(code);
 
   const details = routes.map((r) => {
     return {

--- a/packages/typespec-azure-resource-manager/lib/models.tsp
+++ b/packages/typespec-azure-resource-manager/lib/models.tsp
@@ -44,7 +44,7 @@ model ResourceNameParameter<
  */
 @doc("Concrete tracked resource types can be created by aliasing this type using a specific property type.")
 @armResourceInternal(Properties)
-@includeInapplicableMetadataInPayload(false)
+@Http.Private.includeInapplicableMetadataInPayload(false)
 model TrackedResource<Properties extends {}, PropertiesOptional extends valueof boolean = true>
   extends Foundations.TrackedResource {
   @doc("The resource-specific properties for this resource.")
@@ -62,7 +62,7 @@ model TrackedResource<Properties extends {}, PropertiesOptional extends valueof 
  */
 @doc("Concrete proxy resource types can be created by aliasing this type using a specific property type.")
 @armResourceInternal(Properties)
-@includeInapplicableMetadataInPayload(false)
+@Http.Private.includeInapplicableMetadataInPayload(false)
 model ProxyResource<Properties extends {}, PropertiesOptional extends valueof boolean = true>
   extends Foundations.ProxyResource {
   @doc("The resource-specific properties for this resource.")
@@ -81,7 +81,7 @@ model ProxyResource<Properties extends {}, PropertiesOptional extends valueof bo
 @extensionResource
 @doc("Concrete extension resource types can be created by aliasing this type using a specific property type.")
 @armResourceInternal(Properties)
-@includeInapplicableMetadataInPayload(false)
+@Http.Private.includeInapplicableMetadataInPayload(false)
 model ExtensionResource<Properties extends {}, PropertiesOptional extends valueof boolean = true>
   extends Foundations.ExtensionResource {
   @doc("The resource-specific properties for this resource.")

--- a/packages/typespec-azure-resource-manager/src/namespace.ts
+++ b/packages/typespec-azure-resource-manager/src/namespace.ts
@@ -13,7 +13,8 @@ import {
 } from "@typespec/compiler";
 import { unsafe_Realm } from "@typespec/compiler/experimental";
 import * as http from "@typespec/http";
-import { getAuthentication, setAuthentication, setRouteOptionsForNamespace } from "@typespec/http";
+import { getAuthentication, setAuthentication } from "@typespec/http";
+import { unsafe_setRouteOptionsForNamespace as setRouteOptionsForNamespace } from "@typespec/http/experimental";
 import { getResourceTypeForKeyParam } from "@typespec/rest";
 import {
   ArmLibraryNamespaceDecorator,

--- a/packages/typespec-azure-resource-manager/test/lro-metadata.test.ts
+++ b/packages/typespec-azure-resource-manager/test/lro-metadata.test.ts
@@ -1,18 +1,17 @@
 import { LroMetadata, getLroMetadata } from "@azure-tools/typespec-azure-core";
 import { Diagnostic, Model } from "@typespec/compiler";
 import { BasicTestRunner, expectDiagnosticEmpty } from "@typespec/compiler/testing";
-import { HttpOperation, RouteResolutionOptions, getAllHttpServices } from "@typespec/http";
+import { HttpOperation, getAllHttpServices } from "@typespec/http";
 import { deepStrictEqual, ok } from "assert";
 import { describe, it } from "vitest";
 import { createAzureResourceManagerTestRunner } from "./test-host.js";
 
 async function getOperations(
   code: string,
-  routeOptions?: RouteResolutionOptions,
 ): Promise<[HttpOperation[], readonly Diagnostic[], BasicTestRunner]> {
   const runner = await createAzureResourceManagerTestRunner();
   await runner.compileAndDiagnose(code, { noEmit: true });
-  const [services] = getAllHttpServices(runner.program, routeOptions);
+  const [services] = getAllHttpServices(runner.program);
   return [services[0].operations, runner.program.diagnostics, runner];
 }
 


### PR DESCRIPTION
Uptake change required by this pr https://github.com/microsoft/typespec/pull/6433

There is a few spec that use the includePayload decorator but they are all marked as a pattern you shoul;dn't do already using internal apis so we'll just add `Private.` in front and we'll have to figure out how to solve this so we can completely remove the decorator