### PR TITLE
Rename swagger to OpenAPI

### DIFF
--- a/website/src/content/current-sidebar.ts
+++ b/website/src/content/current-sidebar.ts
@@ -57,7 +57,7 @@ const sidebar: SidebarItem[] = [
     ],
   },
   {
-    label: "Convert Swagger to TypeSpec",
+    label: "Convert OpenAPI to TypeSpec",
     items: [
       "migrate-swagger/01-get-started",
       {

--- a/website/src/content/docs/docs/migrate-swagger/01-get-started.md
+++ b/website/src/content/docs/docs/migrate-swagger/01-get-started.md
@@ -5,9 +5,9 @@ order: 0
 
 # Getting started with TypeSpec migration
 
-We have created a swagger to TypeSpec conversion tool to help take on the bulk of the manual conversion labor. It can handle both data-plane and management-plane swaggers. The produced TypeSpec relies on the Azure.Core and Azure.Resource.Manager libraries.
+We have created a OpenAPI to TypeSpec conversion tool to help take on the bulk of the manual conversion labor. It can handle both data-plane and management-plane OpenAPI files. The produced TypeSpec relies on the Azure.Core and Azure.Resource.Manager libraries.
 
-**_Important!_** Because TypeSpec is more expressive than Swagger and with the help of evolving Azure libraries, this tool should only be used as an aid in the conversion/migration process, not as the sole tool to produce final version of TypeSpec specs without human inspection, correction and optimization.
+**_Important!_** Because TypeSpec is more expressive than OpenAPI and with the help of evolving Azure libraries, this tool should only be used as an aid in the conversion/migration process, not as the sole tool to produce final version of TypeSpec specs without human inspection, correction and optimization.
 
 ## Steps of migration and comparison
 
@@ -38,7 +38,7 @@ We have created a swagger to TypeSpec conversion tool to help take on the bulk o
 
   - Convert a **control-plane** specification to fully compatible output:
 
-    By default, the converted TypeSpec project will leverage TypeSpec built-in libraries with standard patterns and templates (highly recommended), which will cause discrepancies between the generated TypeSpec and original swagger. If you really don't want this intended discrepancy, add `--fully-compatible` flag to generate a TypeSpec project that is fully compatible with the swagger.
+    By default, the converted TypeSpec project will leverage TypeSpec built-in libraries with standard patterns and templates (highly recommended), which will cause discrepancies between the generated TypeSpec and original OpenAPI file. If you really don't want this intended discrepancy, add `--fully-compatible` flag to generate a TypeSpec project that is fully compatible with the OpenAPI file.
 
     ```shell
     tsp-client convert --swagger-readme [path to readme.md] --arm --fully-compatible
@@ -46,9 +46,9 @@ We have created a swagger to TypeSpec conversion tool to help take on the bulk o
 
 ### Review and adjust the TypeSpec
 
-You will need to compare the Swagger generated from TypeSpec with the original Swagger specification(s) to ensure functional equivalence.
+You will need to compare the OpenAPI file generated from TypeSpec with the original OpenAPI specification(s) to ensure functional equivalence.
 
-- In the TypeSpec folder, compile TypeSpec files to emit an auto-generated Swagger:
+- In the TypeSpec folder, compile TypeSpec files to emit an auto-generated OpenAPI file:
 
   ```shell
   tsp compile .
@@ -57,18 +57,18 @@ You will need to compare the Swagger generated from TypeSpec with the original S
 - From the root folder, download the latest specification as baseline. Your original specification will be located at `.\sparse-spec\specification\{service-name}`:
 
   ```shell
-  .\eng\tools\typespec-migration-validation\scripts\download-main.ps1 {path\to\your\generated\swagger}
+  .\eng\tools\typespec-migration-validation\scripts\download-main.ps1 {path\to\your\generated\openapi\file}
   ```
 
-- At the end of the console output, you'll see the next command to sort, merge, and normalize the original Swagger(s) and generated Swagger, making it easier to review changes. Provide an `outputFolder` to store the analysis results:
+- At the end of the console output, you'll see the next command to sort, merge, and normalize the original OpenAPI file(s) and generated OpenAPI file, making it easier to review changes. Provide an `outputFolder` to store the analysis results:
 
   ```shell
-  npx tsmv {your\original\swagger\folder} {your\generated\swagger\file} --outputFolder {outputFolder}
+  npx tsmv {your\original\openapi\folder} {your\generated\openapi\file} --outputFolder {outputFolder}
   ```
 
 - In the `{outputFolder}`:
-  - `newNormalizedSwagger.json` is the processed version of the generated Swagger
-  - `oldNormalizedSwagger.json` is the processed version of the original Swagger(s)
+  - `newNormalizedSwagger.json` is the processed version of the generated OpenAPI file
+  - `oldNormalizedSwagger.json` is the processed version of the original OpenAPI file(s)
 
   In VS Code, select both files (select `oldNormalizedSwagger.json` first, then `newNormalizedSwagger.json`), right-click and choose "Compare Selected". Review these differences to understand their patterns.
 
@@ -82,16 +82,16 @@ You will need to compare the Swagger generated from TypeSpec with the original S
   1. Recompile TypeSpec files with `tsp compile .` in the TypeSpec folder.
   2. Run the `npx tsmv` command again with the same parameters.
   3. Review the updated differences in VS Code.
-  4. Make further adjustments as needed. Refer to [Understanding the Swagger Changes](./faq/mustread.md) to understand expected changes and mitigation steps. For more effective visualization, fix differences in this recommended order:
+  4. Make further adjustments as needed. Refer to [Understanding the OpenAPI Changes](./faq/mustread.md) to understand expected changes and mitigation steps. For more effective visualization, fix differences in this recommended order:
      - Path (route) differences first
      - Definition (model) name differences next
      - Detail differences within paths and definitions last
 
 ### Create Spec PR with new TypeSpec project
 
-- In the `readme.md` file, under the latest tag, change the `input-file` to the swagger generated from TypeSpec.
-- If the generated swagger file(s) for the latest version changed name, delete the old swagger file(s) no longer referenced in README.md.
-- Create a PR with the TypeSpec files, changed swagger files (examples included) and readme file.
+- In the `readme.md` file, under the latest tag, change the `input-file` to the OpenAPI file generated from TypeSpec.
+- If the generated OpenAPI file(s) for the latest version changed name, delete the old OpenAPI file(s) no longer referenced in README.md.
+- Create a PR with the TypeSpec files, changed OpenAPI files (examples included) and readme file.
 - Check CI failures. Refer to [Resolving Pipeline failures](./faq/pipeline.md)
 
 ## How to Get Help

--- a/website/src/content/docs/docs/migrate-swagger/checklists/migrate-arm-tips.md
+++ b/website/src/content/docs/docs/migrate-swagger/checklists/migrate-arm-tips.md
@@ -2,7 +2,7 @@
 title: Migrate ARM spec
 ---
 
-The swagger converter will not be able to accurately represent every part of every API in TypeSpec. This document outlines some common changes you may need to make to a converted TypeSpec to make it conform to your existing service API and pass validation checks.
+The OpenAPI converter will not be able to accurately represent every part of every API in TypeSpec. This document outlines some common changes you may need to make to a converted TypeSpec to make it conform to your existing service API and pass validation checks.
 
 ## Initial pass through checklist
 

--- a/website/src/content/docs/docs/migrate-swagger/checklists/migrate-dp-tips.md
+++ b/website/src/content/docs/docs/migrate-swagger/checklists/migrate-dp-tips.md
@@ -2,7 +2,7 @@
 title: Migrate data-plane specs
 ---
 
-The swagger converter will not be able to accurately represent every part of every API in TypeSpec. This document outlines some common changes you may need to make to a converted TypeSpec to make it conform to your existing service API and pass validation checks.
+The OpenAPI converter will not be able to accurately represent every part of every API in TypeSpec. This document outlines some common changes you may need to make to a converted TypeSpec to make it conform to your existing service API and pass validation checks.
 
 ## Initial pass through checklist
 

--- a/website/src/content/docs/docs/migrate-swagger/faq/breakingchange.md
+++ b/website/src/content/docs/docs/migrate-swagger/faq/breakingchange.md
@@ -1,8 +1,8 @@
 ---
-title: Resolving Swagger Breaking Change Violations
+title: Resolving OpenAPI Breaking Change Violations
 ---
 
-The Swagger Converter cannot perfectly represent every aspect of every API in TypeSpec. This document outlines common changes you may need to make to a converted TypeSpec to ensure compatibility with your existing service API and to pass check-in validations.
+The OpenAPI Converter cannot perfectly represent every aspect of every API in TypeSpec. This document outlines common changes you may need to make to a converted TypeSpec to ensure compatibility with your existing service API and to pass check-in validations.
 
 ## Migrating ARM Specifications
 

--- a/website/src/content/docs/docs/migrate-swagger/faq/conversionfix.md
+++ b/website/src/content/docs/docs/migrate-swagger/faq/conversionfix.md
@@ -4,11 +4,11 @@ title: Fixing Converted TypeSpec
 
 ## Fixing Linter Rules
 
-Ideally, the original Swagger will be converted into equivalent TypeSpec following ARM conventions. However, many Swagger specifications predate current ARM conventions and are 'grandfathered in' to prevent breaking changes. The equivalent TypeSpec that represents the original Swagger will violate linter rules, and linter suppressions must be added. Check out how to fix linter violations below.
+Ideally, the original OpenAPI file will be converted into equivalent TypeSpec following ARM conventions. However, many OpenAPI specifications predate current ARM conventions and are 'grandfathered in' to prevent breaking changes. The equivalent TypeSpec that represents the original OpenAPI file will violate linter rules, and linter suppressions must be added. Check out how to fix linter violations below.
 
 ### @azure-tools/typespec-azure-core/no-openapi
 
-The `operationId` in Swagger is usually formatted as `OperationGroup_OperationName`. Use [`@clientLocation`](https://azure.github.io/typespec-azure/docs/libraries/typespec-client-generator-core/reference/decorators/#@Azure.ClientGenerator.Core.clientLocation) to specify the operation group and [`@clientName`](https://azure.github.io/typespec-azure/docs/libraries/typespec-client-generator-core/reference/decorators/#@Azure.ClientGenerator.Core.clientName) to change the operation name if needed.
+The `operationId` in OpenAPI file is usually formatted as `OperationGroup_OperationName`. Use [`@clientLocation`](https://azure.github.io/typespec-azure/docs/libraries/typespec-client-generator-core/reference/decorators/#@Azure.ClientGenerator.Core.clientLocation) to specify the operation group and [`@clientName`](https://azure.github.io/typespec-azure/docs/libraries/typespec-client-generator-core/reference/decorators/#@Azure.ClientGenerator.Core.clientName) to change the operation name if needed.
 
 **Before:**
 

--- a/website/src/content/docs/docs/migrate-swagger/faq/frequentquestions.md
+++ b/website/src/content/docs/docs/migrate-swagger/faq/frequentquestions.md
@@ -2,9 +2,9 @@
 title: Frequently Asked Questions
 ---
 
-### Renaming the generated Swagger file
+### Renaming the generated OpenAPI file
 
-Rename the generated Swagger file by modifying the `output-file` option in the `tspconfig.yaml`:
+Rename the generated OpenAPI file by modifying the `output-file` option in the `tspconfig.yaml`:
 
 ```yaml
 options:

--- a/website/src/content/docs/docs/migrate-swagger/faq/mustread.md
+++ b/website/src/content/docs/docs/migrate-swagger/faq/mustread.md
@@ -1,8 +1,8 @@
 ---
-title: Understanding the Swagger Changes
+title: Understanding the OpenAPI Changes
 ---
 
-To fully leverage the benefits of TypeSpec and follow best practices, there are some unavoidable changes when migrating from Swagger to TypeSpec.
+To fully leverage the benefits of TypeSpec and follow best practices, there are some unavoidable changes when migrating from OpenAPI to TypeSpec.
 
 ## Using Resources from Common Types
 
@@ -14,7 +14,7 @@ An ARM Resource model should extend one of the typespec common-types Resource mo
 2. At least one operation returns a 200 response containing this model.
 3. The model has properties named `id`, `name`, and `type`.
 
-Once a model is identified as a resource, it is represented by extending an appropriate [resource model](../../howtos/ARM/resource-type.md#modeling-resources-in-typespec) from the TypeSpec library. This can result in textual differences between the original Swagger and generated Swagger like:
+Once a model is identified as a resource, it is represented by extending an appropriate [resource model](../../howtos/ARM/resource-type.md#modeling-resources-in-typespec) from the TypeSpec library. This can result in textual differences between the original OpenAPI file and generated OpenAPI file like:
 
 ```diff
 "YourResource": {
@@ -80,7 +80,7 @@ The `"readOnly": true` property should only be used on properties, not on models
 }
 ```
 
-Decorating the property referencing the model with '@visibility(Lifecycle.Read)` is equivalent to marking the model schema as read-only as in the Swagger above.
+Decorating the property referencing the model with '@visibility(Lifecycle.Read)` is equivalent to marking the model schema as read-only as in the OpenAPI above.
 
 ```tsp
 model ReadOnlyModel {}

--- a/website/src/content/docs/docs/migrate-swagger/faq/pipeline.md
+++ b/website/src/content/docs/docs/migrate-swagger/faq/pipeline.md
@@ -6,9 +6,9 @@ This document explains how to resolve pipeline failures in TypeSpec migration PR
 
 ## Swagger BreakingChange
 
-### Multiple Swagger Files Before Migration
+### Multiple OpenAPI Files Before Migration
 
-This pipeline will fail if there is more than one Swagger file in the latest version. See the detailed explanation in this [issue](https://github.com/Azure/typespec-azure/issues/2194#issue-2844564216).
+This pipeline will fail if there is more than one OpenAPI file in the latest version. See the detailed explanation in this [issue](https://github.com/Azure/typespec-azure/issues/2194#issue-2844564216).
 
 To properly identify real breaking changes, use the "TypeSpec Migration Validation" pipeline instead:
 
@@ -17,9 +17,9 @@ To properly identify real breaking changes, use the "TypeSpec Migration Validati
 3. The output should match exactly what you see in [this step](../01-get-started.md#review-and-adjust-the-typespec) on the local machine
 4. Review the changes to verify they are expected
 
-### Single Swagger File Before Migration
+### Single OpenAPI File Before Migration
 
-If you have only one Swagger file in the latest version, use this pipeline to detect breaking changes. If it fails, refer to [Resolving Swagger Breaking Change Violations](./faq/breakingchange.md).
+If you have only one OpenAPI file in the latest version, use this pipeline to detect breaking changes. If it fails, refer to [Resolving OpenAPI Breaking Change Violations](./faq/breakingchange.md).
 
 **Known Issues**: The following pipeline failures are false alerts and can be safely ignored:
 


### PR DESCRIPTION
Swagger is a trademark of the company SmartBear and is generally deprecated as a spec name as Swagger is now used to refer to SmartBear's tooling.

Use OpenAPI instead.