### PR TITLE
azure-http-specs, add test case for tcgc override

### DIFF
--- a/.chronus/changes/azure-http-specs_tcgc-override-2025-6-7-15-9-14.md
+++ b/.chronus/changes/azure-http-specs_tcgc-override-2025-6-7-15-9-14.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Add test case for TCGC override

--- a/packages/azure-http-specs/spec-summary.md
+++ b/packages/azure-http-specs/spec-summary.md
@@ -57,6 +57,52 @@ Expected response body:
 }
 ```
 
+### Azure_ClientGenerator_Core_ClientLocation_MoveToExistingSubClient
+
+- Endpoints:
+  - `get /azure/client-generator-core/client-location/admin`
+  - `get /azure/client-generator-core/client-location/user`
+  - `get /azure/client-generator-core/client-location/user`
+
+Test moving an operation from one sub client to another existing sub client.
+
+Operation `deleteUser` from interface `UserOperations` should be moved to interface `AdminOperations` using @clientLocation(AdminOperations).
+
+Expected client structure:
+
+- Interface UserOperations should contain only operation `getUser`
+- Interface AdminOperations should contain operations `getAdminInfo` and `deleteUser` (moved from UserOperations)
+
+### Azure_ClientGenerator_Core_ClientLocation_MoveToNewSubClient
+
+- Endpoints:
+  - `get /azure/client-generator-core/client-location/products`
+  - `get /azure/client-generator-core/client-location/products/archive`
+
+Test moving an operation to a new sub client specified by string name.
+
+Operation `archiveProduct` from interface `ProductOperations` should be moved to a new sub client named "ArchiveOperations" using @clientLocation("ArchiveOperations").
+
+Expected client structure:
+
+- Interface ProductOperations should contain only operation `listProducts`
+- A new sub client "ArchiveOperations" should be created containing operation `archiveProduct`
+
+### Azure_ClientGenerator_Core_ClientLocation_MoveToRootClient
+
+- Endpoints:
+  - `get /azure/client-generator-core/client-location/resource`
+  - `get /azure/client-generator-core/client-location/health`
+
+Test moving an operation to the root client.
+
+Operation `getHealthStatus` from interface `ResourceOperations` should be moved to the root client using @clientLocation(service namespace).
+
+Expected client structure:
+
+- Interface ResourceOperations should contain only operation `getResource`
+- Root client should contain operation `getHealthStatus` (moved from ResourceOperations)
+
 ### Azure_ClientGenerator_Core_DeserializeEmptyStringAsNull_get
 
 - Endpoint: `get /azure/client-generator-core/deserialize-empty-string-as-null/responseModel`
@@ -133,6 +179,30 @@ Expected response body:
   }
 }
 ```
+
+### Azure_ClientGenerator_Core_Override_GroupParameters_group
+
+- Endpoint: `get /azure/client-generator-core/override/group`
+
+Verify that after `@override` the parameters are grouped correctly to `GroupParametersOptions` in the client method signature.
+
+Expected query parameter:
+param1: param1
+param2: param2
+
+Expected response: 204 No Content
+
+### Azure_ClientGenerator_Core_Override_ReorderParameters_reorder
+
+- Endpoint: `get /azure/client-generator-core/override/reorder/{param2}/{param1}`
+
+Verify that after `@override` the parameters are reordered correctly in the client method signature.
+
+Expected path parameter:
+param1: param1
+param2: param2
+
+Expected response: 204 No Content
 
 ### Azure_ClientGenerator_Core_Usage_ModelInOperation
 
@@ -1603,76 +1673,6 @@ Expected response body:
 }
 ```
 
-### Azure_ResourceManager_OperationTemplates_OptionalBody_post
-
-- Endpoint: `post https://management.azure.com`
-
-Resource POST action operation using ArmResourceActionSync with optional request body.
-This tests the optional body functionality in two scenarios:
-
-1. Empty body scenario: Request body is not sent
-2. With body scenario: Request body contains action data
-
-Expected verb: POST
-Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.OperationTemplates/widgets/widget1/post
-Expected query parameter: api-version=2023-12-01-preview
-
-Scenario 1 - Expected request body: None (empty body)
-Scenario 2 - Expected request body: {"actionType": "perform", "parameters": "test-parameters"}
-
-Expected status code: 200
-Expected response body (empty body scenario):
-
-```json
-{
-  "result": "Action completed successfully"
-}
-```
-
-Expected response body (with body scenario):
-
-```json
-{
-  "result": "Action completed successfully with parameters"
-}
-```
-
-### Azure_ResourceManager_OperationTemplates_OptionalBody_providerPost
-
-- Endpoint: `post https://management.azure.com`
-
-Provider POST action operation using ArmProviderActionSync with optional request body.
-This tests the optional body functionality for subscription-scoped provider actions in two scenarios:
-
-1. Empty body scenario: Request body is not sent (uses default allowance)
-2. With body scenario: Request body contains allowance change data
-
-Expected verb: POST
-Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/providers/Azure.ResourceManager.OperationTemplates/providerPost
-Expected query parameter: api-version=2023-12-01-preview
-
-Scenario 1 - Expected request body: None (empty body)
-Scenario 2 - Expected request body: {"totalAllowed": 100, "reason": "Increased demand"}
-
-Expected status code: 200
-Expected response body (empty body scenario):
-
-```json
-{
-  "totalAllowed": 50,
-  "status": "Changed to default allowance"
-}
-```
-
-Expected response body (with body scenario):
-
-```json
-{
-  "totalAllowed": 100,
-  "status": "Changed to requested allowance"
-}
-```
-
 ### Azure_ResourceManager_OperationTemplates_OptionalBody_get
 
 - Endpoint: `get https://management.azure.com`
