### PR TITLE
Fix inconsistent `OverrideErrorType` parameter name across templates

### DIFF
--- a/.chronus/changes/fix-error-type-typo-2025-6-3-10-0-41.md
+++ b/.chronus/changes/fix-error-type-typo-2025-6-3-10-0-41.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Fix inconsistent `OverrideErrorType` parameter name across templates 

--- a/packages/typespec-azure-resource-manager/lib/Legacy/operations.tsp
+++ b/packages/typespec-azure-resource-manager/lib/Legacy/operations.tsp
@@ -43,7 +43,7 @@ interface RoutedOperations<
    * @template Parameters Optional. Additional parameters after the path parameters
    * @template Response Optional. The success response(s) for the PUT operation
    * @template OptionalRequestBody Optional. Indicates whether the request body is optional
-   * @template OverrideErrortype Optional. The error response, if non-standard.
+   * @template OverrideErrorType Optional. The error response, if non-standard.
    * @template OverrideRouteOptions Optional. The route options for the operation.
    */
   @doc("Create a {name}", Resource)
@@ -62,14 +62,14 @@ interface RoutedOperations<
       LroHeaders
     >,
     OptionalRequestBody extends valueof boolean = false,
-    OverrideErrortype extends {} = ErrorType,
+    OverrideErrorType extends {} = ErrorType,
     OverrideRouteOptions extends valueof ArmOperationOptions = ResourceRoute
   >(
     ...ParentParameters,
     ...ResourceTypeParameter,
     ...Parameters,
     @doc("Resource create parameters.") @armBodyRoot(OptionalRequestBody) resource: Resource,
-  ): Response | OverrideErrortype;
+  ): Response | OverrideErrorType;
 
   /**
    * A synchronous resource CreateOrUpdate (PUT)
@@ -77,7 +77,7 @@ interface RoutedOperations<
    * @template Parameters Optional. Additional parameters after the path parameters
    * @template Response Optional. The success response(s) for the PUT operation
    * @template OptionalRequestBody Optional. Indicates whether the request body is optional
-   * @template OverrideErrortype Optional. The error response, if non-standard.
+   * @template OverrideErrorType Optional. The error response, if non-standard.
    * @template OverrideRouteOptions Optional. The route options for the operation.
    */
   #suppress "@azure-tools/typespec-azure-core/no-private-usage"
@@ -91,14 +91,14 @@ interface RoutedOperations<
     Parameters extends {} = {},
     Response extends {} = ArmResourceUpdatedResponse<Resource> | ArmResourceCreatedSyncResponse<Resource>,
     OptionalRequestBody extends valueof boolean = false,
-    OverrideErrortype extends {} = ErrorType,
+    OverrideErrorType extends {} = ErrorType,
     OverrideRouteOptions extends valueof ArmOperationOptions = ResourceRoute
   >(
     ...ParentParameters,
     ...ResourceTypeParameter,
     ...Parameters,
     @doc("Resource create parameters.") @armBodyRoot(OptionalRequestBody) resource: Resource,
-  ): Response | OverrideErrortype;
+  ): Response | OverrideErrorType;
 
   /**
    * A long-running resource Update (PATCH)
@@ -108,7 +108,7 @@ interface RoutedOperations<
    * @template Parameters Optional. Additional parameters after the path parameters
    * @template Response Optional. The success response(s) for the PATCH operation
    * @template OptionalRequestBody Optional. Indicates whether the request body is optional
-   * @template OverrideErrortype Optional. The error response, if non-standard.
+   * @template OverrideErrorType Optional. The error response, if non-standard.
    * @template OverrideRouteOptions Optional. The route options for the operation.
    */
   @doc("Update a {name}", Resource)
@@ -131,14 +131,14 @@ interface RoutedOperations<
       LroHeaders
     >,
     OptionalRequestBody extends valueof boolean = false,
-    OverrideErrortype extends {} = ErrorType,
+    OverrideErrorType extends {} = ErrorType,
     OverrideRouteOptions extends valueof ArmOperationOptions = ResourceRoute
   >(
     ...ParentParameters,
     ...ResourceTypeParameter,
     ...Parameters,
     @doc("Resource create parameters.") @armBodyRoot(OptionalRequestBody) properties: PatchModel,
-  ): Response | OverrideErrortype;
+  ): Response | OverrideErrorType;
 
   /**
    * A synchronous resource Update (PATCH)
@@ -147,7 +147,7 @@ interface RoutedOperations<
    * @template Parameters Optional. Additional parameters after the path parameters
    * @template Response Optional. The success response(s) for the PATCH operation
    * @template OptionalRequestBody Optional. Indicates whether the request body is optional
-   * @template OverrideErrortype Optional. The error response, if non-standard.
+   * @template OverrideErrorType Optional. The error response, if non-standard.
    * @template OverrideRouteOptions Optional. The route options for the operation.
    */
   @doc("Update a {name}", Resource)
