### PR TITLE
[website] fix inline codeblocks light/dark mode

### DIFF
--- a/website/src/css/tsp.css
+++ b/website/src/css/tsp.css
@@ -2,7 +2,6 @@
   --header-height: 50px;
   --sl-color-text-accent: var(--colorBrandForeground1);
   --sl-color-gray-5: var(--colorNeutralStroke1);
-  --sl-color-bg-inline-code: var(--ec-frm-edBg);
 }
 
 .DocSearch-Button {


### PR DESCRIPTION
This PR fixes an issue where inline code blocks would appear with the wrong background color when the site is set to `light` mode but the OS is set to `dark` mode.

Example of the incorrect rendering (OS using dark mode, website using light mode):

![image](https://github.com/user-attachments/assets/75c98fa8-2800-4bad-bd48-30ac11ab15cc)

---

After these changes (OS using dark mode, website using light mode):

![image](https://github.com/user-attachments/assets/59374f1e-17a6-4b32-a495-099210106cff)

---

This does cause the dark-mode version of the site to use a slightly lighter background color for inline code-blocks than before. Now it matches what astro starlight uses and provides better contrast:

![image](https://github.com/user-attachments/assets/33d428a2-7fa0-4b33-a6a4-3bd49e7308d1)

