### PR TITLE
Fix DEP0190 deprecation warning in Python emitter setup script

### DIFF
--- a/.chronus/changes/fix-dep0190-deprecation-warning-2026-3-22-16-37-49.md
+++ b/.chronus/changes/fix-dep0190-deprecation-warning-2026-3-22-16-37-49.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Fix DEP0190 deprecation warning in Python emitter setup script

--- a/packages/typespec-python/eng/scripts/setup/run-python3.ts
+++ b/packages/typespec-python/eng/scripts/setup/run-python3.ts
@@ -14,7 +14,8 @@ async function runPython3(...args: string[]) {
     version: ">=3.9",
     environmentVariable: "AUTOREST_PYTHON_EXE",
   });
-  cp.execSync(command.join(" "), {
+  const [cmd, ...cmdArgs] = command;
+  cp.execFileSync(cmd, cmdArgs, {
     stdio: [0, 1, 2],
   });
 }


### PR DESCRIPTION
Replace `execSync` with `execFileSync` in `run-python3.ts` to pass arguments as an array instead of through a shell, eliminating the Node.js DEP0190 deprecation warning.

Fixes #4283