### PR TITLE
[Automated][tcgc] docs(tcgc): update docs for serializationOptions, operation-not-in-client, and external type usage

### DIFF
--- a/eng/scripts/doc-updater/knowledge/tcgc.md
+++ b/eng/scripts/doc-updater/knowledge/tcgc.md
@@ -108,7 +108,18 @@ namespace (@clientNamespace), naming (@clientName), overload, structure (@client
 - UsageFlags reference table was missing — added with all 13 flag values and descriptions.
 - InitializedByFlags documentation was incomplete — added Individually, Parent, CustomizeCode descriptions.
 - The `CustomizeCode` (4) flag means initialization is omitted from generated code and handled manually.
-- `serializationOptions` and `baseModel` properties on SdkModelType are not documented in guideline.md but exist in interfaces.ts.
+- `serializationOptions` on SdkModelType properties was already documented. Now also documented on `SdkBodyParameter` and `SdkHttpResponseBase` in the HTTP Operation Parameters and Response sections.
+- `baseModel` property on SdkModelType is not documented in guideline.md but exists in interfaces.ts.
+
+## Diagnostics
+
+- `operation-not-in-client` (warning): Emitted when explicit `@client` is used but a service operation is not included in any client. Documented in 03client.mdx under the "Fully Customized Client Hierarchy" section.
+
+## External Type Usage Propagation
+
+- Types marked as external (via `@alternateType` with `ExternalTypeInfo`) only receive the `External` usage flag. TCGC blocks propagation of non-`External` usage flags (`Input`, `Output`, `Json`, etc.) through external types. This was a bug fix — previously, types reachable through external types could incorrectly get `Input`/`Output` flags.
+- The `External` usage flag description in guideline.md was expanded to explain the propagation blocking behavior.
+- The `@alternateType` external types Notes section in 08types.mdx was updated to explain that types only reachable through external types won't get `Input`/`Output` flags.
 
 ## Common Mistakes to Avoid
 

--- a/eng/scripts/doc-updater/knowledge/tcgc.meta.json
+++ b/eng/scripts/doc-updater/knowledge/tcgc.meta.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "e8fc41c804776d45aa35bdeff163686e8cf58709",
-  "lastUpdated": "2026-04-15T00:00:00.000Z",
+  "lastCommit": "d6a33e049f73a58b671d4f28e1bdf014b972798b",
+  "lastUpdated": "2026-04-21T06:00:03.310Z",
   "analyzedPaths": [
     "packages/typespec-client-generator-core/src",
     "packages/typespec-client-generator-core/lib",

--- a/website/src/content/docs/docs/howtos/Generate client libraries/03client.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/03client.mdx
@@ -2529,6 +2529,14 @@ In this approach, `autoMergeService` is **not set** (defaults to `false`) on any
 All services being merged must share the same endpoint and authentication method. If not, you will get a diagnostic error.
 :::
 
+:::note[Operation coverage validation]
+When you use explicit `@client` decorators with custom operation mapping, TCGC validates that all service operations are included in at least one client definition. If an operation is not covered, you will see a warning:
+
+> Operation "opName" under namespace "MyService" is not included in any @client definition.
+
+This validation only applies when explicit `@client` is used. It does not apply to default auto-generated clients or when `@client` is applied directly to the service namespace without remapping operations.
+:::
+
 <ClientTabs>
 
 ```typespec title="main.tsp"

--- a/website/src/content/docs/docs/howtos/Generate client libraries/08types.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/08types.mdx
@@ -496,6 +496,7 @@ In this example, instead of generating `MyModel` in the Python sdk, the emitter 
 ### Notes
 
 - The referenced type should be compatible with the intended usage in the generated client library.
+- When a type is marked as an external alternate type, TCGC assigns it the `External` usage flag. Types that are only reachable through external types will also only have the `External` usage flag — they will not receive `Input` or `Output` flags. This signals to emitters that serialization and deserialization code does not need to be generated for these types, since the external package handles them.
 
 ## Client Default Values (Legacy)
 

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
@@ -98,7 +98,7 @@ Most TCGC types share the following common properties:
   - `LroInitial` (2048): Type is used in the initial response of an LRO.
   - `LroPolling` (4096): Type is used in a polling response of an LRO.
   - `LroFinalEnvelope` (8192): Type is used in the final envelope of an LRO.
-  - `External` (16384): Type is only referenced through external alternate types.
+  - `External` (16384): Type is only referenced through external alternate types. When a type has the `External` flag and no `Input` or `Output` flags, it means emitters do not need to generate serialization/deserialization code for it — the external package handles that. TCGC blocks propagation of non-`External` usage flags (such as `Input`, `Output`, `Json`) through types marked as external.
 - **`deprecation`**: Indicates whether the type is deprecated and provides the deprecation message.
 - **`clientDefaultValue`**: The type's default value if provided. Set via the `@clientDefaultValue` decorator or auto-set for endpoint and API version parameters.
 
@@ -314,6 +314,8 @@ TCGC uses several ways to find an HTTP operation's parameter's corresponding met
 - Check if the parameter is a method parameter or a nested model property of a method parameter (nested HTTP metadata case when using `@bodyRoot`).
 - Check if all properties of the parameter can be mapped to a method parameter or a nested model property of a method parameter (spread).
 
+Body parameters include a `serializationOptions` property that indicates how to serialize the body. TCGC automatically populates this from the operation's content types — for example, if the content type is `application/json`, the `json` option is set with the serialized name of the body parameter. This provides a consistent way for emitters to determine the serialization format, regardless of whether the body type is a model or a basic type.
+
 ### HTTP Operation Response Calculation
 
 The response is inferred from TypeSpec HTTP lib type [`HttpOperationResponse`](https://typespec.io/docs/libraries/http/reference/js-api/interfaces/httpoperationresponse/).
@@ -321,6 +323,8 @@ The response is inferred from TypeSpec HTTP lib type [`HttpOperationResponse`](h
 For each response, TCGC will check the response's content. If contents from different responses are not equal, TCGC takes the last one as the response type. Any response with `*` status code or response content type that has `@error` decorator, TCGC puts them into the exception response list. Others are put in the response list.
 
 If `@responseAsBool` is on the operation's upper level method, the `404` status code is always recognized as a normal response.
+
+HTTP responses include a `serializationOptions` property that indicates how to deserialize the response body. TCGC automatically populates this from the response's content types — for example, if the response content type is `application/json`, the `json` option is set. Responses without a body have empty serialization options.
 
 ### Type Detection
 


### PR DESCRIPTION
- Document serializationOptions on SdkBodyParameter and SdkHttpResponseBase in guideline.md
- Document operation-not-in-client diagnostic warning in 03client.mdx
- Document external type usage propagation behavior in 08types.mdx
- Expand External usage flag description in guideline.md
- Update knowledge base with new findings