### PR TITLE
[TCGC] change `isApiVersion` logic

### DIFF
--- a/.chronus/changes/fix_is_api_version-2025-8-15-16-40-8.md
+++ b/.chronus/changes/fix_is_api_version-2025-8-15-16-40-8.md
@@ -1,0 +1,7 @@
+---
+changeKind: breaking
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Change `isApiVersion` logic. If a service is not versioning, the function always return false.

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -88,25 +88,26 @@ export function getDefaultApiVersion(
   }
 }
 
-function isModelProperty(type: any): type is ModelProperty {
-  return type && typeof type === "object" && "kind" in type && type.kind === "ModelProperty";
-}
-
 /**
  * Return whether a parameter is the Api Version parameter of a client
  * @param program
  * @param parameter
  * @returns
  */
-export function isApiVersion(context: TCGCContext, type: { name: string }): boolean {
-  if (isModelProperty(type)) {
-    const override = getIsApiVersion(context, type);
-    if (override !== undefined) {
-      return override;
-    }
+export function isApiVersion(context: TCGCContext, type: ModelProperty): boolean {
+  // author's customization is the highest priority
+  const override = getIsApiVersion(context, type);
+  if (override !== undefined) {
+    return override;
   }
+  // if the service is not versioning, then no api version parameter
+  const versionEnum = context.getPackageVersionEnum();
+  if (!versionEnum) {
+    return false;
+  }
+  // if the parameter type is the version enum or named as "apiVersion" or "api-version", then it is api version
   return (
-    (isModelProperty(type) && type.type === context.getPackageVersionEnum()) ||
+    type.type === versionEnum ||
     type.name.toLowerCase().includes("apiversion") ||
     type.name.toLowerCase().includes("api-version")
   );

--- a/packages/typespec-client-generator-core/test/clients/params.test.ts
+++ b/packages/typespec-client-generator-core/test/clients/params.test.ts
@@ -569,7 +569,7 @@ it("service with no default api version, method with api version param", async (
   const apiVersionMethodParam = withApiVersion.parameters[0];
   strictEqual(apiVersionMethodParam.name, "apiVersion");
   strictEqual(apiVersionMethodParam.kind, "method");
-  strictEqual(apiVersionMethodParam.isApiVersionParam, true);
+  strictEqual(apiVersionMethodParam.isApiVersionParam, false);
   strictEqual(apiVersionMethodParam.optional, false);
   strictEqual(apiVersionMethodParam.onClient, false);
   strictEqual(apiVersionMethodParam.type.kind, "string");
@@ -578,7 +578,7 @@ it("service with no default api version, method with api version param", async (
   strictEqual(withApiVersion.operation.parameters.length, 1);
   const apiVersionParam = withApiVersion.operation.parameters[0];
   strictEqual(apiVersionParam.kind, "query");
-  strictEqual(apiVersionParam.isApiVersionParam, true);
+  strictEqual(apiVersionParam.isApiVersionParam, false);
   strictEqual(apiVersionParam.optional, false);
   strictEqual(apiVersionParam.onClient, false);
   strictEqual(apiVersionParam.type.kind, "string");

--- a/packages/typespec-client-generator-core/test/decorators/override.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/override.test.ts
@@ -419,10 +419,15 @@ it("core template", async () => {
   });
   await runnerWithCore.compileWithCustomization(
     `
-    @useDependency(Versions.v1_0_Preview_2)
     @server("http://localhost:3000", "endpoint")
-    @service()
+    @service
+    @versioned(Versions)
     namespace My.Service;
+
+    enum Versions {
+      @useDependency(Azure.Core.Versions.v1_0_Preview_2)
+      v1
+    }
 
     model Params {
       foo: string;

--- a/packages/typespec-client-generator-core/test/package/versioning.test.ts
+++ b/packages/typespec-client-generator-core/test/package/versioning.test.ts
@@ -612,7 +612,11 @@ it("basic all version", async () => {
 });
 
 it("define own api version param", async () => {
-  await runner.compileWithBuiltInService(`
+  await runner.compile(`
+    @service
+    @versioned(Versions)
+    namespace Test;
+
     model ApiVersionParam {
       @header apiVersion: Versions;
     }
@@ -630,7 +634,7 @@ it("define own api version param", async () => {
   strictEqual(apiVersionParam.kind, "header");
   strictEqual(apiVersionParam.serializedName, "api-version");
   strictEqual(apiVersionParam.name, "apiVersion");
-  strictEqual(apiVersionParam.onClient, false);
+  strictEqual(apiVersionParam.onClient, true);
   strictEqual(apiVersionParam.isApiVersionParam, true);
 });
 

--- a/packages/typespec-client-generator-core/test/public-utils/is-api-version.test.ts
+++ b/packages/typespec-client-generator-core/test/public-utils/is-api-version.test.ts
@@ -12,7 +12,7 @@ beforeEach(async () => {
   runner = await createSdkTestRunner({ emitterName: "@azure-tools/typespec-python" });
 });
 it("is api version query", async () => {
-  const { func } = (await runner.compile(`
+  const { func } = (await runner.compileWithVersionedService(`
     @test op func(@query("api-version") myApiVersion: string): void;
   `)) as { func: Operation };
 
@@ -22,7 +22,7 @@ it("is api version query", async () => {
 });
 
 it("is api version path", async () => {
-  const { func } = (await runner.compile(`
+  const { func } = (await runner.compileWithVersionedService(`
     @test op func(@path apiVersion: string): void;
   `)) as { func: Operation };
 
@@ -57,6 +57,7 @@ it("api version in host param", async () => {
         ApiVersion: APIVersions,
       }
     )
+    @versioned(APIVersions)
     namespace MyService;
     enum APIVersions {
       v1_0: "v1.0",

--- a/packages/typespec-client-generator-core/test/test-host.ts
+++ b/packages/typespec-client-generator-core/test/test-host.ts
@@ -118,10 +118,12 @@ export async function createSdkTestRunner(
   sdkTestRunner.compileWithBuiltInAzureCoreService = async (code) => {
     const result = await baseCompile(
       `
-      @useDependency(Versions.v1_0_Preview_2)
       @server("http://localhost:3000", "endpoint")
-      @service()
+      @service
+      @versioned(Versions)
       namespace My.Service;
+      enum Versions {@useDependency(Azure.Core.Versions.v1_0_Preview_2) v1}
+
       ${code}`,
       {
         noEmit: true,

--- a/packages/typespec-client-generator-core/test/types/model.test.ts
+++ b/packages/typespec-client-generator-core/test/types/model.test.ts
@@ -882,8 +882,9 @@ it("lro core filterOutCoreModels false", async () => {
   strictEqual(models[3].crossLanguageDefinitionId, "Azure.Core.ResourceOperationStatus");
   strictEqual(models[4].name, "User");
   strictEqual(models[4].crossLanguageDefinitionId, "My.Service.User");
-  strictEqual(runner.context.sdkPackage.enums.length, 1);
+  strictEqual(runner.context.sdkPackage.enums.length, 2);
   strictEqual(runner.context.sdkPackage.enums[0].name, "OperationState");
+  strictEqual(runner.context.sdkPackage.enums[1].name, "Versions");
 });
 
 it("model with core property", async () => {


### PR DESCRIPTION
Fix: https://github.com/Azure/typespec-azure/issues/3270

Current logic:
1. Author's customization with `@apiVersion` is the highest priority.
2. If the service is not versioning, always return `false`.
3. Parameter type is the defined service version enum type, return `true`.
4. Parameter name is `apiVersion` or `api-version` (case insensitive), return `true`.
5. Else, return `false`.