### PR TITLE
[TCGC] Fix missing info for multipart cases after model property refactor

### DIFF
--- a/.chronus/changes/fix_multipart-2025-6-18-15-33-1.md
+++ b/.chronus/changes/fix_multipart-2025-6-18-15-33-1.md
@@ -1,0 +1,7 @@
+---
+changeKind: breaking
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Replace the property type of a multipart model with the real body type for the HTTP part. Put all other info into the property's multipart serialization option with `MultipartOptions` type. Add `headers` property with `SdkHeaderParameter[]` type in `MultipartOptions` interface.

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -644,17 +644,20 @@ export interface SdkCredentialParameter
 }
 
 export interface MultipartOptions {
+  /** Name of the part in the multipart payload. */
   name: string;
-  /** whether this part is for file */
+  /** Whether this part is for file */
   isFilePart: boolean;
-  /** whether this part is multi in request payload */
+  /** Whether this part is multi in request payload */
   isMulti: boolean;
-  /** undefined if filename is not set explicitly in Typespec */
+  /** Undefined if filename is not set explicitly in Typespec */
   filename?: SdkModelPropertyType;
-  /** undefined if contentType is not set explicitly in Typespec */
+  /** Undefined if contentType is not set explicitly in Typespec */
   contentType?: SdkModelPropertyType;
-  /** defined in Typespec or calculated by Typespec complier */
+  /** Default content types defined in Typespec or calculated by Typespec complier */
   defaultContentTypes: string[];
+  /** Part headers */
+  headers: SdkHeaderParameter[];
 }
 
 export interface SdkModelPropertyType extends SdkModelPropertyTypeBase {

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -56,12 +56,11 @@ import {
 import {
   AllScopes,
   TspLiteralType,
-  getHttpBodySpreadModel,
+  getHttpBodyType,
   getHttpOperationResponseHeaders,
   hasExplicitClientOrOperationGroup,
   hasNoneVisibility,
   isAzureCoreTspModel,
-  isHttpBodySpread,
   listAllUserDefinedNamespaces,
   removeVersionsLargerThanExplicitlySpecified,
   resolveDuplicateGenearatedName,
@@ -392,12 +391,7 @@ function getContextPath(
     if (httpOperation.parameters.body) {
       visited.clear();
       result = [{ name: root.name, type: root }];
-      let bodyType: Type;
-      if (isHttpBodySpread(httpOperation.parameters.body)) {
-        bodyType = getHttpBodySpreadModel(httpOperation.parameters.body.type as Model);
-      } else {
-        bodyType = httpOperation.parameters.body.type;
-      }
+      const bodyType = getHttpBodyType(httpOperation.parameters.body);
       if (dfsModelProperties(typeToFind, bodyType, "Request")) {
         return result;
       }

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -34,12 +34,9 @@ import {
 } from "@typespec/compiler";
 import {
   Authentication,
-  HttpOperationPart,
   Visibility,
   getAuthentication,
-  getHttpPart,
   getServers,
-  isBody,
   isHeader,
   isOrExtendsHttpFile,
   isStatusCode,
@@ -73,6 +70,7 @@ import {
   SdkDurationType,
   SdkEnumType,
   SdkEnumValueType,
+  SdkHeaderParameter,
   SdkModelPropertyType,
   SdkModelPropertyTypeBase,
   SdkModelType,
@@ -90,7 +88,7 @@ import {
   filterApiVersionsInEnum,
   getAvailableApiVersions,
   getClientDoc,
-  getHttpBodySpreadModel,
+  getHttpBodyType,
   getHttpOperationResponseHeaders,
   getNonNullOptions,
   getNullOption,
@@ -118,6 +116,7 @@ import {
 
 import { getVersions } from "@typespec/versioning";
 import { getNs, isAttribute, isUnwrapped } from "@typespec/xml";
+import { getSdkHttpParameter } from "./http.js";
 import { isMediaTypeJson, isMediaTypeTextPlain, isMediaTypeXml } from "./media-types.js";
 
 export function getTypeSpecBuiltInType(
@@ -835,8 +834,21 @@ export function getSdkModelWithDiagnostics(
         getClientTypeWithDiagnostics(context, type.indexer.value, operation),
       );
     }
-    // propreties should be generated first since base model'sdiscriminator handling is depend on derived model's properties
-    diagnostics.pipe(addPropertiesToModelType(context, type, sdkType, operation));
+
+    // properties should be generated first since base model's discriminator handling is depend on derived model's properties
+    if (operation && isMultipartOperation(context, operation)) {
+      const body = getHttpOperationWithCache(context, operation).parameters.body;
+      if (body && getHttpBodyType(body) === type) {
+        // handle multipart body model properties
+        diagnostics.pipe(addMultipartPropertiesToModelType(context, sdkType, operation));
+      } else {
+        // handle normal model properties
+        diagnostics.pipe(addPropertiesToModelType(context, type, sdkType, operation));
+      }
+    } else {
+      // handle normal model properties
+      diagnostics.pipe(addPropertiesToModelType(context, type, sdkType, operation));
+    }
     if (type.baseModel) {
       sdkType.baseModel = context.__referencedTypeCache.get(type.baseModel) as
         | SdkModelType
@@ -1050,14 +1062,7 @@ export function getClientTypeWithDiagnostics(
     case "Model":
       retval = diagnostics.pipe(getSdkArrayOrDictWithDiagnostics(context, type, operation));
       if (retval === undefined) {
-        const httpPart = getHttpPart(context.program, type);
-        if (httpPart === undefined) {
-          retval = diagnostics.pipe(getSdkModelWithDiagnostics(context, type, operation));
-        } else {
-          retval = diagnostics.pipe(
-            getClientTypeWithDiagnostics(context, httpPart.type, operation),
-          );
-        }
+        retval = diagnostics.pipe(getSdkModelWithDiagnostics(context, type, operation));
       }
       break;
     case "Intrinsic":
@@ -1240,106 +1245,18 @@ export function getSdkModelPropertyTypeBase(
 
 function isFilePart(context: TCGCContext, type: SdkType): boolean {
   if (type.kind === "array") {
-    // HttpFile<T>[]
+    // HttpFile<T>[] or HttpPart<{@body body: bytes}>[]
     return isFilePart(context, type.valueType);
   } else if (type.kind === "bytes") {
-    // Http<bytes>
+    // Http<bytes> or HttpPart<{@body body: bytes}>
     return true;
   } else if (type.kind === "model") {
     if (type.__raw && isOrExtendsHttpFile(context.program, type.__raw)) {
-      // Http<File>
+      // Http<File> or HttpPart<{@body body: File}>
       return true;
     }
-    // HttpPart<{@body body: bytes}> or HttpPart<{@body body: File}>
-    const body = type.properties.find((x) => x.__raw && isBody(context.program, x.__raw));
-    if (body) {
-      return isFilePart(context, body.type);
-    }
   }
   return false;
-}
-
-function getHttpOperationParts(context: TCGCContext, operation: Operation): HttpOperationPart[] {
-  const body = getHttpOperationWithCache(context, operation).parameters.body;
-  if (body?.bodyKind === "multipart") {
-    return body.parts;
-  }
-  return [];
-}
-
-function hasHttpPart(context: TCGCContext, type: Type): boolean {
-  if (type.kind === "Model") {
-    if (type.indexer) {
-      // HttpPart<T>[]
-      return (
-        type.indexer.key.name === "integer" &&
-        getHttpPart(context.program, type.indexer.value) !== undefined
-      );
-    } else {
-      // HttpPart<T>
-      return getHttpPart(context.program, type) !== undefined;
-    }
-  }
-  return false;
-}
-
-function getHttpOperationPart(
-  context: TCGCContext,
-  type: ModelProperty,
-  operation: Operation,
-): HttpOperationPart | undefined {
-  if (hasHttpPart(context, type.type)) {
-    const httpOperationParts = getHttpOperationParts(context, operation);
-    if (
-      type.model &&
-      httpOperationParts.length > 0 &&
-      httpOperationParts.length === type.model.properties.size
-    ) {
-      const index = Array.from(type.model.properties.values()).findIndex((p) => p === type);
-      if (index !== -1) {
-        return httpOperationParts[index];
-      }
-    }
-  }
-  return undefined;
-}
-
-function updateMultiPartInfo(
-  context: TCGCContext,
-  type: ModelProperty,
-  base: SdkModelPropertyType,
-  operation: Operation,
-): [void, readonly Diagnostic[]] {
-  const httpOperationPart = getHttpOperationPart(context, type, operation);
-  const diagnostics = createDiagnosticCollector();
-  if (httpOperationPart) {
-    // body decorated with @multipartBody
-    base.serializationOptions.multipart = {
-      isFilePart: isFilePart(context, base.type),
-      isMulti: httpOperationPart.multi,
-      filename: httpOperationPart.filename
-        ? diagnostics.pipe(getSdkModelPropertyType(context, httpOperationPart.filename, operation))
-        : undefined,
-      contentType: httpOperationPart.body.contentTypeProperty
-        ? diagnostics.pipe(
-            getSdkModelPropertyType(context, httpOperationPart.body.contentTypeProperty, operation),
-          )
-        : undefined,
-      defaultContentTypes: httpOperationPart.body.contentTypes,
-      name: base.name,
-    };
-    // after https://github.com/microsoft/typespec/issues/3779 fixed, could use httpOperationPart.name directly
-    const httpPart = getHttpPart(context.program, type.type);
-    if (httpPart?.options?.name) {
-      base.serializedName = httpPart?.options?.name; // eslint-disable-line @typescript-eslint/no-deprecated
-      base.serializationOptions.multipart.name = httpPart?.options?.name;
-    }
-  }
-  if (base.serializationOptions.multipart !== undefined) {
-    base.isMultipartFileInput = base.serializationOptions.multipart.isFilePart; // eslint-disable-line @typescript-eslint/no-deprecated
-  }
-
-  return diagnostics.wrap(undefined);
 }
 
 export function getSdkModelPropertyType(
@@ -1363,20 +1280,6 @@ export function getSdkModelPropertyType(
       serializationOptions: {},
     };
     context.__modelPropertyCache.set(type, property);
-    if (operation && type.model) {
-      const httpOperation = getHttpOperationWithCache(context, operation);
-      const httpBody = httpOperation.parameters.body;
-      if (httpBody) {
-        const httpBodyType = isHttpBodySpread(httpBody)
-          ? getHttpBodySpreadModel(httpBody.type as Model)
-          : httpBody.type;
-        if (type.model === httpBodyType) {
-          // only try to add multipartOptions for property of body
-          diagnostics.pipe(updateMultiPartInfo(context, type, property, operation));
-          property.multipartOptions = property.serializationOptions.multipart; // eslint-disable-line @typescript-eslint/no-deprecated
-        }
-      }
-    }
   }
   return diagnostics.wrap(property);
 }
@@ -1384,7 +1287,7 @@ export function getSdkModelPropertyType(
 function addPropertiesToModelType(
   context: TCGCContext,
   type: Model,
-  sdkType: SdkType,
+  sdkType: SdkModelType,
   operation?: Operation,
 ): [void, readonly Diagnostic[]] {
   const diagnostics = createDiagnosticCollector();
@@ -1392,17 +1295,68 @@ function addPropertiesToModelType(
     if (
       isStatusCode(context.program, property) ||
       isNeverOrVoidType(property.type) ||
-      hasNoneVisibility(context, property) ||
-      sdkType.kind !== "model"
+      hasNoneVisibility(context, property)
     ) {
       continue;
     }
     const clientProperty = diagnostics.pipe(getSdkModelPropertyType(context, property, operation));
-    if (sdkType.properties) {
-      sdkType.properties.push(clientProperty);
+    sdkType.properties.push(clientProperty);
+  }
+  return diagnostics.wrap(undefined);
+}
+
+function addMultipartPropertiesToModelType(
+  context: TCGCContext,
+  sdkType: SdkModelType,
+  operation: Operation,
+): [void, readonly Diagnostic[]] {
+  const diagnostics = createDiagnosticCollector();
+  const body = getHttpOperationWithCache(context, operation).parameters.body;
+  if (!body || body.bodyKind !== "multipart") {
+    return diagnostics.wrap(undefined);
+  }
+  for (const part of body.parts) {
+    const clientProperty = diagnostics.pipe(
+      getSdkModelPropertyType(context, part.property!, operation),
+    );
+
+    // set the type of the client property based on the part body type
+    const bodyType = getHttpBodyType(part.body);
+    if (clientProperty.type.kind === "array") {
+      clientProperty.type.valueType = diagnostics.pipe(
+        getClientTypeWithDiagnostics(context, bodyType, operation),
+      );
     } else {
-      sdkType.properties = [clientProperty];
+      clientProperty.type = diagnostics.pipe(
+        getClientTypeWithDiagnostics(context, bodyType, operation),
+      );
     }
+
+    clientProperty.serializationOptions.multipart = {
+      isFilePart: isFilePart(context, clientProperty.type),
+      isMulti: part.multi,
+      filename: part.filename
+        ? diagnostics.pipe(getSdkModelPropertyType(context, part.filename, operation))
+        : undefined,
+      contentType: part.body.contentTypeProperty
+        ? diagnostics.pipe(
+            getSdkModelPropertyType(context, part.body.contentTypeProperty, operation),
+          )
+        : undefined,
+      defaultContentTypes: part.body.contentTypes,
+      name: part.name!,
+      headers: part.headers.map((header) => {
+        return diagnostics.pipe(
+          getSdkHttpParameter(context, header.property),
+        ) as SdkHeaderParameter;
+      }),
+    };
+
+    clientProperty.serializedName = clientProperty.serializationOptions.multipart.name; // eslint-disable-line @typescript-eslint/no-deprecated
+    clientProperty.isMultipartFileInput = clientProperty.serializationOptions.multipart.isFilePart; // eslint-disable-line @typescript-eslint/no-deprecated
+    clientProperty.multipartOptions = clientProperty.serializationOptions.multipart; // eslint-disable-line @typescript-eslint/no-deprecated
+
+    sdkType.properties.push(clientProperty);
   }
   return diagnostics.wrap(undefined);
 }
@@ -1598,22 +1552,13 @@ function updateTypesFromOperation(
   const httpBody = httpOperation.parameters.body;
   if (httpBody && !isNeverOrVoidType(httpBody.type)) {
     const spread = isHttpBodySpread(httpBody);
-    let sdkType: SdkType;
-    if (spread) {
-      sdkType = diagnostics.pipe(
-        getClientTypeWithDiagnostics(
-          context,
-          getHttpBodySpreadModel(httpBody.type as Model),
-          operation,
-        ),
-      );
-    } else {
-      sdkType = diagnostics.pipe(getClientTypeWithDiagnostics(context, httpBody.type, operation));
-    }
+    const sdkType = diagnostics.pipe(
+      getClientTypeWithDiagnostics(context, getHttpBodyType(httpBody), operation),
+    );
 
     const multipartOperation = isMultipartOperation(context, operation);
     if (generateConvenient) {
-      if (spread) {
+      if (spread && sdkType.kind === "model") {
         updateUsageOrAccess(context, UsageFlags.Spread, sdkType, { propagation: false });
         updateUsageOrAccess(context, UsageFlags.Input, sdkType, { skipFirst: true });
       } else {


### PR DESCRIPTION
This is a behavior breaking change. Currently, TCGC always replaces the property type of a multipart model with the real body type for the HTTP part. So, emitter could rely on the property type directly to serialize/deserialize an HTTP part. Also, the header parameters in one HTTP part are added to the `headers` property of `MultipartOptions` type.

For example:
```tsp
model MultiPartRequest {
  stringWithContentType: HttpPart<{
    @body body: string;
    @header contentType: "text/html";
  }>;
}
@post
op upload(
  @header contentType: "multipart/form-data",
  @multipartBody body: MultiPartRequest,
): void;
```
The type of `stringWithContentType` is `string` instead of an anonymous model `{@body body: string; @header contentType: "text/html";}` as before.

## Migration Guide
For any property with multipart serialization option, use the property type directly instead of looking for body parameter as before.
