### PR TITLE
Fix arm library self import causing warning with new compiler

### DIFF
--- a/packages/typespec-azure-resource-manager/CHANGELOG.md
+++ b/packages/typespec-azure-resource-manager/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-azure-resource-manager
 
+## 0.67.2
+
+### Bug Fixes
+
+- Remove self import from common-types.tsp
+
+
 ## 0.67.1
 
 ### Bug Fixes

--- a/packages/typespec-azure-resource-manager/lib/common-types/common-types.tsp
+++ b/packages/typespec-azure-resource-manager/lib/common-types/common-types.tsp
@@ -1,6 +1,5 @@
 import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
-import "./common-types.tsp";
 import "./types-ref.tsp";
 import "./managed-identity-ref.tsp";
 import "./managed-identity-with-delegation-ref.tsp";

--- a/packages/typespec-azure-resource-manager/package.json
+++ b/packages/typespec-azure-resource-manager/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-azure-resource-manager",
-  "version": "0.67.1",
+  "version": "0.67.2",
   "author": "Microsoft Corporation",
   "description": "TypeSpec Azure Resource Manager library",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
Doing an hotfix to be able to get a cleaner release with the formatting changes