### PR TITLE
[azure-core] Change type of etagHeader to eTag

### DIFF
--- a/packages/typespec-azure-core/lib/models.tsp
+++ b/packages/typespec-azure-core/lib/models.tsp
@@ -161,7 +161,7 @@ model EtagResponseEnvelope {
   @header("ETag")
   @visibility(Lifecycle.Read)
   @doc("The entity tag for the response.")
-  etagHeader?: string;
+  etagHeader?: eTag;
 }
 
 // https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#repeatability-of-requests


### PR DESCRIPTION
Let's just see if this affects anything. This probably should have just been using the eTag type.

Closes #3101 