### PR TITLE
Revert "add `@clientNamespace` for python"

### DIFF
--- a/.chronus/changes/update-client-namespace-2025-11-12-17-11-38.md
+++ b/.chronus/changes/update-client-namespace-2025-11-12-17-11-38.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/azure-http-specs"
----
-
-update client namespaces for python

--- a/packages/azure-http-specs/specs/azure/client-generator-core/access/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/access/main.tsp
@@ -9,10 +9,6 @@ using Spector;
 @doc("Test for internal decorator.")
 @scenarioService("/azure/client-generator-core/access")
 @global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.access", "java")
-@global.Azure.ClientGenerator.Core.clientNamespace(
-  "specs.azure.clientgenerator.core.access",
-  "python"
-)
 namespace _Specs_.Azure.ClientGenerator.Core.Access;
 
 @route("/publicOperation")

--- a/packages/azure-http-specs/specs/azure/client-generator-core/alternate-type/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/alternate-type/client.tsp
@@ -7,10 +7,6 @@ using Azure.ClientGenerator.Core;
   "azure.clientgenerator.core.alternatetype",
   "java"
 );
-@@global.Azure.ClientGenerator.Core.clientNamespace(_Specs_.Azure.ClientGenerator.Core.AlternateType,
-  "specs.azure.clientgenerator.core.alternatetype",
-  "python"
-);
 
 @@alternateType(_Specs_.Azure.ClientGenerator.Core.AlternateType.ExternalType.Feature,
   {

--- a/packages/azure-http-specs/specs/azure/client-generator-core/api-version/header/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/api-version/header/client.tsp
@@ -16,7 +16,3 @@ namespace Customizations;
   "azure.clientgenerator.core.apiversion.header",
   "java"
 );
-@@clientNamespace(Client.AlternateApiVersion.Service.Header,
-  "specs.azure.clientgenerator.core.apiversion.header",
-  "python"
-);

--- a/packages/azure-http-specs/specs/azure/client-generator-core/api-version/path/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/api-version/path/client.tsp
@@ -16,7 +16,3 @@ namespace Customizations;
   "azure.clientgenerator.core.apiversion.path",
   "java"
 );
-@@clientNamespace(Client.AlternateApiVersion.Service.Path,
-  "specs.azure.clientgenerator.core.apiversion.path",
-  "python"
-);

--- a/packages/azure-http-specs/specs/azure/client-generator-core/api-version/query/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/api-version/query/client.tsp
@@ -16,7 +16,3 @@ namespace Customizations;
   "azure.clientgenerator.core.apiversion.query",
   "java"
 );
-@@clientNamespace(Client.AlternateApiVersion.Service.Query,
-  "specs.azure.clientgenerator.core.apiversion.query",
-  "python"
-);

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/client.tsp
@@ -13,17 +13,9 @@ namespace _Specs_.Azure.ClientGenerator.Core.ClientInitialization;
   "azure.clientgenerator.core.clientinitialization",
   "java"
 );
-@@global.Azure.ClientGenerator.Core.clientNamespace(_Specs_.Azure.ClientGenerator.Core.ClientInitialization,
-  "specs.azure.clientgenerator.core.clientinitialization",
-  "python"
-);
 @@global.Azure.ClientGenerator.Core.clientNamespace(Service,
   "azure.clientgenerator.core.clientinitialization",
   "java"
-);
-@@global.Azure.ClientGenerator.Core.clientNamespace(Service,
-  "specs.azure.clientgenerator.core.clientinitialization",
-  "python"
 );
 
 model HeaderParamClientOptions {

--- a/packages/azure-http-specs/specs/azure/client-generator-core/deserialize-empty-string-as-null/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/deserialize-empty-string-as-null/main.tsp
@@ -12,10 +12,6 @@ using Spector;
   "azure.clientgenerator.core.deserialize.emptystringnull",
   "java"
 )
-@global.Azure.ClientGenerator.Core.clientNamespace(
-  "specs.azure.clientgenerator.core.emptystring",
-  "python"
-)
 namespace _Specs_.Azure.ClientGenerator.Core.DeserializeEmptyStringAsNull;
 
 @doc("This is a Model contains a string-like property of type url.")

--- a/packages/azure-http-specs/specs/azure/client-generator-core/flatten-property/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/flatten-property/main.tsp
@@ -12,10 +12,6 @@ using Spector;
   "azure.clientgenerator.core.flattenproperty",
   "java"
 )
-@global.Azure.ClientGenerator.Core.clientNamespace(
-  "specs.azure.clientgenerator.core.flattenproperty",
-  "python"
-)
 namespace _Specs_.Azure.ClientGenerator.Core.FlattenProperty;
 
 @doc("This is the model with one level of flattening.")

--- a/packages/azure-http-specs/specs/azure/client-generator-core/override/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/override/client.tsp
@@ -6,16 +6,11 @@ using Http;
 using global.Azure.ClientGenerator.Core;
 
 @clientNamespace("azure.clientgenerator.core.methodoverride", "java")
