### PR TITLE
Revert "Prettier use new extension"

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -10,7 +10,7 @@
       // Add the IDs of extensions you want installed when the container is created.
       "extensions": [
         "dbaeumer.vscode-eslint",
-        "prettier.prettier-vscode",
+        "esbenp.prettier-vscode",
         "streetsidesoftware.code-spell-checker",
         "vitest.explorer",
         "typespec.typespec"

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
   "recommendations": [
     "dbaeumer.vscode-eslint",
-    "prettier.prettier-vscode",
+    "esbenp.prettier-vscode",
     "streetsidesoftware.code-spell-checker",
     "vitest.explorer",
     "astro-build.astro-vscode",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -23,7 +23,7 @@
     "editor.insertSpaces": true,
     "editor.tabSize": 2,
     "editor.detectIndentation": false,
-    "editor.defaultFormatter": "prettier.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[json][[jsonc][yaml][typespec][markdown][css][astro][mdx]": {
     "editor.formatOnSave": true,
@@ -31,7 +31,7 @@
     "editor.insertSpaces": true,
     "editor.tabSize": 2,
     "editor.detectIndentation": false,
-    "editor.defaultFormatter": "prettier.prettier-vscode"
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
   },
   "[csharp]": {
     "editor.insertSpaces": true,


### PR DESCRIPTION
Reverts Azure/typespec-azure#3599

Did that too quickly, they turned around and [reverted plan](https://github.com/prettier/prettier-vscode/issues/3936) for a new name as it was too much migration cost
