### PR TITLE
Bump version for hotfix: @azure-tools/typespec-client-generator-core@0.66.1

### DIFF
--- a/.chronus/changes/optimize-findmappingwithpath-perf-2026-03-09-10-37-00.md
+++ b/.chronus/changes/optimize-findmappingwithpath-perf-2026-03-09-10-37-00.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-client-generator-core"
----
-
-Optimize `findMappingWithPath` in `getMethodParameterSegments` for better performance with deeply nested models. Replace O(n) `Array.shift()` with O(1) index-based dequeue, and use parent pointer map instead of O(depth) path copying per node.

--- a/.chronus/changes/tcgc-perf-2026-2-10-17-39-3.md
+++ b/.chronus/changes/tcgc-perf-2026-2-10-17-39-3.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-client-generator-core"
----
-
-Refine orphan model logic to reduce the efforts for model calculations

--- a/packages/typespec-client-generator-core/CHANGELOG.md
+++ b/packages/typespec-client-generator-core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log - @azure-tools/typespec-client-generator-core
 
+## 0.66.1
+
+### Bug Fixes
+
+- [#4020](https://github.com/Azure/typespec-azure/pull/4020) Optimize `findMappingWithPath` in `getMethodParameterSegments` for better performance with deeply nested models. Replace O(n) `Array.shift()` with O(1) index-based dequeue, and use parent pointer map instead of O(depth) path copying per node.
+- [#4024](https://github.com/Azure/typespec-azure/pull/4024) Refine orphan model logic to reduce the efforts for model calculations
+
+
 ## 0.66.0
 
 ### Features

--- a/packages/typespec-client-generator-core/package.json
+++ b/packages/typespec-client-generator-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-core",
-  "version": "0.66.0",
+  "version": "0.66.1",
   "author": "Microsoft Corporation",
   "description": "TypeSpec Data Plane Generation library",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
## Hotfix Release

Bumps \@azure-tools/typespec-client-generator-core\ from \