### PR TITLE
Add csharp @clientName overrides for IndividuallyParent nested clients

### DIFF
--- a/.chronus/changes/individuallyParent-csharp-clientname-2026-4-23-19-50-0.md
+++ b/.chronus/changes/individuallyParent-csharp-clientname-2026-4-23-19-50-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Add `@clientName` csharp-scoped renames for the nested sub-clients of `IndividuallyParentClient` in the `client-initialization/individually-parent` spec. The original names (e.g. `IndividuallyParentNestedWithParamAliasClient`) combined with the deeply-nested test project path produced generated file paths exceeding the 260-character Windows path limit in downstream csharp emitters.

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/individuallyParent/client.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/individuallyParent/client.tsp
@@ -1,0 +1,31 @@
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using global.Azure.ClientGenerator.Core;
+
+// Shorten generated client type names for csharp to avoid exceeding the
+// Windows 260-character path limit when test projects are emitted.
+@@clientName(_Specs_.Azure.ClientGenerator.Core.ClientInitialization.IndividuallyParentClient.IndividuallyParentNestedWithPathClient,
+  "NestedWithPathClient",
+  "csharp"
+);
+@@clientName(_Specs_.Azure.ClientGenerator.Core.ClientInitialization.IndividuallyParentClient.IndividuallyParentNestedWithQueryClient,
+  "NestedWithQueryClient",
+  "csharp"
+);
+@@clientName(_Specs_.Azure.ClientGenerator.Core.ClientInitialization.IndividuallyParentClient.IndividuallyParentNestedWithHeaderClient,
+  "NestedWithHeaderClient",
+  "csharp"
+);
+@@clientName(_Specs_.Azure.ClientGenerator.Core.ClientInitialization.IndividuallyParentClient.IndividuallyParentNestedWithMultipleClient,
+  "NestedWithMultipleClient",
+  "csharp"
+);
+@@clientName(_Specs_.Azure.ClientGenerator.Core.ClientInitialization.IndividuallyParentClient.IndividuallyParentNestedWithMixedClient,
+  "NestedWithMixedClient",
+  "csharp"
+);
+@@clientName(_Specs_.Azure.ClientGenerator.Core.ClientInitialization.IndividuallyParentClient.IndividuallyParentNestedWithParamAliasClient,
+  "NestedWithParamAliasClient",
+  "csharp"
+);


### PR DESCRIPTION
## Description

The nested sub-clients of IndividuallyParentClient in the client-initialization/individually-parent spec have long names (e.g. IndividuallyParentNestedWithParamAliasClient). When emitted to the deeply-nested csharp Spector test project in [azure-sdk-for-net](https://github.com/Azure/azure-sdk-for-net), the resulting file paths exceed the Windows 260-character path limit, breaking csharp CI:

```
Analyzing length of paths...
With a base path length of 49 the following file path exceed the allow path length of 260 characters
eng\packages\http-client-csharp\generator\TestProjects\Spector\http\azure\client-generator-core\client-initialization\individuallyParent\src\Generated\IndividuallyParentNestedWithParamAliasClientHostExtensions.cs
```

Add a `client.tsp` that scopes shorter `@clientName` overrides to csharp, dropping the redundant `IndividuallyParent` prefix from the nested client names.

Context: Azure/azure-sdk-for-net#58615 (comment [4310291803](https://github.com/Azure/azure-sdk-for-net/pull/58615#issuecomment-4310291803)).

--generated by Copilot
