### PR TITLE
Bump version for hotfix: @azure-tools/typespec-client-generator-core@0.67.4

### DIFF
--- a/.chronus/changes/fix-multipart-bytes-encode-2026-4-23-4-12-0.md
+++ b/.chronus/changes/fix-multipart-bytes-encode-2026-4-23-4-12-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-client-generator-core"
----
-
-Fix wrong encode for `bytes` in `HttpPart` for `multipart/form-data`. The encode is now correctly `bytes` instead of `base64`.

--- a/packages/typespec-client-generator-core/CHANGELOG.md
+++ b/packages/typespec-client-generator-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-client-generator-core
 
+## 0.67.4
+
+### Bug Fixes
+
+- [#4345](https://github.com/Azure/typespec-azure/pull/4345) Fix wrong encode for `bytes` in `HttpPart` for `multipart/form-data`. The encode is now correctly `bytes` instead of `base64`.
+
+
 ## 0.67.3
 
 ### Bug Fixes

--- a/packages/typespec-client-generator-core/package.json
+++ b/packages/typespec-client-generator-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-core",
-  "version": "0.67.3",
+  "version": "0.67.4",
   "author": "Microsoft Corporation",
   "description": "TypeSpec Data Plane Generation library",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
Hotfix version bump for TCGC 0.67.4 from release/april-2026 branch.

Fix: #4345 - Fix wrong encode for bytes in HttpPart for multipart/form-data