### PR TITLE
Update documenation about change from lower case to upper case to tenant and resourceGroup

### DIFF
--- a/.chronus/changes/update-doc-2025-5-11-16-41-22.md
+++ b/.chronus/changes/update-doc-2025-5-11-16-41-22.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-azure-core"
+---
+
+Minor documentation update: changed `tenant`, `resourceGroup` to `Tenant`, `ResourceGroup`.

--- a/packages/typespec-azure-core/lib/models.tsp
+++ b/packages/typespec-azure-core/lib/models.tsp
@@ -369,7 +369,7 @@ scalar armResourceType extends string;
  *   otherArmId: armResourceIdentifier;
  *   networkId: armResourceIdentifier<[{type:"Microsoft.Network/vnet"}]>
  *   vmIds: armResourceIdentifier<[{type:"Microsoft.Compute/vm", scopes: ["*"]}]>
- *   scoped: armResourceIdentifier<[{type:"Microsoft.Compute/vm", scopes: ["tenant", "resourceGroup"]}]>
+ *   scoped: armResourceIdentifier<[{type:"Microsoft.Compute/vm", scopes: ["Tenant", "ResourceGroup"]}]>
  * }
  * ```
  */

--- a/website/src/content/docs/docs/libraries/azure-core/reference/data-types.md
+++ b/website/src/content/docs/docs/libraries/azure-core/reference/data-types.md
@@ -529,7 +529,7 @@ model MyModel {
   scoped: armResourceIdentifier<[
     {
       type: "Microsoft.Compute/vm";
-      scopes: ["tenant", "resourceGroup"];
+      scopes: ["Tenant", "ResourceGroup"];
     }
   ]>;
 }


### PR DESCRIPTION
It was reported that the doc was't up to date: https://github.com/Azure/typespec-azure/pull/2670#issuecomment-2954496245