### PR TITLE
Set pnpm minimum release age to 2 days

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.15.1",
+  "packageManager": "pnpm@10.23.0",
   "scripts": {
     "run-all": "pnpm -r --filter=!./core/",
     "run-azure-only": "pnpm -r --filter=\"!./core/**\"",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,3 +11,6 @@ packages:
 overrides:
   "cross-spawn@>=7.0.0 <7.0.5": "^7.0.5"
   rollup: 4.49.0 # Regression in 4.50.0 https://github.com/rollup/rollup/issues/6099
+
+# Minimum age (in minutes) for a new dependency version to be able to be used.
+minimumReleaseAge: 2880 # 2 days


### PR DESCRIPTION
To reduce chance an hijacked dependency gets included when upgrading dependencies add a 2 day delay before any new release can be included