### PR TITLE
[Automated][tcgc] Fix TCGC doc comment typos, improve guideline type descriptions, add `@responseAsBool` spec

### DIFF
--- a/.chronus/changes/azure-http-specs-response-as-bool-2026-04-07-06-55-00.md
+++ b/.chronus/changes/azure-http-specs-response-as-bool-2026-04-07-06-55-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Add Spector test spec for `@responseAsBool` decorator on HEAD operations.

--- a/.chronus/changes/tcgc-doc-fixes-2026-04-07-06-55-00.md
+++ b/.chronus/changes/tcgc-doc-fixes-2026-04-07-06-55-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Fix doc comment typos and inaccuracies: correct "operatio" typo in `@markAsLro`, fix `@clientLocation` parameter descriptions to include `ModelProperty` source and `Operation` target, and remove incomplete `@client` example.

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -81,6 +81,7 @@ words:
   - regionality
   - reinjected
   - Reranker
+  - responseasbool
   - rpaasoneboxacr
   - rpass
   - SERVICERP

--- a/eng/scripts/doc-updater/knowledge/tcgc.md
+++ b/eng/scripts/doc-updater/knowledge/tcgc.md
@@ -1,0 +1,94 @@
+# TCGC Documentation Knowledge Base
+
+## Build & Tooling
+
+- `pnpm` is not on PATH by default in CI. Use `corepack enable --install-directory /home/runner/.local/bin` then `export PATH="/home/runner/.local/bin:$PATH"`.
+- The `core/` git submodule must be initialized (`git submodule update --init`) before building TCGC.
+- Build TCGC: `pnpm -r --filter "@azure-tools/typespec-client-generator-core..." build`
+- Regenerate reference docs after TSP changes: `cd packages/typespec-client-generator-core && pnpm regen-docs`
+- Regenerate Spector summary: `cd packages/azure-http-specs && pnpm regen-docs`
+- The azure-http-specs package name is `@azure-tools/azure-http-specs` (not `@typespec/azure-http-specs`).
+- `pnpm format` and `pnpm lint` are root-level commands; use `pnpm format:dir <path>` for specific directories.
+
+## Documentation Structure
+
+- **Howto docs** (`website/.../howtos/Generate client libraries/`): Files 00-12.mdx, each covering a specific topic. Use `<ClientTabs>` for multi-language examples.
+- **Emitter dev docs** (`guideline.md`): Describes the TCGC type graph for emitter developers. Links to reference/js-api for type details.
+- **Reference docs** (auto-generated): Run `pnpm regen-docs` from TCGC package after changing `.tsp` doc comments. Never edit these manually.
+- **Design docs** (`packages/typespec-client-generator-core/design-docs/`): Internal docs for TCGC contributors. Has `client.md` and `multiple-services.md`.
+
+## Decorator Inventory (as of this run)
+
+### Core Decorators (Azure.ClientGenerator.Core)
+
+1. `@clientName` — rename SDK elements
+2. `@convenientAPI` — enable/disable convenience method
+3. `@protocolAPI` — enable/disable protocol method
+4. `@client` — define client structure (ClientOptions: name, service, autoMergeService)
+5. `@operationGroup` — DEPRECATED alias for @client
+6. `@usage` — add usage flags (input, output, json, xml)
+7. `@access` — set public/internal visibility
+8. `@override` — replace operation with different one
+9. `@useSystemTextJsonConverter` — C# specific
+10. `@clientInitialization` — customize client init params (ClientInitializationOptions: parameters, initializedBy)
+11. `@paramAlias` — alias parameter names
+12. `@clientNamespace` — override SDK namespace
+13. `@alternateType` — replace type with alternate (supports ExternalType)
+14. `@scope` — limit operation/parameter to language scopes
+15. `@apiVersion` — mark parameter as API version
+16. `@clientApiVersions` — client-specific version enum
+17. `@deserializeEmptyStringAsNull` — empty string → null
+18. `@responseAsBool` — HEAD operation returns boolean
+19. `@clientLocation` — move operations/parameters between clients
+20. `@clientDoc` — client-specific documentation (DocumentationMode: append/replace)
+21. `@clientOption` — pass options to emitters
+
+### Legacy Decorators (Azure.ClientGenerator.Core.Legacy)
+
+1. `@hierarchyBuilding` — multi-layer discriminator hierarchy
+2. `@flattenProperty` — flatten model property
+3. `@markAsLro` — force LRO treatment
+4. `@markAsPageable` — force paging treatment
+5. `@disablePageable` — disable paging detection
+6. `@nextLinkVerb` — set HTTP verb for next link
+7. `@clientDefaultValue` — set client-side defaults
+
+### Functions
+
+1. `replaceParameter` — replace operation parameter
+2. `removeParameter` — remove operation parameter
+3. `addParameter` — add operation parameter
+4. `reorderParameters` — reorder operation parameters
+
+## Spector Test Coverage
+
+### Covered decorators (have Spector specs):
+
+- @access, @alternateType, @apiVersion, @clientDefaultValue, @clientInitialization
+- @clientLocation, @deserializeEmptyStringAsNull, @flattenProperty, @hierarchyBuilding
+- @nextLinkVerb, @override, @usage, @responseAsBool
+- @client (client/structure/), @clientName (client/naming/), @clientNamespace (client/namespace/)
+
+### Not covered (no HTTP behavior to test, or legacy):
+
+- @clientDoc — only affects documentation strings, no HTTP behavior
+- @clientOption — passes options to emitters, no HTTP behavior
+- @convenientAPI/@protocolAPI — affects which methods are generated, no HTTP behavior
+- @scope — language filtering, no HTTP behavior
+- @clientApiVersions — extends version enums, covered partially by api-version specs
+- @markAsLro, @markAsPageable, @disablePageable — legacy, complex mock API needed
+
+## Common Mistakes Found
+
+- Typos in doc comments propagate to generated reference docs. Always verify `.tsp` doc comments carefully.
+- The `@client` decorator's third example tag was empty (no content) — removed in this run.
+- The `@clientLocation` decorator's `@param source` description said "operation" but the signature accepts `Operation | ModelProperty` — fixed.
+- The `@clientLocaton` typo in `03client.mdx` line 600 — fixed.
+- The `@markAsLro` doc had "operatio" typo — fixed.
+
+## Guideline.md Patterns
+
+- Type descriptions should include key property names that emitter developers need.
+- For example, `SdkEnumType` needs `isFixed`, `isUnionAsEnum`, `valueType`; `SdkDateTimeType`/`SdkDurationType` need `wireType` and `encode`.
+- Collection types need `valueType`, `keyType` documented explicitly.
+- `SdkModelType` needs `baseModel`, `discriminatorProperty`, `discriminatedSubtypes`, `additionalProperties`.

