### PR TITLE
Bump pyright to 1.1.407 and pythonVersion to 3.10

### DIFF
--- a/packages/typespec-python/dev_requirements.txt
+++ b/packages/typespec-python/dev_requirements.txt
@@ -1,5 +1,5 @@
 # shall keep aligned with dev_requirements.txt of @typspec/http-client-python
-pyright==1.1.391
+pyright==1.1.407
 pylint==3.2.7
 tox==4.23.2
 tox-uv

--- a/packages/typespec-python/eng/scripts/ci/config/pyrightconfig.json
+++ b/packages/typespec-python/eng/scripts/ci/config/pyrightconfig.json
@@ -3,6 +3,6 @@
   "reportTypeCommentUsage": true,
   "reportMissingImports": false,
   "reportAttributeAccessIssue": false,
-  "pythonVersion": "3.9",
+  "pythonVersion": "3.10",
   "exclude": ["**/build/**"]
 }


### PR DESCRIPTION
Bumps pyright and pyright's configured Python version for the typespec-python package.

- packages/typespec-python/eng/scripts/ci/config/pyrightconfig.json: `pythonVersion` 3.9 -> 3.10
- packages/typespec-python/dev_requirements.txt: `pyright` 1.1.391 -> 1.1.407 (to align with `tests/requirements/typecheck.txt`)

Motivation: pyright 1.1.287/1.1.391 was silently crashing on modern TypeSpec-generated Python code in downstream `azure-sdk-for-python` CI (empty stdout/stderr with exit code 1 from `pyright --verifytypes`). Bumping to 1.1.407 resolves it; aligning here keeps dev and CI versions consistent.