### PR TITLE
[autorest] XML emit strategy

### DIFF
--- a/.chronus/changes/main-2025-9-1-13-29-36.md
+++ b/.chronus/changes/main-2025-9-1-13-29-36.md
@@ -1,0 +1,10 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Added an `xml-strategy` option to control whether the emitter outputs XML serialization metadata. The options are:
+
+- `xml-strategy: xml-service`: Emit XML serialization metadata for the whole service and all its schemas if the service uses the "application/xml" content-type.
+- `xml-strategy: none`: Never emit XML serialization metadata.

--- a/.chronus/changes/witemple-msft-autorest-xml-strategy-2025-9-2-11-40-2.md
+++ b/.chronus/changes/witemple-msft-autorest-xml-strategy-2025-9-2-11-40-2.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-autorest-canonical"
+---
+
+Exposed option `xml-strategy` from the base typespec-autorest emitter.

--- a/packages/typespec-autorest-canonical/README.md
+++ b/packages/typespec-autorest-canonical/README.md
@@ -91,3 +91,9 @@ Omit unreachable types. By default all types declared under the service namespac
 
 If the generated openapi types should have the `x-typespec-name` extension set with the name of the TypeSpec type that created it.
 This extension is meant for debugging and should not be depended on.
+
+### `xml-strategy`
+
+**Type:** `"xml-service" | "none"`
+
+Strategy for applying XML serialization metadata to schemas.

--- a/packages/typespec-autorest-canonical/src/emitter.ts
+++ b/packages/typespec-autorest-canonical/src/emitter.ts
@@ -32,6 +32,7 @@ const defaultOptions = {
   "output-file": "{azure-resource-provider-folder}/{service-name}/canonical/openapi.json",
   "new-line": "lf",
   "include-x-typespec-name": "never",
+  "xml-strategy": "xml-service",
 } as const;
 
 export const canonicalVersion = "canonical";
@@ -70,6 +71,7 @@ export async function $onEmit(context: EmitContext<AutorestCanonicalEmitterOptio
     includeXTypeSpecName: resolvedOptions["include-x-typespec-name"],
     armTypesDir,
     useReadOnlyStatusSchema: true,
+    xmlStrategy: resolvedOptions["xml-strategy"],
   };
 
   await emitAllServices(context.program, tcgcSdkContext, options);

--- a/packages/typespec-autorest-canonical/src/lib.ts
+++ b/packages/typespec-autorest-canonical/src/lib.ts
@@ -53,6 +53,16 @@ export interface AutorestCanonicalEmitterOptions {
    * @default "${project-root}/../../common-types/resource-management"
    */
   "arm-types-dir"?: string;
+
+  /**
+   * Strategy for applying XML serialization metadata to schemas.
+   *
+   * - "xml-service": Apply XML serialization metadata for any service that uses the `"application/xml"` content type.
+   * - "none": Do not apply any XML serialization metadata.
+   *
+   * @default "xml-service"
+   */
+  "xml-strategy"?: "xml-service" | "none";
 }
 
 const EmitterOptionsSchema: JSONSchemaType<AutorestCanonicalEmitterOptions> = {
@@ -106,6 +116,13 @@ const EmitterOptionsSchema: JSONSchemaType<AutorestCanonicalEmitterOptions> = {
       default: "never",
       description:
         "If the generated openapi types should have the `x-typespec-name` extension set with the name of the TypeSpec type that created it.\nThis extension is meant for debugging and should not be depended on.",
+    },
+    "xml-strategy": {
+      type: "string",
+      enum: ["xml-service", "none"],
+      nullable: true,
+      default: "xml-service",
+      description: "Strategy for applying XML serialization metadata to schemas.",
     },
   },
   required: [],

--- a/packages/typespec-autorest/README.md
+++ b/packages/typespec-autorest/README.md
@@ -163,6 +163,12 @@ Back-compat flag. If true, continue to emit `x-ms-client-flatten` in for some of
 
 Determine whether and how to emit schemas for common-types rather than referencing them
 
+### `xml-strategy`
+
+**Type:** `"xml-service" | "none"`
+
+Strategy for applying XML serialization metadata to schemas.
+
 ## Decorators
 
 ### Autorest

--- a/packages/typespec-autorest/src/emit.ts
+++ b/packages/typespec-autorest/src/emit.ts
@@ -55,6 +55,7 @@ const defaultOptions = {
     "{azure-resource-provider-folder}/{service-name}/{version-status}/{version}/openapi.json",
   "new-line": "lf",
   "include-x-typespec-name": "never",
+  "xml-strategy": "xml-service",
 } as const;
 
 export async function $onEmit(context: EmitContext<AutorestEmitterOptions>) {
@@ -112,6 +113,7 @@ export function resolveAutorestOptions(
     emitLroOptions: resolvedOptions["emit-lro-options"],
     armResourceFlattening: resolvedOptions["arm-resource-flattening"],
     emitCommonTypesSchema: resolvedOptions["emit-common-types-schema"],
+    xmlStrategy: resolvedOptions["xml-strategy"],
   };
 }
 