--- a/packages/azure-http-specs/spec-summary.md
+++ b/packages/azure-http-specs/spec-summary.md
@@ -1205,6 +1205,19 @@ param2: param2
 
 Expected response: 204 No Content
 
+### Azure_ClientGenerator_Core_ResponseAsBool_exists
+
+- Endpoint: `head /azure/client-generator-core/response-as-bool/exists`
+
+Test that a HEAD operation decorated with @responseAsBool returns a boolean value.
+When the resource exists, the service returns 204 No Content and the client should return true.
+When the resource does not exist, the service returns 404 Not Found and the client should return false.
+
+Expected behavior:
+
+- HEAD /azure/client-generator-core/response-as-bool/exists → 204 → client returns true
+- HEAD /azure/client-generator-core/response-as-bool/exists → 404 → client returns false
+
 ### Azure_ClientGenerator_Core_Usage_ModelInOperation
 
 - Endpoints:

--- a/packages/azure-http-specs/specs/azure/client-generator-core/response-as-bool/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/response-as-bool/main.tsp
@@ -1,0 +1,30 @@
+import "@typespec/http";
+import "@typespec/spector";
+import "@azure-tools/typespec-client-generator-core";
+
+using Http;
+using global.Azure.ClientGenerator.Core;
+using Spector;
+
+@doc("Test decorator @responseAsBool on HEAD operations.")
+@scenarioService("/azure/client-generator-core/response-as-bool")
+@global.Azure.ClientGenerator.Core.clientNamespace(
+  "azure.clientgenerator.core.responseasbool",
+  "java"
+)
+namespace _Specs_.Azure.ClientGenerator.Core.ResponseAsBool;
+
+@scenario
+@scenarioDoc("""
+  Test that a HEAD operation decorated with @responseAsBool returns a boolean value.
+  When the resource exists, the service returns 204 No Content and the client should return true.
+  When the resource does not exist, the service returns 404 Not Found and the client should return false.
+  
+  Expected behavior:
+  - HEAD /azure/client-generator-core/response-as-bool/exists → 204 → client returns true
+  - HEAD /azure/client-generator-core/response-as-bool/exists → 404 → client returns false
+  """)
+@route("/exists")
+@responseAsBool
+@head
+op exists(): void;

