### PR TITLE
[tcgc] add `@scope` support to remove parameters (#4062)

### DIFF
--- a/.chronus/changes/tcgc-removeParamCheck-2026-2-18-14-31-18.md
+++ b/.chronus/changes/tcgc-removeParamCheck-2026-2-18-14-31-18.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Add support to use `@scope` to specify generation of parameters for certain languages

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -31,7 +31,7 @@ import {
 } from "@typespec/http";
 import { StreamMetadata, getStreamMetadata } from "@typespec/http/experimental";
 import { camelCase } from "change-case";
-import { getResponseAsBool, shouldOmitSlashFromEmptyRoute } from "./decorators.js";
+import { getResponseAsBool, isInScope, shouldOmitSlashFromEmptyRoute } from "./decorators.js";
 import {
   CollectionFormat,
   SdkBodyParameter,
@@ -211,11 +211,33 @@ function getSdkHttpParameters(
     }
   });
 
-  retval.parameters = httpOperation.parameters.parameters
-    .filter((x) => !isNeverOrVoidType(x.param.type))
-    .map((x) =>
-      diagnostics.pipe(getSdkHttpParameter(context, x.param, httpOperation.operation, x, x.type)),
-    ) as (SdkPathParameter | SdkQueryParameter | SdkHeaderParameter | SdkCookieParameter)[];
+  // Filter parameters by type and scope, warning if required parameters are scoped out
+  const filteredParams: HttpOperationParameter[] = [];
+  for (const x of httpOperation.parameters.parameters) {
+    if (isNeverOrVoidType(x.param.type)) {
+      continue;
+    }
+    if (!isInScope(context, x.param)) {
+      // Warn if a required parameter is being scoped out
+      if (!x.param.optional) {
+        diagnostics.add(
+          createDiagnostic({
+            code: "required-parameter-scoped-out",
+            target: x.param,
+            format: {
+              paramName: x.param.name,
+              scope: context.emitterName,
+            },
+          }),
+        );
+      }
+      continue;
+    }
+    filteredParams.push(x);
+  }
+  retval.parameters = filteredParams.map((x) =>
+    diagnostics.pipe(getSdkHttpParameter(context, x.param, httpOperation.operation, x, x.type)),
+  ) as (SdkPathParameter | SdkQueryParameter | SdkHeaderParameter | SdkCookieParameter)[];
   const headerParams = retval.parameters.filter(
     (x): x is SdkHeaderParameter => x.kind === "header",
   );

--- a/packages/typespec-client-generator-core/src/lib.ts
+++ b/packages/typespec-client-generator-core/src/lib.ts
@@ -422,6 +422,12 @@ export const $lib = createTypeSpecLibrary({
         default: paramMessage`@scope decorator should be applied with ${"decoratorName"} since it is highly likely this is language-specific`,
       },
     },
