### PR TITLE
[Automated][tcgc] docs(tcgc): document undocumented decorators and create knowledge base

### DIFF
--- a/eng/scripts/doc-updater/knowledge/tcgc.md
+++ b/eng/scripts/doc-updater/knowledge/tcgc.md
@@ -1,0 +1,135 @@
+# TCGC Knowledge Base
+
+## Package Info
+
+- **Name:** `@azure-tools/typespec-client-generator-core`
+- **TSP namespace:** `Azure.ClientGenerator.Core`
+- **Legacy namespace:** `Azure.ClientGenerator.Core.Legacy`
+
+## Decorators (Core)
+
+All decorators support an optional `scope` parameter for language targeting.
+Scope patterns: `"python"`, `"python, java"`, `"!csharp"`, `"!(java, python)"`.
+
+| Decorator                       | Target                                                              | Signature                                                                                 |
+| ------------------------------- | ------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| `@clientName`                   | `unknown`                                                           | `(rename: valueof string, scope?: valueof string)`                                        |
+| `@convenientAPI`                | `Operation \| Namespace \| Interface`                               | `(flag?: valueof boolean, scope?: valueof string)`                                        |
+| `@protocolAPI`                  | `Operation \| Namespace \| Interface`                               | `(flag?: valueof boolean, scope?: valueof string)`                                        |
+| `@client`                       | `Namespace \| Interface`                                            | `(options?: ClientOptions, scope?: valueof string)`                                       |
+| `@operationGroup`               | `Namespace \| Interface`                                            | `(scope?: valueof string)` — **DEPRECATED**, use `@client`                                |
+| `@usage`                        | `Model \| Enum \| Union \| Namespace`                               | `(value: EnumMember \| Union, scope?: valueof string)`                                    |
+| `@access`                       | `ModelProperty \| Model \| Operation \| Enum \| Union \| Namespace` | `(value: EnumMember, scope?: valueof string)`                                             |
+| `@override`                     | `Operation`                                                         | `(override: Operation, scope?: valueof string)`                                           |
+| `@useSystemTextJsonConverter`   | `Model`                                                             | `(scope?: valueof string)` — C# backward compat                                           |
+| `@clientInitialization`         | `Namespace \| Interface`                                            | `(options: ClientInitializationOptions, scope?: valueof string)`                          |
+| `@paramAlias`                   | `ModelProperty`                                                     | `(paramAlias: valueof string, scope?: valueof string)`                                    |
+| `@clientNamespace`              | `Namespace \| Interface \| Model \| Enum \| Union`                  | `(rename: valueof string, scope?: valueof string)`                                        |
+| `@alternateType`                | `ModelProperty \| Scalar \| Model \| Enum \| Union`                 | `(alternate: unknown \| ExternalType, scope?: valueof string)`                            |
+| `@scope`                        | `Operation \| ModelProperty`                                        | `(scope?: valueof string)`                                                                |
+| `@apiVersion`                   | `ModelProperty`                                                     | `(value?: valueof boolean, scope?: valueof string)`                                       |
+| `@clientApiVersions`            | `Namespace`                                                         | `(value: Enum, scope?: valueof string)`                                                   |
+| `@deserializeEmptyStringAsNull` | `ModelProperty`                                                     | `(scope?: valueof string)`                                                                |
+| `@responseAsBool`               | `Operation`                                                         | `(scope?: valueof string)`                                                                |
+| `@clientLocation`               | `Operation \| ModelProperty`                                        | `(target: Interface \| Namespace \| Operation \| valueof string, scope?: valueof string)` |
+| `@clientDoc`                    | `unknown`                                                           | `(documentation: valueof string, mode: EnumMember, scope?: valueof string)`               |
+| `@clientOption`                 | `unknown`                                                           | `(name: valueof string, value: valueof unknown, scope?: valueof string)`                  |
+
+## Decorators (Legacy — `Azure.ClientGenerator.Core.Legacy`)
+
+| Decorator             | Target          | Signature                                                                                      |
+| --------------------- | --------------- | ---------------------------------------------------------------------------------------------- |
+| `@flattenProperty`    | `ModelProperty` | `(scope?: valueof string)`                                                                     |
+| `@clientDefaultValue` | `ModelProperty` | `(value: unknown, scope?: valueof string)`                                                     |
+| `@markAsPageable`     | `Operation`     | `(itemsPath?: valueof string, continuationTokenPath?: valueof string, scope?: valueof string)` |
+| `@disablePageable`    | `Operation`     | `(scope?: valueof string)`                                                                     |
+| `@markAsLro`          | `Operation`     | `(scope?: valueof string)`                                                                     |
+| `@nextLinkVerb`       | `Operation`     | `(value: EnumMember, scope?: valueof string)`                                                  |
+| `@hierarchyBuilding`  | `Model`         | Legacy decorator for multi-level discriminated hierarchy                                       |
+
+## Enums
+
+- **`Access`**: `public`, `internal`
+- **`Usage`**: `input` (2), `output` (4), `json` (256), `xml` (512)
+- **`InitializedBy`**: `individually` (1), `parent` (2), `customizeCode` (4)
+- **`DocumentationMode`**: `append`, `replace`
+
+## Models
+
+- **`ClientOptions`**: `{ service?: Namespace \| Namespace[], name?: string, autoMergeService?: boolean }`
+- **`ClientInitializationOptions`**: `{ parameters?: Model, initializedBy?: EnumMember \| Union }`
+- **`ExternalType`**: `{ identity: string, package?: string, minVersion?: string }`
+
+## Feature Areas
+
+| Area                   | Documented In               | Spector Spec                                                  |
+| ---------------------- | --------------------------- | ------------------------------------------------------------- |
+| Client structure       | 03client.mdx                | client/structure/\*                                           |
+| Client initialization  | 03client.mdx                | azure/client-generator-core/client-initialization/            |
+| Methods                | 04method.mdx                | (covered by client/structure)                                 |
+| Paging                 | 05pagingOperations.mdx      | azure/core/page/\*                                            |
+| LRO                    | 06longRunningOperations.mdx | azure/core/lro/\*                                             |
+| Multipart              | 07multipart.mdx             | (in core specs)                                               |
+| Types                  | 08types.mdx                 | (covered across specs)                                        |
+| Renaming               | 09renaming.mdx              | client/naming/\*                                              |
+| Versioning             | 10versioning.mdx            | azure/client-generator-core/api-version/\*                    |
+| Hierarchy building     | 11hierarchyBuilding.mdx     | azure/client-generator-core/hierarchy-building/               |
+| Client options         | 12clientOptions.mdx         | (no spec)                                                     |
+| Access control         | (no dedicated page)         | azure/client-generator-core/access/                           |
+| Usage                  | (no dedicated page)         | azure/client-generator-core/usage/                            |
+| Override               | 04method.mdx                | azure/client-generator-core/override/                         |
+| Flatten property       | (no dedicated page)         | azure/client-generator-core/flatten-property/                 |
+| Client location        | (no dedicated page)         | azure/client-generator-core/client-location/\*                |
+| Alternate type         | (no dedicated page)         | azure/client-generator-core/alternate-type/                   |
+| Scope                  | (no dedicated page)         | (no spec)                                                     |
+| API version marking    | (no dedicated page)         | azure/client-generator-core/api-version/\*                    |
+| Client API versions    | (no dedicated page)         | (no spec)                                                     |
+| Deserialize empty null | (no dedicated page)         | azure/client-generator-core/deserialize-empty-string-as-null/ |
+| Response as bool       | (no dedicated page)         | (no spec)                                                     |
+| Client doc             | (no dedicated page)         | (no spec)                                                     |
+| Client namespace       | 02package.mdx, 08types.mdx  | client/namespace/                                             |
+| Param alias            | 03client.mdx                | azure/client-generator-core/client-initialization/            |
+| Protocol/Convenient    | 04method.mdx                | azure/client-generator-core/usage/                            |
+
+## Doc Conventions
+
+- Howto docs use `.mdx` extension with Astro Starlight frontmatter (`title`, `sidebar.label`)
+- Code examples use `<ClientTabs>` component with six language blocks: typespec, python, csharp, typescript, java, go
+- Legacy/deprecated decorators are marked with `:::caution` admonitions
+- File naming: `##topic.mdx` where `##` is a two-digit number for ordering
+- Imports at top: `import { ClientTabs } from "@site/src/components/client-tabs"`
+- TypeSpec code blocks inside `<ClientTabs>` use triple-backtick with `typespec` language tag
+- Language blocks that don't support a feature use `// NOT_SUPPORTED` comment
+
+## Test Files
+
+Key test files for verifying decorator behavior:
+
+- `test/decorators/client.test.ts` — @client
+- `test/decorators/access.test.ts` — @access
+- `test/decorators/usage.test.ts`, `usage-extended.test.ts` — @usage
+- `test/decorators/client-name.test.ts` — @clientName
+- `test/decorators/client-namespace.test.ts` — @clientNamespace
+- `test/decorators/client-initialization.test.ts` — @clientInitialization
+- `test/decorators/client-location.test.ts` — @clientLocation
+- `test/decorators/client-doc.test.ts` — @clientDoc
+- `test/decorators/alternate-type.test.ts` — @alternateType
+- `test/decorators/scope.test.ts` — @scope
+- `test/decorators/api-version.test.ts` — @apiVersion
+- `test/decorators/client-api-versions.test.ts` — @clientApiVersions
+- `test/decorators/response-as-bool.test.ts` — @responseAsBool
+- `test/decorators/deserialize-empty-string-as-null.test.ts` — @deserializeEmptyStringAsNull
+- `test/decorators/override.test.ts` — @override
+- `test/decorators/param-alias.test.ts` — @paramAlias
+- `test/decorators/flatten-property.test.ts` — @flattenProperty
+- `test/decorators/client-option.test.ts` — @clientOption
+
+## Cross-References
+
+- `@clientInitialization` works with `@paramAlias` for parameter renaming during elevation
+- `@clientLocation` cannot be used along with `@client` or `@operationGroup`
+- `@client` cannot be used along with `@clientLocation`
+- `@access` propagates to base/sub models and discriminated types
+- `@usage` propagates to properties, parent models, and discriminated sub models
+- `@alternateType` with `ExternalType` identity cannot be applied to model properties — must target type definition
+- `@clientOption` always emits a warning that must be suppressed