--- a/packages/azure-http-specs/specs/azure/client-generator-core/response-as-bool/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/response-as-bool/mockapi.ts
@@ -1,0 +1,13 @@
+import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Azure_ClientGenerator_Core_ResponseAsBool_exists = passOnSuccess({
+  uri: "/azure/client-generator-core/response-as-bool/exists",
+  method: "head",
+  request: {},
+  response: {
+    status: 204,
+  },
+  kind: "MockApiDefinition",
+});

--- a/packages/typespec-client-generator-core/README.md
+++ b/packages/typespec-client-generator-core/README.md
@@ -649,14 +649,14 @@ Change the parameter location to operation or client. For this usage, the decora
 
 ##### Target
 
-The operation to change location for.
+The operation or model property (parameter) to change location for.
 `Operation | ModelProperty`
 
 ##### Parameters
 
 | Name   | Type                                                      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ------ | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| target | `Interface \| Namespace \| Operation` \| `valueof string` | The target `Namespace`, `Interface` or a string which can indicate the client.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| target | `Interface \| Namespace \| Operation` \| `valueof string` | The target `Namespace`, `Interface`, `Operation`, or a string which can indicate the client.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | scope  | `valueof string`                                          | Specifies the target language emitters that the decorator should apply. If not set, the decorator will be applied to all language emitters by default.<br /><br />**Supported language identifiers:** `csharp`, `python`, `java`, `javascript`, `go`, and other language emitter names (derived from the emitter package name, e.g., `@azure-tools/typespec-csharp` → `csharp`).<br /><br />**Valid patterns:**<br />- Single language: `"python"`<br />- Multiple languages (comma-separated): `"python, java"`<br />- Negation to exclude languages: `"!csharp"` or `"!(java, python)"` |
 
 ##### Examples
