### PR TITLE
Fix doc-update workflow to create single PR with lib label

### DIFF
--- a/.github/workflows/doc-update-scheduler.yml
+++ b/.github/workflows/doc-update-scheduler.yml
@@ -7,8 +7,8 @@ name: Documentation Update Scheduler
 # (an agentic workflow compiled to doc-update.md.lock.yml).
 #
 # To add a new package:
-#   1. Create a YAML config in eng/scripts/doc-updater/configs/
-#   2. Create prompt files in eng/scripts/doc-updater/prompts/<name>/
+#   1. Create a YAML config in eng/scripts/doc-updater/configs/<name>.yaml
+#   2. Create a prompt file at eng/scripts/doc-updater/prompts/<name>.md
 #   3. The scheduler will auto-discover and dispatch it.
 
 on:

--- a/.github/workflows/doc-update.md
+++ b/.github/workflows/doc-update.md
@@ -87,7 +87,8 @@ network:
 safe-outputs:
   create-pull-request:
     title-prefix: "[Automated][${{ github.event.inputs.config }}] "
-    labels: [documentation, automated]
+    labels: [docs, "lib:${{ github.event.inputs.config }}"]
+    max: 1
 
 post-steps:
   - name: Validate file scope
@@ -168,6 +169,7 @@ been pre-computed and is available in `/tmp/gh-aw/agent/context.json`.
 - **Complete every step in the domain-specific prompt.** Do not stop after finishing one step. After each step, explicitly state which step you just completed and which step you are starting next. Continue until all steps are done.
 - **Do not defer work.** Fix every issue you find in this run. Do not leave "remaining gaps" or "future work" in the knowledge base or PR description — the knowledge base is for lessons learned, not a to-do list.
 - **Update the knowledge base** at `knowledgePath` as you work (see Knowledge Base Rules below).
+- **Create exactly one pull request at the very end.** Complete ALL file edits across ALL steps first, then create a single pull request that contains every change. Do NOT call `create_pull_request` after each step or file — batch everything into one PR.
 
 ## Knowledge Base Rules
 


### PR DESCRIPTION
- Change label of doc updater PR/issue
- Enforce max: 1 on create-pull-request to prevent multiple PRs
- Add explicit prompt instruction to batch all edits into one PR