--- a/website/src/content/docs/docs/howtos/Generate client libraries/03client.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/03client.mdx
@@ -1112,7 +1112,11 @@ petActionClient.Pet(context.Background(), &PetActionClientPetOptions{})
 
 ### One Client and Two Sub Clients
 
-Two sub clients that separate the operations can be declared using the `@client` decorator (or the `@operationGroup` decorator, which is an alias) from `typespec-client-generator-core`:
+Two sub clients that separate the operations can be declared using the `@client` decorator from `typespec-client-generator-core`:
+
+:::caution
+The `@operationGroup` decorator is deprecated. Use `@client` instead to define sub clients.
+:::
 
 <ClientTabs>
 

--- a/website/src/content/docs/docs/howtos/Generate client libraries/04method.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/04method.mdx
@@ -255,6 +255,8 @@ By default, the code generator will infer the usage based on the TypeSpec. If th
 correspond to expectation, this can be customized with the `usage` decorator. Possible values are
 `input` and `output`, and can be combined with `Usage.input | Usage.output`.
 
+You can also specify the serialization format with `Usage.json` and `Usage.xml` to indicate the content type contexts where a model is used.
+
 > **NOTE:** If a model is never used, it will not be generated. Assigning a usage will force generation.
 
 <ClientTabs>
