### PR TITLE
azure-http-specs, fix dyn in handler

### DIFF
--- a/.chronus/changes/azure-http-specs_fix-dyn-2025-3-30-18-28-19.md
+++ b/.chronus/changes/azure-http-specs_fix-dyn-2025-3-30-18-28-19.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Fix handler

--- a/packages/azure-http-specs/specs/azure/resource-manager/operation-templates/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/operation-templates/mockapi.ts
@@ -269,7 +269,7 @@ Scenarios.Azure_ResourceManager_OperationTemplates_Lro_export = passOnSuccess([
       return {
         status: 202,
         headers: {
-          location: dyn`${dynItem("baseUrl")}/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/providers/Azure.ResourceManager.OperationTemplates/locations/eastus/operations/lro_post_location`,
+          location: `${req.baseUrl}/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/providers/Azure.ResourceManager.OperationTemplates/locations/eastus/operations/lro_post_location`,
           "azure-asyncoperation": `${req.baseUrl}/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/providers/Azure.ResourceManager.OperationTemplates/locations/eastus/operations/lro_post_aao`,
         },
       };


### PR DESCRIPTION
@timotheeguerin

I've got 500 on this API, in nightly build (against unreleased azure-http-specs lib -- released one is good)
https://dev.azure.com/azure-sdk/public/_build/results?buildId=4814852&view=logs&j=ca395085-040a-526b-2ce8-bdc85f692774&t=1fb2445c-3c92-5f9b-bcad-710222d02bc3&l=274

So far, this appears to be the only place `dyn/dynItem` is used in handler. My guess is that this be a mistake.

Let me know if this is the not the correct fix.