### PR TITLE
Bump @typespec/http-client-python catalog to ^0.29.0

### DIFF
--- a/.chronus/changes/bump-http-client-python-catalog-2026-05-12-12-44-33.md
+++ b/.chronus/changes/bump-http-client-python-catalog-2026-05-12-12-44-33.md
@@ -1,0 +1,7 @@
+---
+changeKind: dependencies
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Bump @typespec/http-client-python from ^0.28.3 to ^0.29.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,8 +208,8 @@ catalogs:
       specifier: ^8.58.1
       version: 8.58.1
     '@typespec/http-client-python':
-      specifier: ^0.28.3
-      version: 0.28.3
+      specifier: ^0.29.0
+      version: 0.29.0
     '@typespec/ts-http-runtime':
       specifier: 0.3.4
       version: 0.3.4
@@ -3716,7 +3716,7 @@ importers:
     dependencies:
       '@typespec/http-client-python':
         specifier: 'catalog:'
-        version: 0.28.3(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)
+        version: 0.29.0(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)
       semver:
         specifier: 'catalog:'
         version: 7.7.4
@@ -7823,15 +7823,15 @@ packages:
     resolution: {integrity: sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typespec/http-client-python@0.28.3':
-    resolution: {integrity: sha512-UkahPQB23vAYFY+7YtN1H+wG1+H642Hw8FlF5LAEtSx0bu2PNkrQe9W8COZWLoVKBuWh5oLJEzVZd8FRP9nBbg==}
+  '@typespec/http-client-python@0.29.0':
+    resolution: {integrity: sha512-0IfSjv9k1rkFU4qYV2GLAPFdy2GvcMyhllZJZqKA3pAQpl4Zsi5rcEALcFdx5NgPjbFO+6XCoTB/l/OssWrt1w==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@azure-tools/typespec-autorest': '>=0.67.0 <1.0.0'
-      '@azure-tools/typespec-azure-core': '>=0.67.0 <1.0.0'
-      '@azure-tools/typespec-azure-resource-manager': '>=0.67.0 <1.0.0'
+      '@azure-tools/typespec-azure-core': '>=0.67.1 <1.0.0'
+      '@azure-tools/typespec-azure-resource-manager': '>=0.67.1 <1.0.0'
       '@azure-tools/typespec-azure-rulesets': '>=0.67.0 <1.0.0'
-      '@azure-tools/typespec-client-generator-core': '>=0.67.0 <1.0.0'
+      '@azure-tools/typespec-client-generator-core': '>=0.67.4 <1.0.0'
       '@typespec/compiler': ^1.11.0
       '@typespec/events': '>=0.81.0 <1.0.0'
       '@typespec/http': ^1.11.0
@@ -19886,7 +19886,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.1
       eslint-visitor-keys: 5.0.1
 
-  '@typespec/http-client-python@0.28.3(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)':
+  '@typespec/http-client-python@0.29.0(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)':
     dependencies:
       '@azure-tools/typespec-autorest': link:packages/typespec-autorest
       '@azure-tools/typespec-azure-core': link:packages/typespec-azure-core
@@ -20470,7 +20470,7 @@ snapshots:
       algoliasearch: 4.27.0
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       diff: 5.2.2
-      ink: 3.2.0(@types/react@19.2.14)(react@19.2.5)
+      ink: 3.2.0(@types/react@19.2.14)(react@17.0.2)
       ink-text-input: 4.0.3(ink@3.2.0(@types/react@19.2.14)(react@17.0.2))(react@17.0.2)
       react: 17.0.2
       semver: 7.7.4
@@ -20635,7 +20635,7 @@ snapshots:
       '@yarnpkg/plugin-git': 3.1.4(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       es-toolkit: 1.45.1
-      ink: 3.2.0(@types/react@19.2.14)(react@17.0.2)
+      ink: 3.2.0(@types/react@19.2.14)(react@19.2.5)
       react: 17.0.2
       semver: 7.7.4
       tslib: 2.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -16,6 +16,7 @@ overrides:
 minimumReleaseAge: 2880 # 2 days
 minimumReleaseAgeExclude:
   - "@alloy-js/*"
+  - "@typespec/http-client-python"
 
 catalog:
   "@alloy-js/cli": ^0.23.0
@@ -85,7 +86,7 @@ catalog:
   "@typescript-eslint/rule-tester": ^8.58.1
   "@typescript-eslint/types": ^8.58.1
   "@typescript-eslint/utils": ^8.58.1
-  "@typespec/http-client-python": ^0.28.3
+  "@typespec/http-client-python": ^0.29.0
   "@typespec/ts-http-runtime": "0.3.4"
   "@vitejs/plugin-react": ^6.0.1
   "@vitest/coverage-v8": ^4.1.3


### PR DESCRIPTION
## Problem

All Python CI runs are consistently failing with 2 test failures:
- `test_put_model_property` (sync) in `test_azure_client_generator_core_client_default_value.py`
- `test_put_model_property` (async) in `test_azure_client_generator_core_client_default_value_async.py`

The error is:
```
Body provided doesn't match expected body: at $: Key count mismatch: expected 4 but got 1. missing: [timeout, tier, retry]
```

## Root Cause

The catalog specifies `@typespec/http-client-python: ^0.28.3`. For 0.x semver, `^0.28.3` means `>=0.28.3 <0.29.0`, so version `0.29.0` (which contains the `@clientDefaultValue` serialization fix from [microsoft/typespec#10546](https://github.com/microsoft/typespec/pull/10546)) is excluded.

The `azure-http-specs` mock API was updated to validate that `@clientDefaultValue` defaults are included in request bodies, but the installed generator version (0.28.3) doesn't serialize them.

## Fix

- Bump catalog to `^0.29.0`
- Add `@typespec/http-client-python` to `minimumReleaseAgeExclude` (0.29.0 was published <2 days ago)