### PR TITLE
[Automated][tcgc] Document `exact()` function and `isExactName` property

### DIFF
--- a/.chronus/changes/tcgc-docs-update-2026-5-18-6-5-0.md
+++ b/.chronus/changes/tcgc-docs-update-2026-5-18-6-5-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Update documentation for the `exact()` function and `isExactName` property.

--- a/.chronus/changes/tcgc-exact-name-spector-spec-2026-5-18-6-5-0.md
+++ b/.chronus/changes/tcgc-exact-name-spector-spec-2026-5-18-6-5-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Add Spector spec for the `exact()` function used with `@clientName` to preserve exact naming without casing transformations.

--- a/eng/scripts/doc-updater/knowledge/tcgc.md
+++ b/eng/scripts/doc-updater/knowledge/tcgc.md
@@ -44,12 +44,13 @@
 27. `@nextLinkVerb(target, verb, scope?)` — set HTTP verb for next link (GET or POST)
 28. `@clientDefaultValue(target, value, scope?)` — set client-level defaults
 
-### Functions (lib/functions.tsp) — 4 functions
+### Functions (lib/functions.tsp) — 5 functions
 
 29. `replaceParameter(operation, selector, replacement)` — replace operation parameter
 30. `removeParameter(operation, selector)` — remove optional parameter
 31. `addParameter(operation, parameter)` — add new parameter
 32. `reorderParameters(operation, order)` — reorder parameters by name list
+33. `exact(name)` — mark a client name as exact, preventing casing transformations; used with @clientName; sets `isExactName: true` on the type graph
 
 ## TSP Doc Comment Issues Found
 
@@ -69,7 +70,7 @@
 | 06longRunningOperations.mdx | LRO patterns, @pollingOperation, @markAsLro                                                                                                     |
 | 07multipart.mdx             | @multipartBody, HttpPart, file upload                                                                                                           |
 | 08types.mdx                 | @clientNamespace, @clientDefaultValue, @clientName, @discriminator, @alternateType, @clientDoc, @flattenProperty, @deserializeEmptyStringAsNull |
-| 09renaming.mdx              | @clientName, @encodedName                                                                                                                       |
+| 09renaming.mdx              | @clientName, @encodedName, exact()                                                                                                              |
 | 10versioning.mdx            | @versioned, @added, @removed, @apiVersion, @clientApiVersions                                                                                   |
 | 11hierarchyBuilding.mdx     | @hierarchyBuilding (Legacy)                                                                                                                     |
 | 12clientOptions.mdx         | @clientOption                                                                                                                                   |
@@ -87,7 +88,7 @@
 
 ### Covered in azure/client-generator-core/
 
-access, alternate-type, api-version, client-default-value, client-doc, client-initialization, client-location, deserialize-empty-string-as-null, flatten-property, hierarchy-building, next-link-verb, override, response-as-bool, usage
+access, alternate-type, api-version, client-default-value, client-doc, client-initialization, client-location, deserialize-empty-string-as-null, exact-name, flatten-property, hierarchy-building, next-link-verb, override, response-as-bool, usage
 
 ### Covered in client/
 
