### PR TITLE
[specs] update python client namespace

### DIFF
--- a/.chronus/changes/specs-updatePythonClientNamespace-2025-3-14-14-48-44.md
+++ b/.chronus/changes/specs-updatePythonClientNamespace-2025-3-14-14-48-44.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Fix `@clientNamespace` for python generations

--- a/packages/azure-http-specs/specs/azure/client-generator-core/access/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/access/main.tsp
@@ -8,7 +8,10 @@ using Spector;
 
 @doc("Test for internal decorator.")
 @scenarioService("/azure/client-generator-core/access")
-@global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.access", "java")
+@global.Azure.ClientGenerator.Core.clientNamespace(
+  "azure.clientgenerator.core.access",
+  "java,python"
+)
 namespace _Specs_.Azure.ClientGenerator.Core.Access;
 
 @route("/publicOperation")

--- a/packages/azure-http-specs/specs/azure/client-generator-core/api-version/header/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/api-version/header/client.tsp
@@ -14,5 +14,5 @@ namespace Customizations;
 
 @@clientNamespace(Client.AlternateApiVersion.Service.Header,
   "azure.clientgenerator.core.apiversion.header",
-  "java"
+  "java,python"
 );

--- a/packages/azure-http-specs/specs/azure/client-generator-core/api-version/path/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/api-version/path/client.tsp
@@ -14,5 +14,5 @@ namespace Customizations;
 
 @@clientNamespace(Client.AlternateApiVersion.Service.Path,
   "azure.clientgenerator.core.apiversion.path",
-  "java"
+  "java,python"
 );

--- a/packages/azure-http-specs/specs/azure/client-generator-core/api-version/query/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/api-version/query/client.tsp
@@ -14,5 +14,5 @@ namespace Customizations;
 
 @@clientNamespace(Client.AlternateApiVersion.Service.Query,
   "azure.clientgenerator.core.apiversion.query",
-  "java"
+  "java,python"
 );

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/client.tsp
@@ -11,11 +11,11 @@ namespace _Specs_.Azure.ClientGeneratorCore.ClientInitialization;
 
 @@global.Azure.ClientGenerator.Core.clientNamespace(_Specs_.Azure.ClientGeneratorCore.ClientInitialization,
   "azure.clientgenerator.core.clientinitialization",
-  "java"
+  "java,python"
 );
 @@global.Azure.ClientGenerator.Core.clientNamespace(Service,
   "azure.clientgenerator.core.clientinitialization",
-  "java"
+  "java,python"
 );
 
 model HeaderParamClientOptions {

--- a/packages/azure-http-specs/specs/azure/client-generator-core/flatten-property/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/flatten-property/main.tsp
@@ -10,7 +10,7 @@ using Spector;
 @scenarioService("/azure/client-generator-core/flatten-property")
 @global.Azure.ClientGenerator.Core.clientNamespace(
   "azure.clientgenerator.core.flattenproperty",
-  "java"
+  "java,python"
 )
 namespace _Specs_.Azure.ClientGenerator.Core.FlattenProperty;
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/usage/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/usage/main.tsp
@@ -8,7 +8,10 @@ using Spector;
 
 @doc("Test for internal decorator.")
 @scenarioService("/azure/client-generator-core/usage")
-@global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.usage", "java,python")
+@global.Azure.ClientGenerator.Core.clientNamespace(
+  "azure.clientgenerator.core.usage",
+  "java,python"
+)
 namespace _Specs_.Azure.ClientGenerator.Core.Usage;
 
 @scenario
@@ -17,7 +20,10 @@ namespace _Specs_.Azure.ClientGenerator.Core.Usage;
   'OrphanModel' is not used but specified as 'public' and 'input', so it should be generated in SDK. The 'orphanModelSerializable' operation verifies that the model can be serialized to JSON.
   The other models are override to roundtrip, so they should be generated and exported as well.
   """)
-@global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.usage", "java,python")
+@global.Azure.ClientGenerator.Core.clientNamespace(
+  "azure.clientgenerator.core.usage",
+  "java,python"
+)
 namespace ModelInOperation {
   @doc("Usage override to roundtrip.")
   @global.Azure.ClientGenerator.Core.usage(

--- a/packages/azure-http-specs/specs/azure/client-generator-core/usage/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/usage/main.tsp
@@ -8,7 +8,7 @@ using Spector;
 
 @doc("Test for internal decorator.")
 @scenarioService("/azure/client-generator-core/usage")
-@global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.usage", "java")
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.usage", "java,python")
 namespace _Specs_.Azure.ClientGenerator.Core.Usage;
 
 @scenario
@@ -17,7 +17,7 @@ namespace _Specs_.Azure.ClientGenerator.Core.Usage;
   'OrphanModel' is not used but specified as 'public' and 'input', so it should be generated in SDK. The 'orphanModelSerializable' operation verifies that the model can be serialized to JSON.
   The other models are override to roundtrip, so they should be generated and exported as well.
   """)