@@ -161,14 +161,14 @@ interface RoutedOperations<
     Parameters extends {} = {},
     Response extends {} = ArmResponse<Resource>,
     OptionalRequestBody extends valueof boolean = false,
-    OverrideErrortype extends {} = ErrorType,
+    OverrideErrorType extends {} = ErrorType,
     OverrideRouteOptions extends valueof ArmOperationOptions = ResourceRoute
   >(
     ...ParentParameters,
     ...ResourceTypeParameter,
     ...Parameters,
     @doc("Resource create parameters.") @armBodyRoot(OptionalRequestBody) properties: PatchModel,
-  ): Response | OverrideErrortype;
+  ): Response | OverrideErrorType;
 
   /**
    * Delete a resource asynchronously
@@ -295,7 +295,7 @@ interface RoutedOperations<
    * @template Response The response model for the action
    * @template Parameters Optional. Additional parameters after the path parameters
    * @template OptionalRequestBody Optional. Indicates whether the request body is optional
-   * @template OverrideErrortype Optional. The error response, if non-standard.
+   * @template OverrideErrorType Optional. The error response, if non-standard.
    * @template OverrideRouteOptions Optional. The route options for the operation.
    */
   @doc("")
@@ -311,7 +311,7 @@ interface RoutedOperations<
     Response extends TypeSpec.Reflection.Model | void,
     Parameters extends {} = {},
     OptionalRequestBody extends valueof boolean = false,
-    OverrideErrortype extends {} = ErrorType,
+    OverrideErrorType extends {} = ErrorType,
     OverrideRouteOptions extends valueof ArmOperationOptions = ResourceRoute
   >(
     ...ParentParameters,
@@ -321,7 +321,7 @@ interface RoutedOperations<
     @doc("The content of the action request")
     @armBodyRoot(OptionalRequestBody)
     body: Request,
-  ): Response | OverrideErrortype;
+  ): Response | OverrideErrorType;
 
   /**
    * A long-running resource action.
@@ -332,7 +332,7 @@ interface RoutedOperations<
    * @template Response The union of successful responses for the action
    * @template Parameters Optional. Additional parameters after the path parameters
    * @template OptionalRequestBody Optional. Indicates whether the request body is optional
-   * @template OverrideErrortype Optional. The error response, if non-standard.
+   * @template OverrideErrorType Optional. The error response, if non-standard.
    * @template OverrideRouteOptions Optional. The route options for the operation.
    */
   #suppress "@azure-tools/typespec-azure-core/no-response-body" "ARM"
@@ -359,7 +359,7 @@ interface RoutedOperations<
       LroHeaders
     > | Result,
     OptionalRequestBody extends valueof boolean = false,
