### PR TITLE
[azure-http-specs] ARM case, fix large header action template

### DIFF
--- a/.chronus/changes/HEAD-2025-5-25-19-48-8.md
+++ b/.chronus/changes/HEAD-2025-5-25-19-48-8.md
@@ -4,4 +4,5 @@ packages:
   - "@azure-tools/azure-http-specs"
 ---
 
-Fixed ARM large header action template.
+- Fixed ARM test template for large headers.
+- Fixed ARM mockapi for user-defined error case.

--- a/.chronus/changes/HEAD-2025-5-25-19-48-8.md
+++ b/.chronus/changes/HEAD-2025-5-25-19-48-8.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Fixed ARM large header action template.

--- a/packages/azure-http-specs/specs/azure/resource-manager/common-properties/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/common-properties/mockapi.ts
@@ -220,10 +220,12 @@ Scenarios.Azure_ResourceManager_CommonProperties_Error_createForUserDefinedError
   response: {
     status: 400,
     body: json({
-      code: "BadRequest",
-      message: "Username should not contain only numbers.",
-      innererror: {
-        exceptiontype: "general",
+      error: {
+        code: "BadRequest",
+        message: "Username should not contain only numbers.",
+        innererror: {
+          exceptiontype: "general",
+        },
       },
     }),
   },

--- a/packages/azure-http-specs/specs/azure/resource-manager/large-header/main.tsp
+++ b/packages/azure-http-specs/specs/azure/resource-manager/large-header/main.tsp
@@ -118,6 +118,7 @@ interface LargeHeaders {
     void,
     CancelResult,
     LroHeaders = ArmCombinedLroHeaders<FinalResult = CancelResult> &
-      Azure.Core.Foundations.RetryAfterHeader
+      Azure.Core.Foundations.RetryAfterHeader,
+    OptionalRequestBody = true
   >;
 }


### PR DESCRIPTION
`Request = void` effectively means `OptionalRequestBody = true`. 

Template default value is `false`:
https://github.com/Azure/typespec-azure/blob/88f4622ca3c09af9efce6dc38599a55063037186/packages/typespec-azure-resource-manager/lib/operations.tsp#L536