### PR TITLE
Fix @responseAsBool setting bodyType on HEAD operation HTTP responses

### DIFF
--- a/.chronus/changes/tcgc-responseAsBoolResponseBody-2026-3-28-12-54-0.md
+++ b/.chronus/changes/tcgc-responseAsBoolResponseBody-2026-3-28-12-54-0.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-client-generator-core"
 ---
 
-Fix @responseAsBool setting bodyType on HEAD operation HTTP responses
+Fix `@responseAsBool` setting bodyType on HEAD operation HTTP responses

--- a/.chronus/changes/tcgc-responseAsBoolResponseBody-2026-3-28-12-54-0.md
+++ b/.chronus/changes/tcgc-responseAsBoolResponseBody-2026-3-28-12-54-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Fix @responseAsBool setting bodyType on HEAD operation HTTP responses

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -84,7 +84,6 @@ import {
 import {
   addEncodeInfo,
   getClientTypeWithDiagnostics,
-  getSdkConstant,
   getSdkModelPropertyTypeBase,
   getTypeSpecBuiltInType,
   isReadOnly,
@@ -140,33 +139,31 @@ export function getSdkHttpOperation(
   methodParameters: SdkMethodParameter[],
   client: SdkClientType<SdkHttpOperation>,
 ): [SdkHttpOperation, readonly Diagnostic[]] {
-  const tk = $(context.program);
   const diagnostics = createDiagnosticCollector();
   const { responses, exceptions } = diagnostics.pipe(
     getSdkHttpResponseAndExceptions(context, httpOperation, client),
   );
   if (getResponseAsBool(context, httpOperation.operation)) {
-    // we make sure valid responses and 404 responses are booleans
+    // HEAD operations never have a response body, so we clear response.type here.
+    // The boolean return type is a client-side concept handled at the method response level.
     for (const response of responses) {
-      // all valid responses will return boolean
-      response.type = getSdkConstant(context, tk.literal.createBoolean(true));
+      response.type = undefined;
     }
+    // Promote 404 from exception to valid response.
     const fourOFourResponse = exceptions.find((e) => e.statusCodes === 404);
     if (fourOFourResponse) {
-      fourOFourResponse.type = getSdkConstant(context, tk.literal.createBoolean(false));
       // move from exception to valid response with status code 404
       responses.push({
         ...fourOFourResponse,
+        type: undefined,
         statusCodes: 404,
       });
       exceptions.splice(exceptions.indexOf(fourOFourResponse), 1);
-      // remove the exception from the list
     } else {
       // add 404 response to the list of valid responses
       responses.push({
         kind: "http",
         statusCodes: 404,
-        type: getSdkConstant(context, tk.literal.createBoolean(false)),
         apiVersions: getAvailableApiVersions(
           context,
           httpOperation.operation,

--- a/packages/typespec-client-generator-core/src/methods.ts
+++ b/packages/typespec-client-generator-core/src/methods.ts
@@ -657,8 +657,9 @@ function getSdkMethodResponse(
 
   // Set optional property based on whether responses have bodies
   // If type is undefined (no response), optional remains undefined
+  // For @responseAsBool, the boolean return is never optional — it's always true or false
   let optional: boolean | undefined = undefined;
-  if (type !== undefined) {
+  if (type !== undefined && !getResponseAsBool(context, operation)) {
     // If we have a response type, set optional based on whether some responses lack bodies
     optional = containsResponseWithoutBody;
   }

--- a/packages/typespec-client-generator-core/test/decorators/response-as-bool.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/response-as-bool.test.ts
@@ -18,15 +18,11 @@ it("head operation marked as void", async () => {
 
   const twoOFourResponse = operation.responses.find((x) => x.statusCodes === 204);
   ok(twoOFourResponse);
-  strictEqual(twoOFourResponse.type?.kind, "constant");
-  strictEqual(twoOFourResponse.type.value, true);
-  strictEqual(twoOFourResponse.type.valueType.kind, "boolean");
+  strictEqual(twoOFourResponse.type, undefined);
 
   const fourOFourResponse = operation.responses.find((x) => x.statusCodes === 404);
   ok(fourOFourResponse);
-  strictEqual(fourOFourResponse.type?.kind, "constant");
-  strictEqual(fourOFourResponse.type.value, false);
-  strictEqual(fourOFourResponse.type.valueType.kind, "boolean");
+  strictEqual(fourOFourResponse.type, undefined);
 
   strictEqual(operation.exceptions.length, 0);
 
@@ -54,15 +50,11 @@ it("head operation marked as void with error model", async () => {
 
   const twoOFourResponse = operation.responses.find((x) => x.statusCodes === 204);
   ok(twoOFourResponse);
-  strictEqual(twoOFourResponse.type?.kind, "constant");
-  strictEqual(twoOFourResponse.type.value, true);
-  strictEqual(twoOFourResponse.type.valueType.kind, "boolean");
+  strictEqual(twoOFourResponse.type, undefined);
 
   const fourOFourResponse = operation.responses.find((x) => x.statusCodes === 404);
   ok(fourOFourResponse);
-  strictEqual(fourOFourResponse.type?.kind, "constant");
-  strictEqual(fourOFourResponse.type.value, false);
-  strictEqual(fourOFourResponse.type.valueType.kind, "boolean");
+  strictEqual(fourOFourResponse.type, undefined);
 
   strictEqual(operation.exceptions.length, 1);
 
@@ -83,14 +75,10 @@ it("head operation with explicitly marked valid response", async () => {
   strictEqual(operation.responses.length, 2);
   const twoOFourResponse = operation.responses.find((x) => x.statusCodes === 200);
   ok(twoOFourResponse);
-  strictEqual(twoOFourResponse.type?.kind, "constant");
-  strictEqual(twoOFourResponse.type.value, true);
-  strictEqual(twoOFourResponse.type.valueType.kind, "boolean");
+  strictEqual(twoOFourResponse.type, undefined);
   const fourOFourResponse = operation.responses.find((x) => x.statusCodes === 404);
   ok(fourOFourResponse);
-  strictEqual(fourOFourResponse.type?.kind, "constant");
-  strictEqual(fourOFourResponse.type.value, false);
-  strictEqual(fourOFourResponse.type.valueType.kind, "boolean");
+  strictEqual(fourOFourResponse.type, undefined);
   strictEqual(method.response.type?.kind, "boolean");
 });
 
@@ -120,15 +108,11 @@ it("head operation with explicitly marked 404", async () => {
 
   const twoOFourResponse = operation.responses.find((x) => x.statusCodes === 204);
   ok(twoOFourResponse);
-  strictEqual(twoOFourResponse.type?.kind, "constant");
-  strictEqual(twoOFourResponse.type.value, true);
-  strictEqual(twoOFourResponse.type.valueType.kind, "boolean");
+  strictEqual(twoOFourResponse.type, undefined);
 
   const fourOFourResponse = operation.responses.find((x) => x.statusCodes === 404);
   ok(fourOFourResponse);
-  strictEqual(fourOFourResponse.type?.kind, "constant");
-  strictEqual(fourOFourResponse.type.value, false);
-  strictEqual(fourOFourResponse.type.valueType.kind, "boolean");
+  strictEqual(fourOFourResponse.type, undefined);
 });
 
 it("non-head operation", async () => {


### PR DESCRIPTION
## Problem
`@responseAsBool` was setting `response.type` (body type) to boolean constants on `SdkHttpResponse` objects. HEAD operations never have a response body, so this was semantically wrong and caused the playground to show `bodyType` on the HTTP response.

## Fix
- Clear `response.type` on HTTP responses for `@responseAsBool` operations (HEAD ops have no body)
- Keep 404 promotion from exception to valid response
- The boolean return type now lives only at the **method response** level (which was already correct)
- Prevent method response from being incorrectly marked as optional

Fixes #4272