### PR TITLE
[tcgc] always ignore `null` example value for non-nullable type

### DIFF
--- a/.chronus/changes/tcgc-example_fix-2025-3-11-15-19-7.md
+++ b/.chronus/changes/tcgc-example_fix-2025-3-11-15-19-7.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Always ignore `null` example value for non-nullable type.

--- a/packages/typespec-client-generator-core/src/example.ts
+++ b/packages/typespec-client-generator-core/src/example.ts
@@ -406,6 +406,10 @@ function getSdkTypeExample(
 ): [SdkExampleValue | undefined, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
 
+  if (example === null && type.kind !== "nullable") {
+    return diagnostics.wrap(undefined);
+  }
+
   if (isSdkIntKind(type.kind) || isSdkFloatKind(type.kind)) {
     return getSdkBaseTypeExample("number", type as SdkType, example, relativePath);
   } else {
@@ -547,9 +551,6 @@ function getSdkDictionaryExample(
 ): [SdkDictionaryExampleValue | undefined, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
   if (typeof example === "object") {
-    if (example === null) {
-      return diagnostics.wrap(undefined);
-    }
     const dictionaryExample: Record<string, SdkExampleValue> = {};
     for (const key of Object.keys(example)) {
       const result = diagnostics.pipe(
@@ -577,9 +578,6 @@ function getSdkModelExample(
 ): [SdkModelExampleValue | undefined, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
   if (typeof example === "object") {
-    if (example === null) {
-      return diagnostics.wrap(undefined);
-    }
     // handle discriminated model
     if (type.discriminatorProperty) {
       if (

--- a/packages/typespec-client-generator-core/test/examples/example-types/getUnexpectedNull.json
+++ b/packages/typespec-client-generator-core/test/examples/example-types/getUnexpectedNull.json
@@ -1,0 +1,18 @@
+{
+  "operationId": "getUnexpectedNull",
+  "title": "getUnexpectedNull",
+  "parameters": {},
+  "responses": {
+    "200": {
+      "body": {
+        "a": null,
+        "b": null,
+        "c": null,
+        "d": null,
+        "e": null,
+        "f": null,
+        "g": null
+      }
+    }
+  }
+}

--- a/packages/typespec-client-generator-core/test/examples/types.test.ts
+++ b/packages/typespec-client-generator-core/test/examples/types.test.ts
@@ -999,3 +999,48 @@ it("SdkModelExample with extra paramters", async () => {
 
   expectDiagnostics(runner.context.diagnostics, []);
 });
+
+it("unexpected null value", async () => {
+  await runner.host.addRealTypeSpecFile(
+    "./examples/getUnexpectedNull.json",
+    `${__dirname}/example-types/getUnexpectedNull.json`,
+  );
+  await runner.compile(`
+    @service
+    namespace TestClient {
+      model Test {
+        a: string;
+        b: int32;
+        c: {prop: string};
+        d: {prop: string} | null;
+        e: utcDateTime;
+        f: duration;
+        g: TestEnum;
+      }
+
+      enum TestEnum {
+          one,two,three
+      }
+
+      op getUnexpectedNull(): Test;
+    }
+  `);
+
+  const operation = (
+    runner.context.sdkPackage.clients[0].methods[0] as SdkServiceMethod<SdkHttpOperation>
+  ).operation;
+  ok(operation);
+  strictEqual(operation.examples?.length, 1);
+  const response = operation.examples[0].responses.find((x) => x.statusCode === 200);
+  ok(response);
+
+  const bodyValue = response.bodyValue;
+  ok(bodyValue);
+  strictEqual(bodyValue.kind, "model");
+  strictEqual(bodyValue.type.kind, "model");
+  strictEqual(bodyValue.type.name, "Test");
+  strictEqual(Object.keys(bodyValue.value).length, 1);
+  ok(bodyValue.value["d"]);
+
+  expectDiagnostics(runner.context.diagnostics, []);
+});


### PR DESCRIPTION
fix: https://github.com/Azure/typespec-azure/issues/2525