### PR TITLE
Add Python client namespace to response-as-bool

### DIFF
--- a/.chronus/changes/python-client-namespace-response-as-bool-2026-4-27-2-35-45.md
+++ b/.chronus/changes/python-client-namespace-response-as-bool-2026-4-27-2-35-45.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Add Python client namespace to response-as-bool spec

--- a/packages/azure-http-specs/specs/azure/client-generator-core/response-as-bool/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/response-as-bool/main.tsp
@@ -12,6 +12,10 @@ using Spector;
   "azure.clientgenerator.core.responseasbool",
   "java"
 )
+@global.Azure.ClientGenerator.Core.clientNamespace(
+  "specs.azure.clientgenerator.core.responseasbool",
+  "python"
+)
 namespace _Specs_.Azure.ClientGenerator.Core.ResponseAsBool;
 
 model Resource {


### PR DESCRIPTION
fix nightly build for python https://dev.azure.com/azure-sdk/public/_build/results?buildId=6211571&view=logs&j=ba1d0612-cf69-5eb7-e99b-b5534b1f542d&t=ee7b8759-6cbe-5f07-0826-8e9ce27ba2e5

<img width="855" height="457" alt="image" src="https://github.com/user-attachments/assets/76605838-d777-46ec-9fef-091e44921064" />
