### PR TITLE
[tcgc] add `@inheritsFrom` decorator

### DIFF
--- a/.chronus/changes/tcgc-inheritsFrom-2025-6-22-14-45-43.md
+++ b/.chronus/changes/tcgc-inheritsFrom-2025-6-22-14-45-43.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+add `@inheritsFrom` decorator to allow multi-level discriminator handling

--- a/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.ts
+++ b/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.ts
@@ -861,6 +861,47 @@ export type ClientDocDecorator = (
   scope?: string,
 ) => void;
 
+/**
+ * Adds support for client-level multiple levels of inheritance.
+ *
+ * This decorator will update the models returned from TCGC to include the multi-level inheritance information.
+ *
+ * @param target The target type (operation, model, enum, etc.) for which you want to apply client-specific documentation.
+ * @param documentation The client-specific documentation to apply
+ * @param mode Specifies how to apply the documentation (append or replace)
+ * @param scope Specifies the target language emitters that the decorator should apply. If not set, the decorator will be applied to all language emitters by default.
+ * You can use "!" to exclude specific languages, for example: !(java, python) or !java, !python.
+ * @example Three-level inheritance
+ *
+ * ```typespec
+ * @discriminator("kind")
+ * model A {
+ *   kind: string;
+ * }
+ *
+ * model BContent {
+ *   foo: string;
+ * }
+ *
+ * model B extends A{
+ *   kind: "B";
+ *   ...BContent;
+ * }
+ *
+ * @inheritsFrom(B)
+ * model C extends A{
+ *   ...BContent;
+ *   kind: "C";
+ * }
+ * ```
+ */
+export type InheritsFromDecorator = (
+  context: DecoratorContext,
+  target: Model,
+  value: Model,
+  scope?: string,
+) => void;
+
 export type AzureClientGeneratorCoreDecorators = {
   clientName: ClientNameDecorator;
   convenientAPI: ConvenientAPIDecorator;
@@ -883,4 +924,5 @@ export type AzureClientGeneratorCoreDecorators = {
   responseAsBool: ResponseAsBoolDecorator;
   clientLocation: ClientLocationDecorator;
   clientDoc: ClientDocDecorator;
+  inheritsFrom: InheritsFromDecorator;
 };

--- a/packages/typespec-client-generator-core/lib/decorators.tsp
+++ b/packages/typespec-client-generator-core/lib/decorators.tsp
@@ -902,3 +902,44 @@ extern dec clientDoc(
   mode: EnumMember,
   scope?: valueof string
 );
+
+/**
+ * Adds support for client-level multiple levels of inheritance.
+ * 
+ * This decorator will update the models returned from TCGC to include the multi-level inheritance information.
+ *
+ * @param target The target type (operation, model, enum, etc.) for which you want to apply client-specific documentation.
+ * @param documentation The client-specific documentation to apply
+ * @param mode Specifies how to apply the documentation (append or replace)
+ * @param scope Specifies the target language emitters that the decorator should apply. If not set, the decorator will be applied to all language emitters by default.
+ * You can use "!" to exclude specific languages, for example: !(java, python) or !java, !python.
+ *
+ * @example Three-level inheritance
+ * 
+ * ```typespec
+ * @discriminator("kind")
+ * model A {
+ *   kind: string;
+ * }
+ *
+ * model BContent {
+ *   foo: string;
+ * }
+ *
+ * model B extends A{
+ *   kind: "B";
+ *   ...BContent;
+ * }
+
+ * @inheritsFrom(B)
+ * model C extends A{
+ *   ...BContent;
+ *   kind: "C";
+ * }
+ * ```
+ */
+extern dec inheritsFrom(
+  target: Model,
+  value: Model,
+  scope?: valueof string
+);

--- a/packages/typespec-client-generator-core/lib/decorators.tsp
+++ b/packages/typespec-client-generator-core/lib/decorators.tsp
@@ -938,8 +938,4 @@ extern dec clientDoc(
  * }
  * ```
  */
-extern dec inheritsFrom(
-  target: Model,
-  value: Model,
-  scope?: valueof string
-);
+extern dec inheritsFrom(target: Model, value: Model, scope?: valueof string);

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -33,6 +33,7 @@ import {
   ConvenientAPIDecorator,
   DeserializeEmptyStringAsNullDecorator,
   FlattenPropertyDecorator,
+  InheritsFromDecorator,
   OperationGroupDecorator,
   ParamAliasDecorator,
   ProtocolAPIDecorator,
@@ -1188,6 +1189,21 @@ export function getClientLocation(
     | Interface
     | string
     | undefined;
+}
+
+const inheritsFromKey = createStateSymbol("inheritsFrom");
+
+export const $inheritsFrom: InheritsFromDecorator = (
+  context: DecoratorContext,
+  target: Model,
+  value: Model,
+  scope?: LanguageScopes,
+) => {
+  setScopedDecoratorData(context, $inheritsFrom, inheritsFromKey, target, value, scope);
+};
+
+export function getInheritsFrom(context: TCGCContext, target: Model): Model | undefined {
+  return getScopedDecoratorData(context, inheritsFromKey, target);
 }
 
 /**

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -1203,7 +1203,26 @@ export const $inheritsFrom: InheritsFromDecorator = (
 };
 
 export function getInheritsFrom(context: TCGCContext, target: Model): Model | undefined {
-  return getScopedDecoratorData(context, inheritsFromKey, target);
+  // have to check circular inheritance in getter because in the decorator stage, the circularity of the models isn't fully calculated yet
+  const value = getScopedDecoratorData(context, inheritsFromKey, target);
+  let circular = false;
+  let current: Model | undefined = value;
+  while (current) {
+    if (current === target) {
+      circular = true;
+      break;
+    }
+    current = current.baseModel;
+  }
+  if (circular) {
+    reportDiagnostic(context.program, {
+      code: "inherits-from-circular",
+      format: { target: target.name, value: value.name },
+      target: value,
+    });
+    return undefined;
+  }
+  return value;
 }
 
 /**

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -79,6 +79,7 @@ export interface TCGCContext {
   __mutatedGlobalNamespace?: Namespace; // the root of all tsp namespaces for this instance. Starting point for traversal, so we don't call mutation multiple times
   __packageVersions?: string[]; // the package versions from the service versioning config and api version setting in tspconfig.
   __packageVersionEnum?: Enum; // the enum type that contains all the package versions.
+  __typesCheckedForCircularInheritance?: Set<Type>; // used to track types that have been checked for circular inheritance to avoid redundant checks
 
   getMutatedGlobalNamespace(): Namespace;
   getApiVersionsForType(type: Type): string[];

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -37,7 +37,7 @@ import {
   getVersioningMutators,
   getVersions,
 } from "@typespec/versioning";
-import { getClientDocExplicit, getInheritsFrom, getParamAlias } from "./decorators.js";
+import { getClientDocExplicit, getParamAlias } from "./decorators.js";
 import { getSdkHttpParameter, isSdkHttpParameter } from "./http.js";
 import {
   DecoratorInfo,
@@ -790,8 +790,4 @@ export function* filterMapValuesIterator<V>(
       yield value;
     }
   }
-}
-
-export function getBaseModel(context: TCGCContext, model: Model): Model | undefined {
-  return getInheritsFrom(context, model) ?? model.baseModel;
 }

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -37,7 +37,7 @@ import {
   getVersioningMutators,
   getVersions,
 } from "@typespec/versioning";
-import { getClientDocExplicit, getParamAlias } from "./decorators.js";
+import { getClientDocExplicit, getInheritsFrom, getParamAlias } from "./decorators.js";
 import { getSdkHttpParameter, isSdkHttpParameter } from "./http.js";
 import {
   DecoratorInfo,
@@ -790,4 +790,8 @@ export function* filterMapValuesIterator<V>(
       yield value;
     }
   }
+}
+
+export function getBaseModel(context: TCGCContext, model: Model): Model | undefined {
+  return getInheritsFrom(context, model) ?? model.baseModel;
 }

--- a/packages/typespec-client-generator-core/src/lib.ts
+++ b/packages/typespec-client-generator-core/src/lib.ts
@@ -404,6 +404,19 @@ export const $lib = createTypeSpecLibrary({
           "`@clientLocation`'s target should not duplicate with defined namespace or interface under `@service` namespace.",
       },
     },
+    "inherits-from-circular": {
+      severity: "warning",
+      messages: {
+        default:
+          "Circular inheritance detected in @inheritsFrom decorator. We will ignore this decorator",
+      },
+    },
+    "inherits-from-conflict": {
+      severity: "warning",
+      messages: {
+        default: paramMessage`@inheritsFrom decorator causes conflicts in inherited properties. Please check that the model ${"childModel"} has the same properties as ${"inheritsFromModelName"} in the spec.`,
+      },
+    },
   },
   emitter: {
     options: TCGCEmitterOptionsSchema,

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -56,7 +56,6 @@ import {
 import {
   AllScopes,
   TspLiteralType,
-  getBaseModel,
   getHttpBodyType,
   getHttpOperationResponseHeaders,
   hasExplicitClientOrOperationGroup,
@@ -532,7 +531,7 @@ function getContextPath(
         if (result) return true;
       }
       // handle additional properties type: model MyModel extends Record<> {}
-      const baseModel = getBaseModel(context, currentType);
+      const baseModel = currentType.baseModel;
       if (baseModel) {
         if (baseModel.name === "Record") {
           const result = dfsModelProperties(
@@ -545,11 +544,7 @@ function getContextPath(
       }
       result.pop();
       if (baseModel) {
-        const result = dfsModelProperties(
-          expectedType,
-          baseModel,
-          baseModel.name,
-        );
+        const result = dfsModelProperties(expectedType, baseModel, baseModel.name);
         if (result) return true;
       }
       // TODO: come back and see if derived models are needed to change

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -56,6 +56,7 @@ import {
 import {
   AllScopes,
   TspLiteralType,
+  getBaseModel,
   getHttpBodyType,
   getHttpOperationResponseHeaders,
   hasExplicitClientOrOperationGroup,
@@ -531,25 +532,27 @@ function getContextPath(
         if (result) return true;
       }
       // handle additional properties type: model MyModel extends Record<> {}
-      if (currentType.baseModel) {
-        if (currentType.baseModel.name === "Record") {
+      const baseModel = getBaseModel(context, currentType);
+      if (baseModel) {
+        if (baseModel.name === "Record") {
           const result = dfsModelProperties(
             expectedType,
-            currentType.baseModel.indexer!.value!,
+            baseModel.indexer!.value!,
             "AdditionalProperty",
           );
           if (result) return true;
         }
       }
       result.pop();
-      if (currentType.baseModel) {
+      if (baseModel) {
         const result = dfsModelProperties(
           expectedType,
-          currentType.baseModel,
-          currentType.baseModel.name,
+          baseModel,
+          baseModel.name,
         );
         if (result) return true;
       }
+      // TODO: come back and see if derived models are needed to change
       for (const derivedModel of currentType.derivedModels) {
         const result = dfsModelProperties(expectedType, derivedModel, derivedModel.name);
         if (result) return true;

--- a/packages/typespec-client-generator-core/src/tsp-index.ts
+++ b/packages/typespec-client-generator-core/src/tsp-index.ts
@@ -13,6 +13,7 @@ import {
   $convenientAPI,
   $deserializeEmptyStringAsNull,
   $flattenProperty,
+  $inheritsFrom,
   $operationGroup,
   $override,
   $paramAlias,
@@ -51,5 +52,6 @@ export const $decorators = {
     responseAsBool: $responseAsBool,
     clientDoc: $clientDoc,
     clientLocation: $clientLocation,
+    inheritsFrom: $inheritsFrom,
   } as AzureClientGeneratorCoreDecorators,
 };

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -1749,10 +1749,14 @@ function updateDiscriminatedSubtypesFromInheritsFrom(
     const inheritsFrom = getInheritsFrom(context, sdkType.__raw as Model);
     // must be done after discriminator is added
     if (inheritsFrom && sdkType.discriminatorValue) {
-      if (!sdkType.baseModel!.discriminatedSubtypes) {
-        sdkType.baseModel!.discriminatedSubtypes = {};
+      let currBaseModel: SdkModelType | undefined = sdkType.baseModel;
+      while (currBaseModel) {
+        if (!currBaseModel.discriminatedSubtypes) {
+          currBaseModel.discriminatedSubtypes = {};
+        }
+        currBaseModel.discriminatedSubtypes[sdkType.discriminatorValue] = sdkType;
+        currBaseModel = currBaseModel.baseModel;
       }
-      sdkType.baseModel!.discriminatedSubtypes[sdkType.discriminatorValue] = sdkType;
     }
   }
   return diagnostics.wrap(undefined);

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -87,6 +87,7 @@ import {
   createGeneratedName,
   filterApiVersionsInEnum,
   getAvailableApiVersions,
+  getBaseModel,
   getClientDoc,
   getHttpBodyType,
   getHttpOperationResponseHeaders,
@@ -849,13 +850,14 @@ export function getSdkModelWithDiagnostics(
       // handle normal model properties
       diagnostics.pipe(addPropertiesToModelType(context, type, sdkType, operation));
     }
-    if (type.baseModel) {
-      sdkType.baseModel = context.__referencedTypeCache.get(type.baseModel) as
+    const rawBaseModel = getBaseModel(context, type);
+    if (rawBaseModel) {
+      sdkType.baseModel = context.__referencedTypeCache.get(rawBaseModel) as
         | SdkModelType
         | undefined;
       if (sdkType.baseModel === undefined) {
         const baseModel = diagnostics.pipe(
-          getClientTypeWithDiagnostics(context, type.baseModel, operation),
+          getClientTypeWithDiagnostics(context, rawBaseModel, operation),
         ) as SdkDictionaryType | SdkModelType;
         if (baseModel.kind === "dict") {
           // model MyModel extends Record<> {} should be model with additional properties

--- a/packages/typespec-client-generator-core/test/decorators/inherits-from.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/inherits-from.test.ts
@@ -1,0 +1,318 @@
+import { expectDiagnostics } from "@typespec/compiler/testing";
+import { ok, strictEqual } from "assert";
+import { beforeEach, it } from "vitest";
+import { SdkTestRunner, createSdkTestRunner } from "../test-host.js";
+
+let runner: SdkTestRunner;
+
+beforeEach(async () => {
+  runner = await createSdkTestRunner({ emitterName: "@azure-tools/typespec-java" });
+});
+
+it("three-level inheritance chain", async () => {
+  await runner.compileWithBuiltInService(`
+      @discriminator("kind")
+      model A {
+        kind: string;
+      }
+
+      model BContent {
+        foo: string;
+      }
+
+      model B extends A {
+        kind: "B";
+        ...BContent;
+      }
+
+      @inheritsFrom(B)
+      model C extends A {
+        kind: "C";
+        ...BContent;
+        bar: string;
+      }
+
+      @route("/test")
+      op test(): A;
+    `);
+
+  const models = runner.context.sdkPackage.models;
+  const modelA = models.find((m) => m.name === "A");
+  const modelB = models.find((m) => m.name === "B");
+  const modelC = models.find((m) => m.name === "C");
+
+  ok(modelA);
+  ok(modelB);
+  ok(modelC);
+
+  // C should inherit from B instead of A due to @inheritsFrom
+  strictEqual(modelC.baseModel?.name, "B");
+  strictEqual(modelB.baseModel?.name, "A");
+
+  // Verify discriminator property is correctly identified
+  strictEqual(modelA.discriminatorProperty?.name, "kind");
+  strictEqual(modelB.discriminatorValue, "B");
+  strictEqual(modelC.discriminatorValue, "C");
+  strictEqual(modelA.discriminatorValue, undefined);
+
+  // Verify properties are correctly inherited
+  strictEqual(modelC.properties.length, 3);
+  strictEqual(modelC.properties[0].name, "kind");
+  strictEqual(modelC.properties[1].name, "foo");
+  strictEqual(modelC.properties[2].name, "bar");
+  strictEqual(modelB.properties.length, 2);
+  strictEqual(modelB.properties[0].name, "kind");
+  strictEqual(modelB.properties[1].name, "foo");
+  strictEqual(modelA.properties.length, 1);
+  strictEqual(modelA.properties[0].name, "kind");
+});
+
+it("four-level inheritance chain", async () => {
+  await runner.compileWithBuiltInService(`
+      @discriminator("type")
+      model Vehicle {
+        type: string;
+      }
+
+      model MotorVehicleContent {
+        engine: string;}
+
+      model MotorVehicle extends Vehicle {
+        type: "motor";
+        ...MotorVehicleContent;
+      }
+
+      model CarContent {
+        doors: int32;
+      }
+
+      @inheritsFrom(MotorVehicle)
+      model Car extends Vehicle {
+        type: "car";
+        ...MotorVehicleContent;
+        ...CarContent;
+      }
+
+      @inheritsFrom(Car)
+      model SportsCar extends Vehicle {
+        type: "sports";
+        ...MotorVehicleContent;
+        ...CarContent;
+        topSpeed: int32;
+      }
+
+      @route("/vehicles")
+      op getVehicle(): Vehicle;
+    `);
+
+  const models = runner.context.sdkPackage.models;
+  const vehicleModel = models.find((m) => m.name === "Vehicle");
+  const motorVehicleModel = models.find((m) => m.name === "MotorVehicle");
+  const carModel = models.find((m) => m.name === "Car");
+  const sportsCarModel = models.find((m) => m.name === "SportsCar");
+
+  ok(vehicleModel);
+  ok(motorVehicleModel);
+  ok(carModel);
+  ok(sportsCarModel);
+
+  // SportsCar should inherit from Car instead of Vehicle due to @inheritsFrom
+  strictEqual(sportsCarModel.baseModel?.name, "Car");
+  strictEqual(carModel.baseModel?.name, "MotorVehicle");
+  strictEqual(motorVehicleModel.baseModel?.name, "Vehicle");
+});
+
+it("inheritance with scoped decorator", async () => {
+  await runner.compileWithBuiltInService(`
+      @discriminator("kind")
+      model Base {
+        kind: string;
+      }
+
+      model Parent extends Base {
+        kind: "parent";
+        parentProp: string;
+      }
+
+      @inheritsFrom(Parent, "java")
+      @inheritsFrom(Base, "python")
+      model Child extends Base {
+        kind: "child";
+        childProp: string;
+      }
+
+      @route("/test")
+      op test(): Base;
+    `);
+
+  const models = runner.context.sdkPackage.models;
+  const baseModel = models.find((m) => m.name === "Base");
+  const parentModel = models.find((m) => m.name === "Parent");
+  const childModel = models.find((m) => m.name === "Child");
+
+  ok(baseModel);
+  ok(parentModel);
+  ok(childModel);
+
+  // Since test runner is configured for Java, Child should inherit from Parent
+  strictEqual(childModel.baseModel?.name, "Parent");
+});
+
+it("circular inheritance detection", async () => {
+  const [_, diagnostics] = await runner.compileAndDiagnose(`
+      @service
+      namespace TestService;
+
+      model A extends B {
+        propA: string;
+      }
+
+      @inheritsFrom(A)
+      model B extends C {
+        propB: string;
+      }
+
+      model C {
+        propC: string;
+      }
+
+      @route("/test")
+      op test(): A;
+    `);
+
+  // Should detect circular inheritance and report diagnostic
+  expectDiagnostics(diagnostics, {
+    code: "@azure-tools/typespec-client-generator-core/inherits-from-circular",
+  });
+});
+
+it("conflicting inheritance - warning when @inheritsFrom conflicts with extends", async () => {
+  const [_, diagnostics] = await runner.compileAndDiagnose(`
+      @service
+      namespace TestService;
+
+      model A {
+        propA: string;
+      }
+
+      model B {
+        propB: string;
+      }
+
+      @inheritsFrom(B)
+      model C extends A {  // Extends A but @inheritsFrom says B
+        propC: string;
+      }
+
+      @route("/test")
+      op test(): C;
+    `);
+
+  // Should warn about conflicting inheritance
+  expectDiagnostics(diagnostics, {
+    code: "@azure-tools/typespec-client-generator-core/inherits-from-conflict",
+  });
+});
+
+it("multiple inheritance override with different scopes", async () => {
+  await runner.compileWithBuiltInService(`
+      @discriminator("type")
+      model Vehicle {
+        type: string;
+      }
+
+      model LandVehicle extends Vehicle {
+        type: "land";
+        wheels: int32;
+      }
+
+      model WaterVehicle extends Vehicle {
+        type: "water";
+        propeller: boolean;
+      }
+
+      @inheritsFrom(LandVehicle, "java")
+      @inheritsFrom(WaterVehicle, "csharp")
+      model AmphibiousVehicle extends Vehicle {
+        type: "amphibious";
+        canSwim: boolean;
+      }
+
+      @route("/vehicles")
+      op getVehicle(): Vehicle;
+    `);
+
+  const models = runner.context.sdkPackage.models;
+  const amphibiousModel = models.find((m) => m.name === "AmphibiousVehicle");
+
+  ok(amphibiousModel);
+  // Should inherit from LandVehicle since test runner is configured for Java
+  strictEqual(amphibiousModel.baseModel?.name, "LandVehicle");
+});
+
+it("inheritance override preserves discriminator values", async () => {
+  await runner.compileWithBuiltInService(`
+      @discriminator("kind")
+      model Animal {
+        kind: string;
+      }
+
+      model Mammal extends Animal {
+        kind: "mammal";
+        furColor: string;
+      }
+
+      @inheritsFrom(Mammal)
+      model Dog extends Animal {
+        kind: "dog";
+        breed: string;
+      }
+
+      @route("/animals")
+      op getAnimal(): Animal;
+    `);
+
+  const models = runner.context.sdkPackage.models;
+  const animalModel = models.find((m) => m.name === "Animal");
+  const mammalModel = models.find((m) => m.name === "Mammal");
+  const dogModel = models.find((m) => m.name === "Dog");
+
+  ok(animalModel);
+  ok(mammalModel);
+  ok(dogModel);
+
+  // Dog should inherit from Mammal and maintain its discriminator value
+  strictEqual(dogModel.baseModel?.name, "Mammal");
+  strictEqual(dogModel.discriminatorValue, "dog");
+  strictEqual(mammalModel.discriminatorValue, "mammal");
+});
+
+it("inheritance override with template models", async () => {
+  await runner.compileWithBuiltInService(`
+      @discriminator("type")
+      model Container<T> {
+        type: string;
+        data: T;
+      }
+
+      model StringContainer extends Container<string> {
+        type: "string";
+      }
+
+      @inheritsFrom(StringContainer)
+      model SpecialContainer extends Container<string> {
+        type: "special";
+        metadata: Record<string>;
+      }
+
+      @route("/containers")
+      op getContainer(): Container<string>;
+    `);
+
+  const models = runner.context.sdkPackage.models;
+  const specialContainerModel = models.find((m) => m.name === "SpecialContainer");
+
+  ok(specialContainerModel);
+  // Should inherit from StringContainer instead of Container<string>
+  strictEqual(specialContainerModel.baseModel?.name, "StringContainer");
+});


### PR DESCRIPTION
fixes #3015

Some things to note:
1. This is the solution that it appears the TypeSpec team is more in favor of, bc it doesn't have bearing on the rest api definition
2. I didn't do any automatic property inheritance from parents, I don't think TCGC should do that. Instead, I do have warnings ensuring that the models are defined in the raw TypeSpec such that the properties are correctly inherited, otherwise the `@inheritsFrom` decorator gets ignored.
3. I do some post processing on `.discriminatedSubtypes` on the `SdkModelType`. I make sure that models from `@inheritsFrom` are added here. This is for ease of emitters implementing