### PR TITLE
Add 77 test scenarios to Backlog tier

### DIFF
--- a/website/src/pages/can-i-use/scenario-tiers.ts
+++ b/website/src/pages/can-i-use/scenario-tiers.ts
@@ -2,6 +2,139 @@ export const scenarioTiers = {
   default: "Core",
   tiers: {
     Core: [], // Since default is "core", this tier will be used for all scenarios that don't specify a different tier. Empty will catch all scenarios not explicitly categorized in other tiers.
-    Backlog: ["Streaming_Jsonl_Basic_send", "Streaming_Jsonl_Basic_receive"],
+    Backlog: [
+      // Streaming JSONL — skipped by Go and JS; not a priority for Azure services yet
+      "Streaming_Jsonl_Basic_send",
+      "Streaming_Jsonl_Basic_receive",
+
+      // Routes: Path Parameter Expansion (RFC 6570 advanced URI templating) — skipped by Go, Java, Python;
+      // Go tracks in https://github.com/Azure/autorest.go/issues/1730; rarely used in Azure services
+      "Routes_PathParameters_SimpleExpansion_Standard_primitive",
+      "Routes_PathParameters_SimpleExpansion_Standard_array",
+      "Routes_PathParameters_SimpleExpansion_Standard_record",
+      "Routes_PathParameters_SimpleExpansion_Explode_primitive",
+      "Routes_PathParameters_SimpleExpansion_Explode_array",
+      "Routes_PathParameters_SimpleExpansion_Explode_record",
+      "Routes_PathParameters_PathExpansion_Standard_primitive",
+      "Routes_PathParameters_PathExpansion_Standard_array",
+      "Routes_PathParameters_PathExpansion_Standard_record",
+      "Routes_PathParameters_PathExpansion_Explode_primitive",
+      "Routes_PathParameters_PathExpansion_Explode_array",
+      "Routes_PathParameters_PathExpansion_Explode_record",
+      "Routes_PathParameters_LabelExpansion_Standard_primitive",
+      "Routes_PathParameters_LabelExpansion_Standard_array",
+      "Routes_PathParameters_LabelExpansion_Standard_record",
+      "Routes_PathParameters_LabelExpansion_Explode_primitive",
+      "Routes_PathParameters_LabelExpansion_Explode_array",
+      "Routes_PathParameters_LabelExpansion_Explode_record",
+      "Routes_PathParameters_MatrixExpansion_Standard_primitive",
+      "Routes_PathParameters_MatrixExpansion_Standard_array",
+      "Routes_PathParameters_MatrixExpansion_Standard_record",
+      "Routes_PathParameters_MatrixExpansion_Explode_primitive",
+      "Routes_PathParameters_MatrixExpansion_Explode_array",
+      "Routes_PathParameters_MatrixExpansion_Explode_record",
+
+      // Routes: Query Parameter Expansion with record — skipped by Go, Java, Python;
+      // advanced URI template expansion not required by current Azure services
+      "Routes_QueryParameters_QueryExpansion_Standard_record",
+      "Routes_QueryParameters_QueryExpansion_Explode_record",
+      "Routes_QueryParameters_QueryContinuation_Standard_record",
+      "Routes_QueryParameters_QueryContinuation_Explode_record",
+
+      // Routes: Query Parameter Expansion with array — skipped by Go, Python;
+      // part of the broader URI template expansion feature gap
+      "Routes_QueryParameters_QueryExpansion_Standard_array",
+      "Routes_QueryParameters_QueryExpansion_Explode_array",
+      "Routes_QueryParameters_QueryContinuation_Standard_array",
+      "Routes_QueryParameters_QueryContinuation_Explode_array",
+
+      // Type Union Discriminated — skipped by Go, Java, Python;
+      // advanced discriminated union patterns (envelope/no-envelope) not broadly needed yet;
+      // Go requires full union support first
+      "Type_Union_Discriminated_Envelope_Object_Default_get",
+      "Type_Union_Discriminated_Envelope_Object_Default_put",
+      "Type_Union_Discriminated_Envelope_Object_CustomProperties_get",
+      "Type_Union_Discriminated_Envelope_Object_CustomProperties_put",
+      "Type_Union_Discriminated_NoEnvelope_Default_get",
+      "Type_Union_Discriminated_NoEnvelope_Default_put",
+      "Type_Union_Discriminated_NoEnvelope_CustomDiscriminator_get",
+      "Type_Union_Discriminated_NoEnvelope_CustomDiscriminator_put",
+
+      // Pageable: ContinuationToken — skipped by Go, Java, JS (Python skips 1 of 6);
+      // custom continuation-token pagination; no ask in Azure yet (JS);
+      // Go tracks in https://github.com/Azure/autorest.go/issues/1494
+      "Payload_Pageable_ServerDrivenPagination_ContinuationToken_requestHeaderNestedResponseBody",
+      "Payload_Pageable_ServerDrivenPagination_ContinuationToken_requestHeaderResponseBody",
+      "Payload_Pageable_ServerDrivenPagination_ContinuationToken_requestHeaderResponseHeader",
+      "Payload_Pageable_ServerDrivenPagination_ContinuationToken_requestQueryNestedResponseBody",
+      "Payload_Pageable_ServerDrivenPagination_ContinuationToken_requestQueryResponseBody",
+      "Payload_Pageable_ServerDrivenPagination_ContinuationToken_requestQueryResponseHeader",
+
+      // Pageable: AlternateInitialVerb — newly added (microsoft/typespec#9966);
+      // POST-based initial pagination request; no language has implemented this yet;
+      // fits the same pageable backlog pattern as ContinuationToken/link/PageSize
+      "Payload_Pageable_ServerDrivenPagination_AlternateInitialVerb_post",
+
+      // Azure AlternateType ExternalType — skipped by Go, Python, JS;
+      // @alternateType decorator for external types; no ask in Azure yet (JS);
+      // Go does not support external type mapping
+      "Azure_ClientGenerator_Core_AlternateType_ExternalType_getModel",
+      "Azure_ClientGenerator_Core_AlternateType_ExternalType_putModel",
+      "Azure_ClientGenerator_Core_AlternateType_ExternalType_getProperty",
+      "Azure_ClientGenerator_Core_AlternateType_ExternalType_putProperty",
+
+      // Azure ClientDefaultValue — skipped by Go, Java;
+      // @clientDefaultValue decorator not supported by either emitter
+      "Azure_ClientGenerator_Core_ClientDefaultValue_getHeaderParameter",
+      "Azure_ClientGenerator_Core_ClientDefaultValue_getOperationParameter",
+      "Azure_ClientGenerator_Core_ClientDefaultValue_getPathParameter",
+      "Azure_ClientGenerator_Core_ClientDefaultValue_putModelProperty",
+
+      // Authentication Noauth Union — skipped by Go, JS;
+      // union-based auth selection; requires union support (Go); no ask in Azure yet (JS)
+      "Authentication_Noauth_Union_validNoAuth",
+      "Authentication_Noauth_Union_validToken",
+
+      // Pageable: Link-based pagination — skipped by Java, JS;
+      // nextLink-based pagination patterns; no ask in Azure yet (JS)
+      "Payload_Pageable_ServerDrivenPagination_link",
+      "Payload_Pageable_ServerDrivenPagination_linkString",
+      "Payload_Pageable_ServerDrivenPagination_nestedLink",
+
+      // Pageable: PageSize — skipped by Java, JS;
+      // page-size pagination; no ask in Azure yet (JS)
+      "Payload_Pageable_PageSize_listWithPageSize",
+      "Payload_Pageable_PageSize_listWithoutContinuation",
+
+      // Pageable: XML Pagination — skipped by Go, Java;
+      // XML-based pagination support incomplete in both emitters
+      "Payload_Pageable_XmlPagination_listWithContinuation",
+      "Payload_Pageable_XmlPagination_listWithNextLink",
+
+      // Response StatusCodeRange — skipped by Go, JS;
+      // status code range error handling; no ask in Azure yet (JS);
+      // Go tracks in https://github.com/Azure/autorest.go/issues/1606
+      "Response_StatusCodeRange_errorResponseStatusCodeInRange",
+      "Response_StatusCodeRange_errorResponseStatusCode404",
+
+      // Type File Body — skipped by Python, JS;
+      // file upload/download with specific content types; no real case received (JS)
+      "Type_File_Body_uploadFileSpecificContentType",
+      "Type_File_Body_uploadFileJsonContentType",
+      "Type_File_Body_downloadFileJsonContentType",
+      "Type_File_Body_downloadFileSpecificContentType",
+      "Type_File_Body_uploadFileMultipleContentTypes",
+      "Type_File_Body_downloadFileMultipleContentTypes",
+      "Type_File_Body_uploadFileDefaultContentType",
+      "Type_File_Body_downloadFileDefaultContentType",
+
+      // Encode Duration float*LargerUnit — skipped by Python, JS;
+      // JS fundamentally cannot distinguish 1.0 from 1 (float vs int);
+      // Python does not have urgent demand for these encoding variants
+      "Encode_Duration_Query_floatSecondsLargerUnit",
+      "Encode_Duration_Query_floatMillisecondsLargerUnit",
+      "Encode_Duration_Header_floatSecondsLargerUnit",
+      "Encode_Duration_Header_floatMillisecondsLargerUnit",
+    ],
   },
 };


