### PR TITLE
Hotfix: Bump typespec-client-generator-core to 0.61.1

### DIFF
--- a/.chronus/changes/tcgc-fix_client_location-2025-9-10-11-44-31.md
+++ b/.chronus/changes/tcgc-fix_client_location-2025-9-10-11-44-31.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-client-generator-core"
----
-
-Support `@clientLocation` for model property along with `@override`.

--- a/packages/typespec-client-generator-core/CHANGELOG.md
+++ b/packages/typespec-client-generator-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-client-generator-core
 
+## 0.61.1
+
+### Bug Fixes
+
+- [#3376](https://github.com/Azure/typespec-azure/pull/3376) Support `@clientLocation` for model property along with `@override`.
+
+
 ## 0.61.0
 
 ### Breaking Changes

--- a/packages/typespec-client-generator-core/package.json
+++ b/packages/typespec-client-generator-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-core",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "author": "Microsoft Corporation",
   "description": "TypeSpec Data Plane Generation library",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
This is a patch release for typespec-client-generator-core that includes the fix for supporting @clientLocation with @override on model properties.

Changes:
- Bump version from 0.61.0 to 0.61.1
- Include fix from PR #3376: Support @clientLocation for model property along with @override

This follows the hotfix release process outlined in CONTRIBUTING.md.