### PR TITLE
[tcgc] fix optionality for path and body

### DIFF
--- a/.chronus/changes/tcgc-optional_path-2025-3-10-16-10-10.md
+++ b/.chronus/changes/tcgc-optional_path-2025-3-10-16-10-10.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Fix path and body optionality value to allow them to be optional.

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -612,7 +612,6 @@ export interface SdkPathParameter extends SdkModelPropertyTypeBase {
   style: "simple" | "label" | "matrix" | "fragment" | "path";
   allowReserved: boolean;
   serializedName: string;
-  optional: false;
   correspondingMethodParams: SdkModelPropertyType[];
 }
 
@@ -625,7 +624,6 @@ export interface SdkCookieParameter extends SdkModelPropertyTypeBase {
 export interface SdkBodyParameter extends SdkModelPropertyTypeBase {
   kind: "body";
   serializedName: string;
-  optional: boolean;
   contentTypes: string[];
   defaultContentType: string;
   correspondingMethodParams: SdkModelPropertyType[];

--- a/packages/typespec-client-generator-core/test/http/body.test.ts
+++ b/packages/typespec-client-generator-core/test/http/body.test.ts
@@ -1,0 +1,86 @@
+import { ok, strictEqual } from "assert";
+import { beforeEach, it } from "vitest";
+import { SdkTestRunner, createSdkTestRunner } from "../test-host.js";
+import { getServiceMethodOfClient } from "../utils.js";
+
+let runner: SdkTestRunner;
+
+beforeEach(async () => {
+  runner = await createSdkTestRunner({ emitterName: "@azure-tools/typespec-python" });
+});
+
+it("optional body parameter", async () => {
+  await runner.compileWithBuiltInService(`
+    op myOp(@body body?: string): void;
+    `);
+  const sdkPackage = runner.context.sdkPackage;
+  const method = getServiceMethodOfClient(sdkPackage);
+  const serviceOperation = method.operation;
+  const bodyParam = serviceOperation.bodyParam;
+  ok(bodyParam);
+
+  strictEqual(bodyParam.kind, "body");
+  strictEqual(bodyParam.serializedName, "body");
+  strictEqual(bodyParam.name, "body");
+  strictEqual(bodyParam.optional, true);
+  strictEqual(bodyParam.onClient, false);
+  strictEqual(bodyParam.isApiVersionParam, false);
+  strictEqual(bodyParam.type.kind, "string");
+});
+
+it("required body parameter", async () => {
+  await runner.compileWithBuiltInService(`
+    op myOp(@body body: string): void;
+    `);
+  const sdkPackage = runner.context.sdkPackage;
+  const method = getServiceMethodOfClient(sdkPackage);
+  const serviceOperation = method.operation;
+  const bodyParam = serviceOperation.bodyParam;
+  ok(bodyParam);
+
+  strictEqual(bodyParam.kind, "body");
+  strictEqual(bodyParam.serializedName, "body");
+  strictEqual(bodyParam.name, "body");
+  strictEqual(bodyParam.optional, false);
+  strictEqual(bodyParam.onClient, false);
+  strictEqual(bodyParam.isApiVersionParam, false);
+  strictEqual(bodyParam.type.kind, "string");
+});
+
+it("optional body parameter with spread", async () => {
+  await runner.compileWithBuiltInService(`
+    op myOp(foo?: string, bar?: string): void;
+    `);
+  const sdkPackage = runner.context.sdkPackage;
+  const method = getServiceMethodOfClient(sdkPackage);
+  const serviceOperation = method.operation;
+  const bodyParam = serviceOperation.bodyParam;
+  ok(bodyParam);
+
+  strictEqual(bodyParam.kind, "body");
+  strictEqual(bodyParam.serializedName, "");
+  strictEqual(bodyParam.name, "myOpRequest");
+  strictEqual(bodyParam.optional, true);
+  strictEqual(bodyParam.onClient, false);
+  strictEqual(bodyParam.isApiVersionParam, false);
+  strictEqual(bodyParam.type.kind, "model");
+});
+
+it("required body parameter with spread", async () => {
+  await runner.compileWithBuiltInService(`
+    op myOp(foo: string, bar: string): void;
+    `);
+  const sdkPackage = runner.context.sdkPackage;
+  const method = getServiceMethodOfClient(sdkPackage);
+  const serviceOperation = method.operation;
+  const bodyParam = serviceOperation.bodyParam;
+  ok(bodyParam);
+
+  strictEqual(bodyParam.kind, "body");
+  strictEqual(bodyParam.serializedName, "");
+  strictEqual(bodyParam.name, "myOpRequest");
+  strictEqual(bodyParam.optional, false);
+  strictEqual(bodyParam.onClient, false);
+  strictEqual(bodyParam.isApiVersionParam, false);
+  strictEqual(bodyParam.type.kind, "model");
+});

--- a/packages/typespec-client-generator-core/test/http/path.test.ts
+++ b/packages/typespec-client-generator-core/test/http/path.test.ts
@@ -1,0 +1,56 @@
+import { strictEqual } from "assert";
+import { beforeEach, it } from "vitest";
+import { SdkTestRunner, createSdkTestRunner } from "../test-host.js";
+import { getServiceMethodOfClient } from "../utils.js";
+
+let runner: SdkTestRunner;
+
+beforeEach(async () => {
+  runner = await createSdkTestRunner({ emitterName: "@azure-tools/typespec-python" });
+});
+
+it("optional path parameter", async () => {
+  await runner.compileWithBuiltInService(`
+    op myOp(@path path?: string): void;
+    `);
+  const sdkPackage = runner.context.sdkPackage;
+  const method = getServiceMethodOfClient(sdkPackage);
+  const serviceOperation = method.operation;
+  strictEqual(serviceOperation.path, "/{path}");
+  strictEqual(serviceOperation.uriTemplate, "/{/path}");
+
+  strictEqual(serviceOperation.parameters.length, 1);
+  const pathParam = serviceOperation.parameters[0];
+
+  strictEqual(pathParam.kind, "path");
+  strictEqual(pathParam.serializedName, "path");
+  strictEqual(pathParam.name, "path");
+  strictEqual(pathParam.optional, true);
+  strictEqual(pathParam.onClient, false);
+  strictEqual(pathParam.isApiVersionParam, false);
+  strictEqual(pathParam.type.kind, "string");
+  strictEqual(pathParam.allowReserved, false);
+});
+
+it("required path parameter", async () => {
+  await runner.compileWithBuiltInService(`
+    op myOp(@path path: string): void;
+    `);
+  const sdkPackage = runner.context.sdkPackage;
+  const method = getServiceMethodOfClient(sdkPackage);
+  const serviceOperation = method.operation;
+  strictEqual(serviceOperation.path, "/{path}");
+  strictEqual(serviceOperation.uriTemplate, "/{path}");
+
+  strictEqual(serviceOperation.parameters.length, 1);
+  const pathParam = serviceOperation.parameters[0];
+
+  strictEqual(pathParam.kind, "path");
+  strictEqual(pathParam.serializedName, "path");
+  strictEqual(pathParam.name, "path");
+  strictEqual(pathParam.optional, false);
+  strictEqual(pathParam.onClient, false);
+  strictEqual(pathParam.isApiVersionParam, false);
+  strictEqual(pathParam.type.kind, "string");
+  strictEqual(pathParam.allowReserved, false);
+});


### PR DESCRIPTION
fix: https://github.com/Azure/typespec-azure/issues/2495

for normal case, path and body parameter's optionality will follow typespec definition.
for spread body, only when all the properties are optional, the body is optional.