### PR TITLE
Fix Rpc operation request body regression

### DIFF
--- a/.chronus/changes/fix-rpc-operation-body-regression-2025-8-29-9-27-3.md
+++ b/.chronus/changes/fix-rpc-operation-body-regression-2025-8-29-9-27-3.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-core"
+---
+
+[rpc-operation-request-body] Correctly ignores properties marked with `@bodyIgnore`

--- a/packages/typespec-azure-core/test/rules/rpc-operation-request-body.test.ts
+++ b/packages/typespec-azure-core/test/rules/rpc-operation-request-body.test.ts
@@ -30,6 +30,18 @@ it("allow RPCOperation with `@get` and empty body", async () => {
     .toBeValid();
 });
 
+it("with @bodyIgnore properties", async () => {
+  await tester
+    .expect(
+      `
+        @get
+        @route ("/")
+        op get is RpcOperation<{ @bodyIgnore options: { @query foo: string }}, {}>;
+      `,
+    )
+    .toBeValid();
+});
+
 it("allow RPCOperation with `@delete` and empty body", async () => {
   await tester
     .expect(


### PR DESCRIPTION
In the migration to tester v2 I removed the restriction that prevented this rule from running on non `Azure.` namespace which cause some failure in Azure batch client customization but then uncovered this rule didn't respect `@bodyIgnore`