### PR TITLE
Change the body name of legacy operations

### DIFF
--- a/.chronus/changes/legacyOperationUpdate-2025-4-19-18-33-20.md
+++ b/.chronus/changes/legacyOperationUpdate-2025-4-19-18-33-20.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Change the body name of legacy operations

--- a/packages/typespec-autorest/test/arm/resources.test.ts
+++ b/packages/typespec-autorest/test/arm/resources.test.ts
@@ -501,7 +501,7 @@ it("allows resources with multiple endpoints using LegacyOperations", async () =
       otherCreateOrUpdate is ArmResourceCreateOrReplaceAsync<Employee>;
       createOrUpdate is OtherOps.CreateOrUpdateAsync<Employee>;
       update is OtherOps.CustomPatchAsync<Employee, Employee>;
-      delete is OtherOps.DeleteAsync<Employee>;
+      delete is OtherOps.DeleteWithoutOkAsync<Employee>;
       list is OtherOps.List<Employee>;
       listBySubscription is ArmListBySubscription<Employee>;
 

--- a/packages/typespec-azure-resource-manager/lib/Legacy/operations.tsp
+++ b/packages/typespec-azure-resource-manager/lib/Legacy/operations.tsp
@@ -48,7 +48,7 @@ interface LegacyOperations<
     ...ParentParameters,
     ...ResourceTypeParameter,
     ...Parameters,
-    @doc("Resource create parameters.") @armBodyRoot(OptionalRequestBody) body: Resource,
+    @doc("Resource create parameters.") @armBodyRoot(OptionalRequestBody) resource: Resource,
   ): Response | ErrorType;
 
   /**
@@ -72,7 +72,7 @@ interface LegacyOperations<
     ...ParentParameters,
     ...ResourceTypeParameter,
     ...Parameters,
-    @doc("Resource create parameters.") @armBodyRoot(OptionalRequestBody) body: Resource,
+    @doc("Resource create parameters.") @armBodyRoot(OptionalRequestBody) resource: Resource,
   ): Response | ErrorType;
 
   /**
@@ -107,7 +107,7 @@ interface LegacyOperations<
     ...ParentParameters,
     ...ResourceTypeParameter,
     ...Parameters,
-    @doc("Resource create parameters.") @armBodyRoot(OptionalRequestBody) body: PatchModel,
+    @doc("Resource create parameters.") @armBodyRoot(OptionalRequestBody) properties: PatchModel,
   ): Response | ErrorType;
 
   /**
@@ -132,7 +132,7 @@ interface LegacyOperations<
     ...ParentParameters,
     ...ResourceTypeParameter,
     ...Parameters,
-    @doc("Resource create parameters.") @armBodyRoot(OptionalRequestBody) body: PatchModel,
+    @doc("Resource create parameters.") @armBodyRoot(OptionalRequestBody) properties: PatchModel,
   ): Response | ErrorType;
 
   /**
@@ -148,7 +148,7 @@ interface LegacyOperations<
   @delete
   @deletesResource(Resource)
   @armResourceDelete(Resource)
-  DeleteAsync<
+  DeleteWithoutOkAsync<
     Resource extends Azure.ResourceManager.CommonTypes.Resource,
     LroHeaders extends TypeSpec.Reflection.Model = ArmLroLocationHeader &
       Azure.Core.Foundations.RetryAfterHeader,

--- a/website/src/content/docs/docs/libraries/azure-resource-manager/reference/interfaces.md
+++ b/website/src/content/docs/docs/libraries/azure-resource-manager/reference/interfaces.md
@@ -1216,7 +1216,7 @@ interface Azure.ResourceManager.Legacy.LegacyOperations<ParentParameters, Resour
 A long-running resource CreateOrUpdate (PUT)
 
 ```typespec
-op Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateAsync(body: Resource): Response | ErrorType
+op Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateAsync(resource: Resource): Response | ErrorType
 ```
 
 ##### Template Parameters
@@ -1234,7 +1234,7 @@ op Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateAsync(body: Resou
 A synchronous resource CreateOrUpdate (PUT)
 
 ```typespec
-op Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateSync(body: Resource): Response | ErrorType
+op Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateSync(resource: Resource): Response | ErrorType
 ```
 
 ##### Template Parameters
@@ -1251,7 +1251,7 @@ op Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateSync(body: Resour
 A long-running resource Update (PATCH)
 
 ```typespec
-op Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchAsync(body: PatchModel): Response | ErrorType
+op Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchAsync(properties: PatchModel): Response | ErrorType
 ```
 
 ##### Template Parameters
@@ -1270,7 +1270,7 @@ op Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchAsync(body: PatchMod
 A synchronous resource Update (PATCH)
 
 ```typespec
-op Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchSync(body: PatchModel): Response | ErrorType
+op Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchSync(properties: PatchModel): Response | ErrorType
 ```
 
 ##### Template Parameters
@@ -1283,12 +1283,12 @@ op Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchSync(body: PatchMode
 | Response            | Optional. The success response(s) for the PATCH operation |
 | OptionalRequestBody | Optional. Indicates whether the request body is optional  |
 
-#### `LegacyOperations.DeleteAsync` {#Azure.ResourceManager.Legacy.LegacyOperations.DeleteAsync}
+#### `LegacyOperations.DeleteWithoutOkAsync` {#Azure.ResourceManager.Legacy.LegacyOperations.DeleteWithoutOkAsync}
 
 Delete a resource asynchronously
 
 ```typespec
-op Azure.ResourceManager.Legacy.LegacyOperations.DeleteAsync(): Response | ErrorType
+op Azure.ResourceManager.Legacy.LegacyOperations.DeleteWithoutOkAsync(): Response | ErrorType
 ```
 
 ##### Template Parameters


### PR DESCRIPTION
I want to align the name to our previous design. Justifications:

1. Converter already aligns with these names. It costs to fix the logic in converter.
2. Current name is a breaking to all the ongoing migration PR. We need to rename a lot, including the operations and all the augmented decorators applied on the body name.
3. Current name is a breaking to haven't-merged Compute.