### PR TITLE
[azure-http-specs] internal changelog

### DIFF
--- a/.chronus/changes/azure-http-specs-trigger-dev-2-2025-12-19.md
+++ b/.chronus/changes/azure-http-specs-trigger-dev-2-2025-12-19.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Internal change to trigger release for dev version.

--- a/.chronus/changes/azure-http-specs-trigger-dev-2025-12-19.md
+++ b/.chronus/changes/azure-http-specs-trigger-dev-2025-12-19.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Internal change to trigger release for dev version.


### PR DESCRIPTION
After revert one PR, have to add internal changelog to trigger dev release for azure-http-specs.

<img width="1198" height="579" alt="image" src="https://github.com/user-attachments/assets/19614849-1681-433b-8827-198dab1d06ac" />
