### PR TITLE
[tcgc] spread body param is always required

### DIFF
--- a/.chronus/changes/fix_body-2025-3-21-11-48-17.md
+++ b/.chronus/changes/fix_body-2025-3-21-11-48-17.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-client-generator-core"
 ---
 
-Make spread body parameter alwasys be required.
+Make spread body parameter always be required.

--- a/.chronus/changes/fix_body-2025-3-21-11-48-17.md
+++ b/.chronus/changes/fix_body-2025-3-21-11-48-17.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Make spread body parameter alwasys be required.

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -225,12 +225,6 @@ function getSdkHttpParameters(
             httpOperation.operation,
           ),
         );
-        optional =
-          tspBody.type.kind === "Model"
-            ? [...tspBody.type.properties.values()].some((p) => !p.optional)
-              ? false
-              : true
-            : false;
       } else {
         type = diagnostics.pipe(
           getClientTypeWithDiagnostics(context, tspBody.type, httpOperation.operation),

--- a/packages/typespec-client-generator-core/test/http/body.test.ts
+++ b/packages/typespec-client-generator-core/test/http/body.test.ts
@@ -47,28 +47,9 @@ it("required body parameter", async () => {
   strictEqual(bodyParam.type.kind, "string");
 });
 
-it("optional body parameter with spread", async () => {
+it("spread body always required", async () => {
   await runner.compileWithBuiltInService(`
     op myOp(foo?: string, bar?: string): void;
-    `);
-  const sdkPackage = runner.context.sdkPackage;
-  const method = getServiceMethodOfClient(sdkPackage);
-  const serviceOperation = method.operation;
-  const bodyParam = serviceOperation.bodyParam;
-  ok(bodyParam);
-
-  strictEqual(bodyParam.kind, "body");
-  strictEqual(bodyParam.serializedName, "");
-  strictEqual(bodyParam.name, "myOpRequest");
-  strictEqual(bodyParam.optional, true);
-  strictEqual(bodyParam.onClient, false);
-  strictEqual(bodyParam.isApiVersionParam, false);
-  strictEqual(bodyParam.type.kind, "model");
-});
-
-it("required body parameter with spread", async () => {
-  await runner.compileWithBuiltInService(`
-    op myOp(foo: string, bar: string): void;
     `);
   const sdkPackage = runner.context.sdkPackage;
   const method = getServiceMethodOfClient(sdkPackage);


### PR DESCRIPTION
rollback logic in: https://github.com/Azure/typespec-azure/pull/2556.
refer the discussion: https://github.com/microsoft/typespec/issues/1907