### PR TITLE
[tcgc] fix tcgc issues

### DIFF
--- a/.chronus/changes/fix_target-2025-2-31-11-39-58.md
+++ b/.chronus/changes/fix_target-2025-2-31-11-39-58.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Change diagnostic target for `no-corresponding-method-param` error.

--- a/.chronus/changes/fix_target-2025-2-31-20-5-48.md
+++ b/.chronus/changes/fix_target-2025-2-31-20-5-48.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Change default endpoint's type to `url` and `allowReserved` to `true`.

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -385,16 +385,21 @@ export function getSdkHttpParameter(
   const program = context.program;
   const correspondingMethodParams: SdkParameter[] = []; // we set it later in the operation
   if (isPathParam(context.program, param) || location === "path") {
-    // we don't url encode if the type can be assigned to url
-    const urlEncode = !ignoreDiagnostics(
-      program.checker.isTypeAssignableTo(param.type, program.checker.getStdType("url"), param.type),
-    );
     return diagnostics.wrap({
       ...base,
       kind: "path",
       explode: (httpParam as HttpOperationPathParameter)?.explode ?? false,
       style: (httpParam as HttpOperationPathParameter)?.style ?? "simple",
-      allowReserved: (httpParam as HttpOperationPathParameter)?.allowReserved ?? !urlEncode,
+      // url type need allow reserved
+      allowReserved:
+        (httpParam as HttpOperationPathParameter)?.allowReserved ??
+        ignoreDiagnostics(
+          program.checker.isTypeAssignableTo(
+            param.type,
+            program.checker.getStdType("url"),
+            param.type,
+          ),
+        ),
       serializedName: getPathParamName(program, param) ?? base.name,
       correspondingMethodParams,
       optional: false,

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -590,7 +590,7 @@ export function getCorrespondingMethodParams(
       diagnostics.add(
         createDiagnostic({
           code: "no-corresponding-method-param",
-          target: serviceParam.__raw!,
+          target: operation,
           format: {
             paramName: "apiVersion",
             methodName: operation.name,
@@ -609,7 +609,7 @@ export function getCorrespondingMethodParams(
       diagnostics.add(
         createDiagnostic({
           code: "no-corresponding-method-param",
-          target: serviceParam.__raw!,
+          target: operation,
           format: {
             paramName: "subscriptionId",
             methodName: operation.name,
@@ -649,7 +649,7 @@ export function getCorrespondingMethodParams(
   diagnostics.add(
     createDiagnostic({
       code: "no-corresponding-method-param",
-      target: serviceParam.__raw!,
+      target: operation,
       format: {
         paramName: serviceParam.name,
         methodName: operation.name,

--- a/packages/typespec-client-generator-core/src/lib.ts
+++ b/packages/typespec-client-generator-core/src/lib.ts
@@ -215,7 +215,7 @@ export const $lib = createTypeSpecLibrary({
     "no-corresponding-method-param": {
       severity: "error",
       messages: {
-        default: paramMessage`Missing "${"paramName"}" http operation parameter in method "${"methodName"}". Please check the method definition.`,
+        default: paramMessage`Missing HTTP operation parameter "${"paramName"}" in method "${"methodName"}". Please check the method definition.`,
       },
     },
     "unsupported-protocol": {

--- a/packages/typespec-client-generator-core/src/lib.ts
+++ b/packages/typespec-client-generator-core/src/lib.ts
@@ -215,7 +215,7 @@ export const $lib = createTypeSpecLibrary({
     "no-corresponding-method-param": {
       severity: "error",
       messages: {
-        default: paramMessage`Missing "${"paramName"}" method parameter in method "${"methodName"}", when "${"paramName"}" must be sent to the service. Add a parameter named "${"paramName"}" to the method.`,
+        default: paramMessage`Missing "${"paramName"}" http operation parameter in method "${"methodName"}". Please check the method definition.`,
       },
     },
     "unsupported-protocol": {

--- a/packages/typespec-client-generator-core/src/package.ts
+++ b/packages/typespec-client-generator-core/src/package.ts
@@ -14,6 +14,7 @@ import {
   ModelProperty,
   Operation,
 } from "@typespec/compiler";
+import { $ } from "@typespec/compiler/experimental/typekit";
 import { getServers, HttpServer, isHeader } from "@typespec/http";
 import { resolveVersions } from "@typespec/versioning";
 import {
@@ -87,10 +88,10 @@ import {
 import {
   getAllReferencedTypes,
   getClientTypeWithDiagnostics,
+  getSdkBuiltInType,
   getSdkCredentialParameter,
   getSdkModelPropertyType,
   getSdkModelWithDiagnostics,
-  getTypeSpecBuiltInType,
   handleAllTypes,
 } from "./types.js";
 
@@ -872,11 +873,11 @@ function getEndpointTypeFromSingleServer<
         onClient: true,
         explode: false,
         style: "simple",
-        allowReserved: false,
+        allowReserved: true,
         optional: false,
         serializedName: "endpoint",
         correspondingMethodParams: [],
-        type: getTypeSpecBuiltInType(context, "string"),
+        type: getSdkBuiltInType(context, $.builtin.url),
         isApiVersionParam: false,
         apiVersions: context.getApiVersionsForType(client.__raw.type),
         crossLanguageDefinitionId: `${getCrossLanguageDefinitionId(context, client.__raw.service)}.endpoint`,

--- a/packages/typespec-client-generator-core/test/clients/params.test.ts
+++ b/packages/typespec-client-generator-core/test/clients/params.test.ts
@@ -87,8 +87,8 @@ it("initialization default endpoint no credential", async () => {
   strictEqual(templateArg.kind, "path");
   strictEqual(templateArg.name, "endpoint");
   strictEqual(templateArg.serializedName, "endpoint");
-  strictEqual(templateArg.allowReserved, false);
-  strictEqual(templateArg.type.kind, "string");
+  strictEqual(templateArg.allowReserved, true);
+  strictEqual(templateArg.type.kind, "url");
   strictEqual(templateArg.optional, false);
   strictEqual(templateArg.onClient, true);
   strictEqual(templateArg.clientDefaultValue, "http://localhost:3000");
@@ -115,7 +115,8 @@ it("initialization default endpoint with apikey auth", async () => {
   strictEqual(endpointParam.type.templateArguments.length, 1);
   const templateArg = endpointParam.type.templateArguments[0];
   strictEqual(templateArg.kind, "path");
-  strictEqual(templateArg.type.kind, "string");
+  strictEqual(templateArg.allowReserved, true);
+  strictEqual(templateArg.type.kind, "url");
   strictEqual(templateArg.clientDefaultValue, "http://localhost:3000");
 
   const credentialParam = client.clientInitialization.parameters.filter(
@@ -158,7 +159,8 @@ it("initialization default endpoint with bearer auth", async () => {
   strictEqual(endpointParam.type.templateArguments.length, 1);
   const templateArg = endpointParam.type.templateArguments[0];
   strictEqual(templateArg.kind, "path");
-  strictEqual(templateArg.type.kind, "string");
+  strictEqual(templateArg.allowReserved, true);
+  strictEqual(templateArg.type.kind, "url");
   strictEqual(templateArg.optional, false);
   strictEqual(templateArg.onClient, true);
   strictEqual(templateArg.clientDefaultValue, "http://localhost:3000");


### PR DESCRIPTION
1. Change diagnostic target for `no-corresponding-method-param` error.
2. Change default endpoint's type to `url` and `allowReserved` to `true`.

fix: https://github.com/Azure/typespec-azure/issues/2468