### PR TITLE
[typespec-metadata] Group emitter output by language

### DIFF
--- a/.chronus/changes/metadata-group-emitters-by-language-2026-04-09.md
+++ b/.chronus/changes/metadata-group-emitters-by-language-2026-04-09.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-metadata"
+---
+
+Dummy

--- a/packages/typespec-metadata/CHANGELOG.md
+++ b/packages/typespec-metadata/CHANGELOG.md
@@ -1,5 +1,9 @@
 # @azure-tools/typespec-metadata
 
+## 0.2.0
+- Group emitters by normalized language key in the `languages` output. Each language key now maps to an array of emitter configs instead of a single config, allowing multiple emitters per language (e.g. two C# emitters). Unrecognized emitters are grouped under `"unknown"`. Language is inferred by heuristic when the emitter is not in the built-in registry.
+
+
 ## 0.1.3
 - Fixes issue with azurev2 flavored package names.
 

--- a/packages/typespec-metadata/package.json
+++ b/packages/typespec-metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-metadata",
-  "version": "0.1.3",
+  "version": "0.2.0",
   "description": "TypeSpec emitter that produces structured metadata snapshots for APIView and other tooling.",
   "type": "module",
   "license": "MIT",

--- a/packages/typespec-metadata/src/collector.ts
+++ b/packages/typespec-metadata/src/collector.ts
@@ -97,6 +97,16 @@ const LANGUAGE_HEURISTICS: Array<[RegExp, string]> = [
   [/\bgo\b/i, "go"],
 ];
 
+/** Maps a normalized language key to its parser so heuristic matches can reuse language-specific logic. */
+const LANGUAGE_PARSERS: Record<string, LanguageParser> = {
+  csharp: parseCSharp,
+  java: parseJava,
+  python: parsePython,
+  typescript: parseTypeScript,
+  go: parseGo,
+  rust: parseRust,
+};
+
 interface LanguageParserResult {
   packageName?: string;
   namespace?: string;
@@ -539,9 +549,18 @@ function createLanguageMetadata(
     packageName = result.packageName;
     namespace = result.namespace;
   } else {
-    // Fallback to generic extraction
-    packageName = extractOption(normalizedOptions, PACKAGE_NAME_KEYS);
-    namespace = extractOption(normalizedOptions, NAMESPACE_KEYS);
+    // Try heuristic language match to pick a language-specific parser
+    const heuristicLang = inferLanguageFromEmitterName(emitterName);
+    const heuristicParser = LANGUAGE_PARSERS[heuristicLang];
+    if (heuristicParser) {
+      const result = heuristicParser(normalizedOptions, params);
+      packageName = result.packageName;
+      namespace = result.namespace;
+    } else {
+      // Fallback to generic extraction
+      packageName = extractOption(normalizedOptions, PACKAGE_NAME_KEYS);
+      namespace = extractOption(normalizedOptions, NAMESPACE_KEYS);
+    }
   }
 
   // Convert outputDir to use {output-dir} placeholder

--- a/packages/typespec-metadata/src/collector.ts
+++ b/packages/typespec-metadata/src/collector.ts
@@ -59,28 +59,9 @@ function extractParameters(
   return params;
 }
 
-interface EmitterRegistration {
-  language: string;
-  parser: LanguageParser;
-}
-
-const EMITTER_REGISTRY: Record<string, EmitterRegistration> = {
-  "@azure-tools/typespec-csharp": { language: "csharp", parser: parseCSharp },
-  "@azure-tools/typespec-java": { language: "java", parser: parseJava },
-  "@azure-tools/typespec-python": { language: "python", parser: parsePython },
-  "@azure-tools/typespec-ts": { language: "typescript", parser: parseTypeScript },
-  "@azure-tools/typespec-go": { language: "go", parser: parseGo },
-  "@azure-tools/typespec-rust": { language: "rust", parser: parseRust },
-  "@azure-typespec/http-client-csharp": { language: "csharp", parser: parseCSharp },
-  "@azure-typespec/http-client-csharp-mgmt": {
-    language: "csharp",
-    parser: parseCSharp,
-  },
-};
-
 /**
  * Heuristic patterns used to infer a normalized language key from an emitter
- * package name when the emitter is not found in EMITTER_REGISTRY.
+ * package name.
  *
  * Order matters: more specific patterns (e.g. "typescript") must precede
  * shorter ones (e.g. "java") to avoid false positives ("javascript" matching
@@ -90,6 +71,7 @@ const LANGUAGE_HEURISTICS: Array<[RegExp, string]> = [
   [/csharp/i, "csharp"],
   [/python/i, "python"],
   [/typescript/i, "typescript"],
+  [/\bts\b/i, "typescript"],
   [/javascript/i, "javascript"],
   [/java(?!script)/i, "java"],
   [/\brust\b/i, "rust"],
@@ -541,26 +523,17 @@ function createLanguageMetadata(
   let packageName: string | undefined;
   let namespace: string | undefined;
 
-  const normalizedEmitterName = emitterName.toLowerCase();
-  const registration = EMITTER_REGISTRY[normalizedEmitterName];
-
-  if (registration) {
-    const result = registration.parser(normalizedOptions, params);
+  // Use heuristic language match to pick a language-specific parser
+  const heuristicLang = inferLanguageFromEmitterName(emitterName);
+  const heuristicParser = LANGUAGE_PARSERS[heuristicLang];
+  if (heuristicParser) {
+    const result = heuristicParser(normalizedOptions, params);
     packageName = result.packageName;
     namespace = result.namespace;
   } else {
-    // Try heuristic language match to pick a language-specific parser
-    const heuristicLang = inferLanguageFromEmitterName(emitterName);
-    const heuristicParser = LANGUAGE_PARSERS[heuristicLang];
-    if (heuristicParser) {
-      const result = heuristicParser(normalizedOptions, params);
-      packageName = result.packageName;
-      namespace = result.namespace;
-    } else {
-      // Fallback to generic extraction
-      packageName = extractOption(normalizedOptions, PACKAGE_NAME_KEYS);
-      namespace = extractOption(normalizedOptions, NAMESPACE_KEYS);
-    }
+    // Fallback to generic extraction
+    packageName = extractOption(normalizedOptions, PACKAGE_NAME_KEYS);
+    namespace = extractOption(normalizedOptions, NAMESPACE_KEYS);
   }
 
   // Convert outputDir to use {output-dir} placeholder
@@ -632,10 +605,6 @@ function normalizeKey(key: string): string {
 
 export function inferLanguageFromEmitterName(emitterName: string): string {
   const normalized = emitterName.toLowerCase();
-  const registration = EMITTER_REGISTRY[normalized];
-  if (registration) {
-    return registration.language;
-  }
 
   // Heuristic: scan the emitter name for known language keywords
   for (const [pattern, language] of LANGUAGE_HEURISTICS) {

--- a/packages/typespec-metadata/src/collector.ts
+++ b/packages/typespec-metadata/src/collector.ts
@@ -71,12 +71,31 @@ const EMITTER_REGISTRY: Record<string, EmitterRegistration> = {
   "@azure-tools/typespec-ts": { language: "typescript", parser: parseTypeScript },
   "@azure-tools/typespec-go": { language: "go", parser: parseGo },
   "@azure-tools/typespec-rust": { language: "rust", parser: parseRust },
-  "@azure-typespec/http-client-csharp": { language: "http-client-csharp", parser: parseCSharp },
+  "@azure-typespec/http-client-csharp": { language: "csharp", parser: parseCSharp },
   "@azure-typespec/http-client-csharp-mgmt": {
-    language: "http-client-csharp-mgmt",
+    language: "csharp",
     parser: parseCSharp,
   },
 };
+
+/**
+ * Heuristic patterns used to infer a normalized language key from an emitter
+ * package name when the emitter is not found in EMITTER_REGISTRY.
+ *
+ * Order matters: more specific patterns (e.g. "typescript") must precede
+ * shorter ones (e.g. "java") to avoid false positives ("javascript" matching
+ * "java").
+ */
+const LANGUAGE_HEURISTICS: Array<[RegExp, string]> = [
+  [/csharp/i, "csharp"],
+  [/python/i, "python"],
+  [/typescript/i, "typescript"],
+  [/javascript/i, "javascript"],
+  [/java(?!script)/i, "java"],
+  [/\brust\b/i, "rust"],
+  [/\bswift\b/i, "swift"],
+  [/\bgo\b/i, "go"],
+];
 
 interface LanguageParserResult {
   packageName?: string;
@@ -300,7 +319,7 @@ function parseRust(
 }
 
 export interface LanguageCollectionResult {
-  languages: Record<string, LanguagePackageMetadata>;
+  languages: Record<string, LanguagePackageMetadata[]>;
   sourceConfigPath?: string;
 }
 
@@ -469,8 +488,8 @@ export function buildLanguageMetadata(
   params: Record<string, unknown>,
   baseOutputDir: string,
   defaultServiceDir?: string,
-): Record<string, LanguagePackageMetadata> {
-  const languagesDict: Record<string, LanguagePackageMetadata> = {};
+): Record<string, LanguagePackageMetadata[]> {
+  const languagesDict: Record<string, LanguagePackageMetadata[]> = {};
 
   for (const [emitterName, emitterOptions] of Object.entries(optionMap)) {
     const metadata = createLanguageMetadata(
@@ -481,7 +500,10 @@ export function buildLanguageMetadata(
       defaultServiceDir,
     );
     const language = inferLanguageFromEmitterName(emitterName);
-    languagesDict[language] = metadata;
+    if (!languagesDict[language]) {
+      languagesDict[language] = [];
+    }
+    languagesDict[language].push(metadata);
   }
 
   return languagesDict;
@@ -596,7 +618,14 @@ export function inferLanguageFromEmitterName(emitterName: string): string {
     return registration.language;
   }
 
-  return emitterName;
+  // Heuristic: scan the emitter name for known language keywords
+  for (const [pattern, language] of LANGUAGE_HEURISTICS) {
+    if (pattern.test(normalized)) {
+      return language;
+    }
+  }
+
+  return "unknown";
 }
 
 function trimOrUndefined(value: string | undefined): string | undefined {

--- a/packages/typespec-metadata/src/metadata.ts
+++ b/packages/typespec-metadata/src/metadata.ts
@@ -29,8 +29,8 @@ export interface MetadataSnapshot {
   generatedAt: string;
   /** TypeSpec-level metadata (namespace, documentation, type). */
   typespec: TypeSpecMetadata;
-  /** Per-language package metadata extracted from tspconfig, keyed by language. */
-  languages: Record<string, LanguagePackageMetadata>;
+  /** Per-language package metadata extracted from tspconfig, keyed by normalized language name. Each language maps to an array of emitter configs. Emitters that cannot be linked to a known language are grouped under "unknown". */
+  languages: Record<string, LanguagePackageMetadata[]>;
   /** Absolute tspconfig path when available. */
   sourceConfigPath?: string;
 }

--- a/packages/typespec-metadata/test/collector.test.ts
+++ b/packages/typespec-metadata/test/collector.test.ts
@@ -400,7 +400,8 @@ describe("inferLanguageFromEmitterName", () => {
     expect(inferLanguageFromEmitterName("@azure-tools/typespec-go")).toBe("go");
     expect(inferLanguageFromEmitterName("@azure-tools/typespec-rust")).toBe("rust");
     expect(inferLanguageFromEmitterName("@azure-typespec/http-client-csharp")).toBe("csharp");
-    expect(inferLanguageFromEmitterName("@azure-typespec/http-client-csharp-mgmt")).toBe(
+    expect(inferLanguageFromEmitterName("@azure-typespec/http-client-csharp-mgmt")).toBe("csharp");
+    expect(inferLanguageFromEmitterName("@azure-typespec/http-client-csharp-provisioning")).toBe(
       "csharp",
     );
   });
@@ -507,6 +508,65 @@ describe("@azure-typespec/http-client-csharp emitter", () => {
     const lang = result["csharp"][0];
 
     expect(lang.outputDir).toBe("{output-dir}/sdk/keyvault/Azure.Security.KeyVault");
+  });
+});
+
+describe("@azure-typespec/http-client-csharp-provisioning emitter", () => {
+  it("should parse namespace from provisioning emitter options", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-typespec/http-client-csharp-provisioning": {
+        namespace: "Azure.Provisioning.WeightsAndBiases",
+        "emitter-output-dir":
+          "c:/repos/tsp-output/sdk/weightsandbiases/Azure.Provisioning.WeightsAndBiases",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
+    const lang = result["csharp"][0];
+
+    expect(lang).toBeDefined();
+    expect(lang.namespace).toBe("Azure.Provisioning.WeightsAndBiases");
+    expect(lang.packageName).toBe("Azure.Provisioning.WeightsAndBiases");
+    expect(lang.emitterName).toBe("@azure-typespec/http-client-csharp-provisioning");
+  });
+
+  it("should resolve {namespace} placeholder in emitter-output-dir", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-typespec/http-client-csharp-provisioning": {
+        namespace: "Azure.Provisioning.WeightsAndBiases",
+        "emitter-output-dir": "c:/repos/tsp-output/sdk/weightsandbiases/{namespace}",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
+    const lang = result["csharp"][0];
+
+    expect(lang.outputDir).toBe(
+      "{output-dir}/sdk/weightsandbiases/Azure.Provisioning.WeightsAndBiases",
+    );
+  });
+
+  it("should resolve {namespace} with service-dir in emitter-output-dir", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-typespec/http-client-csharp-provisioning": {
+        namespace: "Azure.Provisioning.HealthDataAIServices",
+        "emitter-output-dir":
+          "c:/repos/tsp-output/sdk/healthdataaiservices/Azure.Provisioning.HealthDataAIServices",
+      },
+    };
+
+    const result = buildLanguageMetadata(
+      optionMap,
+      {},
+      "c:/repos/tsp-output",
+      "sdk/healthdataaiservices",
+    );
+    const lang = result["csharp"][0];
+
+    expect(lang.namespace).toBe("Azure.Provisioning.HealthDataAIServices");
+    expect(lang.outputDir).toBe(
+      "{output-dir}/sdk/healthdataaiservices/Azure.Provisioning.HealthDataAIServices",
+    );
   });
 });
 

