### PR TITLE
[Automated][tcgc] Fix TCGC doc comments, add missing howto sections, and add Spector specs

### DIFF
--- a/.chronus/changes/tcgc-docs-fix-comments-2026-04-07.md
+++ b/.chronus/changes/tcgc-docs-fix-comments-2026-04-07.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Fix inaccurate doc comments: @clientApiVersions param description, @deserializeEmptyStringAsNull example, @markAsLro typo, @client empty example, @override malformed comment.

--- a/.chronus/changes/tcgc-docs-spector-specs-2026-04-07.md
+++ b/.chronus/changes/tcgc-docs-spector-specs-2026-04-07.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Add Spector test specs for @convenientAPI/@protocolAPI, @scope, @responseAsBool, and @clientDoc decorators.

--- a/eng/scripts/doc-updater/knowledge/tcgc.md
+++ b/eng/scripts/doc-updater/knowledge/tcgc.md
@@ -1,0 +1,53 @@
+# TCGC Documentation Knowledge Base
+
+## Decorator Namespace Conventions in Spector Specs
+
+In Spector specs (`packages/azure-http-specs/specs/`), TCGC decorators must use fully qualified names with the `@global.Azure.ClientGenerator.Core.` prefix (e.g., `@global.Azure.ClientGenerator.Core.convenientAPI(false)`). The `using Azure.ClientGenerator.Core;` import alone is NOT sufficient for decorator resolution in Spector spec compilation. The `@@` augmentation syntax also requires the `@@global.Azure.ClientGenerator.Core.` prefix.
+
+## Doc Comment Source for Reference Docs
+
+The auto-generated reference docs at `website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/decorators.md` are generated from doc comments in `packages/typespec-client-generator-core/lib/decorators.tsp` and `lib/legacy.tsp`. Run `pnpm regen-docs` from `packages/typespec-client-generator-core/` after editing doc comments. Never edit the generated `decorators.md` directly.
+
+## Access Decorator Syntax
+
+The `@access` decorator takes `Access.internal` or `Access.public` enum values, NOT string literals. The previous documentation incorrectly showed `@@access(Target, "internal")` — the correct syntax is `@@access(Target, Access.internal)`.
+
+## Howto Doc File Ownership
+
+Each howto file owns specific topics:
+
+- `01setup.mdx` — setup, language scoping (`@scope`)
+- `02package.mdx` — `@service`, `@clientNamespace`, licensing
+- `03client.mdx` — `@client`, `@clientInitialization`, `@paramAlias`, `@clientLocation`, client hierarchy
+- `04method.mdx` — `@protocolAPI`, `@convenientAPI`, `@access`, `@usage`, `@override`, `@responseAsBool`, `@clientDoc`, transformation functions
+- `05pagingOperations.mdx` — paging patterns, `@nextLinkVerb`, `@markAsPageable`, `@disablePageable`
+- `06longRunningOperations.mdx` — LRO patterns, `@markAsLro`
+- `08types.mdx` — type mappings, `@alternateType`, `@clientDefaultValue`, `@flattenProperty`, `@deserializeEmptyStringAsNull`
+- `09renaming.mdx` — `@clientName`, `@encodedName`
+- `10versioning.mdx` — `@versioned`, `@apiVersion`, `@clientApiVersions`
+- `11hierarchyBuilding.mdx` — `@hierarchyBuilding` (legacy)
+- `12clientOptions.mdx` — `@clientOption`
+
+## pnpm Availability
+
+In CI environments, `pnpm` may not be on PATH. Use `corepack pnpm` or create a wrapper script at `/tmp/gh-aw/agent/bin/pnpm` that invokes `node /home/runner/.cache/node/corepack/v1/pnpm/<version>/bin/pnpm.cjs`. Add `/tmp/gh-aw/agent/bin` to PATH.
+
+## Spector Validation Sequence
+
+From `packages/azure-http-specs`, run in this exact order:
+
+1. `pnpm build` (compiles TypeScript and validates scenarios)
+2. `pnpm validate-mock-apis` (verifies mock API implementations)
+3. `pnpm cspell` (check spelling — run from repo root)
+4. `pnpm format:dir packages/azure-http-specs` (run from repo root)
+5. `pnpm regen-docs` (regenerate spec-summary.md)
+
+Note: `pnpm lint` and `pnpm format` scripts don't exist in the azure-http-specs package — use root-level `pnpm format:dir`.
+
+## Legacy Decorators Still Active
+
+All decorators in `Azure.ClientGenerator.Core.Legacy` namespace (`lib/legacy.tsp`) are still functional and used in production: `@hierarchyBuilding`, `@flattenProperty`, `@markAsLro`, `@markAsPageable`, `@disablePageable`, `@nextLinkVerb`, `@clientDefaultValue`. They should be documented with caution warnings but NOT ignored.
+
+## Decorators Without Spector Coverage (remaining)
+
+The following decorators still need Spector specs: `@useSystemTextJsonConverter`, `@clientApiVersions`, `@clientOption`, `@markAsLro`, `@markAsPageable`, `@disablePageable`, and the transformation functions (`replaceParameter`, `removeParameter`, `addParameter`, `reorderParameters`).

