### PR TITLE
[azure-http-specs] add test for mgmt-plane large LRO header

### DIFF
--- a/.chronus/changes/azure_http_specs-large_header-2025-4-14-8-45-41.md
+++ b/.chronus/changes/azure_http_specs-large_header-2025-4-14-8-45-41.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: feature
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+[azure-http-specs] add test for mgmt-plane large LRO header

--- a/packages/azure-http-specs/specs/azure/resource-manager/large-header/main.tsp
+++ b/packages/azure-http-specs/specs/azure/resource-manager/large-header/main.tsp
@@ -1,0 +1,123 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-azure-core";
+import "@azure-tools/typespec-azure-resource-manager";
+import "@azure-tools/typespec-client-generator-core";
+import "@typespec/spector";
+
+using Http;
+using Rest;
+using Versioning;
+using Azure.Core;
+using Azure.ResourceManager;
+using OpenAPI;
+using Spector;
+
+@armProviderNamespace
+@service
+@versioned(Versions)
+@doc("Arm Resource Provider management API.")
+namespace Azure.ResourceManager.LargeHeader;
+
+@doc("Azure API versions.")
+enum Versions {
+  @armCommonTypesVersion(CommonTypes.Versions.v5)
+  @useDependency(Azure.Core.Versions.v1_0_Preview_2)
+  @useDependency(Azure.ResourceManager.Versions.v1_0_Preview_1)
+  @doc("Preview API version 2023-12-01-preview.")
+  v2023_12_01_preview: "2023-12-01-preview",
+}
+
+@resource("largeHeaders")
+model LargeHeader is TrackedResource<LargeHeaderProperties> {
+  ...ResourceNameParameter<LargeHeader>;
+}
+
+model LargeHeaderProperties {
+  @doc("The provisioning state of the resource.")
+  @visibility(Lifecycle.Read)
+  provisioningState?: string;
+}
+
+model CancelResult {
+  succeeded: boolean;
+}
+
+@armResourceOperations
+interface LargeHeaders {
+  @scenario
+  @scenarioDoc("""
+    Resource POST operation with long LRO headers(> 6KB + 6KB = 12KB).
+    To pass the test, client should accept both:
+      1. Single header size that's more than 6KB. 7KB is sure to pass the test.
+      2. Total headers size that's more than 12KB. 13KB is sure to pass the test.
+    
+    Service returns both Location and Azure-AsyncOperation header on initial request.
+    final-state-via: location
+    
+    Expected verb: POST
+    Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.LargeHeader/largeHeaders/header1/two6k
+    Expected query parameter: api-version=2023-12-01-preview
+    Expected response status code: 202
+    Expected response headers: 
+      - Azure-AsyncOperation={endpoint}/subscriptions/00000000-0000-0000-0000-000000000000/providers/Azure.ResourceManager.LargeHeader/locations/eastus/operations/post?userContext=<6KB-string>
+      - Location={endpoint}/subscriptions/00000000-0000-0000-0000-000000000000/providers/Azure.ResourceManager.LargeHeader/operations/post?userContext=<6KB-string>
+    Expected no response body
+    
+    Whether you do polling through AAO, Location or combined, first one will respond with provisioning state "InProgress", second one with "Succeeded".
+    
+    AAO first poll.
+    Expected verb: GET
+    Expected URL: {endpoint}/subscriptions/00000000-0000-0000-0000-000000000000/providers/Azure.ResourceManager.LargeHeader/locations/eastus/operations/post_aao?userContext=<6KB-string>
+    Expected status code: 200
+    Expected response body:
+    ```json
+    {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Azure.ResourceManager.LargeHeader/locations/eastus/operations/post_aao?userContext=<6KB-string>",
+      "name": "post_aao",
+      "status" : "InProgress",
+      "startTime": "2024-11-08T01:41:53.5508583+00:00"
+    }
+    ```
+    
+    AAO second poll.
+    Expected verb: GET
+    Expected URL: {endpoint}/subscriptions/00000000-0000-0000-0000-000000000000/providers/Azure.ResourceManager.LargeHeader/locations/eastus/operations/post_aao?userContext=<6KB-string>
+    Expected status code: 200
+    Expected response body:
+    ```json
+    {
+      "id": "/subscriptions/00000000-0000-0000-0000-000000000000/providers/Azure.ResourceManager.LargeHeader/locations/eastus/operations/post_aao?userContext=<6KB-string>",
+      "name": "post_aao",
+      "status" : "Succeeded",
+      "startTime": "2024-11-08T01:41:53.5508583+00:00",
+      "endTime": "2024-11-08T01:42:41.5354192+00:00"
+    }
+    ```
+    
+    Location first poll.
+    Expected verb: GET
+    Expected URL: {endpoint}/subscriptions/00000000-0000-0000-0000-000000000000/providers/Azure.ResourceManager.LargeHeader/locations/eastus/operations/post_location?userContext=<6KB-string>
+    Expected status code: 202
+    Expected no response body
+    
+    Location second poll.
+    Expected verb: GET
+    Expected URL: {endpoint}/subscriptions/00000000-0000-0000-0000-000000000000/providers/Azure.ResourceManager.LargeHeader/locations/eastus/operations/post_location?userContext=<6KB-string>
+    Expected status code: 200
+    Expected response body:
+    ```json
+    {
+      "succeeded": true
+    }
+    ```
+    """)
+  two8k is ArmResourceActionAsync<
+    LargeHeader,
+    void,
+    CancelResult,
+    LroHeaders = ArmCombinedLroHeaders<FinalResult = CancelResult> &
+      Azure.Core.Foundations.RetryAfterHeader
+  >;
+}

