### PR TITLE
[tcgc] ignore visibility when finding response type if it is anonymous model

### DIFF
--- a/.chronus/changes/tcgc-fix_visibility-2025-2-18-14-24-28.md
+++ b/.chronus/changes/tcgc-fix_visibility-2025-2-18-14-24-28.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Ignore visibility when finding HTTP response type if it is anonymous model.

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -18,6 +18,7 @@ import {
   HttpOperationParameter,
   HttpOperationPathParameter,
   HttpOperationQueryParameter,
+  Visibility,
   getCookieParamOptions,
   getHeaderFieldName,
   getHeaderFieldOptions,
@@ -496,7 +497,7 @@ function getSdkHttpResponseAndExceptions(
         contentTypes = contentTypes.concat(innerResponse.body.contentTypes);
         body =
           innerResponse.body.type.kind === "Model"
-            ? getEffectivePayloadType(context, innerResponse.body.type)
+            ? getEffectivePayloadType(context, innerResponse.body.type, Visibility.Read)
             : innerResponse.body.type;
         if (getStreamMetadata(context.program, innerResponse)) {
           // map stream response body type to bytes

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -119,9 +119,10 @@ export function getClientNamespaceString(context: TCGCContext): string | undefin
 }
 
 /**
- * If the given type is an anonymous model and all of its properties excluding
- * header/query/path/status-code are sourced from a named model, returns that original named model.
- * Otherwise the given type is returned unchanged.
+ * If the given type is an anonymous model, returns a named model with same shape.
+ * The finding logic will ignore all the properties of header/query/path/status-code metadata,
+ * as well as the properties that are not visible in the given visibility if provided.
+ * If the model found is also anonymous, the input type is returned unchanged.
  *
  * @param context
  * @param type

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -17,7 +17,14 @@ import {
   isService,
   resolveEncodedName,
 } from "@typespec/compiler";
-import { HttpOperation, getHttpOperation, getHttpPart, isMetadata } from "@typespec/http";
+import {
+  HttpOperation,
+  Visibility,
+  getHttpOperation,
+  getHttpPart,
+  isMetadata,
+  isVisible,
+} from "@typespec/http";
 import { Version, getVersions } from "@typespec/versioning";
 import { pascalCase } from "change-case";
 import pluralize from "pluralize";
@@ -120,7 +127,11 @@ export function getClientNamespaceString(context: TCGCContext): string | undefin
  * @param type
  * @returns
  */
-export function getEffectivePayloadType(context: TCGCContext, type: Model): Model {
+export function getEffectivePayloadType(
+  context: TCGCContext,
+  type: Model,
+  visibility?: Visibility,
+): Model {
   const program = context.program;
 
   // if a type has name, we should resolve the name
@@ -135,7 +146,10 @@ export function getEffectivePayloadType(context: TCGCContext, type: Model): Mode
   const effective = getEffectiveModelType(
     program,
     type,
-    (t) => !isMetadata(context.program, t) && !hasNoneVisibility(context, t),
+    (t) =>
+      !isMetadata(context.program, t) &&
+      !hasNoneVisibility(context, t) &&
+      (visibility === undefined || isVisible(program, t, visibility)),
   );
   if (effective.name) {
     return effective;

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1752,7 +1752,7 @@ function updateTypesFromOperation(
       if (innerResponse.body?.type && !isNeverOrVoidType(innerResponse.body.type)) {
         const body =
           innerResponse.body.type.kind === "Model"
-            ? getEffectivePayloadType(context, innerResponse.body.type)
+            ? getEffectivePayloadType(context, innerResponse.body.type, Visibility.Read)
             : innerResponse.body.type;
         const sdkType = diagnostics.pipe(getClientTypeWithDiagnostics(context, body, operation));
         if (generateConvenient) {


### PR DESCRIPTION
with previous logic, http library will return a created anonymous model without `Create` visibility, and tcgc could not find the original model, but use this anonymous model as the response type (`GetResponse`). see [playground](https://cadlplayground.z22.web.core.windows.net/cadl-azure/?c=QHNlcnZpY2UNCm5hbWVzcGFjZSBUZXN0Q2xpZW50IHsNCiAgbW9kZWzFFsYQICBAdmlzaWJpbGl0eShMaWZlY3ljbGUuQ3JlYXRlKcYjY8UNOiBzdHJpbmc7DQrGF3JlYWTLFSAgfcYab3AgZ2V0KCk6xWg7DQp9DQo%3D&e=%40azure-tools%2Ftypespec-client-generator-core&options=%7B%7D), line 59.
with current logic, tcgc could find the original model and will use that model as the response type (`Test`). see [playground](https://cadlplayground.z22.web.core.windows.net/typespec-azure/prs/2402/?c=QHNlcnZpY2UNCm5hbWVzcGFjZSBUZXN0Q2xpZW50IHsNCiAgbW9kZWzFFsYQICBAdmlzaWJpbGl0eShMaWZlY3ljbGUuQ3JlYXRlKcYjY8UNOiBzdHJpbmc7DQrGF3JlYWTLFSAgfcYab3AgZ2V0KCk6xWg7DQp9DQo%3D&e=%40azure-tools%2Ftypespec-client-generator-core&options=%7B%7D), line59.