### PR TITLE
Rename namespace to avoid conflict

### DIFF
--- a/packages/azure-http-specs/specs/client/naming/main.tsp
+++ b/packages/azure-http-specs/specs/client/naming/main.tsp
@@ -144,7 +144,7 @@ namespace Header {
 
 @route("/model")
 @operationGroup
-@clientName("ClientModel")
+@clientName("ModelClient")
 namespace Model {
   @clientName("CSModel", "csharp")
   @clientName("GoModel", "go")


### PR DESCRIPTION
Renaming the namespace to "ClientModel" causes a conflict with a model in the spec. This causes build errors in C# and it is not necessary for what this scenario is trying to exercise.

Filed https://github.com/Azure/typespec-azure/issues/3162