--- a/packages/azure-http-specs/specs/azure/resource-manager/large-header/main.tsp
+++ b/packages/azure-http-specs/specs/azure/resource-manager/large-header/main.tsp
@@ -113,7 +113,7 @@ interface LargeHeaders {
     }
     ```
     """)
-  two8k is ArmResourceActionAsync<
+  two6k is ArmResourceActionAsync<
     LargeHeader,
     void,
     CancelResult,

--- a/packages/azure-http-specs/specs/azure/resource-manager/large-header/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/large-header/mockapi.ts
@@ -12,7 +12,7 @@ export const Scenarios: Record<string, ScenarioMockApi> = {};
 
 const SUBSCRIPTION_ID_EXPECTED = "00000000-0000-0000-0000-000000000000";
 const RESOURCE_GROUP_EXPECTED = "test-rg";
-const SIX_KB_STRING = randomString(1024 * 6);
+const SIX_KB_STRING = "a".repeat(1024 * 6);
 let pollCount = 0;
 
 Scenarios.Azure_ResourceManager_LargeHeader_LargeHeaders_two6k = passOnSuccess([
@@ -114,13 +114,3 @@ Scenarios.Azure_ResourceManager_LargeHeader_LargeHeaders_two6k = passOnSuccess([
     kind: "MockApiDefinition",
   },
 ]);
-
-function randomString(length: number) {
-  const characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
-  let result = "";
-  for (let i = 0; i < length; i++) {
-    const randomIndex = Math.floor(Math.random() * characters.length);
-    result += characters.charAt(randomIndex);
-  }
-  return result;
-}

--- a/packages/azure-http-specs/specs/azure/resource-manager/large-header/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/large-header/mockapi.ts
@@ -1,0 +1,126 @@
+import {
+  dyn,
+  dynItem,
+  json,
+  MockRequest,
+  passOnSuccess,
+  ScenarioMockApi,
+  ValidationError,
+} from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+const SUBSCRIPTION_ID_EXPECTED = "00000000-0000-0000-0000-000000000000";
+const RESOURCE_GROUP_EXPECTED = "test-rg";
+const SIX_KB_STRING = randomString(1024 * 6);
+let pollCount = 0;
+
+Scenarios.Azure_ResourceManager_LargeHeader_LargeHeaders_two6k = passOnSuccess([
+  {
+    // LRO POST initial request
+    uri: "/subscriptions/:subscriptionId/resourceGroups/:resourceGroup/providers/Azure.ResourceManager.LargeHeader/largeHeaders/header1/two6k",
+    method: "post",
+    request: {
+      pathParams: {
+        subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+        resourceGroup: RESOURCE_GROUP_EXPECTED,
+      },
+      query: {
+        "api-version": "2023-12-01-preview",
+      },
+    },
+    response: {
+      status: 202,
+      headers: {
+        location: dyn`${dynItem("baseUrl")}/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/providers/Azure.ResourceManager.LargeHeaders/locations/eastus/operations/post_location?userContext=${SIX_KB_STRING}`,
+        "azure-asyncoperation": dyn`${dynItem("baseUrl")}/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/providers/Azure.ResourceManager.LargeHeaders/locations/eastus/operations/post_aao?userContext=${SIX_KB_STRING}`,
+      },
+    },
+    handler: (req: MockRequest) => {
+      pollCount = 0;
+      return {
+        status: 202,
+        headers: {
+          location: `${req.baseUrl}/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/providers/Azure.ResourceManager.LargeHeaders/locations/eastus/operations/post_location?userContext=${SIX_KB_STRING}`,
+          "azure-asyncoperation": `${req.baseUrl}/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/providers/Azure.ResourceManager.LargeHeaders/locations/eastus/operations/post_aao?userContext=${SIX_KB_STRING}`,
+        },
+      };
+    },
+    kind: "MockApiDefinition",
+  },
+  {
+    // LRO POST poll intermediate/get final result
+    uri: "/subscriptions/:subscriptionId/providers/Azure.ResourceManager.LargeHeaders/locations/eastus/operations/:operation_name",
+    method: "get",
+    request: {
+      pathParams: {
+        subscriptionId: SUBSCRIPTION_ID_EXPECTED,
+        operation_name: "post_aao", // operation_name can be "post_location" or "post_aao", depending on the header you choose to poll. "post_aao" here is just for passing e2e test
+      },
+      query: {
+        "api-version": "2023-12-01-preview",
+        userContext: SIX_KB_STRING,
+      },
+    },
+    response: {
+      status: 200, // This is for passing e2e test. For actual status code, see "handler" definition below
+    },
+    handler: (req: MockRequest) => {
+      let response;
+      const operation_name = req.params["operation_name"];
+      if (operation_name === "post_location") {
+        response =
+          // first status will be 200, second and forward be 204
+          pollCount > 0
+            ? {
+                status: 200,
+                body: json({
+                  succeeded: true,
+                }),
+              }
+            : { status: 202 };
+      } else if (operation_name === "post_aao") {
+        const aaoResponse = {
+          id: `/subscriptions/${SUBSCRIPTION_ID_EXPECTED}/providers/Azure.ResourceManager.LargeHeaders/locations/eastus/operations/post_aao?userContext=${SIX_KB_STRING}`,
+          name: "lro_post_aao",
+          startTime: "2024-11-08T01:41:53.5508583+00:00",
+        };
+        // first provisioningState will be "InProgress", second and forward be "Succeeded"
+        const responseBody =
+          pollCount > 0
+            ? {
+                ...aaoResponse,
+                status: "Succeeded",
+                endTime: "2024-11-08T01:42:41.5354192+00:00",
+              }
+            : { ...aaoResponse, status: "InProgress" };
+
+        response = {
+          status: 200, // aao always returns 200 with response body
+          body: json(responseBody),
+        };
+      } else {
+        throw new ValidationError(
+          `Unexpected lro poll operation: ${operation_name}`,
+          undefined,
+          undefined,
+        );
+      }
+
+      pollCount += 1;
+
+      return response;
+    },
+    kind: "MockApiDefinition",
+  },
+]);
+
+function randomString(length: number) {
+  const characters = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  let result = "";
+  for (let i = 0; i < length; i++) {
+    const randomIndex = Math.floor(Math.random() * characters.length);
+    result += characters.charAt(randomIndex);
+  }
+  return result;
+}


### PR DESCRIPTION
## Context
POST/DELETE LRO now requires that both `Location` and `AAO` headers are returned in response.

For each header value, [`Authorization`](https://eng.ms/docs/products/arm/api_contracts/asyncoperationsigningandvalidation) info will be appended at the end, making the URL much longer.

Thus, [doc](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/async-operations#url-to-monitor-status) requires that REST client should accept **minimum** header size of 4KB.

## This PR
Added a POST LRO which will return both `Location` and `AAO` headers with 6KB+ size each, 12KB+ size in total.

## To pass the test
Ensure your HttpClient accepts both
1. 7KB single header size
2. 13KB total header size