### PR TITLE
[Automated][tcgc] Clarify SdkBuiltInType.encode is set contextually for multipart bytes

### DIFF
--- a/eng/scripts/doc-updater/knowledge/tcgc.md
+++ b/eng/scripts/doc-updater/knowledge/tcgc.md
@@ -121,8 +121,14 @@ namespace (@clientNamespace), naming (@clientName), overload, structure (@client
 - The `External` usage flag description in guideline.md was expanded to explain the propagation blocking behavior.
 - The `@alternateType` external types Notes section in 08types.mdx was updated to explain that types only reachable through external types won't get `Input`/`Output` flags.
 
+## Encoding Context Awareness
+
+- The `encode` property on `SdkBuiltInType` is not only set by the `@encode` decorator. TCGC also sets it contextually — for example, `bytes` in a `multipart/form-data` part get `encode: "bytes"` (raw binary) instead of the default `"base64"`. This is handled in `addMultipartPropertiesToModelType` in `src/types.ts`, which calls `addEncodeInfo` with the part's default content type.
+- The guideline.md description of `SdkBuiltInType.encode` was updated to reflect this contextual encoding behavior.
+
 ## Common Mistakes to Avoid
 
 - Don't copy @param descriptions between decorators — @clientApiVersions had @apiVersion's description.
 - The 03client.mdx file had a typo "@clientLocaton" (missing 'i') — fixed to "@clientLocation".
 - In mockapi.ts files, query parameters use `query:` not `params:` in the request object.
+- The guideline.md previously said `encode` is set only when `@encode` exists — this was inaccurate since encode can also be set contextually (e.g., multipart).

--- a/eng/scripts/doc-updater/knowledge/tcgc.meta.json
+++ b/eng/scripts/doc-updater/knowledge/tcgc.meta.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "d6a33e049f73a58b671d4f28e1bdf014b972798b",
-  "lastUpdated": "2026-04-21T06:00:03.310Z",
+  "lastCommit": "5b800fe4731308ccb6a2ca5e73dca40d3c7635e7",
+  "lastUpdated": "2026-04-27T09:57:20.823Z",
   "analyzedPaths": [
     "packages/typespec-client-generator-core/src",
     "packages/typespec-client-generator-core/lib",

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
@@ -185,7 +185,7 @@ For types in TypeSpec, TCGC provides several client types to represent them in a
 
 **Built-in Types:**
 
-- [`SdkBuiltInType`](../reference/js-api/interfaces/sdkbuiltintype/) represents a [built-in TypeSpec type](https://typespec.io/docs/language-basics/built-in-types/) or a [`scalar`](https://typespec.io/docs/language-basics/scalars/) type that derives from a built-in TypeSpec type, excluding `utcDateTime`, `offsetDateTime` and `duration`. The `encode` property is added to these types when the `@encode` decorator exists, indicating how to encode when sending to the service.
+- [`SdkBuiltInType`](../reference/js-api/interfaces/sdkbuiltintype/) represents a [built-in TypeSpec type](https://typespec.io/docs/language-basics/built-in-types/) or a [`scalar`](https://typespec.io/docs/language-basics/scalars/) type that derives from a built-in TypeSpec type, excluding `utcDateTime`, `offsetDateTime` and `duration`. The `encode` property indicates how to encode when sending to the service. It is set when the `@encode` decorator exists, or when the context determines a specific encoding — for example, `bytes` in a `multipart/form-data` part get `encode: "bytes"` (raw binary) rather than the default `"base64"`.
 
 **Date and Time Types:**
 


### PR DESCRIPTION
Update the guideline.md description of SdkBuiltInType.encode to reflect that the encode property is not only set by the @encode decorator but also contextually — for example, bytes in multipart/form-data parts get encode: "bytes" (raw binary) instead of the default "base64".

Resolve: https://github.com/Azure/typespec-azure/issues/4333