### PR TITLE
[tcgc] emitter options split

### DIFF
--- a/.chronus/changes/tcgc-emitterOptionsSplit-2025-2-25-17-26-43.md
+++ b/.chronus/changes/tcgc-emitterOptionsSplit-2025-2-25-17-26-43.md
@@ -1,5 +1,5 @@
 ---
-changeKind: feature
+changeKind: breaking
 packages:
   - "@azure-tools/typespec-client-generator-core"
 ---

--- a/.chronus/changes/tcgc-emitterOptionsSplit-2025-2-25-17-26-43.md
+++ b/.chronus/changes/tcgc-emitterOptionsSplit-2025-2-25-17-26-43.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+split up emitter options into unbranded and branded

--- a/.chronus/changes/tcgc-emitterOptionsSplit-2025-2-25-17-26-43.md
+++ b/.chronus/changes/tcgc-emitterOptionsSplit-2025-2-25-17-26-43.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-client-generator-core"
 ---
 
-split up emitter options into unbranded and branded
+Split emitter options into `UnbrandedSdkEmitterOptions` and `BrandedSdkEmitterOptions`. Each flag will be exported individually, so emitters can choose which flags to support

--- a/packages/typespec-client-generator-core/README.md
+++ b/packages/typespec-client-generator-core/README.md
@@ -53,18 +53,6 @@ When set to `true`, the emitter will generate low-level protocol methods for eac
 
 When set to `true`, the emitter will generate low-level protocol methods for each service operation if `@convenientAPI` is not set for an operation. Default value is `true`.
 
-### `examples-dir`
-
-**Type:** `string`
-
-Specifies the directory where the emitter will look for example files. If the flag isn’t set, the emitter defaults to using an `examples` directory located at the project root.
-
-### `namespace`
-
-**Type:** `string`
-
-Specifies the namespace you want to override for namespaces set in the spec. With this config, all namespace for the spec types will default to it.
-
 ### `api-version`
 
 **Type:** `string`
@@ -76,6 +64,18 @@ Use this flag if you would like to generate the sdk only for a specific version.
 **Type:** `object`
 
 License information for the generated client code.
+
+### `examples-dir`
+
+**Type:** `string`
+
+Specifies the directory where the emitter will look for example files. If the flag isn’t set, the emitter defaults to using an `examples` directory located at the project root.
+
+### `namespace`
+
+**Type:** `string`
+
+Specifies the namespace you want to override for namespaces set in the spec. With this config, all namespace for the spec types will default to it.
 
 ## Usage
 

