### PR TITLE
Fix multipart issues

### DIFF
--- a/.chronus/changes/fix-multipart-issues-2025-2-28-2-35-5.md
+++ b/.chronus/changes/fix-multipart-issues-2025-2-28-2-35-5.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Fix multipart not applying `x-ms-client-name` when using an explicit part name different from the property name

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -1196,17 +1196,20 @@ export async function getOpenAPIForService(
             items: schema.type === "file" ? { type: "string", format: "binary" } : schema,
           };
         }
-        let description;
-        if (part.property) {
-          description = getDoc(program, part.property);
-        }
-        currentEndpoint.parameters.push({
+
+        const param: OpenAPI2Parameter = {
           name: partName,
           in: "formData",
           required: !part.optional,
-          ...(description ? { description } : {}),
           ...schema,
-        });
+        };
+        if (part.property) {
+          param.description = getDoc(program, part.property);
+          if (part.property.name !== partName) {
+            param["x-ms-client-name"] = part.property.name;
+          }
+        }
+        currentEndpoint.parameters.push(param);
       }
     }
   }


### PR DESCRIPTION
fix  #2462 `x-ms-client-name` not applied when part has a different name from property
fix  #2463 Description on targeted schema won over the property description