@@ -2231,3 +2233,163 @@ Use the `scope` parameter to apply customizations only to specific language emit
 ```
 
 Supported scope values include: `"python"`, `"csharp"`, `"java"`, `"javascript"`, `"go"`.
+
+## Using `@scope` to restrict operations to specific languages
+
+The `@scope` decorator restricts an operation or model property so it is only generated for specific language emitters. Unlike the `scope` parameter on other decorators (which scopes the _customization_), `@scope` scopes the _element itself_.
+
+Use `@scope` when an operation or property should only exist in certain language SDKs. For example, a language-specific helper operation that doesn't make sense in every SDK.
+
+<ClientTabs>
+
+```typespec title="main.tsp"
+import "@typespec/http";
+
+using TypeSpec.Http;
+
+@service
+namespace ScopeDemo;
+
+@route("/common")
+@get
+op commonOp(): void;
+
+@route("/data")
+@get
+op getData(): { @body data: string };
+```
+
+```typespec title="client.tsp"
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+
+// This operation will only be generated for Python clients
+@@scope(ScopeDemo.getData, "python");
+```
+
+```python
+class ScopeDemoClient:
+    # Python gets BOTH operations because getData is scoped to Python
+    def common_op(self, **kwargs: Any) -> None: ...
+    def get_data(self, **kwargs: Any) -> str: ...
+```
+
+```csharp
+// C# only gets commonOp — getData is excluded by @scope("python")
+public class ScopeDemoClient
+{
+    public virtual Response CommonOp(RequestContext context);
+    public virtual async Task<Response> CommonOpAsync(RequestContext context);
+}
+```
+
+```typescript
+export class ScopeDemoClient {
+  getData(options?: GetDataOptionalParams): Promise<GetDataResponse>;
+  commonOp(options?: CommonOpOptionalParams): Promise<void>;
+}
+```
+
+```java
+public final class ScopeDemoClient {
+    // Java only gets commonOp — getData is excluded by @scope("python")
+    public void commonOp();
+}
+```
+
+```go
+// Go only gets CommonOp — GetData is excluded by @scope("python")
+func (client *ScopeDemoClient) CommonOp(ctx context.Context, options *ScopeDemoClientCommonOpOptions) (ScopeDemoClientCommonOpResponse, error)
+```
+
+</ClientTabs>
+
+You can also use negation to exclude specific languages:
+
+```typespec
+// This operation will be generated for all languages EXCEPT C#
+@@scope(ScopeDemo.getData, "!csharp");
+```
+
+The `@scope` decorator also works on model properties:
+
+```typespec
+model TestModel {
+  @scope("csharp")
+  csharpOnlyProp: string;
+}
+```
+
+## Using `@responseAsBool` for HEAD operations
+
+The `@responseAsBool` decorator changes a HEAD operation so that the generated client method returns a `boolean` instead of the raw response. A 2xx status code returns `true`, a 404 returns `false`, and all other status codes raise an error.
+
+This is useful for "exists" checks where you want a simple boolean result.
+
+<ClientTabs>
+
+```typespec title="main.tsp"
+import "@typespec/http";
+
+using TypeSpec.Http;
+
+@service
+namespace ResourceService;
+
+model Resource {
+  name: string;
+  id: string;
+}
+
+@route("/resources/{name}")
+@head
+op checkResourceExists(@path name: string): {
+  @statusCode statusCode: 200 | 404;
+};
+```
+
+```typespec title="client.tsp"
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+
+@@responseAsBool(ResourceService.checkResourceExists);
+```
+
+```python
+class ResourceServiceClient:
+    # Returns bool: True for 2xx, False for 404
+    def check_resource_exists(self, name: str, **kwargs: Any) -> bool: ...
+```
+
+```csharp
+public class ResourceServiceClient
+{
+    // Convenience method returns Response<bool>
+    public virtual Response<bool> CheckResourceExists(string name, ...);
+    public virtual async Task<Response<bool>> CheckResourceExistsAsync(string name, ...);
+}
+```
+
+```typescript
+export type CheckResourceExistsResponse = { body: boolean };
+
+export class ResourceServiceClient {
+  checkResourceExists(name: string, options?: CheckResourceExistsOptionalParams): Promise<CheckResourceExistsResponse>;
+}
+```
+
+```java
+public final class ResourceServiceClient {
+    public Response<BinaryData> checkResourceExistsWithResponse(String name, RequestOptions requestOptions);
+}
+```
+
+```go
+// NOT_SUPPORTED
+```
+
+</ClientTabs>

--- a/website/src/content/docs/docs/howtos/Generate client libraries/08types.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/08types.mdx
@@ -2628,3 +2628,93 @@ jsonWriter.writeStringField("prop", Objects.toString(this.value, null));
 </ClientTabItem>
 </ClientTabs>
 ```
