### PR TITLE
[tcgc] add `.decorators` to `SdkNamespace`

### DIFF
--- a/.chronus/changes/tcgc-addDecoratorNamespace-2025-8-2-17-13-20.md
+++ b/.chronus/changes/tcgc-addDecoratorNamespace-2025-8-2-17-13-20.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+add `.decorators` property to `SdkNamespace` type that will display decorators listed in the allowed list

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -1139,7 +1139,7 @@ export interface LicenseInfo {
 /**
  * Represents a namespace in the package, containing all clients, operations, and types.
  */
-export interface SdkNamespace<TServiceOperation extends SdkServiceOperation> {
+export interface SdkNamespace<TServiceOperation extends SdkServiceOperation> extends DecoratedType {
   /** Namespace name. */
   name: string;
   /** Namespace full qualified name. */

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -1140,6 +1140,7 @@ export interface LicenseInfo {
  * Represents a namespace in the package, containing all clients, operations, and types.
  */
 export interface SdkNamespace<TServiceOperation extends SdkServiceOperation> extends DecoratedType {
+  __raw?: Namespace;
   /** Namespace name. */
   name: string;
   /** Namespace full qualified name. */

--- a/packages/typespec-client-generator-core/src/package.ts
+++ b/packages/typespec-client-generator-core/src/package.ts
@@ -16,7 +16,7 @@ import {
 } from "./interfaces.js";
 import { filterApiVersionsWithDecorators, getTypeDecorators } from "./internal-utils.js";
 import { getLicenseInfo } from "./license.js";
-import { getCrossLanguagePackageId } from "./public-utils.js";
+import { getCrossLanguagePackageId, getNamespaceFromType } from "./public-utils.js";
 import { getAllReferencedTypes, handleAllTypes } from "./types.js";
 
 export function createSdkPackage<TServiceOperation extends SdkServiceOperation>(
@@ -88,8 +88,7 @@ function getSdkNamespace<TServiceOperation extends SdkServiceOperation>(
       (ns) => ns.name === segment,
     );
     if (ns === undefined) {
-      const rawNamespace =
-        type.__raw && "namespace" in type.__raw ? type.__raw.namespace : undefined;
+      const rawNamespace = getNamespaceFromType(type.__raw);
       const newNs = {
         __raw: rawNamespace,
         name: segment,

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -41,12 +41,14 @@ import {
 } from "./decorators.js";
 import {
   SdkBodyParameter,
+  SdkClient,
   SdkCookieParameter,
   SdkHeaderParameter,
   SdkHttpOperation,
   SdkHttpOperationExample,
   SdkMethodParameter,
   SdkModelPropertyType,
+  SdkOperationGroup,
   SdkPathParameter,
   SdkQueryParameter,
   SdkServiceMethod,
@@ -818,4 +820,26 @@ export function resolveOperationId(
  */
 export function isHttpMetadata(context: TCGCContext, property: SdkModelPropertyType): boolean {
   return property.__raw !== undefined && isMetadata(context.program, property.__raw);
+}
+
+export function getNamespaceFromType(
+  type: Type | SdkClient | SdkOperationGroup | undefined,
+): Namespace | undefined {
+  if (type === undefined) {
+    return undefined;
+  }
+  if (type.kind === "SdkOperationGroup" || type.kind === "SdkClient") {
+    const rawType = type.type;
+    if (rawType === undefined) {
+      return undefined;
+    }
+    if (rawType.kind === "Namespace") {
+      return rawType;
+    }
+    return rawType.namespace;
+  }
+  if ("namespace" in type) {
+    return type.namespace;
+  }
+  return undefined;
 }

--- a/packages/typespec-client-generator-core/test/decorators/general-list.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/general-list.test.ts
@@ -136,6 +136,31 @@ it("multiple same decorators", async function () {
   expectDiagnostics(runner.context.diagnostics, []);
 });
 
+it("decorators on a namespace", async function () {
+  runner = await createSdkTestRunner({}, { additionalDecorators: ["TypeSpec\\.@service"] });
+
+  await runner.compileWithBuiltInService(`
+    op test(): void;
+  `);
+  const sdkPackage = runner.context.sdkPackage;
+  const namespace = sdkPackage.namespaces[0];
+  ok(namespace);
+  strictEqual(namespace.name, "TestService");
+  strictEqual(namespace.__raw?.kind, "Namespace");
+  strictEqual(namespace.decorators.length, 1);
+  deepStrictEqual(namespace.decorators, [
+    {
+      name: "TypeSpec.@service",
+      arguments: {
+        options: {
+          title: "Test Service",
+        },
+      },
+    },
+  ]);
+  expectDiagnostics(runner.context.diagnostics, []);
+});
+
 describe("xml scenario", () => {
   it("@attribute", async function () {
     runner = await createSdkTestRunner({


### PR DESCRIPTION
Since namespaces can be decorated with types, we want to pass these through if they exist