### PR TITLE
[autorest] XML annotation support

### DIFF
--- a/.chronus/changes/witemple-msft-tsp-autorest-xml-2025-8-17-14-15-26.md
+++ b/.chronus/changes/witemple-msft-tsp-autorest-xml-2025-8-17-14-15-26.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Added support for emitting XML annotations.

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "core"]
 	path = core
-	url = https://github.com/microsoft/typespec
-	branch = main
+	url = https://github.com/witemple-msft/typespec
+	branch = witemple-msft/xml-name

--- a/packages/samples/package.json
+++ b/packages/samples/package.json
@@ -49,7 +49,8 @@
     "@typespec/openapi": "workspace:^",
     "@typespec/openapi3": "workspace:^",
     "@typespec/rest": "workspace:^",
-    "@typespec/versioning": "workspace:^"
+    "@typespec/versioning": "workspace:^",
+    "@typespec/xml": "workspace:^"
   },
   "devDependencies": {
     "@types/node": "~24.3.0",

--- a/packages/typespec-autorest/package.json
+++ b/packages/typespec-autorest/package.json
@@ -63,7 +63,13 @@
     "@typespec/http": "workspace:^",
     "@typespec/openapi": "workspace:^",
     "@typespec/rest": "workspace:^",
-    "@typespec/versioning": "workspace:^"
+    "@typespec/versioning": "workspace:^",
+    "@typespec/xml": "workspace:^"
+  },
+  "peerDependenciesMeta": {
+    "@typespec/xml": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@azure-tools/typespec-azure-core": "workspace:^",

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -2219,6 +2219,15 @@ export async function getOpenAPIForService(
           propSchema.xml["x-ms-text"] = true;
         }
       }
