### PR TITLE
disable e2e tests for merge queue

### DIFF
--- a/eng/pipelines/jobs/e2e-job.yml
+++ b/eng/pipelines/jobs/e2e-job.yml
@@ -26,4 +26,9 @@ jobs:
       - script: pnpm test:e2e
         displayName: E2E Tests
         # E2E test have issue in publish branch due to version being bumped but package not published yet.
-        condition: and(succeeded(), eq(startsWith(variables['System.PullRequest.SourceBranch'], 'publish/'), false))
+        # E2E tests also fail in merge queue from publish branches due to the same reason.
+        # Possible future alternative: parse merge queue branch for PR number, query GitHub and use that to determine if the branch is a publish branch.
+        condition: and(succeeded(), and(
+          eq(startsWith(variables['Build.SourceBranch'], 'refs/heads/gh-readonly-queue/'), false),
+          eq(startsWith(variables['System.PullRequest.SourceBranch'], 'publish/'), false))
+          )


### PR DESCRIPTION
Resolves #2635 

E2E tests are already disabled for `publish/` branches. This PR also disables them for merge queue branches. These tests will still run on PRs, but not be ran on jobs triggered by the merge queue.

Unfortunately both GitHub Actions and Azure DevOps are unable to get the name of the PR branch that a merge queue branch was created from. If we wanted to selectively disable e2e tests for only `publish/` merge queue PRs, we would need to:
1. Check if the job is being ran for a GitHub merge queue branch (follows a common pattern)
2. Parse the PR number from the merge queue branch name
3. Query GitHub API PR metadata using the PR number
4. Check that the PR's head_ref starts with `publish/`

This would require using GitHub credentials but feels fragile if the GitHub merge queue branch names ever deviate from including the pr number.