### PR TITLE
azure-http-specs, escape "scenario" as it is keyword

### DIFF
--- a/.chronus/changes/azure-http-specs_fix-keyword-2025-3-2-11-19-59.md
+++ b/.chronus/changes/azure-http-specs_fix-keyword-2025-3-2-11-19-59.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Escape scenario as this is now keyword

--- a/packages/azure-http-specs/specs/client/structure/default/client.tsp
+++ b/packages/azure-http-specs/specs/client/structure/default/client.tsp
@@ -4,7 +4,7 @@ import "@typespec/spector";
 
 using Spector;
 
-@@scenario(Client.Structure.Service);
+@@`scenario`(Client.Structure.Service);
 @@scenarioDoc(Client.Structure.Service,
   """
     This is to show that if we don't do any customization. The client side should be able to call the api like


### PR DESCRIPTION
`scenario` now is a keyword.

With latest core, formatting would already report error, if this is not escaped https://github.com/Azure/typespec-azure/actions/runs/14210689268/job/39817212216?pr=2484

need to bump core first https://github.com/Azure/typespec-azure/pull/2485