### PR TITLE
Fix HttpPart<File> correctly render as `type:file`

### DIFF
--- a/.chronus/changes/fix-http-part-file-2025-4-29-17-14-9.md
+++ b/.chronus/changes/fix-http-part-file-2025-4-29-17-14-9.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Fix HttpPart<File> correctly render as `type:file`

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -126,6 +126,7 @@ import {
   getServers,
   getStatusCodeDescription,
   getVisibilitySuffix,
+  isHttpFile,
   isSharedRoute,
   reportIfNoRoutes,
   resolveRequestVisibility,
@@ -1282,7 +1283,7 @@ export async function getOpenAPIForService(
     paramName: string,
     target: DiagnosticTarget,
   ): PrimitiveItems | undefined {
-    if (isBytes(type)) {
+    if (isBytes(type) || isHttpFile(program, type)) {
       return { type: "file" };
     }
 

--- a/packages/typespec-autorest/test/multipart.test.ts
+++ b/packages/typespec-autorest/test/multipart.test.ts
@@ -43,6 +43,23 @@ it("part of type `bytes` produce `type: file`", async () => {
   ]);
 });
 
+it("part of type `File` produce `type: file`", async () => {
+  const res = await openApiFor(
+    `
+    op upload(@header contentType: "multipart/form-data", @multipartBody body: { profileImage: HttpPart<File> }): void;
+    `,
+  );
+  const op = res.paths["/"].post;
+  deepStrictEqual(op.parameters, [
+    {
+      in: "formData",
+      name: "profileImage",
+      required: true,
+      type: "file",
+    },
+  ]);
+});
+
 it("part of type `bytes[]` produce `type: array, items: { type: string, format: binary }`", async () => {
   const res = await openApiFor(
     `


### PR DESCRIPTION
fix [#2661](https://github.com/Azure/typespec-azure/issues/2661)