### PR TITLE
Add non-resource arm tests

### DIFF
--- a/packages/azure-http-specs/specs/azure/resource-manager/non-resource/main.tsp
+++ b/packages/azure-http-specs/specs/azure/resource-manager/non-resource/main.tsp
@@ -1,0 +1,29 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.Core;
+using Azure.ResourceManager;
+using TypeSpec.OpenAPI;
+
+@armProviderNamespace
+@service
+@versioned(Versions)
+@doc("Arm Resource Provider management API.")
+namespace Azure.ResourceManager.NonResource;
+
+@doc("Azure API versions.")
+enum Versions {
+  @armCommonTypesVersion(CommonTypes.Versions.v5)
+  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
+  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
+  @doc("Preview API version 2023-12-01-preview.")
+  v2023_12_01_preview: "2023-12-01-preview",
+}
+

--- a/packages/azure-http-specs/specs/azure/resource-manager/non-resource/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/non-resource/mockapi.ts
@@ -1,0 +1,30 @@
+import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+const SUBSCRIPTION_ID_EXPECTED = "00000000-0000-0000-0000-000000000000";
+const LOCATION_EXPECTED = "eastus";
+
+const nonResource = {
+  id: "id",
+  name: "hello",
+  type: "nonResource"
+};
+
+Scenarios.Azure_ResourceManager_NonResource_NonResourceOperations_get = passOnSuccess({
+  uri: "/subscriptions/:subscriptionId/providers/Microsoft.NonResource/locations/:location/otherParameters/:parameter",
+  method: "get",
+  request: {
+    params: {
+      subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+      location: LOCATION_EXPECTED,
+      parameter: "hello",
+      "api-version": "2023-12-01-preview",
+    },
+  },
+  response: {
+    status: 200,
+    body: json(nonResource),
+  },
+  kind: "MockApiDefinition",
+});

--- a/packages/azure-http-specs/specs/azure/resource-manager/non-resource/non-resource.tsp
+++ b/packages/azure-http-specs/specs/azure/resource-manager/non-resource/non-resource.tsp
@@ -1,0 +1,71 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@typespec/spector";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using Azure.Core;
+using Azure.ResourceManager;
+using TypeSpec.OpenAPI;
+using Spector;
+
+/**
+ * Though this model has `id`, `name`, `type` properties, it is not a resource as it doesn't extends `Resource`.
+ */
+model NonResource {
+  /**
+   * The identification of the result
+   */
+  id?: string;
+
+  /**
+   * The name of the result
+   */
+  name?: string;
+
+  /**
+   * The result resource type
+   */
+  type?: string;
+}
+
+/**
+ * Operations on non resource model should not be marked as `@armResourceOperations`.
+ */
+interface NonResourceOperations {
+  @scenario
+  @scenarioDoc("""
+    It's non resource operation operating on non resource model, though the model has `id`, `name`, `type` properties.
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/providers/Microsoft.NonResource/locations/eastus/otherParameters/hello
+    Expected query parameter: api-version=2023-12-01-preview
+    
+    Expected response body:
+    ```json
+    {
+      "id": "id",
+      "name": "hello",
+      "type": "nonResource"
+    }
+    ```
+    """)
+  @route("/subscriptions/{subscriptionId}/providers/Microsoft.NonResource/locations/{location}/otherParameters/{parameter}")
+  @get
+  get(
+    ...ApiVersionParameter,
+    ...SubscriptionIdParameter,
+
+    /**
+     * The location parameter.
+     */
+    @path
+    location: string,
+
+    /**
+     * The cluster code version.
+     */
+    @path
+    parameter: string,
+  ): ArmResponse<NonResource> | ErrorResponse;
+}


### PR DESCRIPTION
In many cases, when a model has id, name, type, customers still want it to be a non resource. To realize it, we ask them 
1. This model should not extend from Resource model form arm libraries.
2. All the operations on that model should not be marked with any arm related decorators and the interface too.
3. They should write these operations in low level way.

Add this test to ensure our client can correctly handle this case.