### PR TITLE
bump http-client-python 0.29.1 for typespec-python

### DIFF
--- a/.chronus/changes/bump-http-client-python-catalog-2026-05-12-12-44-33.md
+++ b/.chronus/changes/bump-http-client-python-catalog-2026-05-12-12-44-33.md
@@ -1,7 +1,0 @@
----
-changeKind: dependencies
-packages:
-  - "@azure-tools/typespec-python"
----
-
-Bump @typespec/http-client-python from ^0.28.3 to ^0.29.0

--- a/packages/typespec-python/CHANGELOG.md
+++ b/packages/typespec-python/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Release
 
+## 0.62.1
+
+### Bump dependencies
+
+- [#4418](https://github.com/Azure/typespec-azure/pull/4418) Bump @typespec/http-client-python to 0.29.1
+
 ## 0.62.0
 
 ### Features

--- a/packages/typespec-python/package.json
+++ b/packages/typespec-python/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-python",
-  "version": "0.62.0",
+  "version": "0.62.1",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Python SDKs",
   "homepage": "https://azure.github.io/typespec-azure",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,8 +208,8 @@ catalogs:
       specifier: ^8.58.1
       version: 8.58.1
     '@typespec/http-client-python':
-      specifier: ^0.29.0
-      version: 0.29.0
+      specifier: ^0.29.1
+      version: 0.29.1
     '@typespec/ts-http-runtime':
       specifier: 0.3.4
       version: 0.3.4
@@ -3719,7 +3719,7 @@ importers:
     dependencies:
       '@typespec/http-client-python':
         specifier: 'catalog:'
-        version: 0.29.0(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)
+        version: 0.29.1(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)
       semver:
         specifier: 'catalog:'
         version: 7.7.4
@@ -7826,24 +7826,24 @@ packages:
     resolution: {integrity: sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typespec/http-client-python@0.29.0':
-    resolution: {integrity: sha512-0IfSjv9k1rkFU4qYV2GLAPFdy2GvcMyhllZJZqKA3pAQpl4Zsi5rcEALcFdx5NgPjbFO+6XCoTB/l/OssWrt1w==}
+  '@typespec/http-client-python@0.29.1':
+    resolution: {integrity: sha512-b4P0tJjOfz/vjp0KzXotLPwdZ8bCoCCVmqb8FM4imtc5Uuw94NlynpMWdbD12XdTGpr4P7zLx6cmyp3rUC2C3A==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
-      '@azure-tools/typespec-autorest': '>=0.67.0 <1.0.0'
-      '@azure-tools/typespec-azure-core': '>=0.67.1 <1.0.0'
-      '@azure-tools/typespec-azure-resource-manager': '>=0.67.1 <1.0.0'
-      '@azure-tools/typespec-azure-rulesets': '>=0.67.0 <1.0.0'
-      '@azure-tools/typespec-client-generator-core': '>=0.67.4 <1.0.0'
-      '@typespec/compiler': ^1.11.0
-      '@typespec/events': '>=0.81.0 <1.0.0'
-      '@typespec/http': ^1.11.0
-      '@typespec/openapi': ^1.11.0
-      '@typespec/rest': '>=0.81.0 <1.0.0'
-      '@typespec/sse': '>=0.81.0 <1.0.0'
-      '@typespec/streams': '>=0.81.0 <1.0.0'
-      '@typespec/versioning': '>=0.81.0 <1.0.0'
-      '@typespec/xml': '>=0.81.0 <1.0.0'
+      '@azure-tools/typespec-autorest': '>=0.68.0 <1.0.0'
+      '@azure-tools/typespec-azure-core': '>=0.68.0 <1.0.0'
+      '@azure-tools/typespec-azure-resource-manager': '>=0.68.0 <1.0.0'
+      '@azure-tools/typespec-azure-rulesets': '>=0.68.0 <1.0.0'
+      '@azure-tools/typespec-client-generator-core': '>=0.68.0 <1.0.0'
+      '@typespec/compiler': ^1.12.0
+      '@typespec/events': '>=0.82.0 <1.0.0'
+      '@typespec/http': ^1.12.0
+      '@typespec/openapi': ^1.12.0
+      '@typespec/rest': '>=0.82.0 <1.0.0'
+      '@typespec/sse': '>=0.82.0 <1.0.0'
+      '@typespec/streams': '>=0.82.0 <1.0.0'
+      '@typespec/versioning': '>=0.82.0 <1.0.0'
+      '@typespec/xml': '>=0.82.0 <1.0.0'
 
   '@typespec/ts-http-runtime@0.3.4':
     resolution: {integrity: sha512-CI0NhTrz4EBaa0U+HaaUZrJhPoso8sG7ZFya8uQoBA57fjzrjRSv87ekCjLZOFExN+gXE/z0xuN2QfH4H2HrLQ==}
@@ -19889,7 +19889,7 @@ snapshots:
       '@typescript-eslint/types': 8.58.1
       eslint-visitor-keys: 5.0.1
 
-  '@typespec/http-client-python@0.29.0(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)':
+  '@typespec/http-client-python@0.29.1(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)':
     dependencies:
       '@azure-tools/typespec-autorest': link:packages/typespec-autorest
       '@azure-tools/typespec-azure-core': link:packages/typespec-azure-core
@@ -20473,7 +20473,7 @@ snapshots:
       algoliasearch: 4.27.0
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       diff: 5.2.2
-      ink: 3.2.0(@types/react@19.2.14)(react@17.0.2)
+      ink: 3.2.0(@types/react@19.2.14)(react@19.2.5)
       ink-text-input: 4.0.3(ink@3.2.0(@types/react@19.2.14)(react@17.0.2))(react@17.0.2)
       react: 17.0.2
       semver: 7.7.4
@@ -20638,7 +20638,7 @@ snapshots:
       '@yarnpkg/plugin-git': 3.1.4(@yarnpkg/core@4.6.0(typanion@3.14.0))(typanion@3.14.0)
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       es-toolkit: 1.45.1
-      ink: 3.2.0(@types/react@19.2.14)(react@19.2.5)
+      ink: 3.2.0(@types/react@19.2.14)(react@17.0.2)
       react: 17.0.2
       semver: 7.7.4
       tslib: 2.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -86,7 +86,7 @@ catalog:
   "@typescript-eslint/rule-tester": ^8.58.1
   "@typescript-eslint/types": ^8.58.1
   "@typescript-eslint/utils": ^8.58.1
-  "@typespec/http-client-python": ^0.29.0
+  "@typespec/http-client-python": ^0.29.1
   "@typespec/ts-http-runtime": "0.3.4"
   "@vitejs/plugin-react": ^6.0.1
   "@vitest/coverage-v8": ^4.1.3


### PR DESCRIPTION
@timotheeguerin I notice you released `typespec-python@0.62.0` for latest tsp version but its dependency `http-client-python@0.28.3` depends on older tsp version. I worry about the mismatch so create this PR to bump a new version with `http-client-python@0.29.1` which also depends on latest tsp version.

CC @iscai-msft 