### PR DESCRIPTION
## Summary

Categorizes 78 test scenarios as **Backlog** in the Can I Use dashboard based on cross-language analysis of skipped tests across Go, Java, Python, and JS emitters.

**Criterion**: A scenario is moved to Backlog if it is skipped by **2 or more** of the 4 major language emitters, indicating the feature is optional rather than a single-emitter gap. Newly added scenarios that fit an existing Backlog category are also included.

### Data Sources
| Language | Source |
|----------|--------|
| Go | [autorest.go#1812 comment](https://github.com/Azure/autorest.go/issues/1812#issuecomment-4022394585) |
| Python | [autorest.python#3372](https://github.com/Azure/autorest.python/issues/3372) |
| Java | \java-skipped.txt\ in repo root |
| JS | \js-skipped.txt\ in repo root |

### Scenarios Added to Backlog (78 tests, skipped by 2+ languages)

| Category | Tests | Languages Skipping |
|----------|-------|--------------------|
| Routes Path/Query Parameter Expansion | 32 | Go, Java, Python |
| Type Union Discriminated | 8 | Go, Java, Python |
| Pageable ContinuationToken | 6 | Go, Java, JS |
| Pageable AlternateInitialVerb | 1 | New ([microsoft/typespec#9966](https://github.com/microsoft/typespec/pull/9966)); no language implemented yet |
| Azure AlternateType ExternalType | 4 | Go, Python, JS |
| Azure ClientDefaultValue | 4 | Go, Java |
| Authentication Noauth Union | 2 | Go, JS |
| Pageable Link-based pagination | 3 | Java, JS |
| Pageable PageSize | 2 | Java, JS |
| Pageable XmlPagination | 2 | Go, Java |
| Response StatusCodeRange | 2 | Go, JS |
| Type File Body | 8 | Python, JS |
| Encode Duration float*LargerUnit | 4 | Python, JS |
| **Total** | **78** | |

### New XML scenarios kept as Core

22 new XML scenarios from [microsoft/typespec#10063](https://github.com/microsoft/typespec/pull/10063) remain **Core**. Existing \Payload_Xml_*\ tests are only skipped by Java (1 language) — Go, Python, and JS pass them — so XML is an emitter-specific gap, not an optional feature.

---

### Scenarios Remaining in Core (~147 skipped tests kept as Core)

Tests skipped by only 1 language remain Core — 3 of 4 emitters already support them, so these are emitter-specific gaps, not optional features.

#### Go-only skips (~86 tests) — mostly blocked on union support

| Category | Count | Reason |
|----------|-------|--------|
| Type_Union (non-discriminated) | 20 | Requires union support |
| Type_Property_AdditionalProperties (union-related) | 34 | Requires union support |
| Encode_Array | 12 | Tracked in [autorest.go#1771](https://github.com/Azure/autorest.go/issues/1771) |
| Type_Model_Inheritance_NestedDiscriminator | 6 | Not a real scenario — will fix on demand |
| Versioning (Added/Removed/RenamedFrom) | 9 | Requires union support |
| Authentication_Union | 2 | Requires union support |
| SpecialHeaders_Repeatability | 1 | Requires union support |
| DeserializeEmptyStringAsNull | 1 | Tracked in [autorest.go#1857](https://github.com/Azure/autorest.go/issues/1857) |
| Azure_Core_Page_withParameterizedNextLink | 1 | Tracked in [autorest.go#1576](https://github.com/Azure/autorest.go/issues/1576) |

> Go's gaps are primarily due to missing union support. Once Go adds unions, ~66 of these tests will pass.

#### Python-only skips (~33 tests) — feature-specific gaps

| Category | Count | Reason |
|----------|-------|--------|
| Encode_Duration (int/non-float variants) | 20 | No urgent demand for these encodings |
| ClientInitialization (Individually*) | 13 | Feature not yet needed by Python |

> Java, Go, and JS support these. Python's gaps are implementation priorities, not optional features.

#### Java-only skips (~28 tests) — XML and misc

| Category | Count | Reason |
|----------|-------|--------|
| Payload_Xml | 26 | XML support incomplete |
| Parameters_Path_optional | 1 | Not yet implemented |
| Resiliency_ServiceDriven_breakTheGlass | 1 | Not yet implemented |

> Go, Python, and JS support these. XML is a real Azure feature used by services like Storage.

#### JS-only skips (0 tests)

All JS-skipped tests overlapped with at least one other language, so they all moved to Backlog.