### PR TITLE
Update location of TrackedResource from string to azureLocation

### DIFF
--- a/packages/typespec-azure-resource-manager/lib/common-types/types.tsp
+++ b/packages/typespec-azure-resource-manager/lib/common-types/types.tsp
@@ -45,7 +45,7 @@ model TrackedResource extends Resource {
 
   /** The geo-location where the resource lives */
   @visibility(Lifecycle.Read, Lifecycle.Create)
-  location: string;
+  location: azureLocation;
 }
 
 /**

--- a/website/src/content/docs/docs/libraries/azure-resource-manager/reference/data-types.md
+++ b/website/src/content/docs/docs/libraries/azure-resource-manager/reference/data-types.md
@@ -2435,10 +2435,10 @@ model Azure.ResourceManager.CommonTypes.TrackedResource
 
 #### Properties
 
-| Name     | Type             | Description                               |
-| -------- | ---------------- | ----------------------------------------- |
-| tags?    | `Record<string>` | Resource tags.                            |
-| location | `string`         | The geo-location where the resource lives |
+| Name     | Type                 | Description                               |
+| -------- | -------------------- | ----------------------------------------- |
+| tags?    | `Record<string>`     | Resource tags.                            |
+| location | `Core.azureLocation` | The geo-location where the resource lives |
 
 ### `UserAssignedIdentities` {#Azure.ResourceManager.CommonTypes.UserAssignedIdentities}
 


### PR DESCRIPTION
`location` in `TrackedResource` should be `azureLocation`
This change is follow-up for https://github.com/Azure/typespec-azure/issues/1138, we just found more cases.