+
+## Using `@deserializeEmptyStringAsNull` for null handling
+
+The `@deserializeEmptyStringAsNull` decorator indicates that a `string` model property (or a scalar derived from `string`) should be deserialized as `null` when its value is an empty string (`""`).
+
+This is useful when a service returns empty strings to represent absent values, but your client SDK should treat them as `null`.
+
+<ClientTabs>
+
+```typespec title="main.tsp"
+import "@typespec/http";
+
+using TypeSpec.Http;
+
+@service
+namespace EmptyStringDemo;
+
+model UserProfile {
+  name: string;
+  nickname?: string;
+  bio?: string;
+}
+
+@route("/users/{name}")
+@get
+op getUser(@path name: string): UserProfile;
+```
+
+```typespec title="client.tsp"
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+
+@@deserializeEmptyStringAsNull(EmptyStringDemo.UserProfile.nickname);
+@@deserializeEmptyStringAsNull(EmptyStringDemo.UserProfile.bio);
+```
+
+```python
+class UserProfile:
+    # When the service returns "" for nickname or bio,
+    # the deserialized value will be None instead of ""
+    name: str
+    nickname: Optional[str]
+    bio: Optional[str]
+```
+
+```csharp
+public partial class UserProfile
+{
+    public string Name { get; }
+    // When the service returns "" for Nickname or Bio,
+    // the deserialized value will be null instead of ""
+    public string Nickname { get; }
+    public string Bio { get; }
+}
+```
+
+```typescript
+export interface UserProfile {
+  name: string;
+  // When the service returns "" for nickname or bio,
+  // the deserialized value will be null/undefined instead of ""
+  nickname?: string;
+  bio?: string;
+}
+```
+
+```java
+public final class UserProfile {
+    // When the service returns "" for nickname or bio,
+    // the deserialized value will be null instead of ""
+    public String getName();
+    public String getNickname();
+    public String getBio();
+}
+```
+
+```go
+type UserProfile struct {
+	// REQUIRED
+	Name     *string
+	// When the service returns "" for Nickname or Bio,
+	// the deserialized value will be nil instead of ""
+	Bio      *string
+	Nickname *string
+}
+```
+
+</ClientTabs>