--- a/packages/azure-http-specs/spec-summary.md
+++ b/packages/azure-http-specs/spec-summary.md
@@ -227,6 +227,38 @@ Expected response body:
 }
 ```
 
+### Azure_ClientGenerator_Core_ClientDoc_AppendDoc
+
+- Endpoint: `get /azure/client-generator-core/client-doc/appendDoc`
+
+This scenario tests @clientDoc with append mode.
+The operation's original doc is "Gets a resource."
+After applying @clientDoc in append mode, the client documentation should be:
+"Gets a resource. Returns null if the resource is not found."
+
+Expected query parameter: name="sample"
+Expected response body:
+
+```json
+{ "name": "sample" }
+```
+
+### Azure_ClientGenerator_Core_ClientDoc_ReplaceDoc
+
+- Endpoint: `get /azure/client-generator-core/client-doc/replaceDoc`
+
+This scenario tests @clientDoc with replace mode.
+The operation's original doc is "Gets a resource."
+After applying @clientDoc in replace mode, the client documentation should be:
+"Fetch the named resource from the service."
+
+Expected query parameter: name="sample"
+Expected response body:
+
+```json
+{ "name": "sample" }
+```
+
 ### Azure_ClientGenerator_Core_ClientInitialization_DefaultClient_HeaderParam
 
 - Endpoints:
@@ -839,6 +871,45 @@ Expected client structure:
 - Interface ResourceOperations should contain only operation `getResource`
 - Root client should contain operation `getHealthStatus` (moved from ResourceOperations)
 
+### Azure_ClientGenerator_Core_ConvenientApi_Both
+
+- Endpoint: `get /azure/client-generator-core/convenient-api/both`
+
+This scenario tests both @convenientAPI and @protocolAPI enabled (default behavior).
+Both protocol and convenience methods should be generated.
+Expected query parameter: name="sample"
+Expected response body:
+
+```json
+{ "name": "sample" }
+```
+
+### Azure_ClientGenerator_Core_ConvenientApi_ConvenientOnly
+
+- Endpoint: `get /azure/client-generator-core/convenient-api/protocolOnly`
+
+This scenario tests @convenientAPI(false) on an operation, meaning only a protocol method
+should be generated. The convenience method should NOT be generated.
+Expected query parameter: name="sample"
+Expected response body:
+
+```json
+{ "name": "sample" }
+```
+
+### Azure_ClientGenerator_Core_ConvenientApi_ProtocolOnly
+
+- Endpoint: `get /azure/client-generator-core/convenient-api/convenientOnly`
+
+This scenario tests @protocolAPI(false) on an operation, meaning only a convenience method
+should be generated. The protocol method should NOT be generated.
+Expected query parameter: name="sample"
+Expected response body:
+
+```json
+{ "name": "sample" }
+```
+
 ### Azure_ClientGenerator_Core_DeserializeEmptyStringAsNull_get
 
 - Endpoint: `get /azure/client-generator-core/deserialize-empty-string-as-null/responseModel`
@@ -1204,6 +1275,50 @@ param1: param1
 param2: param2
 
 Expected response: 204 No Content
+
+### Azure_ClientGenerator_Core_ResponseAsBool_Exists
+
+- Endpoint: `head /azure/client-generator-core/response-as-bool/exists/found`
+
+This scenario tests @responseAsBool on a HEAD operation that returns 200 (exists).
+The generated method should return `true` for 2xx responses.
+Expected request: HEAD /azure/client-generator-core/response-as-bool/exists/found
+Expected response: 200
+
+### Azure_ClientGenerator_Core_ResponseAsBool_NotExists
+
+- Endpoint: `head /azure/client-generator-core/response-as-bool/exists/notFound`
+
+This scenario tests @responseAsBool on a HEAD operation that returns 404 (not found).
+The generated method should return `false` for 404 responses.
+Expected request: HEAD /azure/client-generator-core/response-as-bool/exists/notFound
+Expected response: 404
+
+### Azure_ClientGenerator_Core_Scope_NegatedScopeOperation
+
+- Endpoint: `get /azure/client-generator-core/scope/negatedOp`
+
+This scenario tests that an operation scoped with negation is generated for all
+languages except those excluded. The 'negatedOp' operation should NOT be generated
+for C# but should be generated for all other languages.
+Expected response body:
+
+```json
+{ "name": "sample" }
+```
+
+### Azure_ClientGenerator_Core_Scope_ScopedOperation
+
+- Endpoint: `get /azure/client-generator-core/scope/scopedOp`
+
+This scenario tests that an operation scoped to a specific set of languages is only
+generated for those languages. The 'scopedOp' operation should only be generated for
+Python and Java. Other languages should not include this operation.
+Expected response body:
+
+```json
+{ "name": "sample" }
+```
 
 ### Azure_ClientGenerator_Core_Usage_ModelInOperation
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-doc/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-doc/main.tsp
@@ -1,0 +1,70 @@
+import "@typespec/http";
+import "@typespec/spector";
+import "@azure-tools/typespec-client-generator-core";
+
+using Http;
+using Spector;
+using Azure.ClientGenerator.Core;
+
+@doc("Test for @clientDoc decorator to override or append client documentation.")
+@scenarioService("/azure/client-generator-core/client-doc")
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.clientdoc", "java")
+namespace _Specs_.Azure.ClientGenerator.Core.ClientDoc;
+
+@scenario
+@scenarioDoc("""
+  This scenario tests @clientDoc with append mode.
+  The operation's original doc is "Gets a resource."
+  After applying @clientDoc in append mode, the client documentation should be:
+  "Gets a resource. Returns null if the resource is not found."
+  
+  Expected query parameter: name="sample"
+  Expected response body:
+  ```json
+  { "name": "sample" }
+  ```
+  """)
+namespace AppendDoc {
+  model Resource {
+    name: string;
+  }
+
+  /** Gets a resource. */
+  @route("/appendDoc")
+  @get
+  op getResource(@query name: string): Resource;
+}
+
+@@global.Azure.ClientGenerator.Core.clientDoc(AppendDoc.getResource,
+  "Returns null if the resource is not found.",
+  global.Azure.ClientGenerator.Core.DocumentationMode.append
+);
+
+@scenario
+@scenarioDoc("""
+  This scenario tests @clientDoc with replace mode.
+  The operation's original doc is "Gets a resource."
+  After applying @clientDoc in replace mode, the client documentation should be:
+  "Fetch the named resource from the service."
+  
+  Expected query parameter: name="sample"
+  Expected response body:
+  ```json
+  { "name": "sample" }
+  ```
+  """)
+namespace ReplaceDoc {
+  model Resource {
+    name: string;
+  }
+
+  /** Gets a resource. */
+  @route("/replaceDoc")
+  @get
+  op getResource(@query name: string): Resource;
+}
+
+@@global.Azure.ClientGenerator.Core.clientDoc(ReplaceDoc.getResource,
+  "Fetch the named resource from the service.",
+  global.Azure.ClientGenerator.Core.DocumentationMode.replace
+);

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-doc/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-doc/mockapi.ts
@@ -1,0 +1,28 @@
+import { json, MockApiDefinition, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+function createMockApiDefinition(route: string): MockApiDefinition {
+  return {
+    uri: `/azure/client-generator-core/client-doc/${route}`,
+    method: "get",
+    request: {
+      query: {
+        name: "sample",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({ name: "sample" }),
+    },
+    kind: "MockApiDefinition",
+  };
+}
+
+Scenarios.Azure_ClientGenerator_Core_ClientDoc_AppendDoc = passOnSuccess([
+  createMockApiDefinition("appendDoc"),
+]);
+
+Scenarios.Azure_ClientGenerator_Core_ClientDoc_ReplaceDoc = passOnSuccess([
+  createMockApiDefinition("replaceDoc"),
+]);

--- a/packages/azure-http-specs/specs/azure/client-generator-core/convenient-api/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/convenient-api/main.tsp
@@ -1,0 +1,70 @@
+import "@typespec/http";
+import "@typespec/spector";
+import "@azure-tools/typespec-client-generator-core";
+
+using Http;
+using Spector;
+using Azure.ClientGenerator.Core;
+
+@doc("Test for @convenientAPI and @protocolAPI decorators.")
+@scenarioService("/azure/client-generator-core/convenient-api")
+@global.Azure.ClientGenerator.Core.clientNamespace(
+  "azure.clientgenerator.core.convenientapi",
+  "java"
+)
+namespace _Specs_.Azure.ClientGenerator.Core.ConvenientApi;
+
+model Resource {
+  name: string;
+  description?: string;
+}
+
+@scenario
+@scenarioDoc("""
+  This scenario tests @convenientAPI(false) on an operation, meaning only a protocol method
+  should be generated. The convenience method should NOT be generated.
+  Expected query parameter: name="sample"
+  Expected response body:
+  ```json
+  { "name": "sample" }
+  ```
+  """)
+namespace ConvenientOnly {
+  @route("/protocolOnly")
+  @get
+  @global.Azure.ClientGenerator.Core.convenientAPI(false)
+  op protocolOnlyOp(@query name: string): Resource;
+}
+
+@scenario
+@scenarioDoc("""
+  This scenario tests @protocolAPI(false) on an operation, meaning only a convenience method
+  should be generated. The protocol method should NOT be generated.
+  Expected query parameter: name="sample"
+  Expected response body:
+  ```json
+  { "name": "sample" }
+  ```
+  """)
+namespace ProtocolOnly {
+  @route("/convenientOnly")
+  @get
+  @global.Azure.ClientGenerator.Core.protocolAPI(false)
+  op convenientOnlyOp(@query name: string): Resource;
+}
+
+@scenario
+@scenarioDoc("""
+  This scenario tests both @convenientAPI and @protocolAPI enabled (default behavior).
+  Both protocol and convenience methods should be generated.
+  Expected query parameter: name="sample"
+  Expected response body:
+  ```json
+  { "name": "sample" }
+  ```
+  """)
+namespace Both {
+  @route("/both")
+  @get
+  op bothOp(@query name: string): Resource;
+}

--- a/packages/azure-http-specs/specs/azure/client-generator-core/convenient-api/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/convenient-api/mockapi.ts
@@ -1,0 +1,32 @@
+import { json, MockApiDefinition, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+function createMockApiDefinition(route: string): MockApiDefinition {
+  return {
+    uri: `/azure/client-generator-core/convenient-api/${route}`,
+    method: "get",
+    request: {
+      query: {
+        name: "sample",
+      },
+    },
+    response: {
+      status: 200,
+      body: json({ name: "sample" }),
+    },
+    kind: "MockApiDefinition",
+  };
+}
+
+Scenarios.Azure_ClientGenerator_Core_ConvenientApi_ConvenientOnly = passOnSuccess([
+  createMockApiDefinition("protocolOnly"),
+]);
+
+Scenarios.Azure_ClientGenerator_Core_ConvenientApi_ProtocolOnly = passOnSuccess([
+  createMockApiDefinition("convenientOnly"),
+]);
+
+Scenarios.Azure_ClientGenerator_Core_ConvenientApi_Both = passOnSuccess([
+  createMockApiDefinition("both"),
+]);

--- a/packages/azure-http-specs/specs/azure/client-generator-core/response-as-bool/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/response-as-bool/main.tsp
@@ -1,0 +1,43 @@
+import "@typespec/http";
+import "@typespec/spector";
+import "@azure-tools/typespec-client-generator-core";
+
+using Http;
+using Spector;
+using Azure.ClientGenerator.Core;
+
+@doc("Test for @responseAsBool decorator on HEAD operations.")
+@scenarioService("/azure/client-generator-core/response-as-bool")
+@global.Azure.ClientGenerator.Core.clientNamespace(
+  "azure.clientgenerator.core.responseasbool",
+  "java"
+)
+namespace _Specs_.Azure.ClientGenerator.Core.ResponseAsBool;
+
+@scenario
+@scenarioDoc("""
+  This scenario tests @responseAsBool on a HEAD operation that returns 200 (exists).
+  The generated method should return `true` for 2xx responses.
+  Expected request: HEAD /azure/client-generator-core/response-as-bool/exists/found
+  Expected response: 200
+  """)
+namespace Exists {
+  @route("/exists/found")
+  @head
+  @global.Azure.ClientGenerator.Core.responseAsBool
+  op found(@query name: string): OkResponse;
+}
+
+@scenario
+@scenarioDoc("""
+  This scenario tests @responseAsBool on a HEAD operation that returns 404 (not found).
+  The generated method should return `false` for 404 responses.
+  Expected request: HEAD /azure/client-generator-core/response-as-bool/exists/notFound
+  Expected response: 404
+  """)
+namespace NotExists {
+  @route("/exists/notFound")
+  @head
+  @global.Azure.ClientGenerator.Core.responseAsBool
+  op notFound(@query name: string): OkResponse | NotFoundResponse;
+}

--- a/packages/azure-http-specs/specs/azure/client-generator-core/response-as-bool/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/response-as-bool/mockapi.ts
@@ -1,0 +1,35 @@
+import { MockApiDefinition, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+Scenarios.Azure_ClientGenerator_Core_ResponseAsBool_Exists = passOnSuccess([
+  {
+    uri: `/azure/client-generator-core/response-as-bool/exists/found`,
+    method: "head",
+    request: {
+      query: {
+        name: "sample",
+      },
+    },
+    response: {
+      status: 200,
+    },
+    kind: "MockApiDefinition",
+  } satisfies MockApiDefinition,
+]);
+
+Scenarios.Azure_ClientGenerator_Core_ResponseAsBool_NotExists = passOnSuccess([
+  {
+    uri: `/azure/client-generator-core/response-as-bool/exists/notFound`,
+    method: "head",
+    request: {
+      query: {
+        name: "sample",
+      },
+    },
+    response: {
+      status: 404,
+    },
+    kind: "MockApiDefinition",
+  } satisfies MockApiDefinition,
+]);

--- a/packages/azure-http-specs/specs/azure/client-generator-core/scope/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/scope/main.tsp
@@ -1,0 +1,50 @@
+import "@typespec/http";
+import "@typespec/spector";
+import "@azure-tools/typespec-client-generator-core";
+
+using Http;
+using Spector;
+using Azure.ClientGenerator.Core;
+
+@doc("Test for @scope decorator to control which languages include operations and properties.")
+@scenarioService("/azure/client-generator-core/scope")
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.scope", "java")
+namespace _Specs_.Azure.ClientGenerator.Core.Scope;
+
+model Resource {
+  name: string;
+}
+
+@scenario
+@scenarioDoc("""
+  This scenario tests that an operation scoped to a specific set of languages is only
+  generated for those languages. The 'scopedOp' operation should only be generated for
+  Python and Java. Other languages should not include this operation.
+  Expected response body:
+  ```json
+  { "name": "sample" }
+  ```
+  """)
+namespace ScopedOperation {
+  @route("/scopedOp")
+  @get
+  @global.Azure.ClientGenerator.Core.scope("python, java")
+  op scopedOp(): Resource;
+}
+
+@scenario
+@scenarioDoc("""
+  This scenario tests that an operation scoped with negation is generated for all
+  languages except those excluded. The 'negatedOp' operation should NOT be generated
+  for C# but should be generated for all other languages.
+  Expected response body:
+  ```json
+  { "name": "sample" }
+  ```
+  """)
+namespace NegatedScopeOperation {
+  @route("/negatedOp")
+  @get
+  @global.Azure.ClientGenerator.Core.scope("!csharp")
+  op negatedOp(): Resource;
+}

--- a/packages/azure-http-specs/specs/azure/client-generator-core/scope/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/scope/mockapi.ts
@@ -1,0 +1,24 @@
+import { json, MockApiDefinition, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+function createMockApiDefinition(route: string): MockApiDefinition {
+  return {
+    uri: `/azure/client-generator-core/scope/${route}`,
+    method: "get",
+    request: {},
+    response: {
+      status: 200,
+      body: json({ name: "sample" }),
+    },
+    kind: "MockApiDefinition",
+  };
+}
+
+Scenarios.Azure_ClientGenerator_Core_Scope_ScopedOperation = passOnSuccess([
+  createMockApiDefinition("scopedOp"),
+]);
+
+Scenarios.Azure_ClientGenerator_Core_Scope_NegatedScopeOperation = passOnSuccess([
+  createMockApiDefinition("negatedOp"),
+]);

--- a/packages/typespec-client-generator-core/README.md
+++ b/packages/typespec-client-generator-core/README.md
@@ -505,14 +505,14 @@ It is particularly beneficial when generating a complete API version enum withou
 
 ##### Target
 
-The target client for which you want to define additional API versions.
+The target namespace for which you want to define additional API versions.
 `Namespace`
 
 ##### Parameters
 
 | Name  | Type             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ----- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| value | `Enum`           | If true, we will treat this parameter as an api-version parameter. If false, we will not. Default is true.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| value | `Enum`           | An enum containing the API versions that the client should support.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | scope | `valueof string` | Specifies the target language emitters that the decorator should apply. If not set, the decorator will be applied to all language emitters by default.<br /><br />**Supported language identifiers:** `csharp`, `python`, `java`, `javascript`, `go`, and other language emitter names (derived from the emitter package name, e.g., `@azure-tools/typespec-csharp` → `csharp`).<br /><br />**Valid patterns:**<br />- Single language: `"python"`<br />- Multiple languages (comma-separated): `"python, java"`<br />- Negation to exclude languages: `"!csharp"` or `"!(java, python)"` |
 
 ##### Examples
@@ -959,15 +959,14 @@ The target type that you want to apply this deserialization behavior to.
 ##### Examples
 
 ```typespec
