### PR TITLE
[TCGC] Compare type when map body parameter to method parameter.

### DIFF
--- a/.chronus/changes/tcgc-mapping_fix-2025-7-21-17-40-53.md
+++ b/.chronus/changes/tcgc-mapping_fix-2025-7-21-17-40-53.md
@@ -1,0 +1,7 @@
+---
+changeKind: breaking
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Compare type when map body parameter to method parameter. This is a behavior breaking change. The Http parameter's corresponding parameter may change.

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -716,6 +716,10 @@ function findMapping(
     ) {
       return methodParam;
     }
+    // If the service parameter is a body parameter, try to see if we could find a method parameter with same type of the body parameter.
+    if (serviceParam.kind === "body" && serviceParam.type === methodParam.type) {
+      return methodParam;
+    }
     // BFS to find the mapping.
     if (methodParam.type.kind === "model" && !visited.has(methodParam.type)) {
       visited.add(methodParam.type);

--- a/packages/typespec-client-generator-core/test/decorators/override.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/override.test.ts
@@ -50,9 +50,8 @@ it("basic", async () => {
   strictEqual(paramsModel, paramsParam.type);
 
   ok(method.operation.bodyParam);
-  strictEqual(method.operation.bodyParam.correspondingMethodParams.length, 2);
-  strictEqual(method.operation.bodyParam.correspondingMethodParams[0], paramsModel.properties[0]);
-  strictEqual(method.operation.bodyParam.correspondingMethodParams[1], paramsModel.properties[1]);
+  strictEqual(method.operation.bodyParam.correspondingMethodParams.length, 1);
+  strictEqual(method.operation.bodyParam.correspondingMethodParams[0], paramsParam);
 });
 
 it("basic with scope", async () => {
@@ -135,9 +134,8 @@ it("basic with scope", async () => {
     contentTypeParamWithCsharp,
   );
   ok(httpOpWithCsharp.bodyParam);
-  strictEqual(httpOpWithCsharp.bodyParam.correspondingMethodParams.length, 2);
-  strictEqual(httpOpWithCsharp.bodyParam.correspondingMethodParams[0], paramModel.properties[0]);
-  strictEqual(httpOpWithCsharp.bodyParam.correspondingMethodParams[1], paramModel.properties[1]);
+  strictEqual(httpOpWithCsharp.bodyParam.correspondingMethodParams.length, 1);
+  strictEqual(httpOpWithCsharp.bodyParam.correspondingMethodParams[0], paramsParamWithCsharp);
 });
 
 it("regrouping", async () => {
@@ -409,9 +407,8 @@ it("recursive params", async () => {
   strictEqual(paramsModel, inputParam.type);
 
   ok(method.operation.bodyParam);
-  strictEqual(method.operation.bodyParam.correspondingMethodParams.length, 2);
-  strictEqual(method.operation.bodyParam.correspondingMethodParams[0], paramsModel.properties[0]);
-  strictEqual(method.operation.bodyParam.correspondingMethodParams[1], paramsModel.properties[1]);
+  strictEqual(method.operation.bodyParam.correspondingMethodParams.length, 1);
+  strictEqual(method.operation.bodyParam.correspondingMethodParams[0], inputParam);
 });
 
 it("core template", async () => {

--- a/packages/typespec-client-generator-core/test/public-utils/get-http-operation-parameter.test.ts
+++ b/packages/typespec-client-generator-core/test/public-utils/get-http-operation-parameter.test.ts
@@ -470,27 +470,12 @@ it("@override impact", async () => {
   for (const param of parameters) {
     if (param.name === "params") {
       const httpParam = getHttpOperationParameter(method, param);
-      ok(!httpParam);
+      ok(httpParam);
     } else if (param.name === "contentType") {
       const httpParam = getHttpOperationParameter(method, param);
       ok(httpParam);
       strictEqual(httpParam.kind, "header");
       strictEqual(httpParam.serializedName, "Content-Type");
-    }
-  }
-
-  strictEqual(parameters[0].type.kind, "model");
-  for (const property of parameters[0].type.properties) {
-    if (property.name === "foo") {
-      const httpParam = getHttpOperationParameter(method, property);
-      ok(httpParam);
-      strictEqual(httpParam.kind, "property");
-      strictEqual(httpParam.name, "foo");
-    } else if (property.name === "bar") {
-      const httpParam = getHttpOperationParameter(method, property);
-      ok(httpParam);
-      strictEqual(httpParam.kind, "property");
-      strictEqual(httpParam.name, "bar");
     }
   }
 });


### PR DESCRIPTION
This is a behavior breaking change. The Http parameter's corresponding parameter may change. It mostly happens in `@override` scenario. See the test change in the PR for the breaking change impact.

fix: https://github.com/Azure/typespec-azure/issues/3071