@@ -1542,7 +1542,7 @@ model SportsCar extends Vehicle {
 Forces an operation to be treated as a Long Running Operation (LRO) by the SDK generators,
 even when the operation is not long-running on the service side.
 
-NOTE: When used, you will need to verify the operatio and add tests for the generated code
+NOTE: When used, you will need to verify the operation and add tests for the generated code
 to make sure the end-to-end works for library users, since there is a risk that forcing
 this operation to be LRO will result in errors.
 

--- a/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.Legacy.ts
+++ b/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.Legacy.ts
@@ -82,7 +82,7 @@ export type FlattenPropertyDecorator = (
  * Forces an operation to be treated as a Long Running Operation (LRO) by the SDK generators,
  * even when the operation is not long-running on the service side.
  *
- * NOTE: When used, you will need to verify the operatio and add tests for the generated code
+ * NOTE: When used, you will need to verify the operation and add tests for the generated code
  * to make sure the end-to-end works for library users, since there is a risk that forcing
  * this operation to be LRO will result in errors.
  *

--- a/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.ts
+++ b/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.ts
@@ -185,9 +185,6 @@ export type ProtocolAPIDecorator = (
  * @client({service: MyService, name: "MySpecialClient"})
  * interface MyInterface {}
  * ```
- * @example
- *
- *
  */
 export type ClientDecorator = (
   context: DecoratorContext,
@@ -934,8 +931,8 @@ export type ResponseAsBoolDecorator = (
  * Change the operation location in the client. If the target client is not defined, use `string` to indicate a new client name. For this usage, the decorator cannot be used along with `@client` or `@operationGroup` decorators.
  * Change the parameter location to operation or client. For this usage, the decorator cannot be used in the parameter defined in  `@clientInitialization` decorator.
  *
- * @param source The operation to change location for.
- * @param target The target `Namespace`, `Interface` or a string which can indicate the client.
+ * @param source The operation or model property (parameter) to change location for.
+ * @param target The target `Namespace`, `Interface`, `Operation`, or a string which can indicate the client.
  * @param scope Specifies the target language emitters that the decorator should apply. If not set, the decorator will be applied to all language emitters by default.
  *
  * **Supported language identifiers:** `csharp`, `python`, `java`, `javascript`, `go`, and other language emitter names (derived from the emitter package name, e.g., `@azure-tools/typespec-csharp` → `csharp`).

--- a/packages/typespec-client-generator-core/lib/decorators.tsp
+++ b/packages/typespec-client-generator-core/lib/decorators.tsp
@@ -178,7 +178,6 @@ extern dec protocolAPI(
  * interface MyInterface {}
  * ```
  *
- * @example
  */
 extern dec client(target: Namespace | Interface, options?: ClientOptions, scope?: valueof string);
 
@@ -1000,8 +999,8 @@ extern dec responseAsBool(target: Operation, scope?: valueof string);
 /**
  * Change the operation location in the client. If the target client is not defined, use `string` to indicate a new client name. For this usage, the decorator cannot be used along with `@client` or `@operationGroup` decorators.
  * Change the parameter location to operation or client. For this usage, the decorator cannot be used in the parameter defined in  `@clientInitialization` decorator.
- * @param source The operation to change location for.
- * @param target The target `Namespace`, `Interface` or a string which can indicate the client.
+ * @param source The operation or model property (parameter) to change location for.
+ * @param target The target `Namespace`, `Interface`, `Operation`, or a string which can indicate the client.
  * @param scope Specifies the target language emitters that the decorator should apply. If not set, the decorator will be applied to all language emitters by default.
  *
  * **Supported language identifiers:** `csharp`, `python`, `java`, `javascript`, `go`, and other language emitter names (derived from the emitter package name, e.g., `@azure-tools/typespec-csharp` → `csharp`).

--- a/packages/typespec-client-generator-core/lib/legacy.tsp
+++ b/packages/typespec-client-generator-core/lib/legacy.tsp
@@ -68,7 +68,7 @@ extern dec flattenProperty(target: ModelProperty, scope?: valueof string);
  * Forces an operation to be treated as a Long Running Operation (LRO) by the SDK generators,
  * even when the operation is not long-running on the service side.
  *
- * NOTE: When used, you will need to verify the operatio and add tests for the generated code
+ * NOTE: When used, you will need to verify the operation and add tests for the generated code
  * to make sure the end-to-end works for library users, since there is a risk that forcing
  * this operation to be LRO will result in errors.
  *

--- a/website/src/content/docs/docs/howtos/Generate client libraries/03client.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/03client.mdx
@@ -597,7 +597,7 @@ Customizations SHOULD always be made in a file named `client.tsp` alongside `mai
 There are two ways to customize the client hierarchy: using `@clientLocation` to change the location of the operations, or use `@client` to restructure the client hierarchy.
 Be careful when you use both of them since `@clientLocation` could not move the client that is no longer exist with `@client` customization.
 
-The `@clientLocaton` decorator allows you to change the location of the operations in the client hierarchy.
+The `@clientLocation` decorator allows you to change the location of the operations in the client hierarchy.
 It can be used to move operations to an existed sub client defined by `Interface` or `Namespace`, or move the the root client of namespace with `@service` decorator.
 This decorator is useful when you want to keep the default client hierarchy but need to change the location of some operations.
 

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
@@ -168,15 +168,15 @@ For types in TypeSpec, TCGC provides several client types to represent them in a
 
 **Built-in Types:**
 
-- [`SdkBuiltInType`](../reference/js-api/interfaces/sdkbuiltintype/) represents a [built-in TypeSpec type](https://typespec.io/docs/language-basics/built-in-types/) or a [`scalar`](https://typespec.io/docs/language-basics/scalars/) type that derives from a built-in TypeSpec type, excluding `utcDateTime`, `offsetDateTime` and `duration`. The `encode` property is added to these types when the `@encode` decorator exists, indicating how to encode when sending to the service.
+- [`SdkBuiltInType`](../reference/js-api/interfaces/sdkbuiltintype/) represents a [built-in TypeSpec type](https://typespec.io/docs/language-basics/built-in-types/) or a [`scalar`](https://typespec.io/docs/language-basics/scalars/) type that derives from a built-in TypeSpec type, excluding `utcDateTime`, `offsetDateTime` and `duration`. The `encode` property is added to these types when the `@encode` decorator exists, indicating how to encode when sending to the service. Supported `kind` values include: `string`, `boolean`, `int8`, `int16`, `int32`, `int64`, `uint8`, `uint16`, `uint32`, `uint64`, `integer`, `safeint`, `float`, `float32`, `float64`, `decimal`, `decimal128`, `numeric`, `bytes`, `url`, `plainDate`, `plainTime`, and `unknown`. Scalar types that derive from built-in types preserve the inheritance chain via the `baseType` property.
 
 **Date and Time Types:**
 
-- [`SdkDateTimeType`](../reference/js-api/type-aliases/sdkdatetimetype/) and [`SdkDurationType`](../reference/js-api/interfaces/sdkdurationtype/) are converted from TypeSpec `utcDateTime`, `offsetDateTime` and `duration` types. The datetime encoding info is in the `encode` property.
+- [`SdkDateTimeType`](../reference/js-api/type-aliases/sdkdatetimetype/) and [`SdkDurationType`](../reference/js-api/interfaces/sdkdurationtype/) are converted from TypeSpec `utcDateTime`, `offsetDateTime` and `duration` types. The encoding info is in the `encode` property (e.g., `"rfc3339"`, `"rfc7231"`, `"unixTimestamp"` for datetime; `"ISO8601"`, `"seconds"` for duration). The `wireType` property indicates the serialization type used on the wire (e.g., `string` for RFC formats, `int64` for unix timestamps, `int32`/`float` for duration seconds).
 
 **Collection Types:**
 
-- [`SdkArrayType`](../reference/js-api/interfaces/sdkarraytype/), [`SdkTupleType`](../reference/js-api/interfaces/sdktupletype/) and [`SdkDictionaryType`](../reference/js-api/interfaces/sdkdictionarytype/) are converted from TypeSpec [`Array`](https://typespec.io/docs/language-basics/models/#array), [`Tuple`](https://typespec.io/docs/standard-library/reference/js-api/interfaces/tuple/) and [`Record`](https://typespec.io/docs/language-basics/models/#record) types.
+- [`SdkArrayType`](../reference/js-api/interfaces/sdkarraytype/), [`SdkTupleType`](../reference/js-api/interfaces/sdktupletype/) and [`SdkDictionaryType`](../reference/js-api/interfaces/sdkdictionarytype/) are converted from TypeSpec [`Array`](https://typespec.io/docs/language-basics/models/#array), [`Tuple`](https://typespec.io/docs/standard-library/reference/js-api/interfaces/tuple/) and [`Record`](https://typespec.io/docs/language-basics/models/#record) types. `SdkArrayType` has a `valueType` property for the element type. `SdkDictionaryType` has `keyType` and `valueType` properties. `SdkTupleType` has a `valueTypes` array for each positional element type. Identical collection types are deduplicated to the same instance.
 
 **Nullable Types:**
 
@@ -184,19 +184,19 @@ For types in TypeSpec, TCGC provides several client types to represent them in a
 
 **Enumeration Types:**
 
-- [`SdkEnumType`](../reference/js-api/interfaces/sdkenumtype/) and [`SdkEnumValueType`](../reference/js-api/interfaces/sdkenumvaluetype/) represent TCGC enumeration types. They are typically converted from TypeSpec [`Enum`](https://typespec.io/docs/language-basics/enums/) types or [`Union`](https://typespec.io/docs/language-basics/unions/) types (for extensible enumeration cases).
+- [`SdkEnumType`](../reference/js-api/interfaces/sdkenumtype/) and [`SdkEnumValueType`](../reference/js-api/interfaces/sdkenumvaluetype/) represent TCGC enumeration types. They are typically converted from TypeSpec [`Enum`](https://typespec.io/docs/language-basics/enums/) types or [`Union`](https://typespec.io/docs/language-basics/unions/) types (for extensible enumeration cases). Key properties on `SdkEnumType` include: `isFixed` (whether the enum is a fixed set of values), `isUnionAsEnum` (whether it was converted from a union type), and `valueType` (the underlying built-in type, e.g., `string` or `int32`).
 
 **Literal Types:**
 
-- [`SdkConstantType`](../reference/js-api/interfaces/sdkconstanttype/) represents a literal type in TypeSpec ([`StringLiteral`](https://typespec.io/docs/language-basics/type-literals/#string-literals), [`NumericLiteral`](https://typespec.io/docs/language-basics/type-literals/#numeric-literal), or [`BooleanLiteral`](https://typespec.io/docs/language-basics/type-literals/#boolean-literal)).
+- [`SdkConstantType`](../reference/js-api/interfaces/sdkconstanttype/) represents a literal type in TypeSpec ([`StringLiteral`](https://typespec.io/docs/language-basics/type-literals/#string-literals), [`NumericLiteral`](https://typespec.io/docs/language-basics/type-literals/#numeric-literal), or [`BooleanLiteral`](https://typespec.io/docs/language-basics/type-literals/#boolean-literal)). It has a `value` property containing the literal value and a `valueType` property indicating the underlying built-in type.
 
 **Union Types:**
 
-- [`SdkUnionType`](../reference/js-api/interfaces/sdkuniontype/) represents a TCGC union type. It is typically converted from a TypeSpec [`Union`](https://typespec.io/docs/language-basics/unions/) type.
+- [`SdkUnionType`](../reference/js-api/interfaces/sdkuniontype/) represents a TCGC union type. It is typically converted from a TypeSpec [`Union`](https://typespec.io/docs/language-basics/unions/) type. It has a `variantTypes` array containing each variant's type. For discriminated unions, the `discriminatedOptions` property provides the discriminator property name and envelope information.
 
 **Model Types:**
 
-- [`SdkModelType`](../reference/js-api/interfaces/sdkmodeltype/) represents a TCGC model type. It is typically converted from a TypeSpec [`Model`](https://typespec.io/docs/language-basics/models/) type.
+- [`SdkModelType`](../reference/js-api/interfaces/sdkmodeltype/) represents a TCGC model type. It is typically converted from a TypeSpec [`Model`](https://typespec.io/docs/language-basics/models/) type. Key properties include: `baseModel` (the base model for inheritance), `discriminatorProperty` (the property used as a discriminator), `discriminatedSubtypes` (a map of discriminator values to subtypes), `discriminatorValue` (the discriminator value for this subtype), and `additionalProperties` (the type for additional properties when the model extends `Record<T>`).
 
 **Model Property Types:**
 

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/decorators.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/decorators.md
@@ -522,14 +522,14 @@ Change the parameter location to operation or client. For this usage, the decora
 
 #### Target
 
-The operation to change location for.
+The operation or model property (parameter) to change location for.
 `Operation | ModelProperty`
 
 #### Parameters
 
 | Name   | Type                                                      | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ------ | --------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| target | `Interface \| Namespace \| Operation` \| `valueof string` | The target `Namespace`, `Interface` or a string which can indicate the client.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
+| target | `Interface \| Namespace \| Operation` \| `valueof string` | The target `Namespace`, `Interface`, `Operation`, or a string which can indicate the client.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | scope  | `valueof string`                                          | Specifies the target language emitters that the decorator should apply. If not set, the decorator will be applied to all language emitters by default.<br /><br />**Supported language identifiers:** `csharp`, `python`, `java`, `javascript`, `go`, and other language emitter names (derived from the emitter package name, e.g., `@azure-tools/typespec-csharp` → `csharp`).<br /><br />**Valid patterns:**<br />- Single language: `"python"`<br />- Multiple languages (comma-separated): `"python, java"`<br />- Negation to exclude languages: `"!csharp"` or `"!(java, python)"` |
 
 #### Examples
@@ -1407,7 +1407,7 @@ model SportsCar extends Vehicle {
 Forces an operation to be treated as a Long Running Operation (LRO) by the SDK generators,
 even when the operation is not long-running on the service side.
 
-NOTE: When used, you will need to verify the operatio and add tests for the generated code
+NOTE: When used, you will need to verify the operation and add tests for the generated code
 to make sure the end-to-end works for library users, since there is a risk that forcing
 this operation to be LRO will result in errors.
 


### PR DESCRIPTION
- Fix typo 'operatio' → 'operation' in @markAsLro doc comment (legacy.tsp)
- Fix @clientLocation param descriptions to include ModelProperty and Operation targets
- Remove incomplete empty @example tag from @client decorator
- Fix '@clientLocaton' typo in 03client.mdx
- Enrich guideline.md type descriptions with key properties for emitter developers:
  - SdkBuiltInType: list supported kinds, document baseType for scalar inheritance
  - SdkDateTimeType/SdkDurationType: document wireType and encode values
  - SdkArrayType/SdkDictionaryType/SdkTupleType: document valueType, keyType, valueTypes
  - SdkEnumType: document isFixed, isUnionAsEnum, valueType
  - SdkConstantType: document value and valueType
  - SdkUnionType: document variantTypes and discriminatedOptions
  - SdkModelType: document baseModel, discriminator properties, additionalProperties
- Add Spector test spec for @responseAsBool decorator on HEAD operations
- Add knowledge base for future documentation update runs

Resolve: https://github.com/Azure/typespec-azure/issues/4199