### PR TITLE
Fix namespace duplication bug part 2 (#3953)

### DIFF
--- a/.chronus/changes/fix-namespace-duplication-extending-flag-2026-2-20-23-2-45.md
+++ b/.chronus/changes/fix-namespace-duplication-extending-flag-2026-2-20-23-2-45.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Fix namespace duplication when `@clientNamespace` extends the namespace flag (e.g. `@clientNamespace("Azure.Search.Documents.Indexes")` with namespace flag `Azure.Search.Documents`)

--- a/packages/typespec-client-generator-core/src/decorators.ts
+++ b/packages/typespec-client-generator-core/src/decorators.ts
@@ -1223,8 +1223,11 @@ export function getClientNamespace(
   const override = getScopedDecoratorData(context, clientNamespaceKey, entity);
   if (override) {
     // if `@clientNamespace` is applied to the entity, this wins out
-    // if the override exactly matches the namespace flag, no replacement is needed
-    if (context.namespaceFlag && override === context.namespaceFlag) {
+    // if the override matches or extends the namespace flag, no replacement is needed
+    if (
+      context.namespaceFlag &&
+      (override === context.namespaceFlag || override.startsWith(context.namespaceFlag + "."))
+    ) {
       return override;
     }
     const userDefinedNamespace = findNamespaceOverlapClosestToRoot(

--- a/packages/typespec-client-generator-core/test/package/namespaces.test.ts
+++ b/packages/typespec-client-generator-core/test/package/namespaces.test.ts
@@ -629,6 +629,24 @@ it("customization with models from original namespace", async () => {
   strictEqual(ns.namespaces.length, 0);
 });
 
+it("@clientNamespace extending namespace flag should not duplicate", async () => {
+  const { program } = await SimpleTester.compile(
+    `
+      @clientNamespace("Azure.Search.Documents.Indexes")
+      @service
+      namespace Search {
+        op search(): string;
+      }
+    `,
+  );
+  const context = await createSdkContextForTester(program, {
+    namespace: "Azure.Search.Documents",
+  });
+  const sdkPackage = context.sdkPackage;
+  const client = sdkPackage.clients[0];
+  strictEqual(client.namespace, "Azure.Search.Documents.Indexes");
+});
+
 it("@clientNamespace with same value as namespace flag should not duplicate", async () => {
   const { program } = await SimpleTester.compile(
     `


### PR DESCRIPTION
The fix in https://github.com/Azure/typespec-azure/pull/3849 was not complete.

Cherry-picking https://github.com/Azure/typespec-azure/commit/87a540ca1e1fec1f86518c4a69072d9c966199d9