### PR TITLE
[common-types] sdk generation feedback: match enum definition level

### DIFF
--- a/packages/samples/common-types/gen.ts
+++ b/packages/samples/common-types/gen.ts
@@ -88,6 +88,7 @@ function cleanupDocument(original: OpenAPI2Document): OpenAPI2Document {
   replaceUuidRefs(document, "Azure.Core.uuid");
   replaceUuidRefs(document, "Azure.Core.azureLocation");
   replaceUuidRefs(document, "Azure.Core.armResourceType");
+  replaceUuidRefs(document, "createdByType");
   replaceParameterName(
     document,
     "PrivateEndpointConnectionParameter",

--- a/packages/samples/common-types/openapi/v3/types.json
+++ b/packages/samples/common-types/openapi/v3/types.json
@@ -606,42 +606,6 @@
         }
       ]
     },
-    "createdByType": {
-      "type": "string",
-      "description": "The kind of entity that created the resource.",
-      "enum": [
-        "User",
-        "Application",
-        "ManagedIdentity",
-        "Key"
-      ],
-      "x-ms-enum": {
-        "name": "createdByType",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "User",
-            "value": "User",
-            "description": "The entity was created by a user."
-          },
-          {
-            "name": "Application",
-            "value": "Application",
-            "description": "The entity was created by an application."
-          },
-          {
-            "name": "ManagedIdentity",
-            "value": "ManagedIdentity",
-            "description": "The entity was created by a managed identity."
-          },
-          {
-            "name": "Key",
-            "value": "Key",
-            "description": "The entity was created by a key."
-          }
-        ]
-      }
-    },
     "encryptionProperties": {
       "type": "object",
       "description": "Configuration of key for data encryption",
@@ -691,8 +655,40 @@
           "description": "The identity that created the resource."
         },
         "createdByType": {
-          "$ref": "#/definitions/createdByType",
-          "description": "The type of identity that created the resource."
+          "type": "string",
+          "description": "The type of identity that created the resource.",
+          "enum": [
+            "User",
+            "Application",
+            "ManagedIdentity",
+            "Key"
+          ],
+          "x-ms-enum": {
+            "name": "createdByType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "User",
+                "value": "User",
+                "description": "The entity was created by a user."
+              },
+              {
+                "name": "Application",
+                "value": "Application",
+                "description": "The entity was created by an application."
+              },
+              {
+                "name": "ManagedIdentity",
+                "value": "ManagedIdentity",
+                "description": "The entity was created by a managed identity."
+              },
+              {
+                "name": "Key",
+                "value": "Key",
+                "description": "The entity was created by a key."
+              }
+            ]
+          }
         },
         "createdAt": {
           "type": "string",
@@ -704,8 +700,40 @@
           "description": "The identity that last modified the resource."
         },
         "lastModifiedByType": {
-          "$ref": "#/definitions/createdByType",
-          "description": "The type of identity that last modified the resource."
+          "type": "string",
+          "description": "The type of identity that last modified the resource.",
+          "enum": [
+            "User",
+            "Application",
+            "ManagedIdentity",
+            "Key"
+          ],
+          "x-ms-enum": {
+            "name": "createdByType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "User",
+                "value": "User",
+                "description": "The entity was created by a user."
+              },
+              {
+                "name": "Application",
+                "value": "Application",
+                "description": "The entity was created by an application."
+              },
+              {
+                "name": "ManagedIdentity",
+                "value": "ManagedIdentity",
+                "description": "The entity was created by a managed identity."
+              },
+              {
+                "name": "Key",
+                "value": "Key",
+                "description": "The entity was created by a key."
+              }
+            ]
+          }
         },
         "lastModifiedAt": {
           "type": "string",

--- a/packages/samples/common-types/openapi/v4/types.json
+++ b/packages/samples/common-types/openapi/v4/types.json
@@ -609,42 +609,6 @@
         }
       ]
     },