-@clientNamespace("specs.azure.clientgenerator.core.override", "python")
 namespace Customization;
 
 @@clientNamespace(_Specs_.Azure.ClientGenerator.Core.Override,
   "azure.clientgenerator.core.methodoverride",
   "java"
-);
-@@clientNamespace(_Specs_.Azure.ClientGenerator.Core.Override,
-  "specs.azure.clientgenerator.core.override",
-  "python"
 );
 
 op reorderCustomized(@path param1: string, @path param2: string): void;

--- a/packages/azure-http-specs/specs/azure/client-generator-core/usage/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/usage/main.tsp
@@ -8,10 +8,6 @@ using Spector;
 @doc("Test for internal decorator.")
 @scenarioService("/azure/client-generator-core/usage")
 @global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.usage", "java")
-@global.Azure.ClientGenerator.Core.clientNamespace(
-  "specs.azure.clientgenerator.core.usage",
-  "python"
-)
 namespace _Specs_.Azure.ClientGenerator.Core.Usage;
 
 @scenario
@@ -21,10 +17,6 @@ namespace _Specs_.Azure.ClientGenerator.Core.Usage;
   The other models' usage is additive to roundtrip, so they should be generated and exported as well.
   """)
 @global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.usage", "java")
-@global.Azure.ClientGenerator.Core.clientNamespace(
-  "specs.azure.clientgenerator.core.usage",
-  "python"
-)
 namespace ModelInOperation {
   @doc("Usage additive to roundtrip.")
   @global.Azure.ClientGenerator.Core.usage(

--- a/packages/azure-http-specs/specs/azure/core/basic/client.tsp
+++ b/packages/azure-http-specs/specs/azure/core/basic/client.tsp
@@ -6,4 +6,3 @@ using Azure.ClientGenerator.Core;
 @@convenientAPI(_Specs_.Azure.Core.Basic.createOrUpdate, false, "csharp");
 
 @@clientNamespace(_Specs_.Azure.Core.Basic, "azure.core.basic", "java");
-@@clientNamespace(_Specs_.Azure.Core.Basic, "specs.azure.core.basic", "python");

--- a/packages/azure-http-specs/specs/azure/core/lro/rpc/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/lro/rpc/main.tsp
@@ -20,7 +20,6 @@ using Spector;
   }
 )
 @global.Azure.ClientGenerator.Core.clientNamespace("azure.core.lro.rpc", "java")
-@global.Azure.ClientGenerator.Core.clientNamespace("specs.azure.core.lro.rpc", "python")
 namespace _Specs_.Azure.Core.Lro.Rpc;
 
 @doc("The API version.")

--- a/packages/azure-http-specs/specs/azure/core/lro/standard/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/lro/standard/main.tsp
@@ -20,7 +20,6 @@ using Spector;
   }
 )
 @global.Azure.ClientGenerator.Core.clientNamespace("azure.core.lro.standard", "java")
-@global.Azure.ClientGenerator.Core.clientNamespace("specs.azure.core.lro.standard", "python")
 namespace _Specs_.Azure.Core.Lro.Standard;
 
 @doc("The API version.")

--- a/packages/azure-http-specs/specs/azure/core/model/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/model/main.tsp
@@ -17,7 +17,6 @@ using Spector;
   }
 )
 @global.Azure.ClientGenerator.Core.clientNamespace("azure.core.model", "java")
-@global.Azure.ClientGenerator.Core.clientNamespace("specs.azure.core.model", "python")
 namespace _Specs_.Azure.Core.Model;
 @doc("The version of the API.")
 enum Versions {

--- a/packages/azure-http-specs/specs/azure/core/page/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/page/main.tsp
@@ -20,7 +20,6 @@ using Spector;
   }
 )
 @global.Azure.ClientGenerator.Core.clientNamespace("azure.core.page", "java")
-@global.Azure.ClientGenerator.Core.clientNamespace("specs.azure.core.page", "python")
 namespace _Specs_.Azure.Core.Page;
 
 @doc("The version of the API.")

--- a/packages/azure-http-specs/specs/azure/core/scalar/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/scalar/main.tsp
@@ -17,7 +17,6 @@ using Spector;
   }
 )
 @global.Azure.ClientGenerator.Core.clientNamespace("azure.core.scalar", "java")
-@global.Azure.ClientGenerator.Core.clientNamespace("specs.azure.core.scalar", "python")
 namespace _Specs_.Azure.Core.Scalar;
 @doc("The version of the API.")
 enum Versions {

--- a/packages/azure-http-specs/specs/azure/core/traits/main.tsp
+++ b/packages/azure-http-specs/specs/azure/core/traits/main.tsp
@@ -22,7 +22,6 @@ using Spector;
 )
 @versioned(Versions)
 @global.Azure.ClientGenerator.Core.clientNamespace("azure.core.traits", "java")
-@global.Azure.ClientGenerator.Core.clientNamespace("specs.azure.core.traits", "python")
 namespace _Specs_.Azure.Core.Traits;
 
 @doc("Service versions")

--- a/packages/azure-http-specs/specs/azure/encode/duration/main.tsp
+++ b/packages/azure-http-specs/specs/azure/encode/duration/main.tsp
@@ -11,7 +11,6 @@ using Spector;
 namespace _Specs_.Azure.Encode.Duration;
 
 @@clientNamespace(_Specs_.Azure.Encode.Duration, "azure.encode.duration", "java");
-@@clientNamespace(_Specs_.Azure.Encode.Duration, "specs.azure.encode.duration", "python");
 
 model DurationModel {
   @encode("duration-constant")

--- a/packages/azure-http-specs/specs/azure/example/basic/client.tsp
+++ b/packages/azure-http-specs/specs/azure/example/basic/client.tsp
@@ -11,9 +11,7 @@ using Spector;
 namespace AzureExampleBasicClient;
 
 @@clientNamespace(AzureExampleBasicClient, "azure.example.basic", "java");
-@@clientNamespace(AzureExampleBasicClient, "specs.azure.example.basic", "python");
 @@clientNamespace(_Specs_.Azure.Example.Basic, "azure.example.basic", "java");
-@@clientNamespace(_Specs_.Azure.Example.Basic, "specs.azure.example.basic", "python");
 
 @client({
   name: "AzureExampleClient",

--- a/packages/azure-http-specs/specs/azure/payload/pageable/main.tsp
+++ b/packages/azure-http-specs/specs/azure/payload/pageable/main.tsp
@@ -13,7 +13,6 @@ using global.Azure.ClientGenerator.Core;
 namespace _Specs_.Azure.Payload.Pageable;
 
 @@clientNamespace(_Specs_.Azure.Payload.Pageable, "azure.payload.pageable", "java");
-@@clientNamespace(_Specs_.Azure.Payload.Pageable, "specs.azure.payload.pageable", "python");
 
 @doc("User model")
 model User {

--- a/packages/azure-http-specs/specs/azure/versioning/previewVersion/main.tsp
+++ b/packages/azure-http-specs/specs/azure/versioning/previewVersion/main.tsp
@@ -20,10 +20,6 @@ using global.Azure.Core;
   }
 )
 @global.Azure.ClientGenerator.Core.clientNamespace("azure.versioning.previewversion", "java")
-@global.Azure.ClientGenerator.Core.clientNamespace(
-  "specs.azure.versioning.previewversion",
-  "python"
-)
 namespace _Specs_.Azure.Versioning.PreviewVersion;
 
 @doc("Supported api versions including preview.")

--- a/packages/azure-http-specs/specs/client/naming/main.tsp
+++ b/packages/azure-http-specs/specs/client/naming/main.tsp
@@ -10,7 +10,6 @@ using Spector;
  * Describe changing names of types in a client with `@clientName`
  */
 @scenarioService("/client/naming")
-@clientNamespace("specs.client.naming.main", "python")
 namespace Client.Naming;
 
 @route("/property")

--- a/packages/azure-http-specs/specs/client/overload/main.tsp
+++ b/packages/azure-http-specs/specs/client/overload/main.tsp
@@ -3,14 +3,12 @@ import "@typespec/spector";
 import "@azure-tools/typespec-client-generator-core";
 
 using Http;
-using Azure.ClientGenerator.Core;
 using Spector;
 
 /**
  * Test for overload operation in .NET.
  */
 @scenarioService("/client/overload")
-@clientNamespace("specs.client.overload", "python")
 namespace Client.Overload;
 
 model Resource {

--- a/packages/azure-http-specs/specs/client/structure/client-operation-group/client.tsp
+++ b/packages/azure-http-specs/specs/client/structure/client-operation-group/client.tsp
@@ -5,11 +5,6 @@ import "@typespec/spector";
 using Azure.ClientGenerator.Core;
 using Spector;
 
-@@clientNamespace(Client.Structure.Service,
-  "specs.client.structure.clientoperationgroup",
-  "python"
-);
-
 @scenarioDoc("""
   This is to show we can have multiple clients, with multiple operation groups in each client.
   

--- a/packages/azure-http-specs/specs/client/structure/default/client.tsp
+++ b/packages/azure-http-specs/specs/client/structure/default/client.tsp
@@ -2,10 +2,7 @@ import "./main.tsp";
 import "@azure-tools/typespec-client-generator-core";
 import "@typespec/spector";
 
-using Azure.ClientGenerator.Core;
 using Spector;
-
-@@clientNamespace(Client.Structure.Service, "specs.client.structure.service", "python");
 
 @@scenario(Client.Structure.Service);
 @@scenarioDoc(Client.Structure.Service,


### PR DESCRIPTION
Reverts Azure/typespec-azure#3643 for it breaks the nightly build pipeline