--- a/packages/typespec-autorest/src/lib.ts
+++ b/packages/typespec-autorest/src/lib.ts
@@ -108,6 +108,16 @@ export interface AutorestEmitterOptions {
    * @default "for-visibility-changes"
    */
   "emit-common-types-schema"?: "never" | "for-visibility-changes";
+
+  /**
+   * Strategy for applying XML serialization metadata to schemas.
+   *
+   * - "xml-service": Apply XML serialization metadata for any service that uses the `"application/xml"` content type.
+   * - "none": Do not apply any XML serialization metadata.
+   *
+   * @default "xml-service"
+   */
+  "xml-strategy"?: "xml-service" | "none";
 }
 
 const EmitterOptionsSchema: JSONSchemaType<AutorestEmitterOptions> = {
@@ -232,6 +242,13 @@ const EmitterOptionsSchema: JSONSchemaType<AutorestEmitterOptions> = {
       default: "for-visibility-changes",
       description:
         "Determine whether and how to emit schemas for common-types rather than referencing them",
+    },
+    "xml-strategy": {
+      type: "string",
+      enum: ["xml-service", "none"],
+      nullable: true,
+      default: "xml-service",
+      description: "Strategy for applying XML serialization metadata to schemas.",
     },
   },
   required: [],

--- a/packages/typespec-autorest/test/xml.test.ts
+++ b/packages/typespec-autorest/test/xml.test.ts
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "assert";
+import { deepStrictEqual, strictEqual } from "assert";
 import { it } from "vitest";
 import { openApiFor } from "./test-host.js";
 
@@ -174,4 +174,47 @@ it("can mark a property as XML text using x-ms-text", async () => {
     `);
 
   deepStrictEqual(openapi.definitions["Payload"].properties["content"].xml["x-ms-text"], true);
+});
+
+it("does not emit XML metadata when the xml-strategy is 'none'", async () => {
+  // Example that includes everything
+  const openapi = await openApiFor(
+    `
+      @Xml.name("CustomName")
+      @Xml.ns("http://example.com/ns", "ex")
+      model Payload {
+        @Xml.name("RenamedProperty")
+        @Xml.ns("http://example.com/propns", "prop")
+        property: string;
+
+        @Xml.unwrapped
+        items: string[];
+
+        data: {
+          @Xml.unwrapped
+          content: string;
+        };
+      }
+
+      @get op getXml(
+        @header contentType: "application/xml",
+        @body body: string;
+      ): {
+        @header contentType: "application/xml";
+        @body body: string;
+      };
+    `,
+    /* versions  */ undefined,
+    /* options */ { "xml-strategy": "none" },
+  );
+
+  strictEqual(openapi.definitions["Payload"]["xml"], undefined);
+  strictEqual(openapi.definitions["Payload"].properties["RenamedProperty"].xml, undefined);
+
+  strictEqual(openapi.definitions["Payload"].properties["items"].xml, undefined);
+  strictEqual(openapi.definitions["Payload"].properties["data"].xml, undefined);
+  strictEqual(
+    openapi.definitions["Payload"].properties["data"].properties["content"].xml,
+    undefined,
+  );
 });

--- a/website/src/content/docs/docs/emitters/typespec-autorest-canonical/reference/emitter.md
+++ b/website/src/content/docs/docs/emitters/typespec-autorest-canonical/reference/emitter.md
@@ -85,3 +85,9 @@ Omit unreachable types. By default all types declared under the service namespac
 
 If the generated openapi types should have the `x-typespec-name` extension set with the name of the TypeSpec type that created it.
 This extension is meant for debugging and should not be depended on.
+
+### `xml-strategy`
+
+**Type:** `"xml-service" | "none"`
+
+Strategy for applying XML serialization metadata to schemas.

--- a/website/src/content/docs/docs/emitters/typespec-autorest/reference/emitter.md
+++ b/website/src/content/docs/docs/emitters/typespec-autorest/reference/emitter.md
@@ -156,3 +156,9 @@ Back-compat flag. If true, continue to emit `x-ms-client-flatten` in for some of
 **Type:** `"never" | "for-visibility-changes"`
 
 Determine whether and how to emit schemas for common-types rather than referencing them
+
+### `xml-strategy`
+
+**Type:** `"xml-service" | "none"`
+
+Strategy for applying XML serialization metadata to schemas.


### PR DESCRIPTION
This PR adds an option for autorest XML emit that allows the project configuration to disable XML serialization annotations. This can be useful for some specifications that have operations that return raw XML payloads without polluting the whole spec with XML annotations. It also provides a point of extension in the future if more XML strategies are required.