### PR TITLE
Integration better checks

### DIFF
--- a/.github/scripts/validate-typespec-specs.ts
+++ b/.github/scripts/validate-typespec-specs.ts
@@ -64,9 +64,9 @@ async function findTspEntrypoint(directory: string): Promise<string | null> {
 }
 
 async function verifyProject(dir: string): Promise<{ success: boolean; output: string }> {
-  const entryPoint = await findTspEntrypoint(dir);
+  const entrypoint = await findTspEntrypoint(dir);
 
-  if (!entryPoint) {
+  if (!entrypoint) {
     const result = {
       success: false,
       output: "No main.tsp or client.tsp file found in directory",
@@ -76,13 +76,14 @@ async function verifyProject(dir: string): Promise<{ success: boolean; output: s
     return result;
   }
 
-  return runTspCompile2(dir, entryPoint);
+  return execTspCompile(dir, entrypoint, entrypoint === "client.tsp" ? ["--dry-run"] : []);
 }
-async function runTspCompile2(
+async function execTspCompile(
   directory: string,
   file: string,
+  args: string[] = [],
 ): Promise<{ success: boolean; output: string }> {
-  return execAsync("npx", ["tsp", "compile", file, "--warn-as-error"], {
+  return execAsync("npx", ["tsp", "compile", file, "--warn-as-error", ...args], {
     cwd: directory,
   });
 }

--- a/.github/workflows/external-integration.yml
+++ b/.github/workflows/external-integration.yml
@@ -60,16 +60,12 @@ jobs:
           echo "Installing dependencies..."
           npm install --no-package-lock
 
+          echo "Reverting package.json changes..."
+          git checkout -- package.json || true
+
       - name: Run TypeSpec validation in azure-rest-api-specs
         id: validation
         run: pnpm tsx ../.github/scripts/validate-typespec-specs.ts .
-        working-directory: azure-rest-api-specs
-        continue-on-error: true
-
-      - name: Revert package.json changes
-        run: |
-          echo "Reverting package.json changes..."
-          git checkout -- package.json || true
         working-directory: azure-rest-api-specs
 
       - name: Check for git changes

--- a/.github/workflows/external-integration.yml
+++ b/.github/workflows/external-integration.yml
@@ -73,6 +73,7 @@ jobs:
         working-directory: azure-rest-api-specs
 
       - name: Check for git changes
+        if: success() || failure() # Still run this step even if validation fails to ensure as much information as possible
         run: |
           git_changes=$(git status --porcelain)
           if [ -n "$git_changes" ]; then
@@ -84,9 +85,3 @@ jobs:
             echo "✅ No git changes detected"
           fi
         working-directory: azure-rest-api-specs
-
-      - name: Fail job if TypeSpec validation failed
-        if: steps.validation.outcome == 'failure'
-        run: |
-          echo "❌ TypeSpec validation failed. Check the validation step output for details."
-          exit 1


### PR DESCRIPTION
fix #2981 (Handle specs without main.tsp)
- Make the compile step fail but still run the git diff one so you can see all teh failing step and not assume the compile succeeded if there is git diff
- improve the logging in the compile step to make it easier to find errors