-    "createdByType": {
-      "type": "string",
-      "description": "The kind of entity that created the resource.",
-      "enum": [
-        "User",
-        "Application",
-        "ManagedIdentity",
-        "Key"
-      ],
-      "x-ms-enum": {
-        "name": "createdByType",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "User",
-            "value": "User",
-            "description": "The entity was created by a user."
-          },
-          {
-            "name": "Application",
-            "value": "Application",
-            "description": "The entity was created by an application."
-          },
-          {
-            "name": "ManagedIdentity",
-            "value": "ManagedIdentity",
-            "description": "The entity was created by a managed identity."
-          },
-          {
-            "name": "Key",
-            "value": "Key",
-            "description": "The entity was created by a key."
-          }
-        ]
-      }
-    },
     "encryptionProperties": {
       "type": "object",
       "description": "Configuration of key for data encryption",
@@ -694,8 +658,40 @@
           "description": "The identity that created the resource."
         },
         "createdByType": {
-          "$ref": "#/definitions/createdByType",
-          "description": "The type of identity that created the resource."
+          "type": "string",
+          "description": "The type of identity that created the resource.",
+          "enum": [
+            "User",
+            "Application",
+            "ManagedIdentity",
+            "Key"
+          ],
+          "x-ms-enum": {
+            "name": "createdByType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "User",
+                "value": "User",
+                "description": "The entity was created by a user."
+              },
+              {
+                "name": "Application",
+                "value": "Application",
+                "description": "The entity was created by an application."
+              },
+              {
+                "name": "ManagedIdentity",
+                "value": "ManagedIdentity",
+                "description": "The entity was created by a managed identity."
+              },
+              {
+                "name": "Key",
+                "value": "Key",
+                "description": "The entity was created by a key."
+              }
+            ]
+          }
         },
         "createdAt": {
           "type": "string",
@@ -707,8 +703,40 @@
           "description": "The identity that last modified the resource."
         },
         "lastModifiedByType": {
-          "$ref": "#/definitions/createdByType",
-          "description": "The type of identity that last modified the resource."
+          "type": "string",
+          "description": "The type of identity that last modified the resource.",
+          "enum": [
+            "User",
+            "Application",
+            "ManagedIdentity",
+            "Key"
+          ],
+          "x-ms-enum": {
+            "name": "createdByType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "User",
+                "value": "User",
+                "description": "The entity was created by a user."
+              },
+              {
+                "name": "Application",
+                "value": "Application",
+                "description": "The entity was created by an application."
+              },
+              {
+                "name": "ManagedIdentity",
+                "value": "ManagedIdentity",
+                "description": "The entity was created by a managed identity."
+              },
+              {
+                "name": "Key",
+                "value": "Key",
+                "description": "The entity was created by a key."
+              }
+            ]
+          }
         },
         "lastModifiedAt": {
           "type": "string",

--- a/packages/samples/common-types/openapi/v5/types.json
+++ b/packages/samples/common-types/openapi/v5/types.json
@@ -616,42 +616,6 @@
         }
       ]
     },
-    "createdByType": {
-      "type": "string",
-      "description": "The kind of entity that created the resource.",
-      "enum": [
-        "User",
-        "Application",
-        "ManagedIdentity",
-        "Key"
-      ],
-      "x-ms-enum": {
-        "name": "createdByType",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "User",
-            "value": "User",
-            "description": "The entity was created by a user."
-          },
-          {
-            "name": "Application",
-            "value": "Application",
-            "description": "The entity was created by an application."
-          },
-          {
-            "name": "ManagedIdentity",
-            "value": "ManagedIdentity",
-            "description": "The entity was created by a managed identity."
-          },
-          {
-            "name": "Key",
-            "value": "Key",
-            "description": "The entity was created by a key."
-          }
-        ]
-      }
-    },
     "encryptionProperties": {
       "type": "object",
       "description": "Configuration of key for data encryption",
@@ -701,8 +665,40 @@
           "description": "The identity that created the resource."
         },
         "createdByType": {
-          "$ref": "#/definitions/createdByType",
-          "description": "The type of identity that created the resource."
+          "type": "string",
+          "description": "The type of identity that created the resource.",
+          "enum": [
+            "User",
+            "Application",
+            "ManagedIdentity",
+            "Key"
+          ],
+          "x-ms-enum": {
+            "name": "createdByType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "User",
+                "value": "User",
+                "description": "The entity was created by a user."
+              },
+              {
+                "name": "Application",
+                "value": "Application",
+                "description": "The entity was created by an application."
+              },
+              {
+                "name": "ManagedIdentity",
+                "value": "ManagedIdentity",
+                "description": "The entity was created by a managed identity."
+              },
+              {
+                "name": "Key",
+                "value": "Key",
+                "description": "The entity was created by a key."
+              }
+            ]
+          }
         },
         "createdAt": {
           "type": "string",
@@ -714,8 +710,40 @@
           "description": "The identity that last modified the resource."
         },
         "lastModifiedByType": {
-          "$ref": "#/definitions/createdByType",
-          "description": "The type of identity that last modified the resource."
+          "type": "string",
+          "description": "The type of identity that last modified the resource.",
+          "enum": [
+            "User",
+            "Application",
+            "ManagedIdentity",
+            "Key"
+          ],
+          "x-ms-enum": {
+            "name": "createdByType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "User",
+                "value": "User",
+                "description": "The entity was created by a user."
+              },
+              {
+                "name": "Application",
+                "value": "Application",
+                "description": "The entity was created by an application."
+              },
+              {
+                "name": "ManagedIdentity",
+                "value": "ManagedIdentity",
+                "description": "The entity was created by a managed identity."
+              },
+              {
+                "name": "Key",
+                "value": "Key",
+                "description": "The entity was created by a key."
+              }
+            ]
+          }
         },
         "lastModifiedAt": {
           "type": "string",

--- a/packages/samples/common-types/openapi/v6/types.json
+++ b/packages/samples/common-types/openapi/v6/types.json
@@ -594,42 +594,6 @@
         }
       ]
     },