@@ -1770,6 +1770,76 @@ Expected response body (with body scenario):
     "lastModifiedAt": <any date>,
     "lastModifiedByType": "User"
   }
+}
+```
+
+### Azure_ResourceManager_OperationTemplates_OptionalBody_post
+
+- Endpoint: `post https://management.azure.com`
+
+Resource POST action operation using ArmResourceActionSync with optional request body.
+This tests the optional body functionality in two scenarios:
+
+1. Empty body scenario: Request body is not sent
+2. With body scenario: Request body contains action data
+
+Expected verb: POST
+Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg/providers/Azure.ResourceManager.OperationTemplates/widgets/widget1/post
+Expected query parameter: api-version=2023-12-01-preview
+
+Scenario 1 - Expected request body: None (empty body)
+Scenario 2 - Expected request body: {"actionType": "perform", "parameters": "test-parameters"}
+
+Expected status code: 200
+Expected response body (empty body scenario):
+
+```json
+{
+  "result": "Action completed successfully"
+}
+```
+
+Expected response body (with body scenario):
+
+```json
+{
+  "result": "Action completed successfully with parameters"
+}
+```
+
+### Azure_ResourceManager_OperationTemplates_OptionalBody_providerPost
+
+- Endpoint: `post https://management.azure.com`
+
+Provider POST action operation using ArmProviderActionSync with optional request body.
+This tests the optional body functionality for subscription-scoped provider actions in two scenarios:
+
+1. Empty body scenario: Request body is not sent (uses default allowance)
+2. With body scenario: Request body contains allowance change data
+
+Expected verb: POST
+Expected path: /subscriptions/00000000-0000-0000-0000-000000000000/providers/Azure.ResourceManager.OperationTemplates/providerPost
+Expected query parameter: api-version=2023-12-01-preview
+
+Scenario 1 - Expected request body: None (empty body)
+Scenario 2 - Expected request body: {"totalAllowed": 100, "reason": "Increased demand"}
+
+Expected status code: 200
+Expected response body (empty body scenario):
+
+```json
+{
+  "totalAllowed": 50,
+  "status": "Changed to default allowance"
+}
+```
+
+Expected response body (with body scenario):
+
+```json
+{
+  "totalAllowed": 100,
+  "status": "Changed to requested allowance"
 }
 ```
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/override/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/override/client.tsp
@@ -8,22 +8,22 @@ using global.Azure.ClientGenerator.Core;
 @clientNamespace("azure.clientgenerator.core.methodoverride", "java")
 namespace Customization;
 
-@@clientNamespace(_Specs_.Azure.ClientGenerator.Core.Override, "azure.clientgenerator.core.methodoverride", "java");
+@@clientNamespace(_Specs_.Azure.ClientGenerator.Core.Override,
+  "azure.clientgenerator.core.methodoverride",
+  "java"
+);
 
-op reorderCustomized(
-  @path param1: string,
-  @path param2: string,
-): void;
+op reorderCustomized(@path param1: string, @path param2: string): void;
 
-@@override(_Specs_.Azure.ClientGenerator.Core.Override.ReorderParameters.reorder, reorderCustomized);
+@@override(_Specs_.Azure.ClientGenerator.Core.Override.ReorderParameters.reorder,
+  reorderCustomized
+);
 
 model GroupParametersOptions {
-  @query param1: string,
-  @query param2: string,
+  @query param1: string;
+  @query param2: string;
 }
 
-op groupCustomized(
-  options: GroupParametersOptions
-): void;
+op groupCustomized(options: GroupParametersOptions): void;
 
 @@override(_Specs_.Azure.ClientGenerator.Core.Override.GroupParameters.group, groupCustomized);

