### PR TITLE
Bump version for hotfix: @azure-tools/typespec-client-generator-core@0.66.2

### DIFF
--- a/.chronus/changes/fix-orphan-union-naming-regression-2026-03-12-04-59-00.md
+++ b/.chronus/changes/fix-orphan-union-naming-regression-2026-03-12-04-59-00.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-client-generator-core"
----
-
-Consolidate orphan type discovery into shared cached `listOrphanTypes` used by both `handleServiceOrphanTypes` and `getGeneratedName`, fixing duplicate client name errors for orphan unions and unstable enum naming with versioned services

--- a/packages/typespec-client-generator-core/CHANGELOG.md
+++ b/packages/typespec-client-generator-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-client-generator-core
 
+## 0.66.2
+
+### Bug Fixes
+
+- [#4041](https://github.com/Azure/typespec-azure/pull/4041) Consolidate orphan type discovery into shared cached `listOrphanTypes` used by both `handleServiceOrphanTypes` and `getGeneratedName`, fixing duplicate client name errors for orphan unions and unstable enum naming with versioned services
+
+
 ## 0.66.1
 
 ### Bug Fixes

--- a/packages/typespec-client-generator-core/package.json
+++ b/packages/typespec-client-generator-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-core",
-  "version": "0.66.1",
+  "version": "0.66.2",
   "author": "Microsoft Corporation",
   "description": "TypeSpec Data Plane Generation library",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
## Hotfix Release

Bumps `@azure-tools/typespec-client-generator-core` from `0.66.1` to `0.66.2`