### PR TITLE
azure-http-specs, client initialization with child client

### DIFF
--- a/.chronus/changes/azure-http-specs_client-initialization-child-2025-3-16-17-25-6.md
+++ b/.chronus/changes/azure-http-specs_client-initialization-child-2025-3-16-17-25-6.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Add test case of client initialization and child client

--- a/packages/azure-http-specs/spec-summary.md
+++ b/packages/azure-http-specs/spec-summary.md
@@ -255,7 +255,7 @@ const client = new ParentClient.getChildClient({
 });
 
 // directly
-const client = new ChildChild({
+const client = new ChildClient({
   blobName: "sample-blob"
 });
 

--- a/packages/azure-http-specs/spec-summary.md
+++ b/packages/azure-http-specs/spec-summary.md
@@ -231,7 +231,7 @@ client.withAliasedName();
 client.withOriginalName();
 ```
 
-### Azure_ClientGeneratorCore_ClientInitialization_ParentClient
+### Azure_ClientGeneratorCore_ClientInitialization_ParentClient_ChildClient
 
 - Endpoints:
   - `get /azure/client-generator-core/client-initialization/child-client/{blobName}/with-query`
@@ -239,6 +239,8 @@ client.withOriginalName();
   - `get /azure/client-generator-core/client-initialization/child-client/{blobName}`
 
 Client for testing a path parameter (blobName) moved to client level, in child client.
+
+The child client can be initialized individually, or via its parent client.
 
 Parameters elevated to client level:
 

--- a/packages/azure-http-specs/spec-summary.md
+++ b/packages/azure-http-specs/spec-summary.md
@@ -231,6 +231,38 @@ client.withAliasedName();
 client.withOriginalName();
 ```
 
+### Azure_ClientGeneratorCore_ClientInitialization_ParentClient
+
+- Endpoints:
+  - `get /azure/client-generator-core/client-initialization/child-client/{blobName}/with-query`
+  - `get /azure/client-generator-core/client-initialization/child-client/{blobName}/get-standalone`
+  - `get /azure/client-generator-core/client-initialization/child-client/{blobName}`
+
+Client for testing a path parameter (blobName) moved to client level, in child client.
+
+Parameters elevated to client level:
+
+- blobName: "sample-blob" (path parameter)
+
+Expected client usage:
+
+```ts
+// via ParentClient
+const client = new ParentClient.getChildClient({
+  blobName: "sample-blob"
+});
+
+// directly
+const client = new ChildChild({
+  blobName: "sample-blob"
+});
+
+// No need to pass blobName to any operations
+client.withQuery(format: "text");
+client.getStandalone();
+client.deleteStandalone();
+```
+
 ### Azure_ClientGeneratorCore_ClientInitialization_PathParam
 
 - Endpoints:

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/client.tsp
@@ -200,42 +200,44 @@ interface ParamAlias {
   withOriginalName is Service.ParamAlias.withOriginalName;
 }
 
-@scenarioDoc("""
-  Client for testing a path parameter (blobName) moved to client level, in child client.
-  
-  Parameters elevated to client level:
-  - blobName: "sample-blob" (path parameter)
-  
-  Expected client usage:
-  ```ts
-  // via ParentClient
-  const client = new ParentClient.getChildClient({
-    blobName: "sample-blob"
-  });
-  
-  // directly
-  const client = new ChildChild({
-    blobName: "sample-blob"
-  });
-  
-  // No need to pass blobName to any operations
-  client.withQuery(format: "text");  
-  client.getStandalone();
-  client.deleteStandalone();
-  ```
-  """)
-@scenario
 @global.Azure.ClientGenerator.Core.client({
   name: "ParentClient",
   service: Service,
 })
-@route("/child-client")
 namespace ParentClient {
+  @scenarioDoc("""
+    Client for testing a path parameter (blobName) moved to client level, in child client.
+    
+    The child client can be initialized individually, or via its parent client.
+    
+    Parameters elevated to client level:
+    - blobName: "sample-blob" (path parameter)
+    
+    Expected client usage:
+    ```ts
+    // via ParentClient
+    const client = new ParentClient.getChildClient({
+      blobName: "sample-blob"
+    });
+    
+    // directly
+    const client = new ChildChild({
+      blobName: "sample-blob"
+    });
+    
+    // No need to pass blobName to any operations
+    client.withQuery(format: "text");  
+    client.getStandalone();
+    client.deleteStandalone();
+    ```
+    """)
+  @scenario
   @global.Azure.ClientGenerator.Core.operationGroup
   @global.Azure.ClientGenerator.Core.clientInitialization({
-    paramters: PathParamClientOptions,
+    parameters: PathParamClientOptions,
     initializedBy: global.Azure.ClientGenerator.Core.InitializedBy.individually | global.Azure.ClientGenerator.Core.InitializedBy.parent,
   })
+  @route("/child-client")
   interface ChildClient {
     withQuery is Service.ChildClient.withQuery;
     getStandalone is Service.ChildClient.getStandalone;

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/client.tsp
@@ -199,3 +199,45 @@ interface ParamAlias {
   withAliasedName is Service.ParamAlias.withAliasedName;
   withOriginalName is Service.ParamAlias.withOriginalName;
 }
+
+@global.Azure.ClientGenerator.Core.client({
+  name: "ParentClient",
+  service: Service,
+})
+namespace ParentClient {
+  @scenarioDoc("""
+    Client for testing a path parameter (blobName) moved to client level, in child client.
+    
+    Parameters elevated to client level:
+    - blobName: "sample-blob" (path parameter)
+    
+    Expected client usage:
+    ```ts
+    // via ParentClient
+    const client = new ParentClient.getChildClient({
+      blobName: "sample-blob"
+    });
+    
+    // directly
+    const client = new ChildChild({
+      blobName: "sample-blob"
+    });
+    
+    // No need to pass blobName to any operations
+    client.withQuery(format: "text");  
+    client.getStandalone();
+    client.deleteStandalone();
+    ```
+    """)
+  @global.Azure.ClientGenerator.Core.operationGroup
+  @global.Azure.ClientGenerator.Core.clientInitialization({
+    paramters: PathParamClientOptions,
+    initializedBy: global.Azure.ClientGenerator.Core.InitializedBy.individually | global.Azure.ClientGenerator.Core.InitializedBy.parent,
+  })
+  @route("/child-client")
+  interface ChildClient {
+    withQuery is Service.ChildClient.withQuery;
+    getStandalone is Service.ChildClient.getStandalone;
+    deleteStandalone is Service.ChildClient.deleteStandalone;
+  }
+}

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/client.tsp
@@ -221,7 +221,7 @@ namespace ParentClient {
     });
     
     // directly
-    const client = new ChildChild({
+    const client = new ChildClient({
       blobName: "sample-blob"
     });
     

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/client.tsp
@@ -200,41 +200,42 @@ interface ParamAlias {
   withOriginalName is Service.ParamAlias.withOriginalName;
 }
 
+@scenarioDoc("""
+  Client for testing a path parameter (blobName) moved to client level, in child client.
+  
+  Parameters elevated to client level:
+  - blobName: "sample-blob" (path parameter)
+  
+  Expected client usage:
+  ```ts
+  // via ParentClient
+  const client = new ParentClient.getChildClient({
+    blobName: "sample-blob"
+  });
+  
+  // directly
+  const client = new ChildChild({
+    blobName: "sample-blob"
+  });
+  
+  // No need to pass blobName to any operations
+  client.withQuery(format: "text");  
+  client.getStandalone();
+  client.deleteStandalone();
+  ```
+  """)
+@scenario
 @global.Azure.ClientGenerator.Core.client({
   name: "ParentClient",
   service: Service,
 })
+@route("/child-client")
 namespace ParentClient {
-  @scenarioDoc("""
-    Client for testing a path parameter (blobName) moved to client level, in child client.
-    
-    Parameters elevated to client level:
-    - blobName: "sample-blob" (path parameter)
-    
-    Expected client usage:
-    ```ts
-    // via ParentClient
-    const client = new ParentClient.getChildClient({
-      blobName: "sample-blob"
-    });
-    
-    // directly
-    const client = new ChildChild({
-      blobName: "sample-blob"
-    });
-    
-    // No need to pass blobName to any operations
-    client.withQuery(format: "text");  
-    client.getStandalone();
-    client.deleteStandalone();
-    ```
-    """)
   @global.Azure.ClientGenerator.Core.operationGroup
   @global.Azure.ClientGenerator.Core.clientInitialization({
     paramters: PathParamClientOptions,
     initializedBy: global.Azure.ClientGenerator.Core.InitializedBy.individually | global.Azure.ClientGenerator.Core.InitializedBy.parent,
   })
-  @route("/child-client")
   interface ChildClient {
     withQuery is Service.ChildClient.withQuery;
     getStandalone is Service.ChildClient.getStandalone;

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/main.tsp
@@ -114,3 +114,20 @@ model BlobProperties {
   contentType: string;
   createdOn: utcDateTime;
 }
+
+// Scenario 6: Client iniatialization on child client
+@doc("Blob operations with path parameter that should be moved to client level, in child client")
+@route("/child-client")
+interface ChildClient {
+  @route("/{blobName}/with-query")
+  @get
+  withQuery(@path blobName: string, @query format?: string): void;
+
+  @route("/{blobName}/get-standalone")
+  @get
+  getStandalone(@path blobName: string): BlobProperties;
+
+  @route("/{blobName}")
+  @delete
+  deleteStandalone(@path blobName: string): void;
+}

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/main.tsp
@@ -115,7 +115,7 @@ model BlobProperties {
   createdOn: utcDateTime;
 }
 
-// Scenario 6: Client iniatialization on child client
+// Scenario 6: Client initialization on child client
 @doc("Blob operations with path parameter that should be moved to client level, in child client")
 @route("/child-client")
 interface ChildClient {

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/mockapi.ts
@@ -181,8 +181,8 @@ Scenarios.Azure_ClientGeneratorCore_ClientInitialization_ParamAlias = passOnSucc
   },
 ]);
 
-// Mock responses for PathParam scenario
-Scenarios.Azure_ClientGeneratorCore_ClientInitialization_PathParam = passOnSuccess([
+// Mock responses for ParentClient/ChildClient scenario
+Scenarios.Azure_ClientGeneratorCore_ClientInitialization_ParentClient_ChildClient = passOnSuccess([
   {
     uri: "/azure/client-generator-core/client-initialization/child-client/sample-blob/with-query",
     method: "get",

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/mockapi.ts
@@ -180,3 +180,44 @@ Scenarios.Azure_ClientGeneratorCore_ClientInitialization_ParamAlias = passOnSucc
     kind: "MockApiDefinition",
   },
 ]);
+
+// Mock responses for PathParam scenario
+Scenarios.Azure_ClientGeneratorCore_ClientInitialization_PathParam = passOnSuccess([
+  {
+    uri: "/azure/client-generator-core/client-initialization/child-client/sample-blob/with-query",
+    method: "get",
+    request: {
+      query: {
+        format: "text",
+      },
+    },
+    response: {
+      status: 204,
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/client-generator-core/client-initialization/child-client/sample-blob/get-standalone",
+    method: "get",
+    request: {},
+    response: {
+      status: 200,
+      body: json({
+        name: "sample-blob",
+        size: 42,
+        contentType: "text/plain",
+        createdOn: "2025-04-01T12:00:00Z",
+      }),
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    uri: "/azure/client-generator-core/client-initialization/child-client/sample-blob",
+    method: "delete",
+    request: {},
+    response: {
+      status: 204,
+    },
+    kind: "MockApiDefinition",
+  },
+]);


### PR DESCRIPTION
tested locally
```
var result = new ParentClientBuilder().buildClient()
  .getChildClient("sample-blob")
  .getStandalone();

new ChildClientBuilder().blobName("sample-blob").buildClient()
  .deleteStandalone();
```