--- a/packages/typespec-client-generator-core/src/context.ts
+++ b/packages/typespec-client-generator-core/src/context.ts
@@ -28,7 +28,7 @@ import {
   TCGCContext,
 } from "./interfaces.js";
 import {
-  BrandedSdkEmitterOptions,
+  BrandedSdkEmitterOptionsInterface,
   handleVersioningMutationForGlobalNamespace,
   parseEmitterName,
   TCGCEmitterOptions,
@@ -100,7 +100,7 @@ export interface CreateSdkContextOptions {
 }
 
 export async function createSdkContext<
-  TOptions extends Record<string, any> = BrandedSdkEmitterOptions,
+  TOptions extends Record<string, any> = BrandedSdkEmitterOptionsInterface,
   TServiceOperation extends SdkServiceOperation = SdkHttpOperation,
 >(
   context: EmitContext<TOptions>,

--- a/packages/typespec-client-generator-core/src/context.ts
+++ b/packages/typespec-client-generator-core/src/context.ts
@@ -38,12 +38,11 @@ export interface TCGCEmitterOptions extends SdkEmitterOptions {
   "emitter-name"?: string;
 }
 
-export interface SdkEmitterOptions {
+export interface UnbrandedSdkEmitterOptions {
   "generate-protocol-methods"?: boolean;
   "generate-convenience-methods"?: boolean;
   "api-version"?: string;
   "examples-dir"?: string;
-  namespace?: string;
   license?: {
     name: string;
     company?: string;
@@ -51,6 +50,10 @@ export interface SdkEmitterOptions {
     header?: string;
     description?: string;
   };
+}
+
+export interface SdkEmitterOptions extends UnbrandedSdkEmitterOptions {
+  namespace?: string;
 }
 
 export function createTCGCContext(program: Program, emitterName?: string): TCGCContext {

--- a/packages/typespec-client-generator-core/src/context.ts
+++ b/packages/typespec-client-generator-core/src/context.ts
@@ -28,33 +28,14 @@ import {
   TCGCContext,
 } from "./interfaces.js";
 import {
+  BrandedSdkEmitterOptions,
   handleVersioningMutationForGlobalNamespace,
   parseEmitterName,
+  TCGCEmitterOptions,
   TspLiteralType,
+
 } from "./internal-utils.js";
 import { getSdkPackage } from "./package.js";
-
-export interface TCGCEmitterOptions extends SdkEmitterOptions {
-  "emitter-name"?: string;
-}
-
-export interface UnbrandedSdkEmitterOptions {
-  "generate-protocol-methods"?: boolean;
-  "generate-convenience-methods"?: boolean;
-  "api-version"?: string;
-  "examples-dir"?: string;
-  license?: {
-    name: string;
-    company?: string;
-    link?: string;
-    header?: string;
-    description?: string;
-  };
-}
-
-export interface SdkEmitterOptions extends UnbrandedSdkEmitterOptions {
-  namespace?: string;
-}
 
 export function createTCGCContext(program: Program, emitterName?: string): TCGCContext {
   const diagnostics = createDiagnosticCollector();
@@ -120,7 +101,7 @@ export interface CreateSdkContextOptions {
 }
 
 export async function createSdkContext<
-  TOptions extends Record<string, any> = SdkEmitterOptions,
+  TOptions extends Record<string, any> = BrandedSdkEmitterOptions,
   TServiceOperation extends SdkServiceOperation = SdkHttpOperation,
 >(
   context: EmitContext<TOptions>,

--- a/packages/typespec-client-generator-core/src/context.ts
+++ b/packages/typespec-client-generator-core/src/context.ts
@@ -33,7 +33,6 @@ import {
   parseEmitterName,
   TCGCEmitterOptions,
   TspLiteralType,
-
 } from "./internal-utils.js";
 import { getSdkPackage } from "./package.js";
 

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -63,11 +63,11 @@ import { getClientTypeWithDiagnostics } from "./types.js";
 
 import { $ } from "@typespec/compiler/experimental/typekit";
 
-export interface TCGCEmitterOptions extends BrandedSdkEmitterOptions {
+export interface TCGCEmitterOptions extends BrandedSdkEmitterOptionsInterface {
   "emitter-name"?: string;
 }
 
-export interface UnbrandedSdkEmitterOptions {
+export interface UnbrandedSdkEmitterOptionsInterface {
   "generate-protocol-methods"?: boolean;
   "generate-convenience-methods"?: boolean;
   "api-version"?: string;
@@ -80,7 +80,7 @@ export interface UnbrandedSdkEmitterOptions {
   };
 }
 
-export interface BrandedSdkEmitterOptions extends UnbrandedSdkEmitterOptions {
+export interface BrandedSdkEmitterOptionsInterface extends UnbrandedSdkEmitterOptionsInterface {
   "examples-dir"?: string;
   namespace?: string;
 }

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -63,6 +63,28 @@ import { getClientTypeWithDiagnostics } from "./types.js";
 
 import { $ } from "@typespec/compiler/experimental/typekit";
 
+export interface TCGCEmitterOptions extends BrandedSdkEmitterOptions {
+  "emitter-name"?: string;
+}
+
+export interface UnbrandedSdkEmitterOptions {
+  "generate-protocol-methods"?: boolean;
+  "generate-convenience-methods"?: boolean;
+  "api-version"?: string;
+  license?: {
+    name: string;
+    company?: string;
+    link?: string;
+    header?: string;
+    description?: string;
+  };
+}
+
+export interface BrandedSdkEmitterOptions extends UnbrandedSdkEmitterOptions {
+  "examples-dir"?: string;
+  namespace?: string;
+}
+
 export const AllScopes = Symbol.for("@azure-core/typespec-client-generator-core/all-scopes");
 
 export const clientNameKey = createStateSymbol("clientName");

--- a/packages/typespec-client-generator-core/src/lib.ts
+++ b/packages/typespec-client-generator-core/src/lib.ts
@@ -1,7 +1,7 @@
 import { createTypeSpecLibrary, JSONSchemaType, paramMessage } from "@typespec/compiler";
-import { SdkEmitterOptions, TCGCEmitterOptions } from "./context.js";
+import { SdkEmitterOptions, TCGCEmitterOptions, UnbrandedSdkEmitterOptions } from "./context.js";
 
-export const SdkEmitterOptionsSchema: JSONSchemaType<SdkEmitterOptions> = {
+export const UnbrandedSdkEmitterOptionsSchema: JSONSchemaType<UnbrandedSdkEmitterOptions> = {
   type: "object",
   additionalProperties: false,
   properties: {
@@ -23,12 +23,6 @@ export const SdkEmitterOptionsSchema: JSONSchemaType<SdkEmitterOptions> = {
       format: "absolute-path",
       description:
         "Specifies the directory where the emitter will look for example files. If the flag isn’t set, the emitter defaults to using an `examples` directory located at the project root.",
-    },
-    namespace: {
-      type: "string",
-      nullable: true,
-      description:
-        "Specifies the namespace you want to override for namespaces set in the spec. With this config, all namespace for the spec types will default to it.",
     },
     "api-version": {
       type: "string",
@@ -72,6 +66,20 @@ export const SdkEmitterOptionsSchema: JSONSchemaType<SdkEmitterOptions> = {
       },
       description: "License information for the generated client code.",
     },
+  },
+};
+
+export const SdkEmitterOptionsSchema: JSONSchemaType<SdkEmitterOptions> = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    namespace: {
+      type: "string",
+      nullable: true,
+      description:
+        "Specifies the namespace you want to override for namespaces set in the spec. With this config, all namespace for the spec types will default to it.",
+    },
+    ...UnbrandedSdkEmitterOptionsSchema.properties!,
   },
 };
 

--- a/packages/typespec-client-generator-core/src/lib.ts
+++ b/packages/typespec-client-generator-core/src/lib.ts
@@ -1,11 +1,11 @@
 import { createTypeSpecLibrary, JSONSchemaType, paramMessage } from "@typespec/compiler";
 import {
-  BrandedSdkEmitterOptions,
+  BrandedSdkEmitterOptionsInterface,
   TCGCEmitterOptions,
-  UnbrandedSdkEmitterOptions,
+  UnbrandedSdkEmitterOptionsInterface,
 } from "./internal-utils.js";
 
-export const UnbrandedTcgcOptions = {
+export const UnbrandedSdkEmitterOptions = {
   "generate-protocol-methods": {
     "generate-protocol-methods": {
       type: "boolean",
@@ -70,18 +70,19 @@ export const UnbrandedTcgcOptions = {
   },
 } as const;
 
-const UnbrandedSdkEmitterOptionsSchema: JSONSchemaType<UnbrandedSdkEmitterOptions> = {
-  type: "object",
-  additionalProperties: false,
-  properties: {
-    ...UnbrandedTcgcOptions["generate-protocol-methods"],
-    ...UnbrandedTcgcOptions["generate-convenience-methods"],
-    ...UnbrandedTcgcOptions["api-version"],
-    ...UnbrandedTcgcOptions["license"],
-  },
-};
+const UnbrandedSdkEmitterOptionsInterfaceSchema: JSONSchemaType<UnbrandedSdkEmitterOptionsInterface> =
+  {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      ...UnbrandedSdkEmitterOptions["generate-protocol-methods"],
+      ...UnbrandedSdkEmitterOptions["generate-convenience-methods"],
+      ...UnbrandedSdkEmitterOptions["api-version"],
+      ...UnbrandedSdkEmitterOptions["license"],
+    },
+  };
 
-export const BrandedTcgcOptions = {
+export const BrandedSdkEmitterOptions = {
   "examples-dir": {
     "examples-dir": {
       type: "string",
@@ -101,13 +102,13 @@ export const BrandedTcgcOptions = {
   },
 } as const;
 
-const BrandedSdkEmitterOptionsSchema: JSONSchemaType<BrandedSdkEmitterOptions> = {
+const BrandedSdkEmitterOptionsSchema: JSONSchemaType<BrandedSdkEmitterOptionsInterface> = {
   type: "object",
   additionalProperties: false,
   properties: {
-    ...UnbrandedSdkEmitterOptionsSchema.properties!,
-    ...BrandedTcgcOptions["examples-dir"],
-    ...BrandedTcgcOptions["namespace"],
+    ...UnbrandedSdkEmitterOptionsInterfaceSchema.properties!,
+    ...BrandedSdkEmitterOptions["examples-dir"],
+    ...BrandedSdkEmitterOptions["namespace"],
   },
 };
 

--- a/packages/typespec-client-generator-core/src/lib.ts
+++ b/packages/typespec-client-generator-core/src/lib.ts
@@ -1,35 +1,36 @@
 import { createTypeSpecLibrary, JSONSchemaType, paramMessage } from "@typespec/compiler";
-import { SdkEmitterOptions, TCGCEmitterOptions, UnbrandedSdkEmitterOptions } from "./context.js";
+import {
+  BrandedSdkEmitterOptions,
+  TCGCEmitterOptions,
+  UnbrandedSdkEmitterOptions,
+} from "./internal-utils.js";
 
-export const UnbrandedSdkEmitterOptionsSchema: JSONSchemaType<UnbrandedSdkEmitterOptions> = {
-  type: "object",
-  additionalProperties: false,
-  properties: {
+export const UnbrandedTcgcOptions = {
+  "generate-protocol-methods": {
     "generate-protocol-methods": {
       type: "boolean",
       nullable: true,
       description:
         "When set to `true`, the emitter will generate low-level protocol methods for each service operation if `@protocolAPI` is not set for an operation. Default value is `true`.",
     },
+  },
+  "generate-convenience-methods": {
     "generate-convenience-methods": {
       type: "boolean",
       nullable: true,
       description:
         "When set to `true`, the emitter will generate low-level protocol methods for each service operation if `@convenientAPI` is not set for an operation. Default value is `true`.",
     },
-    "examples-dir": {
-      type: "string",
-      nullable: true,
-      format: "absolute-path",
-      description:
-        "Specifies the directory where the emitter will look for example files. If the flag isn’t set, the emitter defaults to using an `examples` directory located at the project root.",
-    },
+  },
+  "api-version": {
     "api-version": {
       type: "string",
       nullable: true,
       description:
         "Use this flag if you would like to generate the sdk only for a specific version. Default value is the latest version. Also accepts values `latest` and `all`.",
     },
+  },
+  license: {
     license: {
       type: "object",
       additionalProperties: false,
@@ -67,19 +68,46 @@ export const UnbrandedSdkEmitterOptionsSchema: JSONSchemaType<UnbrandedSdkEmitte
       description: "License information for the generated client code.",
     },
   },
-};
+} as const;
 
-export const SdkEmitterOptionsSchema: JSONSchemaType<SdkEmitterOptions> = {
+const UnbrandedSdkEmitterOptionsSchema: JSONSchemaType<UnbrandedSdkEmitterOptions> = {
   type: "object",
   additionalProperties: false,
   properties: {
+    ...UnbrandedTcgcOptions["generate-protocol-methods"],
+    ...UnbrandedTcgcOptions["generate-convenience-methods"],
+    ...UnbrandedTcgcOptions["api-version"],
+    ...UnbrandedTcgcOptions["license"],
+  },
+};
+
+export const BrandedTcgcOptions = {
+  "examples-dir": {
+    "examples-dir": {
+      type: "string",
+      nullable: true,
+      format: "absolute-path",
+      description:
+        "Specifies the directory where the emitter will look for example files. If the flag isn’t set, the emitter defaults to using an `examples` directory located at the project root.",
+    },
+  },
+  namespace: {
     namespace: {
       type: "string",
       nullable: true,
       description:
         "Specifies the namespace you want to override for namespaces set in the spec. With this config, all namespace for the spec types will default to it.",
     },
+  },
+} as const;
+
+const BrandedSdkEmitterOptionsSchema: JSONSchemaType<BrandedSdkEmitterOptions> = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
     ...UnbrandedSdkEmitterOptionsSchema.properties!,
+    ...BrandedTcgcOptions["examples-dir"],
+    ...BrandedTcgcOptions["namespace"],
   },
 };
 
@@ -92,7 +120,7 @@ const TCGCEmitterOptionsSchema: JSONSchemaType<TCGCEmitterOptions> = {
       nullable: true,
       description: "Set `emitter-name` to output TCGC code models for specific language's emitter.",
     },
-    ...SdkEmitterOptionsSchema.properties!,
+    ...BrandedSdkEmitterOptionsSchema.properties!,
   },
 };
 

--- a/packages/typespec-client-generator-core/test/namespaces.test.ts
+++ b/packages/typespec-client-generator-core/test/namespaces.test.ts
@@ -1,7 +1,7 @@
 import { AzureCoreTestLibrary } from "@azure-tools/typespec-azure-core/testing";
 import { ok, strictEqual } from "assert";
 import { beforeEach, describe, it } from "vitest";
-import { SdkEmitterOptions } from "../src/context.js";
+import { BrandedSdkEmitterOptions } from "../src/internal-utils.js";
 import { SdkTestRunner, createSdkContextTestHelper, createSdkTestRunner } from "./test-host.js";
 
 let runner: SdkTestRunner;
@@ -257,7 +257,7 @@ describe("no namespace flag", () => {
       `,
     );
     const sdkPackage = (
-      await createSdkContextTestHelper<SdkEmitterOptions>(runner.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
         namespace: "PetStoreRenamed",
       })
     ).sdkPackage;
@@ -278,7 +278,7 @@ describe("namespace config flag", () => {
     `);
 
     const sdkPackage = (
-      await createSdkContextTestHelper<SdkEmitterOptions>(runner.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
         namespace: "Azure.Foo",
       })
     ).sdkPackage;
@@ -319,7 +319,7 @@ describe("namespace config flag", () => {
       }
     `);
     const sdkPackage = (
-      await createSdkContextTestHelper<SdkEmitterOptions>(runner.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
         namespace: "FooRenamed",
       })
     ).sdkPackage;
@@ -360,7 +360,7 @@ describe("namespace config flag", () => {
       `,
     );
     const sdkPackage = (
-      await createSdkContextTestHelper<SdkEmitterOptions>(runner.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
         namespace: "PetStoreRenamed",
       })
     ).sdkPackage;
@@ -379,7 +379,7 @@ describe("namespace config flag", () => {
     `);
 
     const sdkPackage = (
-      await createSdkContextTestHelper<SdkEmitterOptions>(runnerWithCore.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runnerWithCore.context.program, {
         namespace: "Azure.My.Service",
       })
     ).sdkPackage;
@@ -437,7 +437,7 @@ describe("namespace config flag", () => {
     `,
     );
     const sdkPackage = (
-      await createSdkContextTestHelper<SdkEmitterOptions>(runner.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
         namespace: "PetStoreFlagRenamed",
       })
     ).sdkPackage;
@@ -479,7 +479,7 @@ describe("namespace config flag", () => {
       `,
     );
     const sdkPackage = (
-      await createSdkContextTestHelper<SdkEmitterOptions>(runner.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
         namespace: "PetStoreFlagRenamed",
       })
     ).sdkPackage;
@@ -516,7 +516,7 @@ describe("namespace config flag", () => {
     `);
 
     const sdkPackage = (
-      await createSdkContextTestHelper<SdkEmitterOptions>(runner.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
         namespace: "Azure.A",
       })
     ).sdkPackage;
@@ -555,7 +555,7 @@ it("customization with models from original namespace", async () => {
   );
 
   const sdkPackage = (
-    await createSdkContextTestHelper<SdkEmitterOptions>(runner.context.program, {
+    await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
       namespace: "Renamed",
     })
   ).sdkPackage;

--- a/packages/typespec-client-generator-core/test/namespaces.test.ts
+++ b/packages/typespec-client-generator-core/test/namespaces.test.ts
@@ -1,7 +1,7 @@
 import { AzureCoreTestLibrary } from "@azure-tools/typespec-azure-core/testing";
 import { ok, strictEqual } from "assert";
 import { beforeEach, describe, it } from "vitest";
-import { BrandedSdkEmitterOptions } from "../src/internal-utils.js";
+import { BrandedSdkEmitterOptionsInterface } from "../src/internal-utils.js";
 import { SdkTestRunner, createSdkContextTestHelper, createSdkTestRunner } from "./test-host.js";
 
 let runner: SdkTestRunner;
@@ -257,7 +257,7 @@ describe("no namespace flag", () => {
       `,
     );
     const sdkPackage = (
-      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptionsInterface>(runner.context.program, {
         namespace: "PetStoreRenamed",
       })
     ).sdkPackage;
@@ -278,7 +278,7 @@ describe("namespace config flag", () => {
     `);
 
     const sdkPackage = (
-      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptionsInterface>(runner.context.program, {
         namespace: "Azure.Foo",
       })
     ).sdkPackage;
@@ -319,7 +319,7 @@ describe("namespace config flag", () => {
       }
     `);
     const sdkPackage = (
-      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptionsInterface>(runner.context.program, {
         namespace: "FooRenamed",
       })
     ).sdkPackage;
@@ -360,7 +360,7 @@ describe("namespace config flag", () => {
       `,
     );
     const sdkPackage = (
-      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptionsInterface>(runner.context.program, {
         namespace: "PetStoreRenamed",
       })
     ).sdkPackage;
@@ -379,9 +379,12 @@ describe("namespace config flag", () => {
     `);
 
     const sdkPackage = (
-      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runnerWithCore.context.program, {
-        namespace: "Azure.My.Service",
-      })
+      await createSdkContextTestHelper<BrandedSdkEmitterOptionsInterface>(
+        runnerWithCore.context.program,
+        {
+          namespace: "Azure.My.Service",
+        },
+      )
     ).sdkPackage;
 
     const myNamespace = sdkPackage.namespaces.find((x) => x.name === "My");
@@ -437,7 +440,7 @@ describe("namespace config flag", () => {
     `,
     );
     const sdkPackage = (
-      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptionsInterface>(runner.context.program, {
         namespace: "PetStoreFlagRenamed",
       })
     ).sdkPackage;
@@ -479,7 +482,7 @@ describe("namespace config flag", () => {
       `,
     );
     const sdkPackage = (
-      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptionsInterface>(runner.context.program, {
         namespace: "PetStoreFlagRenamed",
       })
     ).sdkPackage;
@@ -516,7 +519,7 @@ describe("namespace config flag", () => {
     `);
 
     const sdkPackage = (
-      await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
+      await createSdkContextTestHelper<BrandedSdkEmitterOptionsInterface>(runner.context.program, {
         namespace: "Azure.A",
       })
     ).sdkPackage;
@@ -555,7 +558,7 @@ it("customization with models from original namespace", async () => {
   );
 
   const sdkPackage = (
-    await createSdkContextTestHelper<BrandedSdkEmitterOptions>(runner.context.program, {
+    await createSdkContextTestHelper<BrandedSdkEmitterOptionsInterface>(runner.context.program, {
       namespace: "Renamed",
     })
   ).sdkPackage;

--- a/packages/typespec-client-generator-core/test/test-host.ts
+++ b/packages/typespec-client-generator-core/test/test-host.ts
@@ -11,11 +11,12 @@ import {
 import { HttpTestLibrary } from "@typespec/http/testing";
 import { RestTestLibrary } from "@typespec/rest/testing";
 import { VersioningTestLibrary } from "@typespec/versioning/testing";
-import { CreateSdkContextOptions, SdkEmitterOptions, createSdkContext } from "../src/context.js";
+import { CreateSdkContextOptions, createSdkContext } from "../src/context.js";
 import { SdkContext, SdkHttpOperation, SdkServiceOperation } from "../src/interfaces.js";
+import { BrandedSdkEmitterOptions } from "../src/internal-utils.js";
 import { SdkTestLibrary } from "../src/testing/index.js";
 
-export interface CreateSdkTestRunnerOptions extends SdkEmitterOptions {
+export interface CreateSdkTestRunnerOptions extends BrandedSdkEmitterOptions {
   emitterName?: string;
   librariesToAdd?: TypeSpecTestLibrary[];
   autoImports?: string[];

--- a/packages/typespec-client-generator-core/test/test-host.ts
+++ b/packages/typespec-client-generator-core/test/test-host.ts
@@ -13,10 +13,10 @@ import { RestTestLibrary } from "@typespec/rest/testing";
 import { VersioningTestLibrary } from "@typespec/versioning/testing";
 import { CreateSdkContextOptions, createSdkContext } from "../src/context.js";
 import { SdkContext, SdkHttpOperation, SdkServiceOperation } from "../src/interfaces.js";
-import { BrandedSdkEmitterOptions } from "../src/internal-utils.js";
+import { BrandedSdkEmitterOptionsInterface } from "../src/internal-utils.js";
 import { SdkTestLibrary } from "../src/testing/index.js";
 
-export interface CreateSdkTestRunnerOptions extends BrandedSdkEmitterOptions {
+export interface CreateSdkTestRunnerOptions extends BrandedSdkEmitterOptionsInterface {
   emitterName?: string;
   librariesToAdd?: TypeSpecTestLibrary[];
   autoImports?: string[];

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/emitter.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/emitter.md
@@ -47,18 +47,6 @@ When set to `true`, the emitter will generate low-level protocol methods for eac
 
 When set to `true`, the emitter will generate low-level protocol methods for each service operation if `@convenientAPI` is not set for an operation. Default value is `true`.
 
-### `examples-dir`
-
-**Type:** `string`
-
-Specifies the directory where the emitter will look for example files. If the flag isn’t set, the emitter defaults to using an `examples` directory located at the project root.
-
-### `namespace`
-
-**Type:** `string`
-
-Specifies the namespace you want to override for namespaces set in the spec. With this config, all namespace for the spec types will default to it.
-
 ### `api-version`
 
 **Type:** `string`
@@ -70,3 +58,15 @@ Use this flag if you would like to generate the sdk only for a specific version.
 **Type:** `object`
 
 License information for the generated client code.
+
+### `examples-dir`
+
+**Type:** `string`
+
+Specifies the directory where the emitter will look for example files. If the flag isn’t set, the emitter defaults to using an `examples` directory located at the project root.
+
+### `namespace`
+
+**Type:** `string`
+
+Specifies the namespace you want to override for namespaces set in the spec. With this config, all namespace for the spec types will default to it.


### PR DESCRIPTION
BREAKING: emitter options will now be individually exposed and split into `BrandedSdkEmitterOptions` and `UnbrandedSdkEmitterOptions`. This change allows emitters to choose which flags to support, BUT it means that you will have to explicitly choose the flags to support. Example code snippet in an emitter:

```ts
import { BrandedSdkEmitterOptions, UnbrandedSdkEmitterOptions } from "@azure-tools/typespec-client-generator-core"

const UnbrandedPythonEmitterOptionsSchema: JSONSchemaType<UnbrandedPythonEmitterOptions> = {
  type: "object",
  additionalProperties: true,
  properties: {
    "python-specific-flag": {...},
    ...UnbrandedSdkEmitterOptions["api-version"],
    ...UnbrandedSdkEmitterOptions["license"],
  }
}

const BrandedPythonEmitterOptionsSchema: JSONSchemaType<BrandedPythonEmitterOptions> = {
  type: "object",
  additionalProperties: true,
  properties: {
    "branded-python-specific-flag": {...},
    ...BrandedSdkEmitterOptions["namespace"],
    ...UnbrandedPythonEmitterOptionsSchema.properties,
  }
}
```