### PR TITLE
azure-http-specs, override package name for java in test case

### DIFF
--- a/.chronus/changes/azure-http-specs_improve-package-name-for-java-2025-3-10-21-19-5.md
+++ b/.chronus/changes/azure-http-specs_improve-package-name-for-java-2025-3-10-21-19-5.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+override package name for java

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/client.tsp
@@ -6,6 +6,15 @@ using Spector;
 
 namespace _Specs_.Azure.ClientGeneratorCore.ClientInitialization;
 
+@@global.Azure.ClientGenerator.Core.clientNamespace(_Specs_.Azure.ClientGeneratorCore.ClientInitialization,
+  "azure.clientgenerator.core.clientinitialization",
+  "java"
+);
+@@global.Azure.ClientGenerator.Core.clientNamespace(Service,
+  "azure.clientgenerator.core.clientinitialization",
+  "java"
+);
+
 model HeaderParamClientOptions {
   @doc("The name of the client. This parameter is used as a header in all operations.")
   name: string;


### PR DESCRIPTION
minor update to `client-initialization`, for package/namespace for Java (and avoid model to be generated in `service` package).