### PR TITLE
[tcgc] export `SdkEmitterOptionsSchema`

### DIFF
--- a/.chronus/changes/export_schema-2025-2-17-11-42-28.md
+++ b/.chronus/changes/export_schema-2025-2-17-11-42-28.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Export `SdkEmitterOptionsSchema` for downstream emitter to add same options.

--- a/packages/typespec-client-generator-core/src/lib.ts
+++ b/packages/typespec-client-generator-core/src/lib.ts
@@ -1,7 +1,7 @@
 import { createTypeSpecLibrary, JSONSchemaType, paramMessage } from "@typespec/compiler";
 import { SdkEmitterOptions } from "./interfaces.js";
 
-const EmitterOptionsSchema: JSONSchemaType<SdkEmitterOptions> = {
+export const SdkEmitterOptionsSchema: JSONSchemaType<SdkEmitterOptions> = {
   type: "object",
   additionalProperties: true,
   properties: {
@@ -315,7 +315,7 @@ export const $lib = createTypeSpecLibrary({
     },
   },
   emitter: {
-    options: EmitterOptionsSchema as JSONSchemaType<SdkEmitterOptions>,
+    options: SdkEmitterOptionsSchema,
   },
 });
 

--- a/packages/typespec-client-generator-core/src/lib.ts
+++ b/packages/typespec-client-generator-core/src/lib.ts
@@ -3,7 +3,7 @@ import { SdkEmitterOptions } from "./interfaces.js";
 
 export const SdkEmitterOptionsSchema: JSONSchemaType<SdkEmitterOptions> = {
   type: "object",
-  additionalProperties: true,
+  additionalProperties: false,
   properties: {
     "emitter-name": {
       type: "string",


### PR DESCRIPTION
Export `SdkEmitterOptionsSchema` for downstream emitter to add same options.