### PR TITLE
[TCGC] Fix wrong API version elevator logic with `@clientLocation`

### DIFF
--- a/.chronus/changes/tcgc-fix_client_location-2025-6-11-15-59-9.md
+++ b/.chronus/changes/tcgc-fix_client_location-2025-6-11-15-59-9.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Fix wrong API version elevator logic with `@clientLocation`.

--- a/packages/typespec-client-generator-core/src/clients.ts
+++ b/packages/typespec-client-generator-core/src/clients.ts
@@ -228,9 +228,7 @@ function addDefaultClientParameters<
     for (const sc of listOperationGroups(context, client.__raw, true)) {
       // if any sub operation groups have an api version param, the top level needs
       // the api version param as well
-      apiVersionParam = sc.type
-        ? context.__clientParametersCache.get(sc)?.find((x) => x.isApiVersionParam)
-        : undefined;
+      apiVersionParam = context.__clientParametersCache.get(sc)?.find((x) => x.isApiVersionParam);
       if (apiVersionParam) break;
     }
   }

--- a/packages/typespec-client-generator-core/test/decorators/client-location.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/client-location.test.ts
@@ -424,3 +424,51 @@ it("move an operation to root client with api version", async () => {
     rootClientApiVersionParam,
   );
 });
+
+it("all operations have been moved", async () => {
+  await runner.compile(
+    `
+    @service
+    @versioned(Versions)
+    namespace TestService;
+    enum Versions {
+      v1: "v1",
+      v2: "v2",
+    }
+
+    interface A {
+      @route("/a1")
+      @clientLocation("B")
+      op a1(@query apiVersion: string): void;
+
+      @route("/a2")
+      @clientLocation("C")
+      op a2(@query apiVersion: string): void;
+    }
+  `,
+  );
+
+  const sdkPackage = runner.context.sdkPackage;
+  const rootClient = sdkPackage.clients.find((c) => c.name === "TestServiceClient");
+  ok(rootClient);
+  const rootClientApiVersionParam = rootClient.clientInitialization.parameters.find(
+    (p) => p.name === "apiVersion",
+  );
+  ok(rootClientApiVersionParam);
+
+  strictEqual(rootClient.children?.length, 2);
+
+  const bClient = rootClient.children.find((c) => c.name === "B");
+  ok(bClient);
+  const bClientApiVersionParam = bClient.clientInitialization.parameters.find(
+    (p) => p.name === "apiVersion",
+  );
+  ok(bClientApiVersionParam);
+
+  const cClient = rootClient.children.find((c) => c.name === "C");
+  ok(cClient);
+  const cClientApiVersionParam = cClient.clientInitialization.parameters.find(
+    (p) => p.name === "apiVersion",
+  );
+  ok(cClientApiVersionParam);
+});


### PR DESCRIPTION
Fix: https://github.com/Azure/typespec-azure/issues/2951