@@ -177,3 +178,16 @@ namespace (@clientNamespace), naming (@clientName), overload, structure (@client
 - `@apiVersion(false)` prevents a parameter from matching to a client API version parameter, keeping it on the method.
 - Body model properties named "apiVersion" are NOT treated as API version params — only HTTP metadata params (header/query/path/cookie) and server URL template parameters (from `@server`) are matched by name.
 - Server URL template parameters (declared in `@server` decorator's parameter model) named `apiVersion`/`api-version` are recognized as API version params, even with plain `string` type in versioned services.
+
+## isExactName Property (May 2026)
+
+- The `isExactName: boolean` property was added to many SDK type interfaces: SdkModelType, SdkEnumType, SdkUnionType, SdkConstantType, SdkNullableType, SdkClientInitializationType, and SdkModelPropertyTypeBase (base for all property types).
+- Set to `true` when a name is wrapped with the `exact()` function in `@clientName`.
+- The `exact()` function internally prepends `_exact_:` prefix which is stripped by `normalizeExactName()` before the name reaches the type graph.
+- Exported helpers: `EXACT_NAME_PREFIX`, `hasExactNameMarker()`, `normalizeExactName()` from the TCGC package index.
+- Public utility: `isExactClientName(context, type)` checks whether a type has exact name override.
+- Documented in guideline.md under Common Properties and in 09renaming.mdx under "Preserving exact casing".
+
+## Feedback Lessons (PR #4416)
+
+- In TypeScript code examples, keep method signatures on a single line when they fit within ~120 characters. Don't use multi-line formatting for short method signatures.

--- a/eng/scripts/doc-updater/knowledge/tcgc.meta.json
+++ b/eng/scripts/doc-updater/knowledge/tcgc.meta.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "5849136c72dc8034af0c6e6f0c44a2843bf2ef2e",
-  "lastUpdated": "2026-05-11T10:59:26.562Z",
+  "lastCommit": "4e0c41b8c199deff9f2797e943aa568a2500cfb6",
+  "lastUpdated": "2026-05-18T06:28:16.451Z",
   "analyzedPaths": [
     "packages/typespec-client-generator-core/src",
     "packages/typespec-client-generator-core/lib",

--- a/packages/azure-http-specs/spec-summary.md
+++ b/packages/azure-http-specs/spec-summary.md
@@ -881,6 +881,56 @@ Expected response body:
 }
 ```
 
+### Azure_ClientGenerator_Core_ExactName_Model
+
+- Endpoint: `post /azure/client-generator-core/exact-name/model`
+
+This scenario tests the exact() function which prevents language emitters from applying
+casing transformations to client names. The model 'ExactModel' is renamed to 'my_model'
+using exact(), meaning all languages should preserve the name 'my_model' without any
+casing conversion (e.g., Python should NOT convert to 'MyModel' class name,
+and C# should NOT convert to 'MyModel').
+
+Expected request body:
+
+```json
+{
+  "name": "test"
+}
+```
+
+Expected response body:
+
+```json
+{
+  "name": "test"
+}
+```
+
+### Azure_ClientGenerator_Core_ExactName_Property
+
+- Endpoint: `post /azure/client-generator-core/exact-name/property`
+
+This scenario tests the exact() function applied to a model property with language scoping.
+The property 'name' on ScopedModel is renamed to 'my_name' using exact() scoped to Python only.
+Python should preserve the exact name 'my_name' as-is. Other languages use the default name 'name'.
+
+Expected request body:
+
+```json
+{
+  "name": "test"
+}
+```
+
+Expected response body:
+
+```json
+{
+  "name": "test"
+}
+```
+
 ### Azure_ClientGenerator_Core_FlattenProperty_putFlattenModel
 
 - Endpoint: `put /azure/client-generator-core/flatten-property/flattenModel`

--- a/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
@@ -9,7 +9,10 @@ using Spector;
 @doc("Test for the exact() function used with @clientName to preserve exact naming.")
 @scenarioService("/azure/client-generator-core/exact-name")
 @global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.exactname", "java")
-@global.Azure.ClientGenerator.Core.clientNamespace("specs.azure.clientgenerator.core.exactname", "python")
+@global.Azure.ClientGenerator.Core.clientNamespace(
+  "specs.azure.clientgenerator.core.exactname",
+  "python"
+)
 namespace _Specs_.Azure.ClientGenerator.Core.ExactName;
 
 @scenario

--- a/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
@@ -9,6 +9,7 @@ using Spector;
 @doc("Test for the exact() function used with @clientName to preserve exact naming.")
 @scenarioService("/azure/client-generator-core/exact-name")
 @global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.exactname", "java")
+@global.Azure.ClientGenerator.Core.clientNamespace("specs.azure.clientgenerator.core.exactname", "python")
 namespace _Specs_.Azure.ClientGenerator.Core.ExactName;
 
 @scenario

--- a/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
@@ -66,10 +66,6 @@ namespace Model {
 namespace Property {
   model ScopedModel {
     #suppress "experimental-feature" "exact"
-    #suppress "experimental-feature" "exact"
-    #suppress "experimental-feature" "exact"
-    #suppress "experimental-feature" "exact"
-    #suppress "experimental-feature" "exact"
     @global.Azure.ClientGenerator.Core.clientName(
       global.Azure.ClientGenerator.Core.exact("my_name"),
       "python"

--- a/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
@@ -8,10 +8,7 @@ using Spector;
 
 @doc("Test for the exact() function used with @clientName to preserve exact naming.")
 @scenarioService("/azure/client-generator-core/exact-name")
-@global.Azure.ClientGenerator.Core.clientNamespace(
-  "azure.clientgenerator.core.exactname",
-  "java"
-)
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.exactname", "java")
 namespace _Specs_.Azure.ClientGenerator.Core.ExactName;
 
 @scenario
@@ -50,8 +47,8 @@ namespace Model {
 @scenario
 @scenarioDoc("""
   This scenario tests the exact() function applied to a model property with language scoping.
-  The property 'name' on ScopedModel is renamed to 'my_name' using exact() scoped to Python only.
-  Python should preserve the exact name 'my_name' as-is. Other languages use the default name 'name'.
+  The property 'name' on ScopedModel is renamed to 'my_name' using exact() scoped to each language.
+  Each language should preserve the exact name 'my_name' as-is without any casing conversion.
   
   Expected request body:
   ```json
@@ -69,9 +66,29 @@ namespace Model {
 namespace Property {
   model ScopedModel {
     #suppress "experimental-feature" "exact"
+    #suppress "experimental-feature" "exact"
+    #suppress "experimental-feature" "exact"
+    #suppress "experimental-feature" "exact"
+    #suppress "experimental-feature" "exact"
     @global.Azure.ClientGenerator.Core.clientName(
       global.Azure.ClientGenerator.Core.exact("my_name"),
       "python"
+    )
+    @global.Azure.ClientGenerator.Core.clientName(
+      global.Azure.ClientGenerator.Core.exact("my_name"),
+      "java"
+    )
+    @global.Azure.ClientGenerator.Core.clientName(
+      global.Azure.ClientGenerator.Core.exact("my_name"),
+      "csharp"
+    )
+    @global.Azure.ClientGenerator.Core.clientName(
+      global.Azure.ClientGenerator.Core.exact("my_name"),
+      "javascript"
+    )
+    @global.Azure.ClientGenerator.Core.clientName(
+      global.Azure.ClientGenerator.Core.exact("my_name"),
+      "go"
     )
     name: string;
   }

--- a/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
@@ -48,12 +48,12 @@ namespace Model {
 @scenarioDoc("""
   This scenario tests the exact() function applied to a model property with language scoping.
   The property 'name' on ScopedModel is renamed using exact() scoped to each language,
-  with names that follow each language's naming convention:
-  - Python uses snake_case: 'my_name'
-  - Java uses camelCase: 'myName'
-  - C# uses PascalCase: 'MyName'
-  - JavaScript uses camelCase: 'myName'
-  - Go uses PascalCase: 'MyName'
+  with names that include an underscore prefix to verify that language naming logic does not apply:
+  - Python: '_my_name' (should not be converted to 'my_name' or other casing)
+  - Java: '_myName' (should not be converted to remove the underscore prefix)
+  - C#: '_MyName' (should not be converted to remove the underscore prefix)
+  - JavaScript: '_myName' (should not be converted to remove the underscore prefix)
+  - Go: '_MyName' (should not be converted to remove the underscore prefix)
   Each language should preserve the specified exact name as-is without any further casing conversion.
   
   Expected request body:
@@ -73,23 +73,23 @@ namespace Property {
   model ScopedModel {
     #suppress "experimental-feature" "exact"
     @global.Azure.ClientGenerator.Core.clientName(
-      global.Azure.ClientGenerator.Core.exact("my_name"),
+      global.Azure.ClientGenerator.Core.exact("_my_name"),
       "python"
     )
     @global.Azure.ClientGenerator.Core.clientName(
-      global.Azure.ClientGenerator.Core.exact("myName"),
+      global.Azure.ClientGenerator.Core.exact("_myName"),
       "java"
     )
     @global.Azure.ClientGenerator.Core.clientName(
-      global.Azure.ClientGenerator.Core.exact("MyName"),
+      global.Azure.ClientGenerator.Core.exact("_MyName"),
       "csharp"
     )
     @global.Azure.ClientGenerator.Core.clientName(
-      global.Azure.ClientGenerator.Core.exact("myName"),
+      global.Azure.ClientGenerator.Core.exact("_myName"),
       "javascript"
     )
     @global.Azure.ClientGenerator.Core.clientName(
-      global.Azure.ClientGenerator.Core.exact("MyName"),
+      global.Azure.ClientGenerator.Core.exact("_MyName"),
       "go"
     )
     name: string;

--- a/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
@@ -47,8 +47,14 @@ namespace Model {
 @scenario
 @scenarioDoc("""
   This scenario tests the exact() function applied to a model property with language scoping.
-  The property 'name' on ScopedModel is renamed to 'my_name' using exact() scoped to each language.
-  Each language should preserve the exact name 'my_name' as-is without any casing conversion.
+  The property 'name' on ScopedModel is renamed using exact() scoped to each language,
+  with names that follow each language's naming convention:
+  - Python uses snake_case: 'my_name'
+  - Java uses camelCase: 'myName'
+  - C# uses PascalCase: 'MyName'
+  - JavaScript uses camelCase: 'myName'
+  - Go uses PascalCase: 'MyName'
+  Each language should preserve the specified exact name as-is without any further casing conversion.
   
   Expected request body:
   ```json
@@ -71,19 +77,19 @@ namespace Property {
       "python"
     )
     @global.Azure.ClientGenerator.Core.clientName(
-      global.Azure.ClientGenerator.Core.exact("my_name"),
+      global.Azure.ClientGenerator.Core.exact("myName"),
       "java"
     )
     @global.Azure.ClientGenerator.Core.clientName(
-      global.Azure.ClientGenerator.Core.exact("my_name"),
+      global.Azure.ClientGenerator.Core.exact("MyName"),
       "csharp"
     )
     @global.Azure.ClientGenerator.Core.clientName(
-      global.Azure.ClientGenerator.Core.exact("my_name"),
+      global.Azure.ClientGenerator.Core.exact("myName"),
       "javascript"
     )
     @global.Azure.ClientGenerator.Core.clientName(
-      global.Azure.ClientGenerator.Core.exact("my_name"),
+      global.Azure.ClientGenerator.Core.exact("MyName"),
       "go"
     )
     name: string;

--- a/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/main.tsp
@@ -1,0 +1,82 @@
+import "@typespec/http";
+import "@typespec/spector";
+import "@azure-tools/typespec-client-generator-core";
+
+using Http;
+using Azure.ClientGenerator.Core;
+using Spector;
+
+@doc("Test for the exact() function used with @clientName to preserve exact naming.")
+@scenarioService("/azure/client-generator-core/exact-name")
+@global.Azure.ClientGenerator.Core.clientNamespace(
+  "azure.clientgenerator.core.exactname",
+  "java"
+)
+namespace _Specs_.Azure.ClientGenerator.Core.ExactName;
+
+@scenario
+@scenarioDoc("""
+  This scenario tests the exact() function which prevents language emitters from applying
+  casing transformations to client names. The model 'ExactModel' is renamed to 'my_model'
+  using exact(), meaning all languages should preserve the name 'my_model' without any
+  casing conversion (e.g., Python should NOT convert to 'MyModel' class name,
+  and C# should NOT convert to 'MyModel').
+  
+  Expected request body:
+  ```json
+  {
+    "name": "test"
+  }
+  ```
+  Expected response body:
+  ```json
+  {
+    "name": "test"
+  }
+  ```
+  """)
+namespace Model {
+  #suppress "experimental-feature" "exact"
+  @global.Azure.ClientGenerator.Core.clientName(global.Azure.ClientGenerator.Core.exact("my_model"))
+  model ExactModel {
+    name: string;
+  }
+
+  @route("/model")
+  @post
+  op send(@body body: ExactModel): ExactModel;
+}
+
+@scenario
+@scenarioDoc("""
+  This scenario tests the exact() function applied to a model property with language scoping.
+  The property 'name' on ScopedModel is renamed to 'my_name' using exact() scoped to Python only.
+  Python should preserve the exact name 'my_name' as-is. Other languages use the default name 'name'.
+  
+  Expected request body:
+  ```json
+  {
+    "name": "test"
+  }
+  ```
+  Expected response body:
+  ```json
+  {
+    "name": "test"
+  }
+  ```
+  """)
+namespace Property {
+  model ScopedModel {
+    #suppress "experimental-feature" "exact"
+    @global.Azure.ClientGenerator.Core.clientName(
+      global.Azure.ClientGenerator.Core.exact("my_name"),
+      "python"
+    )
+    name: string;
+  }
+
+  @route("/property")
+  @post
+  op send(@body body: ScopedModel): ScopedModel;
+}

--- a/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/mockapi.ts
@@ -1,0 +1,35 @@
+import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+
+export const Scenarios: Record<string, ScenarioMockApi> = {};
+
+const modelBody = { name: "test" };
+
+Scenarios.Azure_ClientGenerator_Core_ExactName_Model = passOnSuccess([
+  {
+    uri: "/azure/client-generator-core/exact-name/model",
+    method: "post",
+    request: {
+      body: json(modelBody),
+    },
+    response: {
+      status: 200,
+      body: json(modelBody),
+    },
+    kind: "MockApiDefinition",
+  },
+]);
+
+Scenarios.Azure_ClientGenerator_Core_ExactName_Property = passOnSuccess([
+  {
+    uri: "/azure/client-generator-core/exact-name/property",
+    method: "post",
+    request: {
+      body: json(modelBody),
+    },
+    response: {
+      status: 200,
+      body: json(modelBody),
+    },
+    kind: "MockApiDefinition",
+  },
+]);

--- a/website/src/content/docs/docs/howtos/Generate client libraries/09renaming.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/09renaming.mdx
@@ -489,7 +489,7 @@ using Azure.ClientGenerator.Core;
 
 </ClientTabs>
 
-In this example, the scoped renames on `ScopedModel.name` use an underscore-prefixed name per language to verify that each emitter preserves the name as-is, without stripping or recasing it. Language emitter support for `isExactName` is not yet available.
+In this example, the scoped renames on `ScopedModel.name` use an underscore-prefixed name per language to verify that each emitter preserves the name as-is, without stripping or re-casing it. Language emitter support for `isExactName` is not yet available.
 
 ## Implementation
 

--- a/website/src/content/docs/docs/howtos/Generate client libraries/09renaming.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/09renaming.mdx
@@ -440,15 +440,23 @@ The `exact()` function marks a client name so that the TCGC type graph sets `isE
 
 ```typespec title=main.tsp
 @service
-namespace PetStoreNamespace;
+namespace ExactNameService;
 
-model InputModel {
+model ExactModel {
   name: string;
 }
 
-@route("/analyze")
+model ScopedModel {
+  name: string;
+}
+
+@route("/model")
 @post
-op analyze(@body body: InputModel): void;
+op sendModel(@body body: ExactModel): ExactModel;
+
+@route("/property")
+@post
+op sendProperty(@body body: ScopedModel): ScopedModel;
 ```
 
 ```typespec title=client.tsp
@@ -457,73 +465,43 @@ import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
 
+// Global rename: preserves "my_model" verbatim for all languages
 #suppress "experimental-feature" "exact"
-@@clientName(PetStoreNamespace.InputModel, exact("InputModel"), "python");
-@@clientName(PetStoreNamespace.InputModel.name, exact("name"), "python");
+@@clientName(ExactNameService.ExactModel, exact("my_model"));
+
+// Scoped renames: per-language exact names with underscore prefix to verify
+// that language naming logic does not strip or recase the name
+#suppress "experimental-feature" "exact"
+@@clientName(ExactNameService.ScopedModel.name, exact("_my_name"), "python");
+@@clientName(ExactNameService.ScopedModel.name, exact("_myName"), "java");
+@@clientName(ExactNameService.ScopedModel.name, exact("_MyName"), "csharp");
+@@clientName(ExactNameService.ScopedModel.name, exact("_myName"), "javascript");
+@@clientName(ExactNameService.ScopedModel.name, exact("_MyName"), "go");
 ```
 
 ```python
-class InputModel(_Model):
-  name: str = rest_field()
-
-def analyze(self, body: InputModel, **kwargs: Any) -> None:
-  ...
+# not supported
 ```
 
 ```csharp
-namespace PetStoreNamespace
-{
-  public partial class InputModel
-  {
-    public string Name { get; }
-  }
-
-  public partial class PetStoreNamespaceClient
-  {
-    public virtual Response Analyze(InputModel body, CancellationToken cancellationToken = default);
-    public virtual async Task<Response> AnalyzeAsync(InputModel body, CancellationToken cancellationToken = default);
-  }
-}
+// not supported
 ```
 
 ```typescript
-export interface InputModel {
-  name: string;
-}
-
-export async function analyze(
-  context: Client,
-  body: InputModel,
-  options: AnalyzeOptionalParams,
-): Promise<void>;
+// not supported
 ```
 
 ```java
-package petstorenamespace.models;
-public final class InputModel {
-    public String getName()
-}
-
-package petstorenamespace;
-public final class PetStoreNamespaceClient {
-    public Response<Void> analyzeWithResponse(BinaryData body, RequestOptions requestOptions)
-    public void analyze(InputModel body)
-}
+// not supported
 ```
 
 ```go
-type InputModel struct {
-	Name *string
-}
-
-type PetStoreNamespaceClient struct {}
-
-func (client *PetStoreNamespaceClient) Analyze(ctx context.Context, body InputModel, options *PetStoreNamespaceClientAnalyzeOptions) (PetStoreNamespaceClientAnalyzeResponse, error)
+// not supported
 ```
 
 </ClientTabs>
 
-In this example, `exact("InputModel")` and `exact("name")` are scoped to Python, ensuring that the Python emitter preserves these names verbatim instead of converting them to `input_model` and `name` (which would be the default snake_case convention). Other languages are unaffected and apply their own idiomatic casing as usual.
+In this example, `exact("my_model")` globally renames `ExactModel` to `my_model` for all languages, preventing any automatic casing conversion. The scoped renames on `ScopedModel.name` use an underscore-prefixed name per language to verify that each emitter preserves the name as-is. Language emitter support for `isExactName` is not yet available.
 
 ## Implementation
 

--- a/website/src/content/docs/docs/howtos/Generate client libraries/09renaming.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/09renaming.mdx
@@ -428,6 +428,103 @@ resp, err := client.Get(context.TODO(), "name", &PetStoreNamespaceClientGetOptio
 
 </ClientTabs>
 
+### Preserving exact casing
+
+By default, language emitters adapt names to idiomatic casing conventions (e.g., `snake_case` for Python, `PascalCase` for C#). When you use `@clientName`, emitters are expected to use that name without applying casing transformations. However, if you want to make this intent explicit and machine-readable, you can wrap the name with the `exact()` function.
+
+The `exact()` function marks a client name so that the TCGC type graph sets `isExactName: true` on the corresponding type or property. Language emitters that check this flag will preserve the name exactly as specified, without any automatic casing conversion.
+
+`exact()` supports language scoping, so you can preserve exact casing for a specific language while letting others apply their own conventions.
+
+<ClientTabs>
+
+```typespec title=main.tsp
+@service
+namespace PetStoreNamespace;
+
+model InputModel {
+  name: string;
+}
+
+@route("/analyze")
+@post
+op analyze(@body body: InputModel): void;
+```
+
+```typespec title=client.tsp
+import "./main.tsp";
+import "@azure-tools/typespec-client-generator-core";
+
+using Azure.ClientGenerator.Core;
+
+#suppress "experimental-feature" "exact"
+@@clientName(PetStoreNamespace.InputModel, exact("InputModel"), "python");
+@@clientName(PetStoreNamespace.InputModel.name, exact("name"), "python");
+```
+
+```python
+class InputModel(_Model):
+  name: str = rest_field()
+
+def analyze(self, body: InputModel, **kwargs: Any) -> None:
+  ...
+```
+
+```csharp
+namespace PetStoreNamespace
+{
+  public partial class InputModel
+  {
+    public string Name { get; }
+  }
+
+  public partial class PetStoreNamespaceClient
+  {
+    public virtual Response Analyze(InputModel body, CancellationToken cancellationToken = default);
+    public virtual async Task<Response> AnalyzeAsync(InputModel body, CancellationToken cancellationToken = default);
+  }
+}
+```
+
+```typescript
+export interface InputModel {
+  name: string;
+}
+
+export async function analyze(
+  context: Client,
+  body: InputModel,
+  options: AnalyzeOptionalParams,
+): Promise<void>;
+```
+
+```java
+package petstorenamespace.models;
+public final class InputModel {
+    public String getName()
+}
+
+package petstorenamespace;
+public final class PetStoreNamespaceClient {
+    public Response<Void> analyzeWithResponse(BinaryData body, RequestOptions requestOptions)
+    public void analyze(InputModel body)
+}
+```
+
+```go
+type InputModel struct {
+	Name *string
+}
+
+type PetStoreNamespaceClient struct {}
+
+func (client *PetStoreNamespaceClient) Analyze(ctx context.Context, body InputModel, options *PetStoreNamespaceClientAnalyzeOptions) (PetStoreNamespaceClientAnalyzeResponse, error)
+```
+
+</ClientTabs>
+
+In this example, `exact("InputModel")` and `exact("name")` are scoped to Python, ensuring that the Python emitter preserves these names verbatim instead of converting them to `input_model` and `name` (which would be the default snake_case convention). Other languages are unaffected and apply their own idiomatic casing as usual.
+
 ## Implementation
 
 ### Order of Operations

--- a/website/src/content/docs/docs/howtos/Generate client libraries/09renaming.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/09renaming.mdx
@@ -442,17 +442,9 @@ The `exact()` function marks a client name so that the TCGC type graph sets `isE
 @service
 namespace ExactNameService;
 
-model ExactModel {
-  name: string;
-}
-
 model ScopedModel {
   name: string;
 }
-
-@route("/model")
-@post
-op sendModel(@body body: ExactModel): ExactModel;
 
 @route("/property")
 @post
@@ -464,10 +456,6 @@ import "./main.tsp";
 import "@azure-tools/typespec-client-generator-core";
 
 using Azure.ClientGenerator.Core;
-
-// Global rename: preserves "my_model" verbatim for all languages
-#suppress "experimental-feature" "exact"
-@@clientName(ExactNameService.ExactModel, exact("my_model"));
 
 // Scoped renames: per-language exact names with underscore prefix to verify
 // that language naming logic does not strip or recase the name
@@ -501,7 +489,7 @@ using Azure.ClientGenerator.Core;
 
 </ClientTabs>
 
-In this example, `exact("my_model")` globally renames `ExactModel` to `my_model` for all languages, preventing any automatic casing conversion. The scoped renames on `ScopedModel.name` use an underscore-prefixed name per language to verify that each emitter preserves the name as-is. Language emitter support for `isExactName` is not yet available.
+In this example, the scoped renames on `ScopedModel.name` use an underscore-prefixed name per language to verify that each emitter preserves the name as-is, without stripping or recasing it. Language emitter support for `isExactName` is not yet available.
 
 ## Implementation
 

--- a/website/src/content/docs/docs/howtos/Generate client libraries/09renaming.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/09renaming.mdx
@@ -430,7 +430,7 @@ resp, err := client.Get(context.TODO(), "name", &PetStoreNamespaceClientGetOptio
 
 ### Preserving exact casing
 
-By default, language emitters adapt names to idiomatic casing conventions (e.g., `snake_case` for Python, `PascalCase` for C#). When you use `@clientName`, emitters are expected to use that name without applying casing transformations. However, if you want to make this intent explicit and machine-readable, you can wrap the name with the `exact()` function.
+By default, language emitters adapt names to idiomatic casing conventions (e.g., `snake_case` for Python, `PascalCase` for C#). `@clientName` also allows emitters to apply language-specific casing transformations to the provided name. To prevent this and preserve the name exactly as specified, wrap it with the `exact()` function.
 
 The `exact()` function marks a client name so that the TCGC type graph sets `isExactName: true` on the corresponding type or property. Language emitters that check this flag will preserve the name exactly as specified, without any automatic casing conversion.
 

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
@@ -260,7 +260,6 @@ If a detected client or sub client does not contain any sub client or operation,
 Normally, a client's initialization parameters include:
 
 1. **Endpoint parameter**: Converted from `@server` definition on the service the client belongs to.
-
    - If the server URL is a constant, TCGC returns a templated endpoint with a default value of the constant server URL.
    - When the endpoint has additional template arguments, the type is a union of a completely-overridable endpoint and an endpoint that accepts template arguments.
    - If there are multiple servers, TCGC returns the union of all possibilities.
@@ -268,7 +267,6 @@ Normally, a client's initialization parameters include:
 2. **Credential parameter**: Converted from `@useAuth` definition on the service the client belongs to.
 
 3. **API version parameter**: If the service is versioned, then the API version parameter on method is elevated to client.
-
    - The API version parameter is detected by parameter name (`api-version` or `apiversion`) or parameter type (API version enum type used in `@versioned` decorator).
 
 4. **Subscription ID parameter**: If the service is an ARM service, then the subscription ID parameter on method is elevated to client.
@@ -374,7 +372,6 @@ This ensures that types reachable only through readonly properties are not incor
 `SdkModelType`, `SdkEnumType`, `SdkUnionType`, and `SdkConstantType` always have names. If the original TypeSpec type does not have a name, TCGC creates a name for it. The naming logic follows these steps:
 
 1. **Find the place where the type is used:**
-
    - Find if the type is used in the method's underlying operation: either in parameters, body parameter, response header, or response body.
    - Find if the type is used in the method's parameters.
    - Find if the type is used in orphan types.

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
@@ -84,6 +84,7 @@ Most TCGC types share the following common properties:
 - **`decorators`**: Stores all TypeSpec decorator info for advanced use cases.
 - **`crossLanguageDefinitionId`**: A unique ID for a TCGC type that can be used for output mapping across different emitters.
 - **`name`** and **`isGeneratedName`**: The type's name and whether the name was created by TCGC.
+- **`isExactName`**: Indicates that the name was set via `@clientName` with the `exact()` function and must be used as-is by language emitters, without applying any casing transformations (e.g., no snake_case for Python, no camelCase for JavaScript).
 - **`access`**: Indicates whether the type has public or private accessibility.
 - **`usage`**: Indicates the type's usage information; its value is a bitmap of [`UsageFlags`](../reference/js-api/enumerations/usageflags/) enumeration. The flags are:
   - `Input` (2): Type is used as input (in a request body).

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
@@ -260,6 +260,7 @@ If a detected client or sub client does not contain any sub client or operation,
 Normally, a client's initialization parameters include:
 
 1. **Endpoint parameter**: Converted from `@server` definition on the service the client belongs to.
+
    - If the server URL is a constant, TCGC returns a templated endpoint with a default value of the constant server URL.
    - When the endpoint has additional template arguments, the type is a union of a completely-overridable endpoint and an endpoint that accepts template arguments.
    - If there are multiple servers, TCGC returns the union of all possibilities.
@@ -267,6 +268,7 @@ Normally, a client's initialization parameters include:
 2. **Credential parameter**: Converted from `@useAuth` definition on the service the client belongs to.
 
 3. **API version parameter**: If the service is versioned, then the API version parameter on method is elevated to client.
+
    - The API version parameter is detected by parameter name (`api-version` or `apiversion`) or parameter type (API version enum type used in `@versioned` decorator).
 
 4. **Subscription ID parameter**: If the service is an ARM service, then the subscription ID parameter on method is elevated to client.
@@ -372,6 +374,7 @@ This ensures that types reachable only through readonly properties are not incor
 `SdkModelType`, `SdkEnumType`, `SdkUnionType`, and `SdkConstantType` always have names. If the original TypeSpec type does not have a name, TCGC creates a name for it. The naming logic follows these steps:
 
 1. **Find the place where the type is used:**
+
    - Find if the type is used in the method's underlying operation: either in parameters, body parameter, response header, or response body.
    - Find if the type is used in the method's parameters.
    - Find if the type is used in orphan types.


### PR DESCRIPTION
- Add 'Preserving exact casing' section to 09renaming.mdx with ClientTabs example
- Add isExactName to guideline.md common properties section
- Add Spector spec for exact-name (model and scoped property scenarios)
- Update knowledge base with exact() function details and feedback lessons


Resolve: https://github.com/Azure/typespec-azure/issues/4429