### PR TITLE
[TCGC] Fix next link re-injection segments missing problem after migrating to unbranded pagination.

### DIFF
--- a/.chronus/changes/fix_reinjection-2025-7-5-13-45-7.md
+++ b/.chronus/changes/fix_reinjection-2025-7-5-13-45-7.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Fix next link re-injection segments missing problem after migrating to unbranded pagination.

--- a/packages/typespec-client-generator-core/src/methods.ts
+++ b/packages/typespec-client-generator-core/src/methods.ts
@@ -209,6 +209,23 @@ function getSdkPagingServiceMethod<TServiceOperation extends SdkServiceOperation
             context.__modelPropertyCache.get(segment)!,
         ),
         pageItemsSegments: baseServiceMethod.response.resultSegments,
+        nextLinkReInjectedParametersSegments:
+          pagingMetadata.output.nextLink?.property.type.kind === "Scalar"
+            ? (
+                getParameterizedNextLinkArguments(
+                  context.program,
+                  pagingMetadata.output.nextLink.property.type,
+                ) ?? []
+              ).map(
+                (t: ModelProperty) =>
+                  getPropertySegmentsFromModelOrParameters(
+                    baseServiceMethod.parameters,
+                    (p) =>
+                      p.__raw?.kind === "ModelProperty" &&
+                      findRootSourceProperty(p.__raw) === findRootSourceProperty(t),
+                  )!,
+              )
+            : undefined,
       },
     });
   }

--- a/packages/typespec-client-generator-core/test/methods/paged-operation.test.ts
+++ b/packages/typespec-client-generator-core/test/methods/paged-operation.test.ts
@@ -805,6 +805,50 @@ it("next link with re-injected parameters", async () => {
   );
 });
 
