### PR TITLE
ci(external-integration): pin contents: read on the workflow

### DIFF
--- a/.github/workflows/external-integration.yml
+++ b/.github/workflows/external-integration.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   azure-rest-api-specs:
     name: Azure REST API Specs


### PR DESCRIPTION
Adds a top-level `permissions: contents: read` block to `external-integration.yml`, the only workflow in this repo currently relying on the default `GITHUB_TOKEN` scope.

The workflow only runs on PRs labeled `int:azure-specs` (or via `workflow_dispatch`): it builds and packs the Azure TypeSpec packages, then runs the `tsp-integration` CLI against azure-rest-api-specs. None of those steps post comments, create releases, push refs, or call the GitHub API for writes, so the read-only scope is sufficient.

Matches the top-level permissions pattern already used in `ci.yml` and the other hardened workflows here. Validated locally with `yaml.safe_load`.