+scalar MyStringLike extends string;
 
 model MyModel {
-  scalar stringlike extends string;
-
   @deserializeEmptyStringAsNull
   prop: string;
 
   @deserializeEmptyStringAsNull
-  prop: stringlike;
+  scalarProp: MyStringLike;
 }
 ```
 
@@ -1057,7 +1056,7 @@ op myOperationCustomization(foo: string, bar: string): void;
 
 @@override(MyService.myOperation, myOperationCustomization)
 
-// method signature is now `op myOperation(params: Params)` just for csharp // method signature is now `op myOperation(foo: string, bar: string)`
+// method signature is now `op myOperation(foo: string, bar: string)` with bar as required
 ```
 
 #### `@paramAlias`
@@ -1542,7 +1541,7 @@ model SportsCar extends Vehicle {
 Forces an operation to be treated as a Long Running Operation (LRO) by the SDK generators,
 even when the operation is not long-running on the service side.
 
-NOTE: When used, you will need to verify the operatio and add tests for the generated code
+NOTE: When used, you will need to verify the operation and add tests for the generated code
 to make sure the end-to-end works for library users, since there is a risk that forcing
 this operation to be LRO will result in errors.
 

--- a/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.Legacy.ts
+++ b/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.Legacy.ts
@@ -82,7 +82,7 @@ export type FlattenPropertyDecorator = (
  * Forces an operation to be treated as a Long Running Operation (LRO) by the SDK generators,
  * even when the operation is not long-running on the service side.
  *
- * NOTE: When used, you will need to verify the operatio and add tests for the generated code
+ * NOTE: When used, you will need to verify the operation and add tests for the generated code
  * to make sure the end-to-end works for library users, since there is a risk that forcing
  * this operation to be LRO will result in errors.
  *

--- a/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.ts
+++ b/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.ts
@@ -185,9 +185,6 @@ export type ProtocolAPIDecorator = (
  * @client({service: MyService, name: "MySpecialClient"})
  * interface MyInterface {}
  * ```
- * @example
- *
- *
  */
 export type ClientDecorator = (
   context: DecoratorContext,
@@ -511,7 +508,7 @@ export type AccessDecorator = (
  *
  * @@override(MyService.myOperation, myOperationCustomization)
  *
- * // method signature is now `op myOperation(params: Params)` just for csharp // method signature is now `op myOperation(foo: string, bar: string)`
+ * // method signature is now `op myOperation(foo: string, bar: string)` with bar as required
  * ```
  */
 export type OverrideDecorator = (
@@ -839,8 +836,8 @@ export type ApiVersionDecorator = (
  * This decorator is useful for extending the API version enum exposed by the client.
  * It is particularly beneficial when generating a complete API version enum without requiring the entire specification to be annotated with versioning decorators, as the generation process does not depend on versioning details.
  *
- * @param target The target client for which you want to define additional API versions.
- * @param value If true, we will treat this parameter as an api-version parameter. If false, we will not. Default is true.
+ * @param target The target namespace for which you want to define additional API versions.
+ * @param value An enum containing the API versions that the client should support.
  * @param scope Specifies the target language emitters that the decorator should apply. If not set, the decorator will be applied to all language emitters by default.
  *
  * **Supported language identifiers:** `csharp`, `python`, `java`, `javascript`, `go`, and other language emitter names (derived from the emitter package name, e.g., `@azure-tools/typespec-csharp` → `csharp`).
@@ -885,15 +882,14 @@ export type ClientApiVersionsDecorator = (
  * - Negation to exclude languages: `"!csharp"` or `"!(java, python)"`
  * @example
  * ```typespec
+ * scalar MyStringLike extends string;
  *
  * model MyModel {
- *   scalar stringlike extends string;
- *
  *   @deserializeEmptyStringAsNull
  *   prop: string;
  *
  *   @deserializeEmptyStringAsNull
- *   prop: stringlike;
+ *   scalarProp: MyStringLike;
  * }
  * ```
  */

--- a/packages/typespec-client-generator-core/lib/decorators.tsp
+++ b/packages/typespec-client-generator-core/lib/decorators.tsp
@@ -177,8 +177,6 @@ extern dec protocolAPI(
  * @client({service: MyService, name: "MySpecialClient"})
  * interface MyInterface {}
  * ```
- *
- * @example
  */
 extern dec client(target: Namespace | Interface, options?: ClientOptions, scope?: valueof string);
 
@@ -552,7 +550,7 @@ extern dec access(
  *
  * @@override(MyService.myOperation, myOperationCustomization)
  *
- * // method signature is now `op myOperation(params: Params)` just for csharp // method signature is now `op myOperation(foo: string, bar: string)`
+ * // method signature is now `op myOperation(foo: string, bar: string)` with bar as required
  * ```
  */
 extern dec override(target: Operation, override: Operation, scope?: valueof string);
@@ -918,8 +916,8 @@ extern dec apiVersion(target: ModelProperty, value?: valueof boolean, scope?: va
  * Specify additional API versions that the client can support. These versions should include those defined by the service's versioning configuration.
  * This decorator is useful for extending the API version enum exposed by the client.
  * It is particularly beneficial when generating a complete API version enum without requiring the entire specification to be annotated with versioning decorators, as the generation process does not depend on versioning details.
- * @param target The target client for which you want to define additional API versions.
- * @param value If true, we will treat this parameter as an api-version parameter. If false, we will not. Default is true.
+ * @param target The target namespace for which you want to define additional API versions.
+ * @param value An enum containing the API versions that the client should support.
  * @param scope Specifies the target language emitters that the decorator should apply. If not set, the decorator will be applied to all language emitters by default.
  *
  * **Supported language identifiers:** `csharp`, `python`, `java`, `javascript`, `go`, and other language emitter names (derived from the emitter package name, e.g., `@azure-tools/typespec-csharp` → `csharp`).
@@ -960,15 +958,14 @@ extern dec clientApiVersions(target: Namespace, value: Enum, scope?: valueof str
  *
  * @example
  * ```typespec
+ * scalar MyStringLike extends string;
  *
  * model MyModel {
- *   scalar stringlike extends string;
- *
  *   @deserializeEmptyStringAsNull
  *   prop: string;
  *
  *   @deserializeEmptyStringAsNull
- *   prop: stringlike;
+ *   scalarProp: MyStringLike;
  * }
  * ```
  */

--- a/packages/typespec-client-generator-core/lib/legacy.tsp
+++ b/packages/typespec-client-generator-core/lib/legacy.tsp
@@ -68,7 +68,7 @@ extern dec flattenProperty(target: ModelProperty, scope?: valueof string);
  * Forces an operation to be treated as a Long Running Operation (LRO) by the SDK generators,
  * even when the operation is not long-running on the service side.
  *
- * NOTE: When used, you will need to verify the operatio and add tests for the generated code
+ * NOTE: When used, you will need to verify the operation and add tests for the generated code
  * to make sure the end-to-end works for library users, since there is a risk that forcing
  * this operation to be LRO will result in errors.
  *

--- a/website/src/content/docs/docs/howtos/Generate client libraries/01setup.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/01setup.mdx
@@ -40,3 +40,54 @@ After you've created your customization file, use the command `tsp compile clien
 ```shell
 tsp compile client.tsp
 ```
+
+## Language scoping
+
+Most TCGC decorators accept an optional `scope` parameter that lets you target customizations to specific language emitters. When no scope is specified, the customization applies to all languages.
+
+**Supported language identifiers:** `csharp`, `python`, `java`, `javascript`, `go`
+
+**Valid scope patterns:**
+
+- Single language: `"python"`
+- Multiple languages (comma-separated): `"python, java"`
+- Negation to exclude languages: `"!csharp"` or `"!(java, python)"`
+
+```typespec
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+
+// Rename for all languages
+@@clientName(MyService.MyModel, "RenamedModel");
+
+// Rename only for Python
+@@clientName(MyService.MyModel, "PythonModel", "python");
+
+// Rename for all languages except C#
+@@clientName(MyService.MyModel, "NonCSharpModel", "!csharp");
+```
+
+The `@scope` decorator can also be used on operations and model properties to control which languages include them in the generated SDK:
+
+```typespec
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+
+@service
+namespace MyService;
+
+model MyModel {
+  name: string;
+
+  // This property will only appear in the Python SDK
+  @scope("python")
+  pythonOnlyProp: string;
+}
+
+// This operation will only be generated for Java and C#
+@scope("java, csharp")
+op javaAndCsharpOnly(): void;
+```

--- a/website/src/content/docs/docs/howtos/Generate client libraries/04method.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/04method.mdx
@@ -176,7 +176,7 @@ public final class PetStoreNamespaceClient {
 
 Sometimes it may be useful to still generate the method, but to make it private, so it can be re-used by a manual code wrapper.
 
-The two possible value for the `Access` enum are `internal` and `public`.
+The `@access` decorator accepts values from the `Access` enum: `Access.internal` makes the method and its associated models internal/private, while `Access.public` (the default) keeps them publicly visible. When an operation is marked as `internal`, the models it uses will also be treated as internal unless they are also used by a public operation.
 
 <ClientTabs>
 
@@ -186,7 +186,7 @@ import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
 
-@@access(PetStoreNamespace.GetModel, "internal");
+@@access(PetStoreNamespace.GetModel, Access.internal);
 ```
 
 ```python
@@ -2231,3 +2231,58 @@ Use the `scope` parameter to apply customizations only to specific language emit
 ```
 
 Supported scope values include: `"python"`, `"csharp"`, `"java"`, `"javascript"`, `"go"`.
+
+## HEAD operations as boolean responses
+
+For HEAD operations, you can use the `@responseAsBool` decorator to model the response as a boolean value. When applied, the generated method will return `true` for 2xx responses, `false` for 404 responses, and raise an exception for all other error status codes.
+
+This decorator can only be applied to HEAD operations.
+
+```typespec
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+
+@service
+namespace MyService;
+
+@route("/resources/{name}")
+@head
+@responseAsBool
+op exists(@path name: string): OkResponse | NotFoundResponse;
+```
+
+## Client documentation with `@clientDoc`
+
+The `@clientDoc` decorator allows you to provide client-specific documentation that may differ from the original service documentation. This is useful when the client API needs different wording than the service description.
+
+The decorator supports two modes:
+
+- `DocumentationMode.append`: Adds to the existing documentation (default)
+- `DocumentationMode.replace`: Replaces the existing documentation entirely
+
+```typespec
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+
+@service
+namespace MyService;
+
+/** Gets the resource. */
+@route("/resources/{name}")
+op getResource(@path name: string): Resource;
+
+// Append client-specific details
+@@clientDoc(MyService.getResource,
+  "Returns null if the resource does not exist.",
+  DocumentationMode.append
+);
+
+// Replace documentation entirely for Python
+@@clientDoc(MyService.getResource,
+  "Fetch the named resource from the service.",
+  DocumentationMode.replace,
+  "python"
+);
+```

--- a/website/src/content/docs/docs/howtos/Generate client libraries/05pagingOperations.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/05pagingOperations.mdx
@@ -427,3 +427,89 @@ model Page {
   ]>;
 }
 ```
+
+### Specifying next link HTTP verb with `@nextLinkVerb`
+
+By default, the next link in a paging operation is fetched using a `GET` request. If your service requires a different HTTP verb (e.g., `POST`) to fetch the next page, use the `@nextLinkVerb` decorator from the legacy namespace.
+
+```typespec
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core.Legacy;
+
+@service
+namespace MyService;
+
+model Item {
+  name: string;
+}
+model PagedItems {
+  @pageItems items: Item[];
+  @nextLink nextLink?: string;
+}
+
+@nextLinkVerb("POST")
+@list
+@route("/items")
+op listItems(): PagedItems;
+```
+
+### Forcing an operation to be pageable with `@markAsPageable`
+
+:::caution
+This is a legacy decorator. Use standard TypeSpec paging patterns (`@list` with `@pageItems`) for new services.
+:::
+
+The `@markAsPageable` decorator forces an operation to be treated as pageable even when it doesn't follow standard paging patterns. The response model must contain an array property (marked with `@pageItems` or named `value`).
+
+```typespec
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core.Legacy;
+
+@service
+namespace MyService;
+
+model Item {
+  name: string;
+}
+model ItemListResult {
+  @pageItems value: Item[];
+  nextLink?: string;
+}
+
+@markAsPageable
+@route("/items")
+op listItems(): ItemListResult;
+```
+
+### Disabling paging with `@disablePageable`
+
+:::caution
+This is a legacy decorator. Consider using standard non-paging patterns for new services.
+:::
+
+The `@disablePageable` decorator prevents an operation from being treated as pageable, even when it follows standard paging patterns. The generated method will return the full result model instead of an iterator over items.
+
+```typespec
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core.Legacy;
+
+@service
+namespace MyService;
+
+model Item {
+  name: string;
+}
+model ItemListResult {
+  @pageItems value: Item[];
+  nextLink?: string;
+}
+
+@disablePageable
+@list
+@route("/items")
+op listItems(): ItemListResult;
+// Generated method will return ItemListResult directly, not an iterator of Item
+```

--- a/website/src/content/docs/docs/howtos/Generate client libraries/06longRunningOperations.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/06longRunningOperations.mdx
@@ -268,3 +268,32 @@ func (c *Client) BeginExportUser(ctx context.Context, name string, format string
 ```
 
 </ClientTabs>
+
+## Forcing an operation to be LRO with `@markAsLro`
+
+:::caution
+This is a legacy decorator from `Azure.ClientGenerator.Core.Legacy`. Use standard TypeSpec LRO patterns (e.g., `@pollingOperation`) for new services when possible.
+:::
+
+The `@markAsLro` decorator forces an operation to be treated as a Long Running Operation by SDK generators, even when the operation does not follow standard LRO patterns. When applied, SDK generators will generate polling mechanisms (pollers), return LRO-specific return types, and handle the operation as an asynchronous long-running process.
+
+> **NOTE:** When used, you will need to verify the operation and add tests for the generated code to ensure end-to-end correctness, since forcing an operation to be LRO may result in unexpected behavior.
+
+```typespec
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core.Legacy;
+
+@service
+namespace MyService;
+
+model DeploymentResult {
+  id: string;
+  status: string;
+}
+
+@markAsLro
+@route("/deployments/{deploymentId}")
+@post
+op startDeployment(@path deploymentId: string): DeploymentResult;
+```

--- a/website/src/content/docs/docs/howtos/Generate client libraries/08types.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/08types.mdx
@@ -2628,3 +2628,30 @@ jsonWriter.writeStringField("prop", Objects.toString(this.value, null));
 </ClientTabItem>
 </ClientTabs>
 ```
+
+## Deserializing Empty Strings as Null
+
+The `@deserializeEmptyStringAsNull` decorator indicates that a string property (or a scalar type derived from `string`) should deserialize empty string values (`""`) as `null`. This is useful for services that return empty strings instead of null for absent values.
+
+```typespec
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+
+@service
+namespace MyService;
+
+scalar MyUrl extends string;
+
+model Resource {
+  name: string;
+
+  @deserializeEmptyStringAsNull
+  description?: string;
+
+  @deserializeEmptyStringAsNull
+  homepage?: MyUrl;
+}
+```
+
+When the service returns `{"name": "test", "description": "", "homepage": ""}`, the generated client will deserialize `description` and `homepage` as `null` instead of empty strings.

--- a/website/src/content/docs/docs/howtos/Generate client libraries/10versioning.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/10versioning.mdx
@@ -944,3 +944,35 @@ func (client *ServiceClient) Get(ctx context.Context, version Versions, options 
 ```
 
 </ClientTabs>
+
+## Extending Client API Versions with `@clientApiVersions`
+
+The `@clientApiVersions` decorator allows you to specify additional API versions that the client should support beyond those defined by the service's `@versioned` configuration. This is useful when you want to extend the API version enum exposed by the client — for example, to include older versions that the spec doesn't annotate with versioning decorators.
+
+```typespec
+import "@typespec/versioning";
+import "@azure-tools/typespec-client-generator-core";
+
+using Versioning;
+using Azure.ClientGenerator.Core;
+
+// The service only defines v4 and v5
+@versioned(Versions)
+@service
+namespace Contoso;
+enum Versions {
+  v4,
+  v5,
+}
+
+// But the client should also support older versions
+enum ClientVersions {
+  v1,
+  v2,
+  v3,
+  ...Contoso.Versions,
+}
+
+@@clientApiVersions(Contoso, ClientVersions);
+// The generated client will expose versions v1 through v5
+```

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/decorators.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/decorators.md
@@ -378,14 +378,14 @@ It is particularly beneficial when generating a complete API version enum withou
 
 #### Target
 
-The target client for which you want to define additional API versions.
+The target namespace for which you want to define additional API versions.
 `Namespace`
 
 #### Parameters
 
 | Name  | Type             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
 | ----- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| value | `Enum`           | If true, we will treat this parameter as an api-version parameter. If false, we will not. Default is true.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| value | `Enum`           | An enum containing the API versions that the client should support.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
 | scope | `valueof string` | Specifies the target language emitters that the decorator should apply. If not set, the decorator will be applied to all language emitters by default.<br /><br />**Supported language identifiers:** `csharp`, `python`, `java`, `javascript`, `go`, and other language emitter names (derived from the emitter package name, e.g., `@azure-tools/typespec-csharp` → `csharp`).<br /><br />**Valid patterns:**<br />- Single language: `"python"`<br />- Multiple languages (comma-separated): `"python, java"`<br />- Negation to exclude languages: `"!csharp"` or `"!(java, python)"` |
 
 #### Examples
@@ -832,15 +832,14 @@ The target type that you want to apply this deserialization behavior to.
 #### Examples
 
 ```typespec
+scalar MyStringLike extends string;
 
 model MyModel {
-  scalar stringlike extends string;
-
   @deserializeEmptyStringAsNull
   prop: string;
 
   @deserializeEmptyStringAsNull
-  prop: stringlike;
+  scalarProp: MyStringLike;
 }
 ```
 
@@ -930,7 +929,7 @@ op myOperationCustomization(foo: string, bar: string): void;
 
 @@override(MyService.myOperation, myOperationCustomization)
 
-// method signature is now `op myOperation(params: Params)` just for csharp // method signature is now `op myOperation(foo: string, bar: string)`
+// method signature is now `op myOperation(foo: string, bar: string)` with bar as required
 ```
 
 ### `@paramAlias` {#@Azure.ClientGenerator.Core.paramAlias}
@@ -1407,7 +1406,7 @@ model SportsCar extends Vehicle {
 Forces an operation to be treated as a Long Running Operation (LRO) by the SDK generators,
 even when the operation is not long-running on the service side.
 
-NOTE: When used, you will need to verify the operatio and add tests for the generated code
+NOTE: When used, you will need to verify the operation and add tests for the generated code
 to make sure the end-to-end works for library users, since there is a risk that forcing
 this operation to be LRO will result in errors.
 


### PR DESCRIPTION
- Fix @clientApiVersions param doc (was copied from @apiVersion, described boolean instead of Enum)
- Fix @deserializeEmptyStringAsNull example (scalar was inside model, invalid syntax)
- Fix @markAsLro typo ('operatio' -> 'operation')
- Remove empty @example tag from @client decorator
- Fix @override malformed comment
- Fix @access usage in docs to use Access.internal enum instead of string
- Add language scoping (@scope) documentation to setup guide
- Add @responseAsBool documentation to methods guide
- Add @clientDoc documentation to methods guide
- Add @nextLinkVerb, @markAsPageable, @disablePageable to paging guide
- Add @markAsLro to LRO guide
- Add @clientApiVersions to versioning guide
- Add @deserializeEmptyStringAsNull to types guide
- Add Spector specs for @convenientAPI/@protocolAPI, @scope, @responseAsBool, @clientDoc
- Create TCGC documentation knowledge base

Resolve: https://github.com/Azure/typespec-azure/issues/4202