+
+      const xmlNs = xml.module.getNs(program, prop);
+
+      if (xmlNs) {
+        propSchema.xml ??= {};
+        propSchema.xml.namespace = xmlNs.namespace;
+
+        if (xmlNs.prefix) propSchema.xml.prefix = xmlNs.prefix;
+      }
     }
 
     if (options.armResourceFlattening && isConditionallyFlattened(program, prop)) {

--- a/packages/typespec-autorest/src/openapi2-document.ts
+++ b/packages/typespec-autorest/src/openapi2-document.ts
@@ -314,6 +314,11 @@ export interface XmlObject {
    * Controls whether array items are wrapped inside a container element. Useful when serializing arrays to XML.
    */
   wrapped?: boolean;
+
+  /**
+   * Microsoft extension that marks a property as the text content of an XML element.
+   */
+  "x-ms-text"?: boolean;
 }
 
 export type OpenAPI2FileSchema = {

--- a/packages/typespec-autorest/src/openapi2-document.ts
+++ b/packages/typespec-autorest/src/openapi2-document.ts
@@ -110,7 +110,10 @@ export type JsonType = "array" | "boolean" | "integer" | "number" | "object" | "
  * Autorest allows a few properties to be next to $ref of a property.
  */
 export type OpenAPI2SchemaRefProperty = Ref<OpenAPI2Schema> &
-  Pick<OpenAPI2Schema, "readOnly" | "description" | "default" | "x-ms-mutability" | "title"> & {
+  Pick<
+    OpenAPI2Schema,
+    "readOnly" | "description" | "default" | "x-ms-mutability" | "title" | "xml"
+  > & {
     /**
      * Provide a different name to be used in the client.
      */
@@ -283,7 +286,35 @@ export type OpenAPI2Schema = Extensions & {
   minProperties?: number;
 
   "x-ms-mutability"?: string[];
+
+  /**
+   * XML metadata for the schema, if applicable.
+   */
+  xml?: XmlObject;
 };
+
+export interface XmlObject {
+  /**
+   * Overrides the XML element name for this schema or property.
+   */
+  name?: string;
+  /**
+   * XML namespace URI to use for the element/property.
+   */
+  namespace?: string;
+  /**
+   * XML namespace prefix to apply.
+   */
+  prefix?: string;
+  /**
+   * If true, the item is serialized as an XML attribute of its parent, not as a child element.
+   */
+  attribute?: boolean;
+  /**
+   * Controls whether array items are wrapped inside a container element. Useful when serializing arrays to XML.
+   */
+  wrapped?: boolean;
+}
 
 export type OpenAPI2FileSchema = {
   type: "file";

--- a/packages/typespec-autorest/src/xml.ts
+++ b/packages/typespec-autorest/src/xml.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+// @typespec/xml is an optional dependency, so we try to await import it, and need three states:
+// 1. Not initialized
+// 2. Initialized and the module is not installed
+// 3. Initialized and the module is installed
+
+export type XmlModule = XmlModuleAvailable | XmlModuleUnavailable;
+
+export interface XmlModuleUnavailable {
+  readonly available: false;
+}
+
+export interface XmlModuleAvailable {
+  readonly available: true;
+  readonly module: typeof import("@typespec/xml");
+}
+
+let XML_MODULE: XmlModule | undefined;
+
+export async function resolveXmlModule(): Promise<XmlModule> {
+  if (XML_MODULE) return XML_MODULE;
+
+  try {
+    const module = await import("@typespec/xml");
+
+    XML_MODULE = { available: true, module };
+  } catch {
+    XML_MODULE = { available: false };
+  }
+
+  return XML_MODULE;
+}

--- a/packages/typespec-autorest/test/parameters.test.ts
+++ b/packages/typespec-autorest/test/parameters.test.ts
@@ -72,7 +72,7 @@ describe("path parameters", () => {
   });
 
   it("report unsupported-param-type diagnostic on the parameter when using unsupported types", async () => {
-    const offset = 223; // hard coding, need better solution in new tester
+    const offset = 258; // hard coding, need better solution in new tester
 
     const { pos, end, source } = extractSquiggles(
       `op test(~~~@path myParam: Record<string>~~~): void;`,
@@ -88,7 +88,7 @@ describe("path parameters", () => {
   });
 
   it("report unsupported-optional-path-param diagnostic on the parameter when using optional path parameters", async () => {
-    const offset = 223; // hard coding, need better solution in new tester
+    const offset = 258; // hard coding, need better solution in new tester
     const { pos, end, source } = extractSquiggles(`op test(~~~@path myParam?: string~~~): void;`);
     const runner = await Tester.createInstance();
     const diagnostics = await runner.diagnose(source);

--- a/packages/typespec-autorest/test/produces-consumes.test.ts
+++ b/packages/typespec-autorest/test/produces-consumes.test.ts
@@ -89,10 +89,10 @@ describe("typespec-autorest: produces/consumes", () => {
       },
     ]);
 
-    strictEqual(result.globalConsumes[0], "application/json");
+    deepStrictEqual(result.globalConsumes, ["application/json"]);
     deepStrictEqual(result.operations.get("/in")?.produces, undefined);
     deepStrictEqual(result.operations.get("/in")?.consumes, undefined);
-    strictEqual(result.operations.get("/out")!.produces![0], "text/json");
+    deepStrictEqual(result.operations.get("/out")?.produces, ["text/json"]);
     strictEqual(result.operations.get("/out")?.consumes, undefined);
   });
 });

--- a/packages/typespec-autorest/test/test-host.ts
+++ b/packages/typespec-autorest/test/test-host.ts
@@ -12,6 +12,7 @@ import { OpenAPI2Document } from "../src/openapi2-document.js";
 export const ApiTester = createTester(resolvePath(import.meta.dirname, ".."), {
   libraries: [
     "@typespec/http",
+    "@typespec/xml",
     "@typespec/rest",
     "@typespec/openapi",
     "@azure-tools/typespec-autorest",
@@ -29,11 +30,12 @@ const defaultOptions = {
 };
 export const Tester = BasicTester.import(
   "@typespec/http",
+  "@typespec/xml",
   "@typespec/rest",
   "@typespec/openapi",
   "@typespec/versioning",
 )
-  .using("Http", "Rest", "OpenAPI", "Versioning")
+  .using("Http", "Xml", "Rest", "OpenAPI", "Versioning")
   .emit("@azure-tools/typespec-autorest", defaultOptions);
 
 /** Tester that will load Azure libraries. Only use if needed, will slow down the tests */
@@ -41,6 +43,7 @@ export const AzureTester = ApiTester.importLibraries()
   .using(
     "Versioning",
     "Http",
+    "Xml",
     "Rest",
     "OpenAPI",
     "Autorest",

--- a/packages/typespec-autorest/test/xml.test.ts
+++ b/packages/typespec-autorest/test/xml.test.ts
@@ -4,9 +4,6 @@ import { openApiFor } from "./test-host.js";
 
 it("chooses XML as the default consumes/produces when an API has only XML payloads", async () => {
   const openapi = await openApiFor(`
-      @service(#{title: "My Service"})
-      namespace Foo;
-
       model Payload {}
 
       @get op getXml(
@@ -27,9 +24,6 @@ it("chooses XML as the default consumes/produces when an API has only XML payloa
 
 it("chooses JSON and XML as the default consumes/produces when an API has JSON and XML payloads", async () => {
   const openapi = await openApiFor(`
-      @service(#{title: "My Service"})
-      namespace Foo;
-
       model JsonPayload {}
       model XmlPayload {}
 
@@ -63,9 +57,6 @@ it("chooses JSON and XML as the default consumes/produces when an API has JSON a
 
 it("applies XML name, namespace, and prefix to a model", async () => {
   const openapi = await openApiFor(`
-      @service(#{title: "My Service"})
-      namespace Foo;
-
       @Xml.name("CustomName")
       @Xml.ns("http://example.com/ns", "ex")
       model Payload {
@@ -96,9 +87,6 @@ it("applies XML name, namespace, and prefix to a model", async () => {
 
 it("treats XMl name as secondary in property schemas when the spec is not only XML", async () => {
   const openapi = await openApiFor(`
-      @service(#{title: "My Service"})
-      namespace Foo;
-
       model Payload {
         @Xml.name("RenamedProperty")
         property: string;
@@ -130,9 +118,6 @@ it("treats XMl name as secondary in property schemas when the spec is not only X
 
 it("wraps XML arrays by default", async () => {
   const openapi = await openApiFor(`
-      @service(#{title: "My Service"})
-      namespace Foo;
-
       model Payload {
         items: string[];
       }
@@ -153,9 +138,6 @@ it("wraps XML arrays by default", async () => {
 
 it("can unwrap XML arrays", async () => {
   const openapi = await openApiFor(`
-      @service(#{title: "My Service"})
-      namespace Foo;
-
       model Payload {
         @Xml.unwrapped
         items: string[];
@@ -177,9 +159,6 @@ it("can unwrap XML arrays", async () => {
 
 it("can mark a property as XML text using x-ms-text", async () => {
   const openapi = await openApiFor(`
-      @service(#{title: "My Service"})
-      namespace Foo;
-
       model Payload {
         @Xml.unwrapped
         content?: string;

--- a/packages/typespec-autorest/test/xml.test.ts
+++ b/packages/typespec-autorest/test/xml.test.ts
@@ -1,0 +1,198 @@
+import { deepStrictEqual } from "assert";
+import { it } from "vitest";
+import { openApiFor } from "./test-host.js";
+
+it("chooses XML as the default consumes/produces when an API has only XML payloads", async () => {
+  const openapi = await openApiFor(`
+      @service(#{title: "My Service"})
+      namespace Foo;
+
+      model Payload {}
+
+      @get op getXml(
+        @header contentType: "application/xml",
+        @body body: Payload;
+      ): {
+        @header contentType: "application/xml";
+        @body body: Payload;
+      };
+    `);
+
+  deepStrictEqual(openapi.consumes, ["application/xml"]);
+  deepStrictEqual(openapi.produces, ["application/xml"]);
+
+  deepStrictEqual(openapi.paths["/"].get.consumes, undefined);
+  deepStrictEqual(openapi.paths["/"].get.produces, undefined);
+});
+
+it("chooses JSON and XML as the default consumes/produces when an API has JSON and XML payloads", async () => {
+  const openapi = await openApiFor(`
+      @service(#{title: "My Service"})
+      namespace Foo;
+
+      model JsonPayload {}
+      model XmlPayload {}
+
+      @route("/json")
+      @get op getJson(
+        @header contentType: "application/json",
+        @body body: JsonPayload;
+      ): {
+        @header contentType: "application/json";
+        @body body: JsonPayload;
+      };
+
+      @route("/xml")
+      @get op getXml(
+        @header contentType: "application/xml",
+        @body body: XmlPayload;
+      ): {
+        @header contentType: "application/xml";
+        @body body: XmlPayload;
+      };
+    `);
+
+  deepStrictEqual(openapi.consumes, ["application/json", "application/xml"]);
+  deepStrictEqual(openapi.produces, ["application/json", "application/xml"]);
+
+  deepStrictEqual(openapi.paths["/json"].get.consumes, ["application/json"]);
+  deepStrictEqual(openapi.paths["/json"].get.produces, ["application/json"]);
+  deepStrictEqual(openapi.paths["/xml"].get.consumes, ["application/xml"]);
+  deepStrictEqual(openapi.paths["/xml"].get.produces, ["application/xml"]);
+});
+
+it("applies XML name, namespace, and prefix to a model", async () => {
+  const openapi = await openApiFor(`
+      @service(#{title: "My Service"})
+      namespace Foo;
+
+      @Xml.name("CustomName")
+      @Xml.ns("http://example.com/ns", "ex")
+      model Payload {
+        @Xml.name("RenamedProperty")
+        @Xml.ns("http://example.com/propns", "prop")
+        property: string;
+      }
+
+      @get op getXml(
+        @header contentType: "application/xml",
+        @body body: Payload;
+      ): {
+        @header contentType: "application/xml";
+        @body body: Payload;
+      };
+    `);
+
+  deepStrictEqual(openapi.definitions["Payload"]["xml"], {
+    name: "CustomName",
+    namespace: "http://example.com/ns",
+    prefix: "ex",
+  });
+  deepStrictEqual(openapi.definitions["Payload"].properties["RenamedProperty"].xml, {
+    namespace: "http://example.com/propns",
+    prefix: "prop",
+  });
+});
+
+it("treats XMl name as secondary in property schemas when the spec is not only XML", async () => {
+  const openapi = await openApiFor(`
+      @service(#{title: "My Service"})
+      namespace Foo;
+
+      model Payload {
+        @Xml.name("RenamedProperty")
+        property: string;
+      }
+
+      @route("/json")
+      @get op getJson(
+        @header contentType: "application/json",
+        @body body: Payload;
+      ): {
+        @header contentType: "application/json";
+        @body body: Payload;
+      };
+
+      @route("/xml")
+      @get op getXml(
+        @header contentType: "application/xml",
+        @body body: Payload;
+      ): {
+        @header contentType: "application/xml";
+        @body body: Payload;
+      };
+    `);
+
+  deepStrictEqual(openapi.definitions["Payload"].properties["property"].xml, {
+    name: "RenamedProperty",
+  });
+});
+
+it("wraps XML arrays by default", async () => {
+  const openapi = await openApiFor(`
+      @service(#{title: "My Service"})
+      namespace Foo;
+
+      model Payload {
+        items: string[];
+      }
+
+      @get op getXml(
+        @header contentType: "application/xml",
+        @body body: Payload;
+      ): {
+        @header contentType: "application/xml";
+        @body body: Payload;
+      };
+    `);
+
+  deepStrictEqual(openapi.definitions["Payload"].properties["items"].xml, {
+    wrapped: true,
+  });
+});
+
+it("can unwrap XML arrays", async () => {
+  const openapi = await openApiFor(`
+      @service(#{title: "My Service"})
+      namespace Foo;
+
+      model Payload {
+        @Xml.unwrapped
+        items: string[];
+      }
+
+      @get op getXml(
+        @header contentType: "application/xml",
+        @body body: Payload;
+      ): {
+        @header contentType: "application/xml";
+        @body body: Payload;
+      };
+    `);
+
+  deepStrictEqual(openapi.definitions["Payload"].properties["items"].xml, {
+    wrapped: false,
+  });
+});
+
+it("can mark a property as XML text using x-ms-text", async () => {
+  const openapi = await openApiFor(`
+      @service(#{title: "My Service"})
+      namespace Foo;
+
+      model Payload {
+        @Xml.unwrapped
+        content?: string;
+      }
+
+      @get op getXml(
+        @header contentType: "application/xml",
+        @body body: Payload;
+      ): {
+        @header contentType: "application/xml";
+        @body body: Payload;
+      };
+    `);
+
+  deepStrictEqual(openapi.definitions["Payload"].properties["content"].xml["x-ms-text"], true);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2677,6 +2677,9 @@ importers:
       '@typespec/versioning':
         specifier: workspace:^
         version: link:../../core/packages/versioning
+      '@typespec/xml':
+        specifier: workspace:^
+        version: link:../../core/packages/xml
     devDependencies:
       '@types/node':
         specifier: ~24.3.0
@@ -2710,6 +2713,10 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.1)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@25.0.1)(tsx@4.20.5)(yaml@2.8.1)
 
   packages/typespec-autorest:
+    dependencies:
+      '@typespec/xml':
+        specifier: workspace:^
+        version: link:../../core/packages/xml
     devDependencies:
       '@azure-tools/typespec-azure-core':
         specifier: workspace:^

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2683,6 +2683,9 @@ importers:
       '@typespec/versioning':
         specifier: workspace:^
         version: link:../../core/packages/versioning
+      '@typespec/xml':
+        specifier: workspace:^
+        version: link:../../core/packages/xml
     devDependencies:
       '@types/node':
         specifier: ~24.3.0
@@ -2716,6 +2719,10 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.1)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jsdom@25.0.1)(tsx@4.20.5)(yaml@2.8.1)
 
   packages/typespec-autorest:
+    dependencies:
+      '@typespec/xml':
+        specifier: workspace:^
+        version: link:../../core/packages/xml
     devDependencies:
       '@azure-tools/typespec-azure-core':
         specifier: workspace:^
@@ -19507,7 +19514,7 @@ snapshots:
       algoliasearch: 4.25.2
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       diff: 5.2.0
-      ink: 3.2.0(@types/react@18.3.24)(react@18.3.1)
+      ink: 3.2.0(@types/react@18.3.24)(react@17.0.2)
       ink-text-input: 4.0.3(ink@3.2.0(@types/react@18.3.24)(react@17.0.2))(react@17.0.2)
       react: 17.0.2
       semver: 7.7.2
@@ -19656,7 +19663,7 @@ snapshots:
       '@yarnpkg/plugin-git': 3.1.3(@yarnpkg/core@4.4.3(typanion@3.14.0))(typanion@3.14.0)
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       es-toolkit: 1.39.10
-      ink: 3.2.0(@types/react@18.3.24)(react@17.0.2)
+      ink: 3.2.0(@types/react@18.3.24)(react@18.3.1)
       react: 17.0.2
       semver: 7.7.2
       tslib: 2.8.1


### PR DESCRIPTION
This PR adds support for XML metadata annotations to typespec-autorest:

- Changes the logic around top-level produces/consumes. It will now allow JSON or XML, rather than always using JSON only. If a service uses both, then it will pick both. It maintains the logic of only emitting operation-level produces/consumes if an operation differs from the top-level.
- Optionally depends on `@typespec/xml`. If it is not installed, all XML emit functionality is disabled.
- Emits `xml.name` for processed schemas if the XML name differs from the schema name.
- Emits `xml.namespace` and `xml.prefix` as needed.
- Emits `xml.attribute` for properties that are marked as attributes.
- Prefers XML names for properties if the service is only XML.
- Emits `x-ms-text` for properties that are `@unwrapped` if the property's effective encoded type is or extends `TypeSpec.string`.
- Emits `xml.wrapped: true` by default for all properties that have array types, unless the property is marked `@unwrapped`.
- Adds several validation tests for XML and hybrid XML/json services.

Closes https://github.com/Azure/typespec-azure/issues/1682