### PR TITLE
Validate uptake of HTTP bodyKind: "file"

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "core"]
 	path = core
-	url = https://github.com/microsoft/typespec
-	branch = main
+	url = https://github.com/witemple-msft/typespec
+	branch = witemple-msft/http-file-body

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -111,6 +111,7 @@ import {
   HttpOperationMultipartBody,
   HttpOperationParameters,
   HttpOperationResponse,
+  HttpPayloadBody,
   HttpProperty,
   HttpStatusCodeRange,
   HttpStatusCodesEntry,
@@ -857,7 +858,7 @@ export async function getOpenAPIForService(
       openapiResponse["x-ms-error-response"] = true;
     }
     const contentTypes: string[] = [];
-    let body: HttpOperationBody | HttpOperationMultipartBody | undefined;
+    let body: HttpPayloadBody | undefined;
     for (const data of response.responses) {
       if (data.headers && Object.keys(data.headers).length > 0) {
         openapiResponse.headers ??= {};
@@ -890,11 +891,11 @@ export async function getOpenAPIForService(
   }
 
   function getSchemaForResponseBody(
-    body: HttpOperationBody | HttpOperationMultipartBody,
+    body: HttpPayloadBody,
     contentTypes: string[],
   ): OpenAPI2Schema | OpenAPI2FileSchema {
     const isBinary = contentTypes.every((t) => isBinaryPayload(body!.type, t));
-    if (isBinary) {
+    if (body.bodyKind === "file" || isBinary) {
       return { type: "file" };
     }
     if (body.bodyKind === "multipart") {
@@ -1145,16 +1146,24 @@ export async function getOpenAPIForService(
     }
   }
 
-  function emitBodyParameters(
-    body: HttpOperationBody | HttpOperationMultipartBody,
-    visibility: Visibility,
-  ) {
+  function emitBodyParameters(body: HttpPayloadBody, visibility: Visibility) {
     switch (body.bodyKind) {
       case "single":
         emitSingleBodyParameters(body, visibility);
         break;
       case "multipart":
         emitMultipartBodyParameters(body, visibility);
+        break;
+      case "file":
+        currentEndpoint.parameters.push({
+          name: "body",
+          in: "body",
+          schema: {
+            type: "string",
+            format: "binary",
+          },
+          required: true,
+        });
         break;
     }
   }

--- a/packages/typespec-azure-resource-manager/src/rules/arm-post-response-codes.ts
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-post-response-codes.ts
@@ -1,11 +1,7 @@
 import { Program, createRule } from "@typespec/compiler";
 
 import { getLroMetadata } from "@azure-tools/typespec-azure-core";
-import {
-  HttpOperationBody,
-  HttpOperationMultipartBody,
-  HttpOperationResponse,
-} from "@typespec/http";
+import { HttpOperationResponse, HttpPayloadBody } from "@typespec/http";
 import { ArmResourceOperation } from "../operations.js";
 import { getArmResources } from "../resource.js";
 
@@ -24,7 +20,7 @@ export const armPostResponseCodesRule = createRule({
   create(context) {
     function getResponseBody(
       response: HttpOperationResponse | undefined,
-    ): HttpOperationBody | HttpOperationMultipartBody | undefined {
+    ): HttpPayloadBody | undefined {
       if (response === undefined) return undefined;
       if (response.responses.length > 1) {
         throw new Error("Multiple responses are not supported.");

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -28,12 +28,7 @@ import {
   unsafe_mutateSubgraphWithNamespace,
   unsafe_MutatorWithNamespace,
 } from "@typespec/compiler/experimental";
-import {
-  HttpOperation,
-  HttpOperationBody,
-  HttpOperationMultipartBody,
-  HttpOperationResponseContent,
-} from "@typespec/http";
+import { HttpOperation, HttpOperationResponseContent, HttpPayloadBody } from "@typespec/http";
 import {
   getAddedOnVersions,
   getRemovedOnVersions,
@@ -489,8 +484,8 @@ export function twoParamsEquivalent(
  * @param parameters
  * @returns
  */
-export function isHttpBodySpread(httpBody: HttpOperationBody | HttpOperationMultipartBody) {
-  return httpBody.property === undefined;
+export function isHttpBodySpread(httpBody: HttpPayloadBody): boolean {
+  return httpBody.bodyKind !== "file" && httpBody.property === undefined;
 }
 
 /**


### PR DESCRIPTION
This is the Azure companion of https://github.com/microsoft/typespec/pull/6563

So far, this PR does the minimum required to get the azure packages to build with the changes

- everywhere: use HttpPayloadBody instead of HttpOperationBody | HttpOperationMultipartBody to allow `"file"` bodies to flow.
- TCGC: exempt `"file"` bodies from isHttpBodySpread.
- typespec-autorest: treat `"file"` bodies as binary bodies