-    OverrideErrortype extends {} = ErrorType,
+    OverrideErrorType extends {} = ErrorType,
     OverrideRouteOptions extends valueof ArmOperationOptions = ResourceRoute
   >(
     ...ParentParameters,
@@ -369,7 +369,7 @@ interface RoutedOperations<
     @doc("The content of the action request")
     @armBodyRoot(OptionalRequestBody)
     body: Request,
-  ): Response | OverrideErrortype;
+  ): Response | OverrideErrorType;
 }
 /**
  * @dev DEPRECATED: Use ProviderParameter instead. Get the provider namespace key-value pair

--- a/website/src/content/docs/docs/libraries/azure-resource-manager/reference/interfaces.md
+++ b/website/src/content/docs/docs/libraries/azure-resource-manager/reference/interfaces.md
@@ -1760,7 +1760,7 @@ interface Azure.ResourceManager.Legacy.LegacyOperations<ParentParameters, Resour
 A long-running resource CreateOrUpdate (PUT)
 
 ```typespec
-op Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateAsync(resource: Resource): Response | OverrideErrortype
+op Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateAsync(resource: Resource): Response | OverrideErrorType
 ```
 
 #### `LegacyOperations.CreateOrUpdateSync` {#Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateSync}
@@ -1768,7 +1768,7 @@ op Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateAsync(resource: R
 A synchronous resource CreateOrUpdate (PUT)
 
 ```typespec
-op Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateSync(resource: Resource): Response | OverrideErrortype
+op Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateSync(resource: Resource): Response | OverrideErrorType
 ```
 
 #### `LegacyOperations.CustomPatchAsync` {#Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchAsync}
@@ -1776,7 +1776,7 @@ op Azure.ResourceManager.Legacy.LegacyOperations.CreateOrUpdateSync(resource: Re
 A long-running resource Update (PATCH)
 
 ```typespec
-op Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchAsync(properties: PatchModel): Response | OverrideErrortype
+op Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchAsync(properties: PatchModel): Response | OverrideErrorType
 ```
 
 #### `LegacyOperations.CustomPatchSync` {#Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchSync}
@@ -1784,7 +1784,7 @@ op Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchAsync(properties: Pa
 A synchronous resource Update (PATCH)
 
 ```typespec
-op Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchSync(properties: PatchModel): Response | OverrideErrortype
+op Azure.ResourceManager.Legacy.LegacyOperations.CustomPatchSync(properties: PatchModel): Response | OverrideErrorType
 ```
 
 #### `LegacyOperations.DeleteWithoutOkAsync` {#Azure.ResourceManager.Legacy.LegacyOperations.DeleteWithoutOkAsync}
@@ -1830,7 +1830,7 @@ op Azure.ResourceManager.Legacy.LegacyOperations.List(): Response | ErrorType
 A synchronous resource action.
 
 ```typespec
-op Azure.ResourceManager.Legacy.LegacyOperations.ActionSync(body: Request): Response | OverrideErrortype
+op Azure.ResourceManager.Legacy.LegacyOperations.ActionSync(body: Request): Response | OverrideErrorType
 ```
 
 #### `LegacyOperations.ActionAsync` {#Azure.ResourceManager.Legacy.LegacyOperations.ActionAsync}
@@ -1838,7 +1838,7 @@ op Azure.ResourceManager.Legacy.LegacyOperations.ActionSync(body: Request): Resp
 A long-running resource action.
 
 ```typespec
-op Azure.ResourceManager.Legacy.LegacyOperations.ActionAsync(body: Request): Response | OverrideErrortype
+op Azure.ResourceManager.Legacy.LegacyOperations.ActionAsync(body: Request): Response | OverrideErrorType
 ```
 
 ### `Operations` {#Azure.ResourceManager.Legacy.Operations}
@@ -1888,7 +1888,7 @@ interface Azure.ResourceManager.Legacy.RoutedOperations<ParentParameters, Resour
 A long-running resource CreateOrUpdate (PUT)
 
 ```typespec
-op Azure.ResourceManager.Legacy.RoutedOperations.CreateOrUpdateAsync(resource: Resource): Response | OverrideErrortype
+op Azure.ResourceManager.Legacy.RoutedOperations.CreateOrUpdateAsync(resource: Resource): Response | OverrideErrorType
 ```
 
 ##### Template Parameters
@@ -1900,7 +1900,7 @@ op Azure.ResourceManager.Legacy.RoutedOperations.CreateOrUpdateAsync(resource: R
 | Parameters           | Optional. Additional parameters after the path parameters               |
 | Response             | Optional. The success response(s) for the PUT operation                 |
 | OptionalRequestBody  | Optional. Indicates whether the request body is optional                |
-| OverrideErrortype    | Optional. The error response, if non-standard.                          |
+| OverrideErrorType    | Optional. The error response, if non-standard.                          |
 | OverrideRouteOptions | Optional. The route options for the operation.                          |
 
 #### `RoutedOperations.CreateOrUpdateSync` {#Azure.ResourceManager.Legacy.RoutedOperations.CreateOrUpdateSync}
@@ -1908,7 +1908,7 @@ op Azure.ResourceManager.Legacy.RoutedOperations.CreateOrUpdateAsync(resource: R
 A synchronous resource CreateOrUpdate (PUT)
 
 ```typespec
-op Azure.ResourceManager.Legacy.RoutedOperations.CreateOrUpdateSync(resource: Resource): Response | OverrideErrortype
+op Azure.ResourceManager.Legacy.RoutedOperations.CreateOrUpdateSync(resource: Resource): Response | OverrideErrorType
 ```
 
 ##### Template Parameters
@@ -1919,7 +1919,7 @@ op Azure.ResourceManager.Legacy.RoutedOperations.CreateOrUpdateSync(resource: Re
 | Parameters           | Optional. Additional parameters after the path parameters |
 | Response             | Optional. The success response(s) for the PUT operation   |
 | OptionalRequestBody  | Optional. Indicates whether the request body is optional  |
-| OverrideErrortype    | Optional. The error response, if non-standard.            |
+| OverrideErrorType    | Optional. The error response, if non-standard.            |
 | OverrideRouteOptions | Optional. The route options for the operation.            |
 
 #### `RoutedOperations.CustomPatchAsync` {#Azure.ResourceManager.Legacy.RoutedOperations.CustomPatchAsync}
@@ -1927,7 +1927,7 @@ op Azure.ResourceManager.Legacy.RoutedOperations.CreateOrUpdateSync(resource: Re
 A long-running resource Update (PATCH)
 
 ```typespec
-op Azure.ResourceManager.Legacy.RoutedOperations.CustomPatchAsync(properties: PatchModel): Response | OverrideErrortype
+op Azure.ResourceManager.Legacy.RoutedOperations.CustomPatchAsync(properties: PatchModel): Response | OverrideErrorType
 ```
 
 ##### Template Parameters
@@ -1940,7 +1940,7 @@ op Azure.ResourceManager.Legacy.RoutedOperations.CustomPatchAsync(properties: Pa
 | Parameters           | Optional. Additional parameters after the path parameters               |
 | Response             | Optional. The success response(s) for the PATCH operation               |
 | OptionalRequestBody  | Optional. Indicates whether the request body is optional                |
-| OverrideErrortype    | Optional. The error response, if non-standard.                          |
+| OverrideErrorType    | Optional. The error response, if non-standard.                          |
 | OverrideRouteOptions | Optional. The route options for the operation.                          |
 
 #### `RoutedOperations.CustomPatchSync` {#Azure.ResourceManager.Legacy.RoutedOperations.CustomPatchSync}
@@ -1948,7 +1948,7 @@ op Azure.ResourceManager.Legacy.RoutedOperations.CustomPatchAsync(properties: Pa
 A synchronous resource Update (PATCH)
 
 ```typespec
-op Azure.ResourceManager.Legacy.RoutedOperations.CustomPatchSync(properties: PatchModel): Response | OverrideErrortype
+op Azure.ResourceManager.Legacy.RoutedOperations.CustomPatchSync(properties: PatchModel): Response | OverrideErrorType
 ```
 
 ##### Template Parameters
@@ -1960,7 +1960,7 @@ op Azure.ResourceManager.Legacy.RoutedOperations.CustomPatchSync(properties: Pat
 | Parameters           | Optional. Additional parameters after the path parameters |
 | Response             | Optional. The success response(s) for the PATCH operation |
 | OptionalRequestBody  | Optional. Indicates whether the request body is optional  |
-| OverrideErrortype    | Optional. The error response, if non-standard.            |
+| OverrideErrorType    | Optional. The error response, if non-standard.            |
 | OverrideRouteOptions | Optional. The route options for the operation.            |
 
 #### `RoutedOperations.DeleteWithoutOkAsync` {#Azure.ResourceManager.Legacy.RoutedOperations.DeleteWithoutOkAsync}
@@ -2057,7 +2057,7 @@ op Azure.ResourceManager.Legacy.RoutedOperations.List(): Response | ErrorType
 A synchronous resource action.
 
 ```typespec
-op Azure.ResourceManager.Legacy.RoutedOperations.ActionSync(body: Request): Response | OverrideErrortype
+op Azure.ResourceManager.Legacy.RoutedOperations.ActionSync(body: Request): Response | OverrideErrorType
 ```
 
 ##### Template Parameters
@@ -2069,7 +2069,7 @@ op Azure.ResourceManager.Legacy.RoutedOperations.ActionSync(body: Request): Resp
 | Response             | The response model for the action                         |
 | Parameters           | Optional. Additional parameters after the path parameters |
 | OptionalRequestBody  | Optional. Indicates whether the request body is optional  |
-| OverrideErrortype    | Optional. The error response, if non-standard.            |
+| OverrideErrorType    | Optional. The error response, if non-standard.            |
 | OverrideRouteOptions | Optional. The route options for the operation.            |
 
 #### `RoutedOperations.ActionAsync` {#Azure.ResourceManager.Legacy.RoutedOperations.ActionAsync}
@@ -2077,7 +2077,7 @@ op Azure.ResourceManager.Legacy.RoutedOperations.ActionSync(body: Request): Resp
 A long-running resource action.
 
 ```typespec
-op Azure.ResourceManager.Legacy.RoutedOperations.ActionAsync(body: Request): Response | OverrideErrortype
+op Azure.ResourceManager.Legacy.RoutedOperations.ActionAsync(body: Request): Response | OverrideErrorType
 ```
 
 ##### Template Parameters
@@ -2091,7 +2091,7 @@ op Azure.ResourceManager.Legacy.RoutedOperations.ActionAsync(body: Request): Res
 | Parameters           | Optional. Additional parameters after the path parameters                 |
 | Response             | The union of successful responses for the action                          |
 | OptionalRequestBody  | Optional. Indicates whether the request body is optional                  |
-| OverrideErrortype    | Optional. The error response, if non-standard.                            |
+| OverrideErrorType    | Optional. The error response, if non-standard.                            |
 | OverrideRouteOptions | Optional. The route options for the operation.                            |
 
 ### `CustomPatchAsync` {#Azure.ResourceManager.Legacy.CustomPatchAsync}


### PR DESCRIPTION
issue: https://github.com/Azure/typespec-azure/issues/2922