### PR TITLE
bump azure-http-specs

### DIFF
--- a/packages/azure-http-specs/package.json
+++ b/packages/azure-http-specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/azure-http-specs",
-  "version": "0.1.0-alpha.17",
+  "version": "0.1.0-alpha.18",
   "description": "Azure Spec scenarios and mock apis",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
Didn't bump package.json last time. Strangely changelog.md did.. https://github.com/Azure/typespec-azure/pull/2737