### PR TITLE
[Automated][azure-resource-manager] Fix doc comment typos in ARM list operation templates

### DIFF
--- a/.chronus/changes/fix-arm-list-operation-doc-comments-2026-5-13-3-13-0.md
+++ b/.chronus/changes/fix-arm-list-operation-doc-comments-2026-5-13-3-13-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Fix doc comment typos in list operation templates where `@template Resource` was incorrectly described as "the resource being patched" instead of "the resource being listed".

--- a/eng/scripts/doc-updater/knowledge/azure-resource-manager.md
+++ b/eng/scripts/doc-updater/knowledge/azure-resource-manager.md
@@ -79,4 +79,20 @@ Old paths like `dynatrace/`, `tenantResource/`, `arm-scenarios/singleton/`, `ope
 
 `ArmResourcePatchAsync` and `ArmResourcePatchSync` exist and are not deprecated, though they are noted as "not recommended" in resource-operations.md. `ArmCustomPatchSync` and `ArmCustomPatchAsync` are the preferred alternatives.
 
-`TrackedResourceOperations` interface is current. `ResourceOperations` is deprecated (use `TrackedResourceOperations` instead).
+`ArmResourcePatchAsync` and `ArmResourcePatchSync` are not deprecated but are "not recommended". `ArmCustomPatchSync` and `ArmCustomPatchAsync` are preferred.
+
+## Getting-Started Examples
+
+- **Do not use `TrackedResourceOperations`** in getting-started guides. Instead, list individual operations explicitly (e.g., `get is ArmResourceRead<User>; create is ArmResourceCreateOrReplaceAsync<User>;`). This makes the tutorial clearer and avoids hiding what operations are generated. `TrackedResourceOperations` is technically current but is not appropriate for beginner tutorials.
+- **Do not include `version` in `@service()`**. Use `@service(#{ title: "..." })` without a `version` parameter. Versioning is handled by the `@versioned` decorator, not `@service`.
+- All resource models must use `...ResourceNameParameter<Model>` instead of manual `@key/@segment/@path name: string` patterns.
+
+## Rule Documentation Integrity
+
+- Only create rule documentation files for rules that actually exist in `src/rules/` and are registered in `src/linter.ts`. Never fabricate rule docs for non-existent rules (e.g., `arm-legacy-operations-discourage` was incorrectly documented in a past run and had to be removed).
+- When new rules are added to `src/linter.ts`, check whether their rule doc files under `rules/` already exist before creating them. The auto-generated `reference/linter.md` will list them after `pnpm regen-docs`.
+
+## Common Doc Comment Copy-Paste Errors
+
+- List operation templates (e.g., `ArmListBySubscription`, `ArmResourceListByParent`, `ArmResourceListAtScope`, `ArmListSinglePageBySubscription`, `ArmListSinglePageByParent`) sometimes have `@template Resource the resource being patched` — this should be `the resource being listed`. These are copy-paste errors from patch operation templates.
+- Always verify the `@template Resource` description matches the actual operation type (read, list, create, patch, delete, action).

--- a/eng/scripts/doc-updater/knowledge/azure-resource-manager.meta.json
+++ b/eng/scripts/doc-updater/knowledge/azure-resource-manager.meta.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "c28b4645003e1b948275b7c2854911dd09d800c8",
-  "lastUpdated": "2026-04-29T04:58:33.314Z",
+  "lastCommit": "0f02931d69f08fcbe26749f9fbf6c642d9a348f1",
+  "lastUpdated": "2026-05-13T03:23:37.471Z",
   "analyzedPaths": [
     "packages/typespec-azure-resource-manager/src",
     "packages/typespec-azure-resource-manager/lib",

--- a/packages/typespec-azure-resource-manager/lib/legacy-types/operations.tsp
+++ b/packages/typespec-azure-resource-manager/lib/legacy-types/operations.tsp
@@ -658,7 +658,7 @@ op CreateOrReplaceSync<
 
 /**
  * A resource list operation, at the subscription scope, that lists only a single page
- * @template Resource the resource being patched
+ * @template Resource the resource being listed
  * @template Parameters Optional. Additional parameters after the path parameters
  * @template Response Optional. The success response for the list operation
  * @template Error Optional. The error response, if non-standard.
@@ -679,7 +679,7 @@ op ArmListSinglePageBySubscription<
 
 /**
  * A resource list operation, at the scope of the resource's parent that lists only a single page.
- * @template Resource the resource being patched
+ * @template Resource the resource being listed
  * @template BaseParameters Optional. Allows overriding the operation parameters
  * @template ParentName Optional. The name of the parent resource
  * @template ParentFriendlyName Optional. The friendly name of the parent resource

--- a/packages/typespec-azure-resource-manager/lib/operations.tsp
+++ b/packages/typespec-azure-resource-manager/lib/operations.tsp
@@ -9,7 +9,7 @@ namespace Azure.ResourceManager;
 
 /**
  * A resource list operation, at the subscription scope
- * @template Resource the resource being patched
+ * @template Resource the resource being listed
  * @template Parameters Optional. Additional parameters after the path parameters
  * @template Response Optional. The success response for the list operation
  * @template Error Optional. The error response, if non-standard.
@@ -58,7 +58,7 @@ op ArmListBySubscriptionScope<
 
 /**
  * A resource list operation, at the scope of the resource's parent
- * @template Resource the resource being patched
+ * @template Resource the resource being listed
  * @template BaseParameters Optional. Allows overriding the operation parameters
  * @template ParentName Optional. The name of the parent resource
  * @template ParentFriendlyName Optional. The friendly name of the parent resource
@@ -92,7 +92,7 @@ op ArmResourceListByParent<
 
 /**
  * A resource list operation, with scope determined by BaseParameters
- * @template Resource the resource being patched
+ * @template Resource the resource being listed
  * @template BaseParameters Optional. Allows overriding the operation parameters
  * @template Parameters Optional. Additional parameters after the path parameters
  * @template Response Optional. The success response for the list operation

--- a/website/src/content/docs/docs/libraries/azure-resource-manager/reference/interfaces.md
+++ b/website/src/content/docs/docs/libraries/azure-resource-manager/reference/interfaces.md
@@ -984,7 +984,7 @@ op Azure.ResourceManager.ArmListBySubscription(apiVersion: string, subscriptionI
 
 | Name       | Description                                               |
 | ---------- | --------------------------------------------------------- |
-| Resource   | the resource being patched                                |
+| Resource   | the resource being listed                                 |
 | Parameters | Optional. Additional parameters after the path parameters |
 | Response   | Optional. The success response for the list operation     |
 | Error      | Optional. The error response, if non-standard.            |
@@ -1349,7 +1349,7 @@ op Azure.ResourceManager.ArmResourceListAtScope(): Response | Error
 
 | Name           | Description                                               |
 | -------------- | --------------------------------------------------------- |
-| Resource       | the resource being patched                                |
+| Resource       | the resource being listed                                 |
 | BaseParameters | Optional. Allows overriding the operation parameters      |
 | Parameters     | Optional. Additional parameters after the path parameters |
 | Response       | Optional. The success response for the list operation     |
@@ -1368,7 +1368,7 @@ op Azure.ResourceManager.ArmResourceListByParent(): Response | Error
 
 | Name               | Description                                               |
 | ------------------ | --------------------------------------------------------- |
-| Resource           | the resource being patched                                |
+| Resource           | the resource being listed                                 |
 | BaseParameters     | Optional. Allows overriding the operation parameters      |
 | ParentName         | Optional. The name of the parent resource                 |
 | ParentFriendlyName | Optional. The friendly name of the parent resource        |
@@ -2714,7 +2714,7 @@ op Azure.ResourceManager.Legacy.ArmListSinglePageByParent(provider: "Microsoft.T
 
 | Name               | Description                                               |
 | ------------------ | --------------------------------------------------------- |
-| Resource           | the resource being patched                                |
+| Resource           | the resource being listed                                 |
 | BaseParameters     | Optional. Allows overriding the operation parameters      |
 | ParentName         | Optional. The name of the parent resource                 |
 | ParentFriendlyName | Optional. The friendly name of the parent resource        |
@@ -2734,7 +2734,7 @@ op Azure.ResourceManager.Legacy.ArmListSinglePageBySubscription(apiVersion: stri
 
 | Name       | Description                                               |
 | ---------- | --------------------------------------------------------- |
-| Resource   | the resource being patched                                |
+| Resource   | the resource being listed                                 |
 | Parameters | Optional. Additional parameters after the path parameters |
 | Response   | Optional. The success response for the list operation     |
 | Error      | Optional. The error response, if non-standard.            |


### PR DESCRIPTION
Corrected @template Resource descriptions in list operation templates (ArmListBySubscription, ArmResourceListByParent, ArmResourceListAtScope, ArmListSinglePageBySubscription, ArmListSinglePageByParent) from "the resource being patched" to "the resource being listed".

Regenerated reference docs to reflect the fixes.

Updated knowledge base with lessons learned from previous PR feedback.