### PR TITLE
Disable no-unamed-types due to bad performance

### DIFF
--- a/.chronus/changes/disable-no-unamed-types-2025-5-6-21-11-5.md
+++ b/.chronus/changes/disable-no-unamed-types-2025-5-6-21-11-5.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-azure-rulesets"
+---
+
+Disable no-unamed-types due to bad performance

--- a/packages/typespec-azure-rulesets/src/rulesets/data-plane.ts
+++ b/packages/typespec-azure-rulesets/src/rulesets/data-plane.ts
@@ -45,7 +45,7 @@ export default {
     // TCGC rules
     "@azure-tools/typespec-client-generator-core/require-client-suffix": true,
     "@azure-tools/typespec-client-generator-core/property-name-conflict": true,
-    "@azure-tools/typespec-client-generator-core/no-unnamed-types": true,
+    "@azure-tools/typespec-client-generator-core/no-unnamed-types": false, // Too bad performance https://github.com/Azure/typespec-azure/issues/2803
 
     // Azure core rules enabled via an optional rulesets
     "@azure-tools/typespec-azure-core/non-breaking-versioning": false,

--- a/packages/typespec-azure-rulesets/src/rulesets/resource-manager.ts
+++ b/packages/typespec-azure-rulesets/src/rulesets/resource-manager.ts
@@ -90,6 +90,6 @@ export default {
     // TCGC rules
     "@azure-tools/typespec-client-generator-core/require-client-suffix": true,
     "@azure-tools/typespec-client-generator-core/property-name-conflict": true,
-    "@azure-tools/typespec-client-generator-core/no-unnamed-types": true,
+    "@azure-tools/typespec-client-generator-core/no-unnamed-types": false, // Too bad performance https://github.com/Azure/typespec-azure/issues/2803
   },
 } satisfies LinterRuleSet;


### PR DESCRIPTION
Disabling the rule due to terrible performance just choking ide experience https://github.com/Azure/typespec-azure/issues/2803