### PR TITLE
[tcgc] rollback `SdkApiVersionParameter` and remove some deprecations

### DIFF
--- a/.chronus/changes/tcgc-remove_deprecation-2025-2-20-13-57-34.md
+++ b/.chronus/changes/tcgc-remove_deprecation-2025-2-20-13-57-34.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Rollback change of `SdkApiVersionParameter`.

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -575,7 +575,7 @@ export function getCorrespondingMethodParams(
   }
 
   // 2. To see if the service parameter is api version parameter that has been elevated to client.
-  if (isApiVersion(context, serviceParam) && serviceParam.onClient) {
+  if (serviceParam.isApiVersionParam && serviceParam.onClient) {
     const existingApiVersion = clientParams?.find((x) => isApiVersion(context, x));
     if (!existingApiVersion) {
       diagnostics.add(

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -543,9 +543,6 @@ export interface SdkModelPropertyTypeBase<TType extends SdkTypeBase = SdkType>
   apiVersions: string[];
   onClient: boolean;
   clientDefaultValue?: unknown;
-  /**
-   * @deprecated This property is deprecated. See if the kind is `apiVersion` instead
-   */
   isApiVersionParam: boolean;
   optional: boolean;
   crossLanguageDefinitionId: string;
@@ -607,34 +604,17 @@ export interface SdkEndpointParameter
   serializedName?: string;
 }
 
-export interface SdkApiVersionParameter
-  extends SdkModelPropertyTypeBase<
-    SdkBuiltInType<"string"> | SdkEnumValueType<SdkBuiltInType<"string">>
-  > {
-  kind: "apiVersion";
-  onClient: true;
-  type: SdkBuiltInType<"string"> | SdkEnumValueType<SdkBuiltInType<"string">>;
-  isApiVersionParam: true;
-}
-
 export interface SdkCredentialParameter
   extends SdkModelPropertyTypeBase<SdkCredentialType | SdkUnionType<SdkCredentialType>> {
   kind: "credential";
   onClient: true;
 }
 
-export type SdkModelPropertyType<TType extends SdkTypeBase = SdkType> =
-  | SdkBodyModelPropertyType<TType>
-  | SdkParameter<TType>
-  | SdkEndpointParameter
-  | SdkCredentialParameter
-  | SdkApiVersionParameter
-  | SdkQueryParameter<TType>
-  | SdkPathParameter<TType>
-  | SdkBodyParameter<TType>
-  | SdkHeaderParameter<TType>
-  | SdkCookieParameter<TType>
-  | SdkServiceResponseHeader<TType>;
+export type SdkModelPropertyType =
+  | SdkBodyModelPropertyType
+  | SdkParameter
+  | SdkHttpParameter
+  | SdkServiceResponseHeader;
 
 export interface MultipartOptions {
   name: string;
@@ -650,8 +630,7 @@ export interface MultipartOptions {
   defaultContentTypes: string[];
 }
 
-export interface SdkBodyModelPropertyType<TType extends SdkTypeBase = SdkType>
-  extends SdkModelPropertyTypeBase<TType> {
+export interface SdkBodyModelPropertyType extends SdkModelPropertyTypeBase {
   kind: "property";
   discriminator: boolean;
   /**
@@ -672,16 +651,14 @@ export interface SdkBodyModelPropertyType<TType extends SdkTypeBase = SdkType>
 
 export type CollectionFormat = "multi" | "csv" | "ssv" | "tsv" | "pipes" | "simple" | "form";
 
-export interface SdkHeaderParameter<TType extends SdkTypeBase = SdkType>
-  extends SdkModelPropertyTypeBase<TType> {
+export interface SdkHeaderParameter extends SdkModelPropertyTypeBase {
   kind: "header";
   collectionFormat?: CollectionFormat;
   serializedName: string;
   correspondingMethodParams: SdkModelPropertyType[];
 }
 
-export interface SdkQueryParameter<TType extends SdkTypeBase = SdkType>
-  extends SdkModelPropertyTypeBase<TType> {
+export interface SdkQueryParameter extends SdkModelPropertyTypeBase {
   kind: "query";
   collectionFormat?: CollectionFormat;
   serializedName: string;
@@ -689,8 +666,7 @@ export interface SdkQueryParameter<TType extends SdkTypeBase = SdkType>
   explode: boolean;
 }
 
-export interface SdkPathParameter<TType extends SdkTypeBase = SdkType>
-  extends SdkModelPropertyTypeBase<TType> {
+export interface SdkPathParameter extends SdkModelPropertyTypeBase {
   kind: "path";
   /**
    * @deprecated This property is deprecated. Use `allowReserved` instead.
@@ -705,15 +681,13 @@ export interface SdkPathParameter<TType extends SdkTypeBase = SdkType>
   correspondingMethodParams: SdkModelPropertyType[];
 }
 
-export interface SdkCookieParameter<TType extends SdkTypeBase = SdkType>
-  extends SdkModelPropertyTypeBase<TType> {
+export interface SdkCookieParameter extends SdkModelPropertyTypeBase {
   kind: "cookie";
   serializedName: string;
   correspondingMethodParams: SdkModelPropertyType[];
 }
 
-export interface SdkBodyParameter<TType extends SdkTypeBase = SdkType>
-  extends SdkModelPropertyTypeBase<TType> {
+export interface SdkBodyParameter extends SdkModelPropertyTypeBase {
   kind: "body";
   serializedName: string;
   optional: boolean;
@@ -729,13 +703,11 @@ export type SdkHttpParameter =
   | SdkHeaderParameter
   | SdkCookieParameter;
 
-export interface SdkMethodParameter<TType extends SdkTypeBase = SdkType>
-  extends SdkModelPropertyTypeBase<TType> {
+export interface SdkMethodParameter extends SdkModelPropertyTypeBase {
   kind: "method";
 }
 
-export interface SdkServiceResponseHeader<TType extends SdkTypeBase = SdkType>
-  extends SdkModelPropertyTypeBase<TType> {
+export interface SdkServiceResponseHeader extends SdkModelPropertyTypeBase {
   __raw: ModelProperty;
   kind: "responseheader";
   serializedName: string;
@@ -778,11 +750,7 @@ export interface SdkHttpErrorResponse extends SdkHttpResponseBase {
 
 interface SdkServiceOperationBase {}
 
-export type SdkParameter<TType extends SdkTypeBase = SdkType> =
-  | SdkEndpointParameter
-  | SdkCredentialParameter
-  | SdkApiVersionParameter
-  | SdkMethodParameter<TType>;
+export type SdkParameter = SdkEndpointParameter | SdkCredentialParameter | SdkMethodParameter;
 
 export interface SdkHttpOperation extends SdkServiceOperationBase {
   __raw: HttpOperation;

--- a/packages/typespec-client-generator-core/test/clients/params.test.ts
+++ b/packages/typespec-client-generator-core/test/clients/params.test.ts
@@ -631,7 +631,7 @@ it("service with default api version, method with api version param", async () =
   strictEqual(clientApiVersionParam.name, "apiVersion");
   strictEqual(clientApiVersionParam.onClient, true);
   strictEqual(clientApiVersionParam.optional, false);
-  strictEqual(clientApiVersionParam.kind, "apiVersion");
+  strictEqual(clientApiVersionParam.kind, "method");
   strictEqual(clientApiVersionParam.clientDefaultValue, "2022-12-01-preview");
   strictEqual(clientApiVersionParam.isApiVersionParam, true);
   strictEqual(clientApiVersionParam.type.kind, "string");
@@ -685,7 +685,7 @@ it("service with default api version, method with path api version param", async
   strictEqual(clientApiVersionParam.name, "apiVersion");
   strictEqual(clientApiVersionParam.onClient, true);
   strictEqual(clientApiVersionParam.optional, false);
-  strictEqual(clientApiVersionParam.kind, "apiVersion");
+  strictEqual(clientApiVersionParam.kind, "method");
   strictEqual(clientApiVersionParam.clientDefaultValue, "2022-12-01-preview");
   strictEqual(clientApiVersionParam.isApiVersionParam, true);
   strictEqual(clientApiVersionParam.type.kind, "string");

--- a/packages/typespec-client-generator-core/test/clients/structure.test.ts
+++ b/packages/typespec-client-generator-core/test/clients/structure.test.ts
@@ -494,7 +494,7 @@ it("single with core", async () => {
   strictEqual(apiVersionParam.name, "apiVersion");
   strictEqual(apiVersionParam.onClient, true);
   strictEqual(apiVersionParam.optional, false);
-  strictEqual(apiVersionParam.kind, "apiVersion");
+  strictEqual(apiVersionParam.kind, "method");
   strictEqual(apiVersionParam.clientDefaultValue, "2022-12-01-preview");
 });
 
@@ -566,7 +566,7 @@ it("multiple with core", async () => {
   strictEqual(apiVersionParam.name, "apiVersion");
   strictEqual(apiVersionParam.onClient, true);
   strictEqual(apiVersionParam.optional, false);
-  strictEqual(apiVersionParam.kind, "apiVersion");
+  strictEqual(apiVersionParam.kind, "method");
   strictEqual(apiVersionParam.clientDefaultValue, "2022-12-01");
 });
 


### PR DESCRIPTION
1. since we could not use `SdkApiVersionParameter` in endpoint template arguments, we decided to rollback to previous logic of `isApiVersionParam`.
2. clean up some deprecations that emitter has already finished the migration.