### PR TITLE
Add model-name-resource-suffix linter rule

### DIFF
--- a/.chronus/changes/add-model-name-resource-suffix-rule-2026-5-19-17-25-0.md
+++ b/.chronus/changes/add-model-name-resource-suffix-rule-2026-5-19-17-25-0.md
@@ -1,0 +1,8 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+  - "@azure-tools/typespec-azure-rulesets"
+---
+
+Add `model-name-resource-suffix` linter rule that flags model names ending with `Resource` and suggests dropping the suffix or renaming to `Data`/`Info`, per Azure SDK .NET naming conventions. Includes auto-fix codefixes via `@clientName`.

--- a/packages/typespec-azure-rulesets/src/rulesets/resource-manager.ts
+++ b/packages/typespec-azure-rulesets/src/rulesets/resource-manager.ts
@@ -98,5 +98,6 @@ export default {
     "@azure-tools/typespec-client-generator-core/require-client-suffix": true,
     "@azure-tools/typespec-client-generator-core/property-name-conflict": true,
     "@azure-tools/typespec-client-generator-core/no-unnamed-types": false, // Too bad performance https://github.com/Azure/typespec-azure/issues/2803
+    "@azure-tools/typespec-client-generator-core/model-name-resource-suffix": true,
   },
 } satisfies LinterRuleSet;

--- a/packages/typespec-client-generator-core/src/linter.ts
+++ b/packages/typespec-client-generator-core/src/linter.ts
@@ -1,11 +1,17 @@
 import { defineLinter } from "@typespec/compiler";
+import { modelNameResourceSuffixRule } from "./rules/model-name-resource-suffix.rule.js";
 import { noUnnamedTypesRule } from "./rules/no-unnamed-types.rule.js";
 import { propertyNameConflictRule } from "./rules/property-name-conflict.rule.js";
 import { requireClientSuffixRule } from "./rules/require-client-suffix.rule.js";
 
-const rules = [requireClientSuffixRule, propertyNameConflictRule, noUnnamedTypesRule];
+const rules = [
+  requireClientSuffixRule,
+  propertyNameConflictRule,
+  noUnnamedTypesRule,
+  modelNameResourceSuffixRule,
+];
 
