### PR TITLE
Ensure there is no examples emitted for parameters

### DIFF
--- a/.chronus/changes/fix-autorest-param-no-examples-2026-4-13-21-36-0.md
+++ b/.chronus/changes/fix-autorest-param-no-examples-2026-4-13-21-36-0.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Ensure there is no examples emitted for parameters

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -2282,7 +2282,7 @@ export async function getOpenAPIForService(
     }
 
     const examples = getTypeSpecExamples(program, typespecType);
-    if (typespecType.kind === "ModelProperty" && examples.length > 0) {
+    if (typespecType.kind === "ModelProperty" && usage !== "parameter" && examples.length > 0) {
       newTarget.example = serializeValueAsJson(program, examples[0].value, typespecType);
     }
 

--- a/packages/typespec-autorest/test/parameters.test.ts
+++ b/packages/typespec-autorest/test/parameters.test.ts
@@ -87,6 +87,13 @@ describe("path parameters", () => {
     });
   });
 
+  it("does not emit @example on path parameters", async () => {
+    const param = await getPathParam(`
+      @get op test(@path @TypeSpec.example("testVal") myParam: string): void;
+    `);
+    strictEqual((param as any).example, undefined);
+  });
+
   it("report unsupported-optional-path-param diagnostic on the parameter when using optional path parameters", async () => {
     const offset = 258; // hard coding, need better solution in new tester
     const { pos, end, source } = extractSquiggles(`op test(~~~@path myParam?: string~~~): void;`);


### PR DESCRIPTION
`example` is not a valid property for parameters in openapi 2.0