### PR TITLE
[Spector] Add test for overload method in C# client code.

### DIFF
--- a/.chronus/changes/overload_test-2025-6-31-18-25-45.md
+++ b/.chronus/changes/overload_test-2025-6-31-18-25-45.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Add test for overload method in C# client code.

--- a/packages/azure-http-specs/specs/client/overload/client.tsp
+++ b/packages/azure-http-specs/specs/client/overload/client.tsp
@@ -1,0 +1,11 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+using Client.Overload;
+
+namespace Customization;
+
+// This creates an overload in C# where both `list()` and `list(scope)` methods exist
+#suppress "@azure-tools/typespec-client-generator-core/duplicate-client-name-warning" "Intentional overload for testing method overloading in C#"
+@@clientName(listByScope, "list", "csharp");

--- a/packages/azure-http-specs/specs/client/overload/main.tsp
+++ b/packages/azure-http-specs/specs/client/overload/main.tsp
@@ -1,0 +1,49 @@
+import "@typespec/http";
+import "@typespec/spector";
+import "@azure-tools/typespec-client-generator-core";
+
+using Http;
+using Spector;
+
+/**
+ * Test for overload operation in .NET.
+ */
+@scenarioService("/client/overload")
+namespace Client.Overload;
+
+model Resource {
+  id: string;
+  name: string;
+  scope: string;
+}
+
+@scenario
+@scenarioDoc("""
+  List all resources operation.
+  
+  Expected request: GET /client/overload/resources
+  Expected response body:
+  ```json
+  [
+    {"id": "1", "name": "foo", "scope": "car"},
+    {"id": "2", "name": "bar", "scope": "bike"}
+  ]
+  ```
+  """)
+@route("/resources")
+op list(): Resource[];
+
+@scenario
+@scenarioDoc("""
+  List resources by scope operation. This operation uses `@clientName("list", "csharp")` to generate it as an overload method named "list" in C# client code, demonstrating method overloading capabilities.
+  
+  Expected request: GET /client/overload/resources/car
+  Expected response body:
+  ```json
+  [
+    {"id": "1", "name": "foo", "scope": "car"}
+  ]
+  ```
+  """)
+@route("/resources/{scope}")
+op listByScope(@path scope: string): Resource[];

--- a/packages/azure-http-specs/specs/client/overload/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/overload/mockapi.ts
@@ -1,0 +1,26 @@
+import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Client_Overload_list = passOnSuccess({
+  uri: "/client/overload/resources",
+  method: "get",
+  response: {
+    status: 200,
+    body: json([
+      { id: "1", name: "foo", scope: "car" },
+      { id: "2", name: "bar", scope: "bike" },
+    ]),
+  },
+  kind: "MockApiDefinition",
+});
+
+Scenarios.Client_Overload_listByScope = passOnSuccess({
+  uri: "/client/overload/resources/car",
+  method: "get",
+  response: {
+    status: 200,
+    body: json([{ id: "1", name: "foo", scope: "car" }]),
+  },
+  kind: "MockApiDefinition",
+});


### PR DESCRIPTION
Spector test for this feature: https://github.com/Azure/typespec-azure/pull/3093