+    "required-parameter-scoped-out": {
+      severity: "warning",
+      messages: {
+        default: paramMessage`Required parameter "${"paramName"}" is scoped out for emitter "${"scope"}". This may cause runtime errors unless the parameter is provided through other means (e.g., custom headers).`,
+      },
+    },
     "external-library-version-mismatch": {
       severity: "warning",
       messages: {

--- a/packages/typespec-client-generator-core/src/methods.ts
+++ b/packages/typespec-client-generator-core/src/methods.ts
@@ -26,6 +26,7 @@ import {
   getNextLinkVerb,
   getOverriddenClientMethod,
   getResponseAsBool,
+  isInScope,
   listOperationsInOperationGroup,
   shouldGenerateConvenient,
   shouldGenerateProtocol,
@@ -701,6 +702,8 @@ export function getSdkBasicServiceMethod<TServiceOperation extends SdkServiceOpe
 
   for (const param of params) {
     if (isNeverOrVoidType(param.type)) continue;
+    // Skip parameters that are not in scope for this emitter
+    if (!isInScope(context, param)) continue;
     const sdkMethodParam = diagnostics.pipe(getSdkMethodParameter(context, param, operation));
     if (sdkMethodParam.onClient) {
       // add API version and subscription ID parameters to the client parameters

--- a/packages/typespec-client-generator-core/test/decorators/scope.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/scope.test.ts
@@ -1,4 +1,4 @@
-import { t } from "@typespec/compiler/testing";
+import { expectDiagnostics, t } from "@typespec/compiler/testing";
 import { ok, strictEqual } from "assert";
 import { describe, it } from "vitest";
 import { getAccess } from "../../src/decorators.js";
@@ -825,5 +825,310 @@ describe("model property scope", () => {
     strictEqual(pythonProp, undefined);
     strictEqual(javaProp, undefined);
     ok(commonProp);
+  });
+});
+
+describe("http parameter scope", () => {
+  it("exclude header parameter with negation scope", async () => {
+    const mainCode = `
+      op func(
+        @header("X-Custom-Header")
+        @scope("!python")
+        customHeader: string;
+      ): void;
+    `;
+
+    // Python: parameter should be excluded from both method and http operation
+    const { program: pythonProgram } = await SimpleTesterWithService.compile(mainCode);
+    const pythonContext = await createSdkContextForTester(pythonProgram, {
+      emitterName: "@azure-tools/typespec-python",
+    });
+    const pythonClient = pythonContext.sdkPackage.clients[0];
+    ok(pythonClient);
+    const pythonMethod = pythonClient.methods[0];
+    ok(pythonMethod);
+    ok(pythonMethod.kind === "basic");
+    // Method parameter should be excluded
+    const pythonMethodParam = pythonMethod.parameters.find((x) => x.name === "customHeader");
+    strictEqual(pythonMethodParam, undefined);
+    // HTTP parameter should be excluded
+    const pythonHeaderParam = pythonMethod.operation.parameters.find(
+      (x) => x.kind === "header" && x.serializedName === "X-Custom-Header",
+    );
+    strictEqual(pythonHeaderParam, undefined);
+
+    // C#: parameter should be included in both method and http operation
+    const { program: csharpProgram } = await SimpleTesterWithService.compile(mainCode);
+    const csharpContext = await createSdkContextForTester(csharpProgram, {
+      emitterName: "@azure-tools/typespec-csharp",
+    });
+    const csharpClient = csharpContext.sdkPackage.clients[0];
+    ok(csharpClient);
+    const csharpMethod = csharpClient.methods[0];
+    ok(csharpMethod);
+    ok(csharpMethod.kind === "basic");
+    // Method parameter should be included
+    const csharpMethodParam = csharpMethod.parameters.find((x) => x.name === "customHeader");
+    ok(csharpMethodParam);
+    // HTTP parameter should be included
+    const csharpHeaderParam = csharpMethod.operation.parameters.find(
+      (x) => x.kind === "header" && x.serializedName === "X-Custom-Header",
+    );
+    ok(csharpHeaderParam);
+  });
+
+  it("include header parameter for matching scope", async () => {
+    const mainCode = `
+      op func(
+        @header("X-Custom-Header")
+        @scope("python")
+        customHeader: string;
+      ): void;
+    `;
+
+    // Python: parameter should be included in both method and http operation
+    const { program: pythonProgram } = await SimpleTesterWithService.compile(mainCode);
+    const pythonContext = await createSdkContextForTester(pythonProgram, {
+      emitterName: "@azure-tools/typespec-python",
+    });
+    const pythonClient = pythonContext.sdkPackage.clients[0];
+    ok(pythonClient);
+    const pythonMethod = pythonClient.methods[0];
+    ok(pythonMethod);
+    ok(pythonMethod.kind === "basic");
+    // Method parameter should be included
+    const pythonMethodParam = pythonMethod.parameters.find((x) => x.name === "customHeader");
+    ok(pythonMethodParam);
+    // HTTP parameter should be included
+    const pythonHeaderParam = pythonMethod.operation.parameters.find(
+      (x) => x.kind === "header" && x.serializedName === "X-Custom-Header",
+    );
+    ok(pythonHeaderParam);
+
+    // C#: parameter should be excluded from both method and http operation
+    const { program: csharpProgram } = await SimpleTesterWithService.compile(mainCode);
+    const csharpContext = await createSdkContextForTester(csharpProgram, {
+      emitterName: "@azure-tools/typespec-csharp",
+    });
+    const csharpClient = csharpContext.sdkPackage.clients[0];
+    ok(csharpClient);
+    const csharpMethod = csharpClient.methods[0];
+    ok(csharpMethod);
+    ok(csharpMethod.kind === "basic");
+    // Method parameter should be excluded
+    const csharpMethodParam = csharpMethod.parameters.find((x) => x.name === "customHeader");
+    strictEqual(csharpMethodParam, undefined);
+    // HTTP parameter should be excluded
+    const csharpHeaderParam = csharpMethod.operation.parameters.find(
+      (x) => x.kind === "header" && x.serializedName === "X-Custom-Header",
+    );
+    strictEqual(csharpHeaderParam, undefined);
+  });
+
+  it("exclude query parameter with negation scope", async () => {
+    const mainCode = `
+      op func(
+        @query("customQuery")
+        @scope("!python")
+        customQuery: string;
+      ): void;
+    `;
+
+    // Python: parameter should be excluded from both method and http operation
+    const { program: pythonProgram } = await SimpleTesterWithService.compile(mainCode);
+    const pythonContext = await createSdkContextForTester(pythonProgram, {
+      emitterName: "@azure-tools/typespec-python",
+    });
+    const pythonClient = pythonContext.sdkPackage.clients[0];
+    ok(pythonClient);
+    const pythonMethod = pythonClient.methods[0];
+    ok(pythonMethod);
+    ok(pythonMethod.kind === "basic");
+    // Method parameter should be excluded
+    const pythonMethodParam = pythonMethod.parameters.find((x) => x.name === "customQuery");
+    strictEqual(pythonMethodParam, undefined);
+    // HTTP parameter should be excluded
+    const pythonQueryParam = pythonMethod.operation.parameters.find(
+      (x) => x.kind === "query" && x.serializedName === "customQuery",
+    );
+    strictEqual(pythonQueryParam, undefined);
+
+    // C#: parameter should be included in both method and http operation
+    const { program: csharpProgram } = await SimpleTesterWithService.compile(mainCode);
+    const csharpContext = await createSdkContextForTester(csharpProgram, {
+      emitterName: "@azure-tools/typespec-csharp",
+    });
+    const csharpClient = csharpContext.sdkPackage.clients[0];
+    ok(csharpClient);
+    const csharpMethod = csharpClient.methods[0];
+    ok(csharpMethod);
+    ok(csharpMethod.kind === "basic");
+    // Method parameter should be included
+    const csharpMethodParam = csharpMethod.parameters.find((x) => x.name === "customQuery");
+    ok(csharpMethodParam);
+    // HTTP parameter should be included
+    const csharpQueryParam = csharpMethod.operation.parameters.find(
+      (x) => x.kind === "query" && x.serializedName === "customQuery",
+    );
+    ok(csharpQueryParam);
+  });
+
+  it("include query parameter for matching scope", async () => {
+    const mainCode = `
+      op func(
+        @query("customQuery")
+        @scope("python")
+        customQuery: string;
+      ): void;
+    `;
+
+    // Python: parameter should be included in both method and http operation
+    const { program: pythonProgram } = await SimpleTesterWithService.compile(mainCode);
+    const pythonContext = await createSdkContextForTester(pythonProgram, {
+      emitterName: "@azure-tools/typespec-python",
+    });
+    const pythonClient = pythonContext.sdkPackage.clients[0];
+    ok(pythonClient);
+    const pythonMethod = pythonClient.methods[0];
+    ok(pythonMethod);
+    ok(pythonMethod.kind === "basic");
+    // Method parameter should be included
+    const pythonMethodParam = pythonMethod.parameters.find((x) => x.name === "customQuery");
+    ok(pythonMethodParam);
+    // HTTP parameter should be included
+    const pythonQueryParam = pythonMethod.operation.parameters.find(
+      (x) => x.kind === "query" && x.serializedName === "customQuery",
+    );
+    ok(pythonQueryParam);
+
+    // C#: parameter should be excluded from both method and http operation
+    const { program: csharpProgram } = await SimpleTesterWithService.compile(mainCode);
+    const csharpContext = await createSdkContextForTester(csharpProgram, {
+      emitterName: "@azure-tools/typespec-csharp",
+    });
+    const csharpClient = csharpContext.sdkPackage.clients[0];
+    ok(csharpClient);
+    const csharpMethod = csharpClient.methods[0];
+    ok(csharpMethod);
+    ok(csharpMethod.kind === "basic");
+    // Method parameter should be excluded
+    const csharpMethodParam = csharpMethod.parameters.find((x) => x.name === "customQuery");
+    strictEqual(csharpMethodParam, undefined);
+    // HTTP parameter should be excluded
+    const csharpQueryParam = csharpMethod.operation.parameters.find(
+      (x) => x.kind === "query" && x.serializedName === "customQuery",
+    );
+    strictEqual(csharpQueryParam, undefined);
+  });
+
+  it("warn when required header parameter is scoped out", async () => {
+    const { program } = await SimpleTesterWithService.compile(`
+      op func(
+        @header("X-Required-Header")
+        @scope("!python")
+        requiredHeader: string;
+      ): void;
+    `);
+
+    const context = await createSdkContextForTester(program, {
+      emitterName: "@azure-tools/typespec-python",
+    });
+    expectDiagnostics(context.diagnostics, {
+      code: "@azure-tools/typespec-client-generator-core/required-parameter-scoped-out",
+      message: `Required parameter "requiredHeader" is scoped out for emitter "python". This may cause runtime errors unless the parameter is provided through other means (e.g., custom headers).`,
+    });
+    // Parameter should still be excluded from both method and http operation
+    const sdkPackage = context.sdkPackage;
+    const client = sdkPackage.clients[0];
+    ok(client);
+    const method = client.methods[0];
+    ok(method);
+    ok(method.kind === "basic");
+    // Method parameter should be excluded
+    const methodParam = method.parameters.find((x) => x.name === "requiredHeader");
+    strictEqual(methodParam, undefined);
+    // HTTP parameter should be excluded
+    const headerParam = method.operation.parameters.find(
+      (x) => x.kind === "header" && x.serializedName === "X-Required-Header",
+    );
+    strictEqual(headerParam, undefined);
+  });
+
+  it("no warning when optional header parameter is scoped out", async () => {
+    const { program } = await SimpleTesterWithService.compile(`
+      op func(
+        @header("X-Optional-Header")
+        @scope("!python")
+        optionalHeader?: string;
+      ): void;
+    `);
+
+    const context = await createSdkContextForTester(program, {
+      emitterName: "@azure-tools/typespec-python",
+    });
+    // No warning for optional parameters
+    const scopedOutWarnings = context.diagnostics.filter(
+      (d) => d.code === "@azure-tools/typespec-client-generator-core/required-parameter-scoped-out",
+    );
+    strictEqual(scopedOutWarnings.length, 0);
+    // But parameter should still be excluded from both method and http operation
+    const client = context.sdkPackage.clients[0];
+    ok(client);
+    const method = client.methods[0];
+    ok(method);
+    ok(method.kind === "basic");
+    // Method parameter should be excluded
+    const methodParam = method.parameters.find((x) => x.name === "optionalHeader");
+    strictEqual(methodParam, undefined);
+    // HTTP parameter should be excluded
+    const headerParam = method.operation.parameters.find(
+      (x) => x.kind === "header" && x.serializedName === "X-Optional-Header",
+    );
+    strictEqual(headerParam, undefined);
+  });
+
+  it("scope out spread body parameter", async () => {
+    const mainCode = `
+      op func(
+        @scope("python")
+        a: string;
+        b: string;
+        c: string;
+      ): void;
+    `;
+
+    // Python: all parameters should be present
+    const { program: pythonProgram } = await SimpleTesterWithService.compile(mainCode);
+    const pythonContext = await createSdkContextForTester(pythonProgram, {
+      emitterName: "@azure-tools/typespec-python",
+    });
+    const pythonClient = pythonContext.sdkPackage.clients[0];
+    ok(pythonClient);
+    const pythonMethod = pythonClient.methods[0];
+    ok(pythonMethod);
+    ok(pythonMethod.kind === "basic");
+    // All method parameters should be present for Python
+    ok(pythonMethod.parameters.find((x) => x.name === "a"));
+    ok(pythonMethod.parameters.find((x) => x.name === "b"));
+    ok(pythonMethod.parameters.find((x) => x.name === "c"));
+
+    // C#: parameter 'a' should be excluded, 'b' and 'c' should be present
+    const { program: csharpProgram } = await SimpleTesterWithService.compile(mainCode);
+    const csharpContext = await createSdkContextForTester(csharpProgram, {
+      emitterName: "@azure-tools/typespec-csharp",
+    });
+    const csharpClient = csharpContext.sdkPackage.clients[0];
+    ok(csharpClient);
+    const csharpMethod = csharpClient.methods[0];
+    ok(csharpMethod);
+    ok(csharpMethod.kind === "basic");
+    // Parameter 'a' should be excluded for C#
+    strictEqual(
+      csharpMethod.parameters.find((x) => x.name === "a"),
+      undefined,
+    );
+    // Parameters 'b' and 'c' should still be present
+    ok(csharpMethod.parameters.find((x) => x.name === "b"));
+    ok(csharpMethod.parameters.find((x) => x.name === "c"));
   });
 });


### PR DESCRIPTION
Right now, we are able to remove operations and properties using `@scope`. The ability to remove properties with scope has led us to be able to remove certain parts of the body parameter / parameters from an operation using scope, but we aren't able to remove other kinds of parameters. This is a mismatch, and it is blocking @dargilco in his efforts to generate.

His scenario is a required "opt-in" header in a group of operations, but he wants the emitted SDK to hide that and deal with it in a more friendly way. I think it's fair, and that we should also add a warning for scope-removal of required parameters: he is going to patch it, and it's what he's been doing, but with a post-processing script.

I think this coupled with the fact that we already inadvertently expose this behavior with certain kinds of parameters, makes me think that we should add this change

---------