-const csharpRules = [propertyNameConflictRule];
+const csharpRules = [propertyNameConflictRule, modelNameResourceSuffixRule];
 
 export const $linter = defineLinter({
   rules,

--- a/packages/typespec-client-generator-core/src/rules/model-name-resource-suffix.rule.ts
+++ b/packages/typespec-client-generator-core/src/rules/model-name-resource-suffix.rule.ts
@@ -79,6 +79,10 @@ export const modelNameResourceSuffixRule = createRule({
     );
     return {
       model: (model: Model) => {
+        // TODO: Currently uses string suffix matching on the model name. If more precise
+        // ARM resource detection is needed, walk the model's inheritance chain to check
+        // if it extends TrackedResource<T>, ProxyResource<T>, etc. This would require
+        // either depending on the ARM package or replicating the base type check here.
         const csharpName = getLibraryName(tcgcContext, model, "csharp");
         if (!csharpName.endsWith("Resource")) return;
         // Don't flag if the name is exactly "Resource" (too generic to lint)

--- a/packages/typespec-client-generator-core/src/rules/model-name-resource-suffix.rule.ts
+++ b/packages/typespec-client-generator-core/src/rules/model-name-resource-suffix.rule.ts
@@ -1,0 +1,113 @@
+import {
+  createRule,
+  defineCodeFix,
+  getSourceLocation,
+  Model,
+  paramMessage,
+} from "@typespec/compiler";
+import { createTCGCContext } from "../context.js";
+import { getLibraryName } from "../public-utils.js";
+
+function createDropResourceSuffixCodeFix(target: Model, csharpName: string) {
+  const newName = csharpName.replace(/Resource$/, "");
+  return defineCodeFix({
+    id: "drop-resource-suffix",
+    label: `Add @clientName("${newName}", "csharp")`,
+    fix: (fixContext) => {
+      const location = getSourceLocation(target);
+      const text = location.file.text;
+      let lineStart = location.pos;
+      while (lineStart > 0 && text[lineStart - 1] !== "\n") {
+        lineStart--;
+      }
+      let indentEnd = lineStart;
+      while (indentEnd < text.length && (text[indentEnd] === " " || text[indentEnd] === "\t")) {
+        indentEnd++;
+      }
+      const indent = text.slice(lineStart, indentEnd);
+      const updatedLocation = { ...location, pos: lineStart };
+      return fixContext.prependText(
+        updatedLocation,
+        `${indent}@clientName("${newName}", "csharp")\n`,
+      );
+    },
+  });
+}
+
+function createRenameToDataCodeFix(target: Model, csharpName: string) {
+  const newName = csharpName.replace(/Resource$/, "Data");
+  return defineCodeFix({
+    id: "rename-resource-to-data",
+    label: `Add @clientName("${newName}", "csharp")`,
+    fix: (fixContext) => {
+      const location = getSourceLocation(target);
+      const text = location.file.text;
+      let lineStart = location.pos;
+      while (lineStart > 0 && text[lineStart - 1] !== "\n") {
+        lineStart--;
+      }
+      let indentEnd = lineStart;
+      while (indentEnd < text.length && (text[indentEnd] === " " || text[indentEnd] === "\t")) {
+        indentEnd++;
+      }
+      const indent = text.slice(lineStart, indentEnd);
+      const updatedLocation = { ...location, pos: lineStart };
+      return fixContext.prependText(
+        updatedLocation,
+        `${indent}@clientName("${newName}", "csharp")\n`,
+      );
+    },
+  });
+}
+
+export const modelNameResourceSuffixRule = createRule({
+  name: "model-name-resource-suffix",
+  description:
+    "Model names ending with 'Resource' should drop the suffix or rename to 'Data'/'Info'.",
+  severity: "warning",
+  url: "https://azure.github.io/typespec-azure/docs/libraries/typespec-client-generator-core/rules/model-name-resource-suffix",
+  messages: {
+    default: paramMessage`Model name '${"name"}' ends with 'Resource'. Consider dropping the suffix (e.g. '${"suggestion"}') or use @clientName("${"suggestion"}", "csharp") to rename it for C#.`,
+  },
+  create(context) {
+    const tcgcContext = createTCGCContext(
+      context.program,
+      "@azure-tools/typespec-client-generator-core",
+      {
+        mutateNamespace: false,
+      },
+    );
+    return {
+      model: (model: Model) => {
+        const csharpName = getLibraryName(tcgcContext, model, "csharp");
+        if (!csharpName.endsWith("Resource")) return;
+        // Don't flag if the name is exactly "Resource" (too generic to lint)
+        if (csharpName === "Resource") return;
+        // Don't flag well-known base types like TrackedResource, ProxyResource, ExtensionResource
+        const wellKnown = [
+          "TrackedResource",
+          "ProxyResource",
+          "ExtensionResource",
+          "GenericResource",
+        ];
+        if (wellKnown.includes(csharpName)) return;
+
+        const baseName = csharpName.replace(/Resource$/, "");
+        const suggestion = baseName;
+        const codefixes = [
+          createDropResourceSuffixCodeFix(model, csharpName),
+          createRenameToDataCodeFix(model, csharpName),
+        ];
+
+        context.reportDiagnostic({
+          format: {
+            name: csharpName,
+            suggestion,
+          },
+          target: model,
+          codefixes,
+        });
+      },
+    };
+  },
+});

--- a/packages/typespec-client-generator-core/test/rules/model-name-resource-suffix.test.ts
+++ b/packages/typespec-client-generator-core/test/rules/model-name-resource-suffix.test.ts
@@ -1,0 +1,164 @@
+import {
+  createLinterRuleTester,
+  LinterRuleTester,
+  TesterInstance,
+} from "@typespec/compiler/testing";
+import { beforeEach, describe, it } from "vitest";
+import { modelNameResourceSuffixRule } from "../../src/rules/model-name-resource-suffix.rule.js";
+import { SimpleTester } from "../tester.js";
+
+let runner: TesterInstance;
+let tester: LinterRuleTester;
+
+beforeEach(async () => {
+  runner = await SimpleTester.createInstance();
+  tester = createLinterRuleTester(
+    runner,
+    modelNameResourceSuffixRule,
+    "@azure-tools/typespec-client-generator-core",
+  );
+});
+
+it("emits warning when model name ends with Resource", async () => {
+  await tester
+    .expect(
+      `model EvidenceResource {
+        value: string;
+      }`,
+    )
+    .toEmitDiagnostics({
+      code: "@azure-tools/typespec-client-generator-core/model-name-resource-suffix",
+      message: `Model name 'EvidenceResource' ends with 'Resource'. Consider dropping the suffix (e.g. 'Evidence') or use @clientName("Evidence", "csharp") to rename it for C#.`,
+    });
+});
+
+it("is valid when model name does not end with Resource", async () => {
+  await tester
+    .expect(
+      `model Evidence {
+        value: string;
+      }`,
+    )
+    .toBeValid();
+});
+
+it("is valid when model name ends with Resources (plural)", async () => {
+  await tester
+    .expect(
+      `model BatchResources {
+        items: string[];
+      }`,
+    )
+    .toBeValid();
+});
+
+it("does not flag model named exactly Resource", async () => {
+  await tester
+    .expect(
+      `model Resource {
+        id: string;
+      }`,
+    )
+    .toBeValid();
+});
+
+it("does not flag well-known base types", async () => {
+  await tester
+    .expect(
+      `model TrackedResource {
+        id: string;
+      }
+      model ProxyResource {
+        id: string;
+      }
+      model ExtensionResource {
+        id: string;
+      }
+      model GenericResource {
+        id: string;
+      }`,
+    )
+    .toBeValid();
+});
+
+it("is valid when @clientName removes Resource suffix", async () => {
+  await tester
+    .expect(
+      `@clientName("Evidence", "csharp")
+      model EvidenceResource {
+        value: string;
+      }`,
+    )
+    .toBeValid();
+});
+
+it("is valid when @clientName renames to Data suffix", async () => {
+  await tester
+    .expect(
+      `@clientName("EvidenceData", "csharp")
+      model EvidenceResource {
+        value: string;
+      }`,
+    )
+    .toBeValid();
+});
+
+it("emits warning when @clientName still ends with Resource", async () => {
+  await tester
+    .expect(
+      `@clientName("MyEvidenceResource", "csharp")
+      model SomeEvidence {
+        value: string;
+      }`,
+    )
+    .toEmitDiagnostics({
+      code: "@azure-tools/typespec-client-generator-core/model-name-resource-suffix",
+      message: `Model name 'MyEvidenceResource' ends with 'Resource'. Consider dropping the suffix (e.g. 'MyEvidence') or use @clientName("MyEvidence", "csharp") to rename it for C#.`,
+    });
+});
+
+it("is case-sensitive - does not flag lowercase resource", async () => {
+  await tester
+    .expect(
+      `model Myresource {
+        value: string;
+      }`,
+    )
+    .toBeValid();
+});
+
+it("does not flag non-model types", async () => {
+  await tester.expect(`scalar ResourceId extends string;`).toBeValid();
+});
+
+describe("codefix", () => {
+  it("offers drop Resource suffix codefix", async () => {
+    await tester
+      .expect(
+        `
+        model EvidenceResource {
+          value: string;
+        }`,
+      )
+      .applyCodeFix("drop-resource-suffix").toEqual(`
+        @clientName("Evidence", "csharp")
+        model EvidenceResource {
+          value: string;
+        }`);
+  });
+
+  it("offers rename to Data suffix codefix", async () => {
+    await tester
+      .expect(
+        `
+        model EvidenceResource {
+          value: string;
+        }`,
+      )
+      .applyCodeFix("rename-resource-to-data").toEqual(`
+        @clientName("EvidenceData", "csharp")
+        model EvidenceResource {
+          value: string;
+        }`);
+  });
+});

--- a/packages/typespec-client-generator-core/test/rules/model-name-resource-suffix.test.ts
+++ b/packages/typespec-client-generator-core/test/rules/model-name-resource-suffix.test.ts
@@ -127,6 +127,10 @@ it("is case-sensitive - does not flag lowercase resource", async () => {
     .toBeValid();
 });
 
+// Note: @suppress / #suppress works at the compiler level to silence warnings for edge cases.
+// Example: #suppress "@azure-tools/typespec-client-generator-core/model-name-resource-suffix" "reason"
+// This cannot be tested via the linter rule tester as it doesn't process suppress directives.
+
 it("does not flag non-model types", async () => {
   await tester.expect(`scalar ResourceId extends string;`).toBeValid();
 });

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/rules/model-name-resource-suffix.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/rules/model-name-resource-suffix.md
@@ -1,0 +1,60 @@
+---
+title: model-name-resource-suffix
+---
+
+```text title="Full name"
+@azure-tools/typespec-client-generator-core/model-name-resource-suffix
+```
+
+Model names should not end with `Resource`. The
+[Azure SDK for .NET management plane naming convention](https://github.com/Azure/azure-sdk-for-net/blob/main/doc/dev/Mgmt-Naming-Conventions.md)
+recommends dropping the `Resource` suffix when the remaining noun is
+descriptive enough, or replacing it with `Data` or `Info`. This rule is
+part of the `best-practices:csharp` ruleset.
+
+The rule inspects the C#-scoped name of each model (the value of
+`@clientName(..., "csharp")` if provided, otherwise the TypeSpec name).
+Well-known base types (`TrackedResource`, `ProxyResource`,
+`ExtensionResource`, `GenericResource`) are excluded.
+
+To fix violations, either rename the model in TypeSpec when the
+convention applies cross-language, or use `@clientName` to provide a
+C#-only override while keeping the original TypeSpec name.
+
+#### ❌ Incorrect
+
+```tsp
+model EvidenceResource {
+  value: string;
+}
+
+model ReportResource {
+  name: string;
+}
+```
+
+#### ✅ Correct (drop suffix)
+
+```tsp
+model Evidence {
+  value: string;
+}
+
+model Report {
+  name: string;
+}
+```
+
+#### ✅ Correct (rename for C# only)
+
+```tsp
+@clientName("Evidence", "csharp")
+model EvidenceResource {
+  value: string;
+}
+
+@clientName("ReportData", "csharp")
+model ReportResource {
+  name: string;
+}
+```


### PR DESCRIPTION
## Summary

New lint rule that flags model names ending with `Resource` and suggests dropping the suffix or renaming to `Data`, per [Azure SDK .NET Mgmt Naming Conventions](https://github.com/Azure/azure-sdk-for-net/blob/main/doc/dev/Mgmt-Naming-Conventions.md).

Closes #4451

## Changes

- **Rule**: `model-name-resource-suffix` in `@azure-tools/typespec-client-generator-core`
  - Checks C#-scoped model name (respects `@clientName` overrides)
  - Excludes well-known base types: `TrackedResource`, `ProxyResource`, `ExtensionResource`, `GenericResource`
  - Two codefixes: drop `Resource` suffix, or rename to `Data` suffix
- **Ruleset**: Added to `resource-manager` mega-ruleset (management plane only)
- **Tests**: 12 tests covering positive/negative cases, well-known exclusions, `@clientName` overrides, case sensitivity, and codefixes
- **Docs**: Rule documentation page
- **Changelog**: `.chronus/changes` entry
