### PR TITLE
[tcgc] do not add encode for bytes according to content type if it has user defined encode

### DIFF
--- a/.chronus/changes/tcgc-fix_response_encode-2025-2-19-15-1-46.md
+++ b/.chronus/changes/tcgc-fix_response_encode-2025-2-19-15-1-46.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Do not add encode for bytes according to content type if it has user defined encode.

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -121,7 +121,7 @@ import {
 import { getVersions } from "@typespec/versioning";
 import { getNs, isAttribute, isUnwrapped } from "@typespec/xml";
 import { getSdkHttpParameter, isSdkHttpParameter } from "./http.js";
-import { isMediaTypeJson, isMediaTypeXml } from "./media-types.js";
+import { isMediaTypeJson, isMediaTypeTextPlain, isMediaTypeXml } from "./media-types.js";
 
 export function getTypeSpecBuiltInType(
   context: TCGCContext,
@@ -190,12 +190,14 @@ export function addEncodeInfo(
     if (encodeData) {
       innerType.encode = encodeData.encoding as BytesKnownEncoding;
     } else if (
-      !defaultContentType ||
-      isMediaTypeJson(defaultContentType) ||
-      isMediaTypeXml(defaultContentType)
+      innerType.encode === "bytes" && // the inner type encode is default to bytes, we will use the defaultContentType to determine the encoding
+      (!defaultContentType ||
+        isMediaTypeJson(defaultContentType) ||
+        isMediaTypeXml(defaultContentType) ||
+        isMediaTypeTextPlain(defaultContentType))
     ) {
       innerType.encode = "base64";
-    } else {
+    } else if (!innerType.encode) {
       innerType.encode = "bytes";
     }
   }

--- a/packages/typespec-client-generator-core/test/methods/responses.test.ts
+++ b/packages/typespec-client-generator-core/test/methods/responses.test.ts
@@ -396,3 +396,20 @@ it("response body with non-read visibility", async () => {
   ok(method);
   strictEqual((method.response as SdkMethodResponse).type, model);
 });
+
+it("response body of scalar with encode", async () => {
+  await runner.compileWithBuiltInService(
+    `
+    @encode(BytesKnownEncoding.base64url)
+    scalar base64urlBytes extends bytes;
+    
+    op get(): {@header contentType: "application/json", @body body: base64urlBytes;};
+    `,
+  );
+  const sdkPackage = runner.context.sdkPackage;
+  const method = getServiceMethodOfClient(sdkPackage);
+  const serviceResponse = method.operation.responses[0];
+  deepStrictEqual(serviceResponse.contentTypes, ["application/json"]);
+  strictEqual(serviceResponse.type?.kind, "bytes");
+  strictEqual(serviceResponse.type?.encode, "base64url");
+});


### PR DESCRIPTION
fix issue found from this change: https://github.com/microsoft/typespec/pull/6528/files#diff-0418e97da7c7dc0d4288a53251656d4e7aaaef49797ea9f5829e54d315eb8361R363