--- a/packages/typespec-metadata/test/collector.test.ts
+++ b/packages/typespec-metadata/test/collector.test.ts
@@ -155,7 +155,7 @@ describe("language-specific parsers", () => {
     };
 
     const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
-    const lang = result["java"];
+    const lang = result["java"][0];
 
     // Package name should include the Maven groupId prefix
     expect(lang.packageName).toBe("com.azure:azure-security-keyvault-secrets");
@@ -170,7 +170,7 @@ describe("language-specific parsers", () => {
     };
 
     const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
-    const lang = result["java"];
+    const lang = result["java"][0];
 
     expect(lang.packageName).toBe("com.azure.resourcemanager:azure-resourcemanager-frontdoor");
     expect(lang.namespace).toBe("com.azure.resourcemanager.frontdoor");
@@ -185,7 +185,7 @@ describe("language-specific parsers", () => {
     };
 
     const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
-    const lang = result["java"];
+    const lang = result["java"][0];
 
     expect(lang.packageName).toBe("com.azure.v2:azure-ai-agents");
     expect(lang.namespace).toBe("com.azure.ai.agents");
@@ -202,7 +202,7 @@ describe("language-specific parsers", () => {
     };
 
     const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
-    const lang = result["java"];
+    const lang = result["java"][0];
 
     expect(lang.packageName).toBe("com.azure.v2:azure-security-keyvault-administration");
     expect(lang.namespace).toBe("com.azure.v2.security.keyvault.administration");
@@ -217,7 +217,7 @@ describe("language-specific parsers", () => {
     };
 
     const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
-    const lang = result["java"];
+    const lang = result["java"][0];
 
     expect(lang.packageName).toBe("com.azure.resourcemanager.v2:azure-resourcemanager-cdn");
     expect(lang.namespace).toBe("com.azure.resourcemanager.cdn");
@@ -234,7 +234,7 @@ describe("language-specific parsers", () => {
     };
 
     const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
-    const lang = result["java"];
+    const lang = result["java"][0];
 
     expect(lang.packageName).toBe("com.azure.resourcemanager.v2:azure-resourcemanager-cdn");
     expect(lang.namespace).toBe("com.azure.resourcemanager.v2.cdn");
@@ -249,7 +249,7 @@ describe("language-specific parsers", () => {
     };
 
     const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
-    const lang = result["java"];
+    const lang = result["java"][0];
 
     // Explicit package-name should also get the groupId prefix
     expect(lang.packageName).toBe("com.azure:azure-storage-blobs");
@@ -264,7 +264,7 @@ describe("language-specific parsers", () => {
     };
 
     const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
-    const lang = result["java"];
+    const lang = result["java"][0];
 
     // Already has groupId:artifactId format – should not be modified
     expect(lang.packageName).toBe("com.azure.spring:azure-spring-data-cosmos");
@@ -386,12 +386,10 @@ describe("namespace selection logic", () => {
 });
 
 describe("inferLanguageFromEmitterName", () => {
-  it("should return full emitter name for unrecognized emitters", () => {
-    // Emitters not in EMITTER_REGISTRY should use the full emitter name as the language key.
-    expect(inferLanguageFromEmitterName("@unknown/some-emitter")).toBe("@unknown/some-emitter");
-    expect(inferLanguageFromEmitterName("@azure-tools/typespec-swift")).toBe(
-      "@azure-tools/typespec-swift",
-    );
+  it("should return 'unknown' for unrecognized emitters with no language keyword", () => {
+    expect(inferLanguageFromEmitterName("@unknown/some-emitter")).toBe("unknown");
+    expect(inferLanguageFromEmitterName("@typespec/openapi3")).toBe("unknown");
+    expect(inferLanguageFromEmitterName("@typespec/json-schema")).toBe("unknown");
   });
 
   it("should return known alias for registered emitters", () => {
@@ -401,12 +399,23 @@ describe("inferLanguageFromEmitterName", () => {
     expect(inferLanguageFromEmitterName("@azure-tools/typespec-ts")).toBe("typescript");
     expect(inferLanguageFromEmitterName("@azure-tools/typespec-go")).toBe("go");
     expect(inferLanguageFromEmitterName("@azure-tools/typespec-rust")).toBe("rust");
-    expect(inferLanguageFromEmitterName("@azure-typespec/http-client-csharp")).toBe(
-      "http-client-csharp",
-    );
+    expect(inferLanguageFromEmitterName("@azure-typespec/http-client-csharp")).toBe("csharp");
     expect(inferLanguageFromEmitterName("@azure-typespec/http-client-csharp-mgmt")).toBe(
-      "http-client-csharp-mgmt",
+      "csharp",
     );
+  });
+
+  it("should infer language by heuristic for unregistered emitters", () => {
+    expect(inferLanguageFromEmitterName("@typespec/http-client-csharp")).toBe("csharp");
+    expect(inferLanguageFromEmitterName("@azure-tools/typespec-swift")).toBe("swift");
+    expect(inferLanguageFromEmitterName("@contoso/typespec-python-experimental")).toBe("python");
+    expect(inferLanguageFromEmitterName("@contoso/some-java-emitter")).toBe("java");
+    expect(inferLanguageFromEmitterName("@contoso/some-javascript-emitter")).toBe("javascript");
+  });
+
+  it("should not match 'java' inside 'javascript'", () => {
+    expect(inferLanguageFromEmitterName("@contoso/javascript-emitter")).toBe("javascript");
+    expect(inferLanguageFromEmitterName("@contoso/javascript-emitter")).not.toBe("java");
   });
 });
 
@@ -421,7 +430,7 @@ describe("@azure-typespec/http-client-csharp-mgmt emitter", () => {
     };
 
     const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
-    const lang = result["http-client-csharp-mgmt"];
+    const lang = result["csharp"][0];
 
     expect(lang).toBeDefined();
     expect(lang.namespace).toBe("Azure.ResourceManager.WeightsAndBiases");
@@ -438,7 +447,7 @@ describe("@azure-typespec/http-client-csharp-mgmt emitter", () => {
     };
 
     const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
-    const lang = result["http-client-csharp-mgmt"];
+    const lang = result["csharp"][0];
 
     expect(lang.outputDir).toBe(
       "{output-dir}/sdk/weightsandbiases/Azure.ResourceManager.WeightsAndBiases",
@@ -460,7 +469,7 @@ describe("@azure-typespec/http-client-csharp-mgmt emitter", () => {
       "c:/repos/tsp-output",
       "sdk/healthdataaiservices",
     );
-    const lang = result["http-client-csharp-mgmt"];
+    const lang = result["csharp"][0];
 
     expect(lang.namespace).toBe("Azure.ResourceManager.HealthDataAIServices");
     expect(lang.outputDir).toBe(
@@ -479,7 +488,7 @@ describe("@azure-typespec/http-client-csharp emitter", () => {
     };
 
     const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
-    const lang = result["http-client-csharp"];
+    const lang = result["csharp"][0];
 
     expect(lang).toBeDefined();
     expect(lang.namespace).toBe("Azure.Security.KeyVault");
@@ -495,8 +504,59 @@ describe("@azure-typespec/http-client-csharp emitter", () => {
     };
 
     const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
-    const lang = result["http-client-csharp"];
+    const lang = result["csharp"][0];
 
     expect(lang.outputDir).toBe("{output-dir}/sdk/keyvault/Azure.Security.KeyVault");
+  });
+});
+
+describe("multiple emitters per language", () => {
+  it("should group two C# emitters under the same 'csharp' key", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@typespec/http-client-csharp": {
+        "package-name": "Azure.AI.Projects",
+        "emitter-output-dir": "c:/repos/tsp-output/sdk/ai/Azure.AI.Projects",
+      },
+      "@azure-tools/typespec-csharp": {
+        "package-name": "Azure.AI.Agents.Contracts.V2",
+        namespace: "Azure.AI.Agents.Contracts.V2",
+        "emitter-output-dir": "c:/repos/tsp-output/sdk/ai/Azure.AI.Agents.Contracts.V2",
+        flavor: "azure",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
+
+    expect(result["csharp"]).toHaveLength(2);
+    expect(result["csharp"][0].emitterName).toBe("@typespec/http-client-csharp");
+    expect(result["csharp"][0].packageName).toBe("Azure.AI.Projects");
+    expect(result["csharp"][1].emitterName).toBe("@azure-tools/typespec-csharp");
+    expect(result["csharp"][1].packageName).toBe("Azure.AI.Agents.Contracts.V2");
+  });
+
+  it("should produce array of one for single-emitter languages", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-python": {
+        "package-name": "azure-keyvault-secrets",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+
+    expect(result["python"]).toHaveLength(1);
+    expect(result["python"][0].packageName).toBe("azure-keyvault-secrets");
+  });
+
+  it("should group unrecognized emitters under 'unknown'", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@typespec/openapi3": {},
+      "@typespec/json-schema": {},
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+
+    expect(result["unknown"]).toHaveLength(2);
+    expect(result["unknown"][0].emitterName).toBe("@typespec/openapi3");
+    expect(result["unknown"][1].emitterName).toBe("@typespec/json-schema");
   });
 });

--- a/packages/typespec-metadata/test/metadata.test.ts
+++ b/packages/typespec-metadata/test/metadata.test.ts
@@ -79,44 +79,75 @@ describe("TypeSpecMetadata structure", () => {
 
 describe("LanguagePackageMetadata structure", () => {
   it("should use language name as dictionary key", () => {
-    const languages: Record<string, LanguagePackageMetadata> = {
-      python: {
-        emitterName: "@azure-tools/typespec-python",
-        packageName: "azure-keyvault-secrets",
-        namespace: "azure.keyvault.secrets",
-        outputDir: "{output-dir}/sdk/keyvault/azure-keyvault-secrets",
-        flavor: "azure",
-        serviceDir: "sdk/keyvault",
-      },
+    const languages: Record<string, LanguagePackageMetadata[]> = {
+      python: [
+        {
+          emitterName: "@azure-tools/typespec-python",
+          packageName: "azure-keyvault-secrets",
+          namespace: "azure.keyvault.secrets",
+          outputDir: "{output-dir}/sdk/keyvault/azure-keyvault-secrets",
+          flavor: "azure",
+          serviceDir: "sdk/keyvault",
+        },
+      ],
     };
 
     expect(languages).toHaveProperty("python");
-    expect(languages.python.packageName).toBe("azure-keyvault-secrets");
+    expect(languages.python[0].packageName).toBe("azure-keyvault-secrets");
   });
 
   it("should support multiple languages", () => {
-    const languages: Record<string, LanguagePackageMetadata> = {
-      python: {
-        emitterName: "@azure-tools/typespec-python",
-        packageName: "azure-keyvault-secrets",
-        namespace: "azure.keyvault.secrets",
-        outputDir: "{output-dir}/sdk/keyvault/azure-keyvault-secrets",
-        flavor: "azure",
-        serviceDir: "sdk/keyvault",
-      },
-      java: {
-        emitterName: "@azure-tools/typespec-java",
-        packageName: "com.azure:azure-security-keyvault-secrets",
-        namespace: "com.azure.security.keyvault.secrets",
-        outputDir: "{output-dir}/sdk/keyvault/azure-security-keyvault-secrets",
-        flavor: "azure",
-        serviceDir: "sdk/keyvault",
-      },
+    const languages: Record<string, LanguagePackageMetadata[]> = {
+      python: [
+        {
+          emitterName: "@azure-tools/typespec-python",
+          packageName: "azure-keyvault-secrets",
+          namespace: "azure.keyvault.secrets",
+          outputDir: "{output-dir}/sdk/keyvault/azure-keyvault-secrets",
+          flavor: "azure",
+          serviceDir: "sdk/keyvault",
+        },
+      ],
+      java: [
+        {
+          emitterName: "@azure-tools/typespec-java",
+          packageName: "com.azure:azure-security-keyvault-secrets",
+          namespace: "com.azure.security.keyvault.secrets",
+          outputDir: "{output-dir}/sdk/keyvault/azure-security-keyvault-secrets",
+          flavor: "azure",
+          serviceDir: "sdk/keyvault",
+        },
+      ],
     };
 
     expect(Object.keys(languages)).toHaveLength(2);
     expect(languages).toHaveProperty("python");
     expect(languages).toHaveProperty("java");
+  });
+
+  it("should support multiple emitters under the same language", () => {
+    const languages: Record<string, LanguagePackageMetadata[]> = {
+      csharp: [
+        {
+          emitterName: "@typespec/http-client-csharp",
+          packageName: "Azure.AI.Projects",
+          outputDir: "{output-dir}/sdk/ai/Azure.AI.Projects",
+          serviceDir: "sdk/ai",
+        },
+        {
+          emitterName: "@azure-tools/typespec-csharp",
+          packageName: "Azure.AI.Agents.Contracts.V2",
+          namespace: "Azure.AI.Agents.Contracts.V2",
+          outputDir: "{output-dir}/sdk/ai/Azure.AI.Agents.Contracts.V2",
+          flavor: "azure",
+          serviceDir: "sdk/ai",
+        },
+      ],
+    };
+
+    expect(languages.csharp).toHaveLength(2);
+    expect(languages.csharp[0].emitterName).toBe("@typespec/http-client-csharp");
+    expect(languages.csharp[1].emitterName).toBe("@azure-tools/typespec-csharp");
   });
 
   it("should use {output-dir} placeholder in outputDir", () => {
@@ -145,25 +176,29 @@ describe("LanguagePackageMetadata structure", () => {
   });
 
   it("should support language-specific service-dir", () => {
-    const languages: Record<string, LanguagePackageMetadata> = {
-      go: {
-        emitterName: "@azure-tools/typespec-go",
-        packageName: "sdk/security/keyvault/azsecrets",
-        namespace: "sdk/security/keyvault/azsecrets",
-        outputDir: "{output-dir}/sdk/security/keyvault/azsecrets",
-        serviceDir: "sdk/security/keyvault", // Different from other languages
-      },
-      python: {
-        emitterName: "@azure-tools/typespec-python",
-        packageName: "azure-keyvault-secrets",
-        namespace: "azure.keyvault.secrets",
-        outputDir: "{output-dir}/sdk/keyvault/azure-keyvault-secrets",
-        serviceDir: "sdk/keyvault", // Default service-dir
-      },
+    const languages: Record<string, LanguagePackageMetadata[]> = {
+      go: [
+        {
+          emitterName: "@azure-tools/typespec-go",
+          packageName: "sdk/security/keyvault/azsecrets",
+          namespace: "sdk/security/keyvault/azsecrets",
+          outputDir: "{output-dir}/sdk/security/keyvault/azsecrets",
+          serviceDir: "sdk/security/keyvault", // Different from other languages
+        },
+      ],
+      python: [
+        {
+          emitterName: "@azure-tools/typespec-python",
+          packageName: "azure-keyvault-secrets",
+          namespace: "azure.keyvault.secrets",
+          outputDir: "{output-dir}/sdk/keyvault/azure-keyvault-secrets",
+          serviceDir: "sdk/keyvault", // Default service-dir
+        },
+      ],
     };
 
-    expect(languages.go.serviceDir).toBe("sdk/security/keyvault");
-    expect(languages.python.serviceDir).toBe("sdk/keyvault");
+    expect(languages.go[0].serviceDir).toBe("sdk/security/keyvault");
+    expect(languages.python[0].serviceDir).toBe("sdk/keyvault");
   });
 });
 
@@ -179,30 +214,36 @@ describe("Complete snapshot example", () => {
         type: "data",
       },
       languages: {
-        python: {
-          emitterName: "@azure-tools/typespec-python",
-          packageName: "azure-keyvault-secrets",
-          namespace: "azure.keyvault.secrets",
-          outputDir: "{output-dir}/sdk/keyvault/azure-keyvault-secrets",
-          flavor: "azure",
-          serviceDir: "sdk/keyvault",
-        },
-        java: {
-          emitterName: "@azure-tools/typespec-java",
-          packageName: "com.azure:azure-security-keyvault-secrets",
-          namespace: "com.azure.security.keyvault.secrets",
-          outputDir: "{output-dir}/sdk/keyvault/azure-security-keyvault-secrets",
-          flavor: "azure",
-          serviceDir: "sdk/keyvault",
-        },
-        typescript: {
-          emitterName: "@azure-tools/typespec-ts",
-          packageName: "@azure/keyvault-secrets",
-          namespace: "@azure/keyvault-secrets",
-          outputDir: "{output-dir}/sdk/keyvault/keyvault-secrets",
-          flavor: "azure",
-          serviceDir: "sdk/keyvault",
-        },
+        python: [
+          {
+            emitterName: "@azure-tools/typespec-python",
+            packageName: "azure-keyvault-secrets",
+            namespace: "azure.keyvault.secrets",
+            outputDir: "{output-dir}/sdk/keyvault/azure-keyvault-secrets",
+            flavor: "azure",
+            serviceDir: "sdk/keyvault",
+          },
+        ],
+        java: [
+          {
+            emitterName: "@azure-tools/typespec-java",
+            packageName: "com.azure:azure-security-keyvault-secrets",
+            namespace: "com.azure.security.keyvault.secrets",
+            outputDir: "{output-dir}/sdk/keyvault/azure-security-keyvault-secrets",
+            flavor: "azure",
+            serviceDir: "sdk/keyvault",
+          },
+        ],
+        typescript: [
+          {
+            emitterName: "@azure-tools/typespec-ts",
+            packageName: "@azure/keyvault-secrets",
+            namespace: "@azure/keyvault-secrets",
+            outputDir: "{output-dir}/sdk/keyvault/keyvault-secrets",
+            flavor: "azure",
+            serviceDir: "sdk/keyvault",
+          },
+        ],
       },
       sourceConfigPath:
         "C:/repos/azure-rest-api-specs/specification/keyvault/Security.KeyVault.Secrets/tspconfig.yaml",
@@ -217,10 +258,12 @@ describe("Complete snapshot example", () => {
     expect(snapshot.sourceConfigPath).toBeTruthy();
 
     // Validate no absolute paths in output directories
-    Object.values(snapshot.languages).forEach((lang) => {
-      if (lang.outputDir) {
-        expect(lang.outputDir).toContain("{output-dir}");
-      }
+    Object.values(snapshot.languages).forEach((langs) => {
+      langs.forEach((lang) => {
+        if (lang.outputDir) {
+          expect(lang.outputDir).toContain("{output-dir}");
+        }
+      });
     });
   });
 });


### PR DESCRIPTION
Allow more than one set of emitter metadata per language.

See: https://github.com/Azure/azure-sdk-tools/issues/14975