-    "createdByType": {
-      "type": "string",
-      "description": "The kind of entity that created the resource.",
-      "enum": [
-        "User",
-        "Application",
-        "ManagedIdentity",
-        "Key"
-      ],
-      "x-ms-enum": {
-        "name": "createdByType",
-        "modelAsString": true,
-        "values": [
-          {
-            "name": "User",
-            "value": "User",
-            "description": "The entity was created by a user."
-          },
-          {
-            "name": "Application",
-            "value": "Application",
-            "description": "The entity was created by an application."
-          },
-          {
-            "name": "ManagedIdentity",
-            "value": "ManagedIdentity",
-            "description": "The entity was created by a managed identity."
-          },
-          {
-            "name": "Key",
-            "value": "Key",
-            "description": "The entity was created by a key."
-          }
-        ]
-      }
-    },
     "encryptionProperties": {
       "type": "object",
       "description": "Configuration of key for data encryption",
@@ -679,8 +643,40 @@
           "description": "The identity that created the resource."
         },
         "createdByType": {
-          "$ref": "#/definitions/createdByType",
-          "description": "The type of identity that created the resource."
+          "type": "string",
+          "description": "The type of identity that created the resource.",
+          "enum": [
+            "User",
+            "Application",
+            "ManagedIdentity",
+            "Key"
+          ],
+          "x-ms-enum": {
+            "name": "createdByType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "User",
+                "value": "User",
+                "description": "The entity was created by a user."
+              },
+              {
+                "name": "Application",
+                "value": "Application",
+                "description": "The entity was created by an application."
+              },
+              {
+                "name": "ManagedIdentity",
+                "value": "ManagedIdentity",
+                "description": "The entity was created by a managed identity."
+              },
+              {
+                "name": "Key",
+                "value": "Key",
+                "description": "The entity was created by a key."
+              }
+            ]
+          }
         },
         "createdAt": {
           "type": "string",
@@ -692,8 +688,40 @@
           "description": "The identity that last modified the resource."
         },
         "lastModifiedByType": {
-          "$ref": "#/definitions/createdByType",
-          "description": "The type of identity that last modified the resource."
+          "type": "string",
+          "description": "The type of identity that last modified the resource.",
+          "enum": [
+            "User",
+            "Application",
+            "ManagedIdentity",
+            "Key"
+          ],
+          "x-ms-enum": {
+            "name": "createdByType",
+            "modelAsString": true,
+            "values": [
+              {
+                "name": "User",
+                "value": "User",
+                "description": "The entity was created by a user."
+              },
+              {
+                "name": "Application",
+                "value": "Application",
+                "description": "The entity was created by an application."
+              },
+              {
+                "name": "ManagedIdentity",
+                "value": "ManagedIdentity",
+                "description": "The entity was created by a managed identity."
+              },
+              {
+                "name": "Key",
+                "value": "Key",
+                "description": "The entity was created by a key."
+              }
+            ]
+          }
         },
         "lastModifiedAt": {
           "type": "string",


### PR DESCRIPTION
for common-types we have this ongoing pull request: https://github.com/Azure/azure-rest-api-specs/pull/32562

SDK is working on the validation and a problem has been reported: 

### Issue reported
error in: [connectedvmware](https://github.com/Azure/azure-rest-api-specs/tree/main/specification/connectedvmware/resource-manager)
The SDK generation failed with duplicate schema from M4
`error   | PreCheck/DuplicateSchema | Duplicate Schema named 'systemData' (3 differences)`
The reason is, we changed the createByType to a unified definition [here](https://github.com/Azure/azure-rest-api-specs/blob/8ee345ddb40577f1d306e80a1c071032a625b59a/specification/common-types/resource-management/v5/types.json#L703-L706) in this PR, but we did not change v2/systemData, it still contains an anonymous type [here](https://github.com/Azure/azure-rest-api-specs/blob/8ee345ddb40577f1d306e80a1c071032a625b59a/specification/common-types/resource-management/v2/types.json#L528-L541).

### Proposed change
As there is not a plan of moving v1/v2, let's change this to match the current swagger so the duplicate schema is avoided and can be identified as the same schema 

@live1206  please let me know if this would fix the current issue