--- a/packages/azure-http-specs/specs/azure/client-generator-core/override/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/override/client.tsp
@@ -1,0 +1,29 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+import "@typespec/http";
+
+using Http;
+using global.Azure.ClientGenerator.Core;
+
+@clientNamespace("azure.clientgenerator.core.methodoverride", "java")
+namespace Customization;
+
+@@clientNamespace(_Specs_.Azure.ClientGenerator.Core.Override, "azure.clientgenerator.core.methodoverride", "java");
+
+op reorderCustomized(
+  @path param1: string,
+  @path param2: string,
+): void;
+
+@@override(_Specs_.Azure.ClientGenerator.Core.Override.ReorderParameters.reorder, reorderCustomized);
+
+model GroupParametersOptions {
+  @query param1: string,
+  @query param2: string,
+}
+
+op groupCustomized(
+  options: GroupParametersOptions
+): void;
+
+@@override(_Specs_.Azure.ClientGenerator.Core.Override.GroupParameters.group, groupCustomized);

--- a/packages/azure-http-specs/specs/azure/client-generator-core/override/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/override/main.tsp
@@ -13,36 +13,30 @@ interface ReorderParameters {
   @scenario
   @scenarioDoc("""
     Verify that after `@override` the parameters are reordered correctly in the client method signature.
-
+    
     Expected path parameter:
     param1: param1
     param2: param2
-
+    
     Expected response: 204 No Content
     """)
   @route("/reorder/{param2}/{param1}")
   @get
-  op reorder(
-    @path param2: string,
-    @path param1: string,
-  ): void;
+  reorder(@path param2: string, @path param1: string): void;
 }
 
 interface GroupParameters {
   @scenario
   @scenarioDoc("""
     Verify that after `@override` the parameters are grouped correctly to `GroupParametersOptions` in the client method signature.
-
+    
     Expected query parameter:
     param1: param1
     param2: param2
-
+    
     Expected response: 204 No Content
     """)
   @route("/group")
   @get
-  op group(
-    @query param1: string,
-    @query param2: string,
-  ): void;
+  group(@query param1: string, @query param2: string): void;
 }

--- a/packages/azure-http-specs/specs/azure/client-generator-core/override/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/override/main.tsp
@@ -1,0 +1,48 @@
+import "@typespec/http";
+import "@typespec/spector";
+import "@azure-tools/typespec-client-generator-core";
+
+using Http;
+using Spector;
+
+@doc("Test scenarios for client override behavior.")
+@scenarioService("/azure/client-generator-core/override")
+namespace _Specs_.Azure.ClientGenerator.Core.Override;
+
+interface ReorderParameters {
+  @scenario
+  @scenarioDoc("""
+    Verify that after `@override` the parameters are reordered correctly in the client method signature.
+
+    Expected path parameter:
+    param1: param1
+    param2: param2
+
+    Expected response: 204 No Content
+    """)
+  @route("/reorder/{param2}/{param1}")
+  @get
+  op reorder(
+    @path param2: string,
+    @path param1: string,
+  ): void;
+}
+
+interface GroupParameters {
+  @scenario
+  @scenarioDoc("""
+    Verify that after `@override` the parameters are grouped correctly to `GroupParametersOptions` in the client method signature.
+
+    Expected query parameter:
+    param1: param1
+    param2: param2
+
+    Expected response: 204 No Content
+    """)
+  @route("/group")
+  @get
+  op group(
+    @query param1: string,
+    @query param2: string,
+  ): void;
+}

--- a/packages/azure-http-specs/specs/azure/client-generator-core/override/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/override/mockapi.ts
@@ -1,0 +1,39 @@
+import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+// Test parameter reordering with @override decorator
+// Verifies that parameters are reordered correctly in client method signature
+// Expected path: /azure/client-generator-core/override/reorder/{param2}/{param1}
+// Where param1="param1" and param2="param2"
+Scenarios.Azure_ClientGenerator_Core_Override_ReorderParameters_reorder = passOnSuccess([
+  {
+    uri: "/azure/client-generator-core/override/reorder/param2/param1",
+    method: "get",
+    request: {},
+    response: {
+      status: 204,
+    },
+    kind: "MockApiDefinition",
+  },
+]);
+
+// Test parameter grouping with @override decorator
+// Verifies that parameters are grouped correctly into GroupParametersOptions
+// Expected query parameters: param1="param1", param2="param2"
+Scenarios.Azure_ClientGenerator_Core_Override_GroupParameters_group = passOnSuccess([
+  {
+    uri: "/azure/client-generator-core/override/group",
+    method: "get",
+    request: {
+      query: {
+        param1: "param1",
+        param2: "param2",
+      },
+    },
+    response: {
+      status: 204,
+    },
+    kind: "MockApiDefinition",
+  },
+]);


### PR DESCRIPTION
Add test case for 2 applications of `@override` decorator.
1. reorder client method parameters
2. group parameters to a model (option bag) in client method

Reorder path parameters may be used to "mitigate the breaking changes" from the difference of path parameter order between Swagger (with inconsistent order) with TypeSpec (where path always follow the order in URL template),

Java supports this decorator (though may not have enabled it in ARM).