### PR TITLE
Bump version for hotfix: @azure-tools/typespec-client-generator-core@0.67.3

### DIFF
--- a/.chronus/changes/copilot-fix-method-parameter-segments-2026-3-22-8-8-34.md
+++ b/.chronus/changes/copilot-fix-method-parameter-segments-2026-3-22-8-8-34.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-client-generator-core"
----
-
-Fix wrong `methodParameterSegments` for op with `@clientLocation` and `@override`

--- a/packages/typespec-client-generator-core/CHANGELOG.md
+++ b/packages/typespec-client-generator-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-client-generator-core
 
+## 0.67.3
+
+### Bug Fixes
+
+- [#4302](https://github.com/Azure/typespec-azure/pull/4302) Fix wrong `methodParameterSegments` for op with `@clientLocation` and `@override`
+
+
 ## 0.67.2
 
 ### Bug Fixes

--- a/packages/typespec-client-generator-core/package.json
+++ b/packages/typespec-client-generator-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-core",
-  "version": "0.67.2",
+  "version": "0.67.3",
   "author": "Microsoft Corporation",
   "description": "TypeSpec Data Plane Generation library",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
Hotfix version bump for TCGC 0.67.3 from release/april-2026 branch.