### PR TITLE
[tcgc] take into account `@bodyRoot` when generating names for anonymous models

### DIFF
--- a/.chronus/changes/tcgc-emptyModelName-2025-2-31-17-48-47.md
+++ b/.chronus/changes/tcgc-emptyModelName-2025-2-31-17-48-47.md
@@ -1,0 +1,7 @@
+---
+changeKind: breaking
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Take into account `@bodyRoot` to anchor parameters when creating generated names for anonymous models. Breaking because it can add to the generated name.

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -403,7 +403,9 @@ function getContextPath(
       if (isHttpBodySpread(httpOperation.parameters.body)) {
         bodyType = getHttpBodySpreadModel(httpOperation.parameters.body.type as Model);
       } else {
-        bodyType = httpOperation.parameters.body.type;
+        // find the parameter in the method that corresponds to the http body
+        bodyType =
+          httpOperation.parameters.body.property?.model || httpOperation.parameters.body.type;
       }
       if (dfsModelProperties(typeToFind, bodyType, "Request")) {
         return result;

--- a/packages/typespec-client-generator-core/test/methods/spread.test.ts
+++ b/packages/typespec-client-generator-core/test/methods/spread.test.ts
@@ -388,7 +388,7 @@ it("anonymous model with @body should not be spread", async () => {
   const method = getServiceMethodOfClient(runner.context.sdkPackage);
   const models = runner.context.sdkPackage.models;
   strictEqual(models.length, 1);
-  const model = models.find((x) => x.name === "TestRequest");
+  const model = models.find((x) => x.name === "TestRequestBody");
   ok(model);
   strictEqual(model.usage, UsageFlags.Input | UsageFlags.Json);
 
@@ -433,7 +433,7 @@ it("anonymous model from spread with @bodyRoot should not be spread", async () =
   const method = getServiceMethodOfClient(runner.context.sdkPackage);
   const models = runner.context.sdkPackage.models;
   strictEqual(models.length, 1);
-  const model = models.find((x) => x.name === "TestRequest");
+  const model = models.find((x) => x.name === "TestRequestBody");
   ok(model);
   strictEqual(model.usage, UsageFlags.Input | UsageFlags.Json);
 

--- a/packages/typespec-client-generator-core/test/public-utils/get-generated-name.test.ts
+++ b/packages/typespec-client-generator-core/test/public-utils/get-generated-name.test.ts
@@ -20,8 +20,8 @@ describe("simple anonymous model", () => {
     `);
     const models = runner.context.sdkPackage.models;
     strictEqual(models.length, 1);
-    strictEqual(models[0].name, "TestRequest");
-    strictEqual(models[0].crossLanguageDefinitionId, "TestService.test.Request.anonymous");
+    strictEqual(models[0].name, "TestRequestBody");
+    strictEqual(models[0].crossLanguageDefinitionId, "TestService.test.Request.body.anonymous");
     ok(models[0].isGeneratedName);
   });
 
@@ -45,9 +45,9 @@ describe("simple anonymous model", () => {
     ok(
       models.find(
         (x) =>
-          x.name === "TestRequest" &&
+          x.name === "TestRequestBody" &&
           x.isGeneratedName &&
-          x.crossLanguageDefinitionId === "TestService.test.Request.anonymous",
+          x.crossLanguageDefinitionId === "TestService.test.Request.body.anonymous",
       ),
     );
     ok(
@@ -160,8 +160,8 @@ describe("anonymous model with array or dict", () => {
     );
     const models = runner.context.sdkPackage.models;
     strictEqual(models.length, 1);
-    strictEqual(models[0].name, "TestRequest");
-    strictEqual(models[0].crossLanguageDefinitionId, "TestService.test.Request.anonymous");
+    strictEqual(models[0].name, "TestRequestBody");
+    strictEqual(models[0].crossLanguageDefinitionId, "TestService.test.Request.body.anonymous");
     ok(models[0].isGeneratedName);
   });
 
@@ -173,8 +173,8 @@ describe("anonymous model with array or dict", () => {
     );
     const models = runner.context.sdkPackage.models;
     strictEqual(models.length, 1);
-    strictEqual(models[0].name, "TestRequest");
-    strictEqual(models[0].crossLanguageDefinitionId, "TestService.test.Request.anonymous");
+    strictEqual(models[0].name, "TestRequestBody");
+    strictEqual(models[0].crossLanguageDefinitionId, "TestService.test.Request.body.anonymous");
     ok(models[0].isGeneratedName);
   });
 

--- a/packages/typespec-client-generator-core/test/types/model.test.ts
+++ b/packages/typespec-client-generator-core/test/types/model.test.ts
@@ -1846,3 +1846,25 @@ it("discriminator from template", async function () {
 
   expectDiagnosticEmpty(runner.context.diagnostics);
 });
+
+it("generated name for body root anonymous model", async function () {
+  await runner.compileWithBuiltInService(`
+    model Test {
+      prop: string;
+    }
+    op test(@bodyRoot body: {@body body: Test}): void;
+  `);
+  const sdkPackage = runner.context.sdkPackage;
+  strictEqual(sdkPackage.models.length, 2);
+  const testModel = sdkPackage.models.find((m) => m.name === "Test");
+  ok(testModel);
+  strictEqual(testModel.properties.length, 1);
+  strictEqual(testModel.properties[0].name, "prop");
+
+  const anonymousModel = sdkPackage.models.find((m) => m.name === "TestRequest");
+  ok(anonymousModel);
+  strictEqual(anonymousModel.properties.length, 1);
+  strictEqual(anonymousModel.properties[0].kind, "body");
+  strictEqual(anonymousModel.properties[0].name, "body");
+  strictEqual(anonymousModel.properties[0].type, testModel);
+});

--- a/packages/typespec-client-generator-core/test/types/union.test.ts
+++ b/packages/typespec-client-generator-core/test/types/union.test.ts
@@ -609,7 +609,7 @@ it("nullable union with anonymous model ref self", async function () {
 
   strictEqual(models.length, 1);
   strictEqual(models[0].kind, "model");
-  strictEqual(models[0].name, "PostRequest");
+  strictEqual(models[0].name, "PostRequestBody");
   strictEqual(models[0].properties[2].type, unions[0]);
 
   strictEqual(unions.length, 1);


### PR DESCRIPTION
fixes #1713