+it("unbranded next link with re-injected parameters", async () => {
+  await runner.compileWithBuiltInAzureCoreService(`
+    model TestOptions {
+      @query
+      includePending?: boolean;
+
+      @query
+      includeExpired?: boolean;
+    }
+
+    @list
+    op test(...TestOptions): ListTestResult;
+
+    model ListTestResult {
+      @pageItems
+      values: Test[];
+      @nextLink
+      nextLink: Azure.Core.Legacy.parameterizedNextLink<[TestOptions.includePending, TestOptions.includeExpired]>;
+    }
+
+    model Test {
+      id: string;
+    }
+  `);
+
+  const sdkPackage = runner.context.sdkPackage;
+  const method = getServiceMethodOfClient(sdkPackage);
+  strictEqual(method.name, "test");
+  strictEqual(method.kind, "paging");
+  strictEqual(method.pagingMetadata.nextLinkSegments?.length, 1);
+  strictEqual(method.pagingMetadata.nextLinkSegments[0], sdkPackage.models[0].properties[1]);
+  strictEqual(method.pagingMetadata.nextLinkReInjectedParametersSegments?.length, 2);
+  strictEqual(method.pagingMetadata.nextLinkReInjectedParametersSegments[0].length, 1);
+  strictEqual(
+    method.pagingMetadata.nextLinkReInjectedParametersSegments[0][0],
+    method.parameters[0],
+  );
+  strictEqual(method.pagingMetadata.nextLinkReInjectedParametersSegments[1].length, 1);
+  strictEqual(
+    method.pagingMetadata.nextLinkReInjectedParametersSegments[1][0],
+    method.parameters[1],
+  );
+});
+
 it("next link with mix of re-injected parameters and not", async () => {
   await runner.compileWithBuiltInAzureCoreService(`
     model IncludePendingOptions {
@@ -851,7 +895,51 @@ it("next link with mix of re-injected parameters and not", async () => {
   );
 });
 
-it.skip("next link with reinjected parameters with versioning", async () => {
+it("unbranded next link with mix of re-injected parameters and not", async () => {
+  await runner.compileWithBuiltInAzureCoreService(`
+    model IncludePendingOptions {
+      @query
+      includePending?: boolean;
+    }
+      
+    model User {
+      @key
+      @visibility(Lifecycle.Read)
+      id: int32;
+    }
+
+    model ParameterizedNextLinkPagingResult {
+      @pageItems
+      values: User[];
+
+      @nextLink
+      nextLink: Azure.Core.Legacy.parameterizedNextLink<[IncludePendingOptions.includePending]>;
+    }
+
+    @doc("List with parameterized next link that re-injects parameters.")
+    @route("/with-parameterized-next-link")
+    @list
+    op test(
+      ...IncludePendingOptions,
+      @query select: string,
+    ): ParameterizedNextLinkPagingResult;
+  `);
+
+  const sdkPackage = runner.context.sdkPackage;
+  const method = getServiceMethodOfClient(sdkPackage);
+  strictEqual(method.name, "test");
+  strictEqual(method.kind, "paging");
+  strictEqual(method.pagingMetadata.nextLinkSegments?.length, 1);
+  strictEqual(method.pagingMetadata.nextLinkSegments[0], sdkPackage.models[0].properties[1]);
+  strictEqual(method.pagingMetadata.nextLinkReInjectedParametersSegments?.length, 1);
+  strictEqual(method.pagingMetadata.nextLinkReInjectedParametersSegments[0].length, 1);
+  strictEqual(
+    method.pagingMetadata.nextLinkReInjectedParametersSegments[0][0],
+    method.parameters[0],
+  );
+});
+
+it("next link with reinjected parameters with versioning", async () => {
   await runner.compile(`
     @server("http://localhost:3000", "endpoint")
     @service()
@@ -872,9 +960,59 @@ it.skip("next link with reinjected parameters with versioning", async () => {
 
     op test(...TestOptions): ListTestResult;
 
+    #suppress "deprecated" "Keep for validation purposes."
     @pagedResult
     model ListTestResult {
+      #suppress "deprecated" "Keep for validation purposes."
       @items
+      values: Test[];
+      @nextLink
+      nextLink: Azure.Core.Legacy.parameterizedNextLink<[TestOptions.includePending]>;
+    }
+
+    model Test {
+      id: string;
+    }
+  `);
+
+  const sdkPackage = runner.context.sdkPackage;
+  const method = getServiceMethodOfClient(sdkPackage);
+  strictEqual(method.name, "test");
+  strictEqual(method.kind, "paging");
+  strictEqual(method.pagingMetadata.nextLinkSegments?.length, 1);
+  strictEqual(method.pagingMetadata.nextLinkSegments[0], sdkPackage.models[0].properties[1]);
+  strictEqual(method.pagingMetadata.nextLinkReInjectedParametersSegments?.length, 1);
+  strictEqual(method.pagingMetadata.nextLinkReInjectedParametersSegments[0].length, 1);
+  strictEqual(
+    method.pagingMetadata.nextLinkReInjectedParametersSegments[0][0],
+    method.parameters[0],
+  );
+});
+
+it("unbranded next link with reinjected parameters with versioning", async () => {
+  await runner.compile(`
+    @server("http://localhost:3000", "endpoint")
+    @service()
+    @versioned(Versions)
+    namespace My.Service;
+
+    /** Api versions */
+    enum Versions {
+      /** 2024-04-01-preview api version */
+      @useDependency(Azure.Core.Versions.v1_0_Preview_2)
+      V2024_04_01_PREVIEW: "2024-04-01-preview",
+    }
+
+    model TestOptions {
+      @query
+      includePending?: boolean;
+    }
+
+    @list
+    op test(...TestOptions): ListTestResult;
+
+    model ListTestResult {
+      @pageItems
       values: Test[];
       @nextLink
       nextLink: Azure.Core.Legacy.parameterizedNextLink<[TestOptions.includePending]>;


### PR DESCRIPTION
Fix: https://github.com/Azure/typespec-azure/issues/3115