### PR TITLE
[Experimental] model-name-request-suffix rule in ARM package

### DIFF
--- a/packages/typespec-azure-resource-manager/src/linter.ts
+++ b/packages/typespec-azure-resource-manager/src/linter.ts
@@ -35,6 +35,7 @@ import { retryAfterRule } from "./rules/retry-after.js";
 import { secretProprule } from "./rules/secret-prop.js";
 import { unsupportedTypeRule } from "./rules/unsupported-type.js";
 import { versionProgressionRule } from "./rules/version-progression.js";
+import { modelNameRequestSuffixRule } from "./rules/arm-model-name-request-suffix.js";
 
 const rules = [
   armNoRecordRule,
@@ -73,6 +74,7 @@ const rules = [
   unsupportedTypeRule,
   secretProprule,
   noEmptyModel,
+  modelNameRequestSuffixRule,
 ];
 
 export const $linter = defineLinter({

--- a/packages/typespec-azure-resource-manager/src/rules/arm-model-name-request-suffix.ts
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-model-name-request-suffix.ts
@@ -1,0 +1,61 @@
+import { createRule, defineCodeFix, getSourceLocation, Model, paramMessage } from "@typespec/compiler";
+
+function createReplaceRequestWithContentCodeFix(target: Model, name: string) {
+  const newName = name.replace(/Request$/, "Content");
+  return defineCodeFix({
+    id: "replace-request-with-content",
+    label: `Add @clientName("${newName}", "csharp")`,
+    fix: (fixContext) => {
+      const location = getSourceLocation(target);
+      const text = location.file.text;
+      let lineStart = location.pos;
+      while (lineStart > 0 && text[lineStart - 1] !== "\n") {
+        lineStart--;
+      }
+      let indentEnd = lineStart;
+      while (indentEnd < text.length && (text[indentEnd] === " " || text[indentEnd] === "\t")) {
+        indentEnd++;
+      }
+      const indent = text.slice(lineStart, indentEnd);
+      const updatedLocation = { ...location, pos: lineStart };
+      return fixContext.prependText(
+        updatedLocation,
+        `${indent}@clientName("${newName}", "csharp")\n`,
+      );
+    },
+  });
+}
+
+export const modelNameRequestSuffixRule = createRule({
+  name: "arm-model-name-request-suffix",
+  description: "Model names should not end with 'Request'. Use 'Content' suffix instead.",
+  severity: "warning",
+  url: "https://azure.github.io/typespec-azure/docs/libraries/azure-resource-manager/rules/arm-model-name-request-suffix",
+  messages: {
+    default: paramMessage`Model name '${"name"}' ends with 'Request'. Consider renaming it to '${"suggestion"}' or use @clientName("${"suggestion"}", "csharp") to rename it for C#.`,
+  },
+  create(context) {
+    // NOTE: Cannot use getLibraryName/createTCGCContext here because
+    // typespec-azure-resource-manager does not depend on typespec-client-generator-core.
+    // This means we can only check the raw TypeSpec model name, NOT the C#-scoped
+    // name from @clientName overrides. If a model has @clientName("FooContent", "csharp")
+    // but its TypeSpec name is still FooRequest, this rule will STILL flag it as a
+    // false positive.
+    return {
+      model: (model: Model) => {
+        if (typeof model.name !== "string") return;
+        const name = model.name;
+        if (!name.endsWith("Request")) return;
+        const suggestion = name.replace(/Request$/, "Content");
+        context.reportDiagnostic({
+          format: {
+            name,
+            suggestion,
+          },
+          target: model,
+          codefixes: [createReplaceRequestWithContentCodeFix(model, name)],
+        });
+      },
+    };
+  },
+});

--- a/packages/typespec-azure-rulesets/src/rulesets/resource-manager.ts
+++ b/packages/typespec-azure-rulesets/src/rulesets/resource-manager.ts
@@ -93,6 +93,7 @@ export default {
     "@azure-tools/typespec-azure-resource-manager/retry-after": false, // Disable https://github.com/Azure/typespec-azure/issues/3351
     "@azure-tools/typespec-azure-resource-manager/secret-prop": true,
     "@azure-tools/typespec-azure-resource-manager/unsupported-type": true,
+    "@azure-tools/typespec-azure-resource-manager/arm-model-name-request-suffix": true,
 
     // TCGC rules
     "@azure-tools/typespec-client-generator-core/require-client-suffix": true,


### PR DESCRIPTION
## Experimental: model-name-request-suffix rule in ARM package

This is an **experimental** PR to compare placing the `Request` → `Content` model
name rule in the ARM package vs TCGC (see #4460).

Related issue: #4448

### Why this is NOT the recommended approach

The ARM package (`@azure-tools/typespec-azure-resource-manager`) does **not** depend
on `@azure-tools/typespec-client-generator-core`, so this rule:

- ❌ **Cannot** check `@clientName` overrides — only sees raw TypeSpec model names
- ❌ **Produces false positives** when `client.tsp` already has `@@clientName("...Content", "csharp")`
- ❌ Both `tsp compile .` and `tsp compile client.tsp` show the **same** warnings

Compare with the TCGC version (#4460) which:

- ✅ Uses `getLibraryName(ctx, model, "csharp")` to check the C#-resolved name
- ✅ Respects `@clientName` overrides — no false positives
- ✅ `tsp compile client.tsp` correctly shows 0 warnings when overrides exist

### Test results (advisor spec)

| Compile mode | ARM version (this PR) | TCGC version (#4460) |
|---|---|---|
| `tsp compile .` | ⚠️ 1 warning | ⚠️ 1 warning |
| `tsp compile client.tsp` | ⚠️ 1 warning (**false positive**) | ✅ 0 warnings |