--- a/website/src/content/docs/docs/howtos/Generate client libraries/10versioning.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/10versioning.mdx
@@ -944,3 +944,90 @@ func (client *ServiceClient) Get(ctx context.Context, version Versions, options 
 ```
 
 </ClientTabs>
+
+## Using `@clientApiVersions` to extend available API versions
+
+The `@clientApiVersions` decorator allows you to define additional API versions that the client can support beyond those declared in the service's `@versioned` decorator. This is useful when you want the generated client to expose a complete API version enum without requiring every version to be annotated in the service specification.
+
+The enum you pass to `@clientApiVersions` should include both the extra versions and the service's existing versions (using the spread operator `...`).
+
+<ClientTabs>
+
+```typespec title="main.tsp"
+import "@typespec/http";
+import "@typespec/versioning";
+
+using TypeSpec.Http;
+using TypeSpec.Versioning;
+
+@versioned(Versions)
+@service
+namespace VersionedService;
+
+enum Versions {
+  v2024_01_01: "2024-01-01",
+  v2024_06_01: "2024-06-01",
+}
+
+@route("/resources")
+@get
+op listResources(): { @body items: string[] };
+```
+
+```typespec title="client.tsp"
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+
+enum AllApiVersions {
+  v2023_01_01: "2023-01-01",
+  v2023_06_01: "2023-06-01",
+  ...VersionedService.Versions,
+}
+
+@@clientApiVersions(VersionedService, AllApiVersions);
+```
+
+```python
+# Python does not generate an explicit version enum in this scenario.
+# The client uses the latest version by default.
+class VersionedServiceClient:
+    def __init__(self, endpoint: str, **kwargs: Any) -> None: ...
+```
+
+```csharp
+// The ServiceVersion enum now includes all four versions
+public class VersionedServiceClientOptions
+{
+    public enum ServiceVersion
+    {
+        V2023_01_01 = 1,
+        V2023_06_01 = 2,
+        V2024_01_01 = 3,
+        V2024_06_01 = 4,
+    }
+}
+```
+
+```typescript
+export enum KnownAllApiVersions {
+  V20230101 = "2023-01-01",
+  V20230601 = "2023-06-01",
+  V20240101 = "2024-01-01",
+  V20240601 = "2024-06-01",
+}
+```
+
+```java
+public enum VersionedServiceVersion implements ServiceVersion {
+    V2024_01_01("2024-01-01"),
+    V2024_06_01("2024-06-01");
+}
+```
+
+```go
+// NOT_SUPPORTED
+```
+
+</ClientTabs>


### PR DESCRIPTION
- Add @scope decorator documentation to 04method.mdx
- Add @responseAsBool decorator documentation to 04method.mdx
- Add @deserializeEmptyStringAsNull decorator documentation to 08types.mdx
- Add @clientApiVersions decorator documentation to 10versioning.mdx
- Add @operationGroup deprecation notice in 03client.mdx
- Add Usage.json/xml flags documentation to 04method.mdx
- Create TCGC knowledge base at eng/scripts/doc-updater/knowledge/tcgc.md

Resolve: https://github.com/Azure/typespec-azure/issues/4148