-@global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.usage", "java")
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.usage", "java,python")
 namespace ModelInOperation {
   @doc("Usage override to roundtrip.")
   @global.Azure.ClientGenerator.Core.usage(

--- a/packages/azure-http-specs/specs/azure/core/basic/client.tsp
+++ b/packages/azure-http-specs/specs/azure/core/basic/client.tsp
@@ -5,4 +5,4 @@ using Azure.ClientGenerator.Core;
 
 @@convenientAPI(_Specs_.Azure.Core.Basic.createOrUpdate, false, "csharp");
 
-@@clientNamespace(_Specs_.Azure.Core.Basic, "azure.core.basic", "java");
+@@clientNamespace(_Specs_.Azure.Core.Basic, "azure.core.basic", "java,python");

--- a/packages/azure-http-specs/specs/azure/core/lro/rpc/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/lro/rpc/main.tsp
@@ -19,7 +19,7 @@ using Spector;
     versioned: Versions,
   }
 )
-@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.lro.rpc", "java")
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.lro.rpc", "java,python")
 namespace _Specs_.Azure.Core.Lro.Rpc;
 
 @doc("The API version.")

--- a/packages/azure-http-specs/specs/azure/core/lro/standard/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/lro/standard/main.tsp
@@ -19,7 +19,7 @@ using Spector;
     versioned: Versions,
   }
 )
-@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.lro.standard", "java")
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.lro.standard", "java,python")
 namespace _Specs_.Azure.Core.Lro.Standard;
 
 @doc("The API version.")

--- a/packages/azure-http-specs/specs/azure/core/model/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/model/main.tsp
@@ -16,7 +16,7 @@ using Spector;
     versioned: Versions,
   }
 )
-@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.model", "java")
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.model", "java,python")
 namespace _Specs_.Azure.Core.Model;
 @doc("The version of the API.")
 enum Versions {

--- a/packages/azure-http-specs/specs/azure/core/page/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/page/main.tsp
@@ -19,7 +19,7 @@ using Spector;
     versioned: Versions,
   }
 )
-@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.page", "java")
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.page", "java,python")
 namespace _Specs_.Azure.Core.Page;
 
 @doc("The version of the API.")

--- a/packages/azure-http-specs/specs/azure/core/scalar/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/scalar/main.tsp
@@ -16,7 +16,7 @@ using Spector;
     versioned: Versions,
   }
 )
-@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.scalar", "java")
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.scalar", "java,python")
 namespace _Specs_.Azure.Core.Scalar;
 @doc("The version of the API.")
 enum Versions {

--- a/packages/azure-http-specs/specs/azure/core/traits/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/traits/main.tsp
@@ -21,7 +21,7 @@ using Spector;
   }
 )
 @versioned(Versions)
-@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.traits", "java")
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.core.traits", "java,python")
 namespace _Specs_.Azure.Core.Traits;
 
 @doc("Service versions")

--- a/packages/azure-http-specs/specs/azure/encode/duration/main.tsp
+++ b/packages/azure-http-specs/specs/azure/encode/duration/main.tsp
@@ -10,7 +10,7 @@ using Spector;
 @scenarioService("/azure/encode/duration")
 namespace _Specs_.Azure.Encode.Duration;
 
-@@clientNamespace(_Specs_.Azure.Encode.Duration, "azure.encode.duration", "java");
+@@clientNamespace(_Specs_.Azure.Encode.Duration, "azure.encode.duration", "java,python");
 
 model DurationModel {
   @encode("duration-constant")

--- a/packages/azure-http-specs/specs/azure/example/basic/client.tsp
+++ b/packages/azure-http-specs/specs/azure/example/basic/client.tsp
@@ -10,8 +10,8 @@ using Spector;
 @route("/azure/example/basic")
 namespace AzureExampleBasicClient;
 
-@@clientNamespace(AzureExampleBasicClient, "azure.example.basic", "java");
-@@clientNamespace(_Specs_.Azure.Example.Basic, "azure.example.basic", "java");
+@@clientNamespace(AzureExampleBasicClient, "azure.example.basic", "java,python");
+@@clientNamespace(_Specs_.Azure.Example.Basic, "azure.example.basic", "java,python");
 
 @client({
   name: "AzureExampleClient",

--- a/packages/azure-http-specs/specs/azure/payload/pageable/main.tsp
+++ b/packages/azure-http-specs/specs/azure/payload/pageable/main.tsp
@@ -13,7 +13,7 @@ using global.Azure.ClientGenerator.Core;
 @useDependency(global.Azure.Core.Versions.v1_0_Preview_2)
 namespace _Specs_.Azure.Payload.Pageable;
 
-@@clientNamespace(_Specs_.Azure.Payload.Pageable, "azure.payload.pageable", "java");
+@@clientNamespace(_Specs_.Azure.Payload.Pageable, "azure.payload.pageable", "java,python");
 
 @doc("User model")
 model User {


### PR DESCRIPTION
cc @msyyc @tadelesh . We can piggyback onto what java has done, this way we don't have to set the `namespace` for all of our azure generations. This will have a big change in the autorest.python repo, since I think we can also get rid of the `specs.` prefix from the namespaces