### PR TITLE
Add agent tooling: linter rule scaffold, validate:pr, and skill

### DIFF
--- a/.github/skills/create-linter-rule/SKILL.md
+++ b/.github/skills/create-linter-rule/SKILL.md
@@ -1,0 +1,161 @@
+---
+name: create-linter-rule
+description: >
+  Create a new TypeSpec linter rule with TDD approach, including implementation,
+  tests, documentation, ruleset registration, and changeset. Use this skill when
+  asked to create, add, or implement a new linter rule for TypeSpec Azure libraries.
+allowed-tools: shell
+---
+
+# Create a TypeSpec Linter Rule
+
+Follow these steps in order to create a complete, high-quality linter rule.
+
+## Step 1: IDENTIFY
+
+Determine the rule metadata before writing any code:
+
+- **Package**: `typespec-azure-core` (data-plane rules) or `typespec-azure-resource-manager` (ARM rules)
+- **Rule name**: kebab-case (e.g., `no-nullable-key`, `require-pagination`)
+- **Severity**: `warning` (style/best practice) or `error` (correctness/breaking)
+- **Target ruleset(s)**: `data-plane`, `resource-manager`, or both
+- **Description**: One-line explanation of what the rule enforces
+
+## Step 2: SCAFFOLD
+
+Generate all required files using the repo's scaffolding tool:
+
+```bash
+pnpm create:linter-rule <rule-name> --package <azure-core|azure-resource-manager> --severity <warning|error> --description "<description>"
+```
+
+This creates:
+- `packages/<pkg>/src/rules/<rule-name>.ts` — rule skeleton
+- `packages/<pkg>/test/rules/<rule-name>.test.ts` — test skeleton
+- `website/src/content/docs/docs/libraries/<pkg>/rules/<rule-name>.md` — docs skeleton
+- Updates `packages/<pkg>/src/linter.ts` — registers the rule
+
+## Step 3: WRITE FAILING TESTS FIRST (TDD)
+
+Edit `packages/<pkg>/test/rules/<rule-name>.test.ts`:
+
+1. Write tests for **valid code** that should produce no diagnostics (`.toBeValid()`)
+2. Write tests for **invalid code** that should produce specific diagnostics (`.toEmitDiagnostics()`)
+3. Write tests for **edge cases**:
+   - Empty/minimal inputs
+   - Nested types and generics
+   - Decorated types
+   - Cross-namespace references
+   - Multiple violations in one file
+   - Types that look similar but shouldn't trigger the rule
+
+Test API reference:
+```typescript
+// No diagnostics expected
+await tester.expect(`model Foo {}`).toBeValid();
+
+// Specific diagnostic expected
+await tester.expect(`model foo {}`).toEmitDiagnostics([{
+  code: "@azure-tools/typespec-<pkg>/<rule-name>",
+  severity: "<severity>",
+  message: "Expected message text",
+}]);
+
+// Test code fix (if rule provides one)
+await tester.expect(`enum Color { red }`).applyCodeFix("fix-id").toEqual(`union Color { string, red: "red" }`);
+```
+
+Verify tests fail before implementing:
+```bash
+pnpm --filter "@azure-tools/typespec-<pkg>..." build
+pnpm --filter "@azure-tools/typespec-<pkg>..." test
+```
+
+## Step 4: IMPLEMENT THE RULE
+
+Edit `packages/<pkg>/src/rules/<rule-name>.ts`:
+
+- Implement visitor logic in the `create(context)` function
+- Return a `SemanticNodeListener` with the appropriate hooks:
+  - `model` — for model-level checks
+  - `modelProperty` — for property-level checks
+  - `operation` — for operation-level checks
+  - `enum` — for enum checks
+  - `namespace` — for namespace-level checks
+  - `interface` — for interface checks
+  - `union` / `unionVariant` — for union checks
+- Use `context.reportDiagnostic({ target })` to report violations
+- Use `paramMessage` from `@typespec/compiler` for interpolated messages
+- Add `codefixes` array to `reportDiagnostic()` if a fix is possible
+
+## Step 5: VERIFY TESTS PASS
+
+```bash
+pnpm --filter "@azure-tools/typespec-<pkg>..." build
+pnpm --filter "@azure-tools/typespec-<pkg>..." test
+```
+
+All tests should pass. If not, fix the implementation until they do.
+
+## Step 6: REGISTER IN RULESETS
+
+Add the rule to the appropriate ruleset(s):
+
+- **Data-plane rules**: Edit `packages/typespec-azure-rulesets/src/rulesets/data-plane.ts`
+- **ARM rules**: Edit `packages/typespec-azure-rulesets/src/rulesets/resource-manager.ts`
+
+Add an entry: `"@azure-tools/typespec-<pkg>/<rule-name>": true,`
+
+Every rule MUST be explicitly listed (enabled or disabled). The `validate-rules-defined.test.ts` test will fail otherwise.
+
+Verify:
+```bash
+pnpm --filter "@azure-tools/typespec-azure-rulesets..." build
+pnpm --filter "@azure-tools/typespec-azure-rulesets..." test
+```
+
+## Step 7: WRITE DOCUMENTATION AND REGENERATE DOCS
+
+Edit `website/src/content/docs/docs/libraries/<pkg>/rules/<rule-name>.md`:
+
+- Replace all placeholder text
+- Write a clear description of what the rule checks and why
+- Provide realistic ❌ Incorrect and ✅ Correct examples using actual TypeSpec patterns
+- Ensure the `Full name` code block shows the correct fully-qualified rule name
+
+Then regenerate the library's reference docs (updates the rule listing):
+```bash
+pnpm --filter "@azure-tools/typespec-<pkg>..." build
+pnpm --filter "@azure-tools/typespec-<pkg>" regen-docs
+```
+
+## Step 8: CREATE CHANGESET
+
+```bash
+pnpm change add
+```
+
+When prompted:
+- Select change kind: `feature` (new rule) or `fix` (bugfix to existing rule)
+- Select affected package: `@azure-tools/typespec-<pkg>`
+- Write a concise description: "Add `<rule-name>` linter rule that <what it does>"
+
+## Step 9: FINAL VALIDATION
+
+Run the general pre-PR validation to ensure everything is ready:
+
+```bash
+pnpm validate:pr
+```
+
+This checks: branch is up to date, build passes, tests pass, lint passes, format is clean, spelling is clean, regen-docs is clean, changeset exists, and diff only contains expected files.
+
+If any check fails, fix the issue and re-run. Use `pnpm validate:pr --fix` to auto-fix formatting and lint issues.
+
+## Important Notes
+
+- **Import extensions**: Always use `.js` extensions in imports (e.g., `from "./rules/my-rule.js"`)
+- **Rule URL**: Must match `https://azure.github.io/typespec-azure/docs/libraries/<pkg>/rules/<rule-name>`
+- **Test coverage**: Aim for ≥ 95% branch coverage of the rule file
+- **Existing patterns**: Look at similar existing rules in `packages/<pkg>/src/rules/` for reference
+- **ARM rules can import from azure-core**: `import { ... } from "@azure-tools/typespec-azure-core"`

--- a/eng/scripts/create-linter-rule.ts
+++ b/eng/scripts/create-linter-rule.ts
@@ -1,0 +1,328 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { dirname, resolve } from "path";
+import process from "process";
+
+type PackageOption = "azure-core" | "azure-resource-manager";
+type Severity = "warning" | "error";
+
+interface Options {
+  ruleName: string;
+  packageName: PackageOption;
+  severity: Severity;
+  description: string;
+  dryRun: boolean;
+}
+
+interface PackageConfig {
+  packageDir: string;
+  packageShort: PackageOption;
+  packageNpmName: string;
+  testHostImport: string;
+  testHostFactory: string;
+}
+
+const usage =
+  "Usage: pnpm create:linter-rule <rule-name> [--package <azure-core|azure-resource-manager>] [--severity <warning|error>] [--description <text>] [--dry-run]";
+
+const packageConfigs: Record<PackageOption, PackageConfig> = {
+  "azure-core": {
+    packageDir: "typespec-azure-core",
+    packageShort: "azure-core",
+    packageNpmName: "@azure-tools/typespec-azure-core",
+    testHostImport: 'import { TesterWithService } from "#test/test-host.js";',
+    testHostFactory: "TesterWithService.createInstance()",
+  },
+  "azure-resource-manager": {
+    packageDir: "typespec-azure-resource-manager",
+    packageShort: "azure-resource-manager",
+    packageNpmName: "@azure-tools/typespec-azure-resource-manager",
+    testHostImport: 'import { Tester } from "#test/tester.js";',
+    testHostFactory: "Tester.createInstance()",
+  },
+};
+
+const scriptDir = import.meta.dirname;
+const repoRoot = resolve(scriptDir, "..", "..");
+
+function fail(message: string): never {
+  console.error(`Error: ${message}`);
+  console.error(usage);
+  process.exit(1);
+}
+
+function isKebabCase(value: string): boolean {
+  return /^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(value);
+}
+
+function toCamelCase(value: string): string {
+  return value.replace(/-([a-z0-9])/g, (_, letter: string) => letter.toUpperCase());
+}
+
+function toDoubleQuotedString(value: string): string {
+  return JSON.stringify(value);
+}
+
+function normalizeNewlines(content: string): string {
+  return content.replace(/\r\n/g, "\n");
+}
+
+function readText(path: string): string {
+  return normalizeNewlines(readFileSync(path, "utf8"));
+}
+
+function writeText(path: string, content: string): void {
+  mkdirSync(dirname(path), { recursive: true });
+  writeFileSync(path, content, "utf8");
+}
+
+function parseArgs(argv: string[]): Options {
+  const positionals: string[] = [];
+  let packageName: PackageOption = "azure-core";
+  let severity: Severity = "warning";
+  let description = "TODO: Add rule description.";
+  let dryRun = false;
+
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index];
+
+    if (!arg.startsWith("--")) {
+      positionals.push(arg);
+      continue;
+    }
+
+    switch (arg) {
+      case "--package": {
+        const value = argv[++index];
+        if (value !== "azure-core" && value !== "azure-resource-manager") {
+          fail("--package must be either azure-core or azure-resource-manager.");
+        }
+        packageName = value;
+        break;
+      }
+      case "--severity": {
+        const value = argv[++index];
+        if (value !== "warning" && value !== "error") {
+          fail("--severity must be either warning or error.");
+        }
+        severity = value;
+        break;
+      }
+      case "--description": {
+        const value = argv[++index];
+        if (!value) {
+          fail("--description requires a value.");
+        }
+        description = value;
+        break;
+      }
+      case "--dry-run":
+        dryRun = true;
+        break;
+      default:
+        fail(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (positionals.length !== 1) {
+    fail("You must provide exactly one rule name.");
+  }
+
+  const [ruleName] = positionals;
+  if (!isKebabCase(ruleName)) {
+    fail("rule-name must be kebab-case using lowercase letters, numbers, and hyphens only.");
+  }
+
+  return { ruleName, packageName, severity, description, dryRun };
+}
+
+function updateLinterFile(linterPath: string, importLine: string, ruleIdentifier: string): string {
+  const current = readText(linterPath);
+
+  if (current.includes(importLine) || current.includes(`  ${ruleIdentifier},`)) {
+    fail(`Linter is already wired for rule '${ruleIdentifier}'.`);
+  }
+
+  const importBlockMatch = current.match(/^(import .*;\n)+/m);
+  if (!importBlockMatch || importBlockMatch.index !== 0) {
+    fail(`Could not find import block in ${linterPath}.`);
+  }
+
+  const importBlock = importBlockMatch[0];
+  const importLines = importBlock.trimEnd().split("\n");
+  importLines.push(importLine);
+  importLines.sort((left, right) => left.localeCompare(right));
+  const updatedImports = `${importLines.join("\n")}\n\n`;
+  const afterImports = current.slice(importBlock.length);
+  const withUpdatedImports = `${updatedImports}${afterImports}`;
+
+  const rulesArrayMatch = withUpdatedImports.match(/const rules = \[(?<body>[\s\S]*?)\n\];/);
+  if (!rulesArrayMatch || rulesArrayMatch.index === undefined || rulesArrayMatch.groups === undefined) {
+    fail(`Could not find rules array in ${linterPath}.`);
+  }
+
+  const start = rulesArrayMatch.index;
+  const end = start + rulesArrayMatch[0].length;
+  const body = rulesArrayMatch.groups.body;
+  const updatedBody = body.endsWith("\n")
+    ? `${body}  ${ruleIdentifier},`
+    : `${body}\n  ${ruleIdentifier},`;
+  const updatedRules = `const rules = [${updatedBody}\n];`;
+
+  return `${withUpdatedImports.slice(0, start)}${updatedRules}${withUpdatedImports.slice(end)}`;
+}
+
+function main(): void {
+  const options = parseArgs(process.argv.slice(2));
+  const config = packageConfigs[options.packageName];
+  const camelCaseName = toCamelCase(options.ruleName);
+  const ruleIdentifier = `${camelCaseName}Rule`;
+
+  const packageRoot = resolve(repoRoot, "packages", config.packageDir);
+  const rulePath = resolve(packageRoot, "src", "rules", `${options.ruleName}.ts`);
+  const testPath = resolve(packageRoot, "test", "rules", `${options.ruleName}.test.ts`);
+  const docsPath = resolve(
+    repoRoot,
+    "website",
+    "src",
+    "content",
+    "docs",
+    "docs",
+    "libraries",
+    config.packageShort,
+    "rules",
+    `${options.ruleName}.md`,
+  );
+  const linterPath = resolve(packageRoot, "src", "linter.ts");
+
+  const fileTargets = [rulePath, testPath, docsPath];
+  const existingFiles = fileTargets.filter((path) => existsSync(path));
+  if (existingFiles.length > 0) {
+    fail(`The following file(s) already exist:\n${existingFiles.map((path) => `- ${path}`).join("\n")}`);
+  }
+
+  if (!existsSync(linterPath)) {
+    fail(`Could not find linter file at ${linterPath}.`);
+  }
+
+  const ruleFile = [
+    'import { createRule } from "@typespec/compiler";',
+    "",
+    `export const ${ruleIdentifier} = createRule({`,
+    `  name: ${toDoubleQuotedString(options.ruleName)},`,
+    `  description: ${toDoubleQuotedString(options.description)},`,
+    `  severity: ${toDoubleQuotedString(options.severity)},`,
+    `  url: ${toDoubleQuotedString(`https://azure.github.io/typespec-azure/docs/libraries/${config.packageShort}/rules/${options.ruleName}`)},`,
+    "  messages: {",
+    '    default: "TODO: Add default diagnostic message.",',
+    "  },",
+    "  create(context) {",
+    "    return {",
+    "      // TODO: Implement visitor hooks (model, modelProperty, operation, enum, namespace, interface, union)",
+    "    };",
+    "  },",
+    "});",
+    "",
+  ].join("\n");
+
+  const testFile = [
+    config.testHostImport,
+    'import { LinterRuleTester, createLinterRuleTester } from "@typespec/compiler/testing";',
+    'import { beforeEach, describe, it } from "vitest";',
+    `import { ${ruleIdentifier} } from "../../src/rules/${options.ruleName}.js";`,
+    "",
+    "let tester: LinterRuleTester;",
+    "",
+    "beforeEach(async () => {",
+    `  const runner = await ${config.testHostFactory};`,
+    "  tester = createLinterRuleTester(",
+    "    runner,",
+    `    ${ruleIdentifier},`,
+    `    ${toDoubleQuotedString(config.packageNpmName)},`,
+    "  );",
+    "});",
+    "",
+    `describe(${toDoubleQuotedString(options.ruleName)}, () => {`,
+    '  it("is valid when TODO: describe valid case", async () => {',
+    "    await tester",
+    '      .expect(',
+    '        `',
+    '        model Example {}',
+    '        `,',
+    "      )",
+    "      .toBeValid();",
+    "  });",
+    "",
+    '  it("emits diagnostic when TODO: describe invalid case", async () => {',
+    "    await tester",
+    '      .expect(',
+    '        `',
+    '        model Example {}',
+    '        `,',
+    "      )",
+    "      .toEmitDiagnostics([",
+    "        {",
+    `          code: ${toDoubleQuotedString(`${config.packageNpmName}/${options.ruleName}`)},`,
+    `          severity: ${toDoubleQuotedString(options.severity)},`,
+    '          message: "TODO: Expected diagnostic message",',
+    "        },",
+    "      ]);",
+    "  });",
+    "});",
+    "",
+  ].join("\n");
+
+  const docsFile = [
+    "---",
+    `title: ${toDoubleQuotedString(options.ruleName)}`,
+    "---",
+    "",
+    "```text title=\"Full name\"",
+    `@azure-tools/typespec-${config.packageShort}/${options.ruleName}`,
+    "```",
+    "",
+    "TODO: Add a description of what this rule checks and why it matters.",
+    "",
+    "#### ❌ Incorrect",
+    "",
+    "```tsp",
+    "// TODO: Add example of code that violates this rule",
+    "```",
+    "",
+    "#### ✅ Correct",
+    "",
+    "```tsp",
+    "// TODO: Add example of code that satisfies this rule",
+    "```",
+    "",
+  ].join("\n");
+
+  const importLine = `import { ${ruleIdentifier} } from "./rules/${options.ruleName}.js";`;
+  const updatedLinter = updateLinterFile(linterPath, importLine, ruleIdentifier);
+
+  const plannedActions = [
+    `create ${rulePath}`,
+    `create ${testPath}`,
+    `create ${docsPath}`,
+    `update ${linterPath}`,
+  ];
+
+  if (options.dryRun) {
+    console.log("Dry run: no files were written.");
+    for (const action of plannedActions) {
+      console.log(`- ${action}`);
+    }
+    return;
+  }
+
+  writeText(rulePath, ruleFile);
+  writeText(testPath, testFile);
+  writeText(docsPath, docsFile);
+  writeText(linterPath, updatedLinter);
+
+  console.log("Created linter rule scaffold:");
+  for (const action of plannedActions) {
+    console.log(`- ${action}`);
+  }
+}
+
+main();

--- a/eng/scripts/validate-pr.ts
+++ b/eng/scripts/validate-pr.ts
@@ -1,0 +1,594 @@
+import { readFileSync } from "fs";
+import path from "path";
+import process from "process";
+import { spawnSync, type SpawnSyncReturns } from "child_process";
+
+type StepStatus = "passed" | "failed" | "warning" | "skipped";
+
+type Options = {
+  fix: boolean;
+  skipBuild: boolean;
+  skipTest: boolean;
+  base: string;
+  verbose: boolean;
+  help: boolean;
+};
+
+type CommandResult = {
+  command: string;
+  args: string[];
+  result: SpawnSyncReturns<string>;
+  stdout: string;
+  stderr: string;
+};
+
+type StepResult = {
+  label: string;
+  status: StepStatus;
+  durationMs: number;
+  details: string[];
+};
+
+const RESET = "\u001b[0m";
+const GREEN = "\u001b[32m";
+const RED = "\u001b[31m";
+const YELLOW = "\u001b[33m";
+const CYAN = "\u001b[36m";
+const BOLD = "\u001b[1m";
+const LINE = "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━";
+const STATUS_ICON: Record<StepStatus, string> = {
+  passed: `${GREEN}✅${RESET}`,
+  failed: `${RED}❌${RESET}`,
+  warning: `${YELLOW}⚠️${RESET}`,
+  skipped: `${YELLOW}⚠️${RESET}`,
+};
+
+const repoRoot = path.resolve(process.cwd());
+const options = parseArgs(process.argv.slice(2));
+
+if (options.help) {
+  printUsage();
+  process.exit(0);
+}
+
+const diffCache = new Map<string, string[]>();
+const changedFilesExclusions = loadChangedFilesExclusions();
+const steps: StepResult[] = [];
+
+printHeader();
+
+steps.push(runStep("Branch is up to date", checkBranchUpToDate));
+steps.push(runStep("Build succeeds", checkBuild));
+steps.push(runStep("Tests pass", checkTests));
+steps.push(runStep("Lint passes", checkLint));
+steps.push(runStep("Format check passes", checkFormat));
+steps.push(runStep("Spelling check passes", checkSpelling));
+steps.push(runStep("Regen-docs is clean", checkRegenDocs));
+steps.push(runStep("Changeset exists", checkChangeset));
+steps.push(runStep("Diff is clean", checkDiff));
+
+printSummary(steps);
+
+const hasFailures = steps.some((step) => step.status === "failed");
+process.exit(hasFailures ? 1 : 0);
+
+function parseArgs(args: string[]): Options {
+  const parsed: Options = {
+    fix: false,
+    skipBuild: false,
+    skipTest: false,
+    base: "origin/main",
+    verbose: false,
+    help: false,
+  };
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+
+    switch (arg) {
+      case "--fix":
+        parsed.fix = true;
+        break;
+      case "--skip-build":
+        parsed.skipBuild = true;
+        break;
+      case "--skip-test":
+        parsed.skipTest = true;
+        break;
+      case "--base": {
+        const value = args[index + 1];
+        if (!value) {
+          failWithUsage("Missing value for --base");
+        }
+        parsed.base = value;
+        index++;
+        break;
+      }
+      case "--verbose":
+        parsed.verbose = true;
+        break;
+      case "--help":
+        parsed.help = true;
+        break;
+      default:
+        failWithUsage(`Unknown option: ${arg}`);
+    }
+  }
+
+  return parsed;
+}
+
+function failWithUsage(message: string): never {
+  console.error(`${RED}Error:${RESET} ${message}`);
+  console.log();
+  printUsage();
+  process.exit(1);
+}
+
+function printUsage(): void {
+  console.log(
+    [
+      "Usage: pnpm validate:pr [options]",
+      "",
+      "Options:",
+      "  --fix              Auto-fix formatting and lint issues",
+      "  --skip-build       Skip the build step",
+      "  --skip-test        Skip the test step",
+      "  --base <branch>    Base branch for diff comparison (default: origin/main)",
+      "  --verbose          Show detailed command output",
+      "  --help             Show usage",
+    ].join("\n"),
+  );
+}
+
+function printHeader(): void {
+  console.log(`${BOLD}Pre-PR Validation${RESET}`);
+  console.log(LINE);
+  console.log();
+}
+
+function printSummary(results: StepResult[]): void {
+  const passed = results.filter((step) => step.status === "passed").length;
+  const warnings = results.filter((step) => step.status === "warning").length;
+  const skipped = results.filter((step) => step.status === "skipped").length;
+  const failed = results.filter((step) => step.status === "failed").length;
+
+  console.log();
+  console.log(LINE);
+
+  if (failed > 0) {
+    console.log(`Result: ${passed}/${results.length} passed ${RED}❌${RESET}`);
+    return;
+  }
+
+  if (warnings > 0 || skipped > 0) {
+    const extra: string[] = [];
+    if (warnings > 0) {
+      extra.push(`${warnings} warning${warnings === 1 ? "" : "s"}`);
+    }
+    if (skipped > 0) {
+      extra.push(`${skipped} skipped`);
+    }
+    console.log(`Result: ${passed}/${results.length} passed ${GREEN}✅${RESET} (${extra.join(", ")})`);
+    return;
+  }
+
+  console.log(`Result: ${passed}/${results.length} passed ${GREEN}✅${RESET}`);
+}
+
+function runStep(label: string, action: () => Omit<StepResult, "label" | "durationMs">): StepResult {
+  const start = Date.now();
+
+  try {
+    const outcome = action();
+    const step = {
+      label,
+      status: outcome.status,
+      details: outcome.details,
+      durationMs: Date.now() - start,
+    };
+    printStep(steps.length + 1, step);
+    return step;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const step = {
+      label,
+      status: "failed" as const,
+      details: [message],
+      durationMs: Date.now() - start,
+    };
+    printStep(steps.length + 1, step);
+    return step;
+  }
+}
+
+function printStep(index: number, step: StepResult): void {
+  const prefix = ` ${index}. ${step.label} `;
+  const dots = ".".repeat(Math.max(2, 58 - prefix.length));
+  console.log(`${prefix}${dots} ${STATUS_ICON[step.status]} (${formatDuration(step.durationMs)})`);
+
+  for (const detail of step.details) {
+    if (!detail) continue;
+    for (const line of detail.split(/\r?\n/)) {
+      console.log(`    ${line}`);
+    }
+  }
+}
+
+function formatDuration(durationMs: number): string {
+  return `${(durationMs / 1000).toFixed(1)}s`;
+}
+
+function checkBranchUpToDate(): Omit<StepResult, "label" | "durationMs"> {
+  const fetchResult = fetchBaseBranch(options.base);
+  if (!isSuccess(fetchResult.result)) {
+    return failFromCommand(fetchResult, `Unable to fetch ${options.base}.`);
+  }
+
+  const baseExists = runCommand("git", ["rev-parse", "--verify", options.base]);
+  if (!isSuccess(baseExists.result)) {
+    return failFromCommand(baseExists, `Base reference ${options.base} was not found.`);
+  }
+
+  const ancestorCheck = runCommand("git", ["merge-base", "--is-ancestor", options.base, "HEAD"]);
+  const mergeTreeCheck = runCommand("git", ["merge-tree", "--write-tree", options.base, "HEAD"]);
+
+  if (!isSuccess(mergeTreeCheck.result)) {
+    return {
+      status: "failed",
+      details: [
+        `Potential merge conflicts detected with ${options.base}. Rebase before opening the PR.`,
+        ...commandOutput(mergeTreeCheck),
+      ],
+    };
+  }
+
+  if (!isSuccess(ancestorCheck.result)) {
+    return {
+      status: "warning",
+      details: [
+        `Branch is behind ${options.base}. Run: git fetch origin main && git rebase ${options.base}`,
+      ],
+    };
+  }
+
+  return { status: "passed", details: [] };
+}
+
+function checkBuild(): Omit<StepResult, "label" | "durationMs"> {
+  if (options.skipBuild) {
+    return { status: "skipped", details: ["Skipped by --skip-build."] };
+  }
+
+  const result = runCommand("pnpm", ["build"]);
+  if (!isSuccess(result.result)) {
+    return failFromCommand(result, "Build failed.");
+  }
+
+  return { status: "passed", details: [] };
+}
+
+function checkTests(): Omit<StepResult, "label" | "durationMs"> {
+  if (options.skipTest) {
+    return { status: "skipped", details: ["Skipped by --skip-test."] };
+  }
+
+  const result = runCommand("pnpm", ["test"]);
+  if (!isSuccess(result.result)) {
+    return failFromCommand(result, "Test failures found.");
+  }
+
+  return { status: "passed", details: [] };
+}
+
+function checkLint(): Omit<StepResult, "label" | "durationMs"> {
+  const command = options.fix ? ["lint:fix"] : ["lint"];
+  const result = runCommand("pnpm", command);
+
+  if (!isSuccess(result.result)) {
+    return failFromCommand(
+      result,
+      options.fix ? "Lint auto-fix failed." : "Lint errors found. Run: pnpm lint:fix",
+    );
+  }
+
+  return { status: "passed", details: [] };
+}
+
+function checkFormat(): Omit<StepResult, "label" | "durationMs"> {
+  if (options.fix) {
+    const formatResult = runCommand("pnpm", ["format"]);
+    if (!isSuccess(formatResult.result)) {
+      return failFromCommand(formatResult, "Formatting failed.");
+    }
+  }
+
+  const checkResult = runCommand("pnpm", ["format:check"]);
+  if (!isSuccess(checkResult.result)) {
+    return failFromCommand(
+      checkResult,
+      options.fix
+        ? "Formatting still has issues after pnpm format."
+        : "Formatting issues found. Run: pnpm format",
+    );
+  }
+
+  return { status: "passed", details: options.fix ? ["Applied formatting fixes before re-checking."] : [] };
+}
+
+function checkSpelling(): Omit<StepResult, "label" | "durationMs"> {
+  const result = runCommand("pnpm", ["cspell"]);
+  if (!isSuccess(result.result)) {
+    return failFromCommand(result, "Spelling issues found.");
+  }
+
+  return { status: "passed", details: [] };
+}
+
+function checkRegenDocs(): Omit<StepResult, "label" | "durationMs"> {
+  if (options.skipBuild) {
+    return { status: "skipped", details: ["Skipped because --skip-build also skips regen-docs."] };
+  }
+
+  const regenResult = runCommand("pnpm", ["regen-docs"]);
+  if (!isSuccess(regenResult.result)) {
+    return failFromCommand(regenResult, "Doc regeneration failed.");
+  }
+
+  const diffResult = runCommand("git", ["diff", "--name-only", "--", "docs", "website"]);
+  if (!isSuccess(diffResult.result)) {
+    return failFromCommand(diffResult, "Unable to inspect regenerated docs.");
+  }
+
+  const changedDocs = splitLines(diffResult.stdout);
+  if (changedDocs.length > 0) {
+    return {
+      status: "failed",
+      details: ["Generated docs are stale. Run: pnpm regen-docs", ...changedDocs],
+    };
+  }
+
+  return { status: "passed", details: [] };
+}
+
+function checkChangeset(): Omit<StepResult, "label" | "durationMs"> {
+  const changedFiles = getDiffFiles(options.base);
+  if (!changedFiles) {
+    return {
+      status: "failed",
+      details: [`Unable to diff against ${options.base}.`],
+    };
+  }
+
+  const sourceFiles = changedFiles.filter((file) => {
+    const normalized = normalizePath(file);
+    if (normalized.startsWith(".chronus/changes/")) {
+      return false;
+    }
+    return !matchesExcludedFile(normalized);
+  });
+
+  if (sourceFiles.length === 0) {
+    return { status: "skipped", details: ["No source file changes detected."] };
+  }
+
+  const changesetResult = runCommand("git", [
+    "diff",
+    "--name-only",
+    "--diff-filter=A",
+    `${options.base}...HEAD`,
+    "--",
+    ".chronus/changes/",
+  ]);
+
+  if (!isSuccess(changesetResult.result)) {
+    return failFromCommand(changesetResult, "Unable to inspect changesets.");
+  }
+
+  const addedChangesets = splitLines(changesetResult.stdout);
+  if (addedChangesets.length === 0) {
+    return {
+      status: "failed",
+      details: [
+        "Source files changed but no new changeset was added under .chronus/changes/.",
+        "Run: pnpm change add",
+      ],
+    };
+  }
+
+  return { status: "passed", details: [] };
+}
+
+function checkDiff(): Omit<StepResult, "label" | "durationMs"> {
+  const changedFiles = getDiffFiles(options.base);
+  if (!changedFiles) {
+    return {
+      status: "failed",
+      details: [`Unable to diff against ${options.base}.`],
+    };
+  }
+
+  const details = changedFiles.length > 0 ? [...changedFiles] : ["No files changed."];
+  const warnings: string[] = [];
+  const hasPackageJsonChange = changedFiles.some((file) => normalizePath(file).endsWith("package.json"));
+
+  if (changedFiles.some((file) => /(^|\/)dist\//.test(normalizePath(file)))) {
+    warnings.push("PR diff includes files under dist/.");
+  }
+
+  if (changedFiles.some((file) => normalizePath(file).endsWith(".lock.yml"))) {
+    warnings.push("PR diff includes *.lock.yml files (often generated by gh-aw).");
+  }
+
+  if (
+    changedFiles.some((file) => normalizePath(file) === "pnpm-lock.yaml") &&
+    !hasPackageJsonChange
+  ) {
+    warnings.push("pnpm-lock.yaml changed without any package.json change.");
+  }
+
+  if (changedFiles.some((file) => /(^|\/)node_modules\//.test(normalizePath(file)))) {
+    warnings.push("PR diff includes files under node_modules/.");
+  }
+
+  if (warnings.length > 0) {
+    return { status: "warning", details: [...details, ...warnings.map((warning) => `Warning: ${warning}`)] };
+  }
+
+  return { status: "passed", details };
+}
+
+function fetchBaseBranch(base: string): CommandResult {
+  const remoteMatch = /^([^/]+)\/(.+)$/.exec(base);
+  if (remoteMatch) {
+    const [, remote, branch] = remoteMatch;
+    return runCommand("git", ["fetch", remote, branch, "--quiet"]);
+  }
+
+  return runCommand("git", ["fetch", "origin", "main", "--quiet"]);
+}
+
+function getDiffFiles(base: string): string[] | undefined {
+  const cached = diffCache.get(base);
+  if (cached) {
+    return cached;
+  }
+
+  const diffResult = runCommand("git", ["diff", "--name-only", `${base}...HEAD`]);
+  if (!isSuccess(diffResult.result)) {
+    if (options.verbose) {
+      for (const line of commandOutput(diffResult)) {
+        console.log(`    ${line}`);
+      }
+    }
+    return undefined;
+  }
+
+  const files = splitLines(diffResult.stdout);
+  diffCache.set(base, files);
+  return files;
+}
+
+function loadChangedFilesExclusions(): RegExp[] {
+  const configPath = path.join(repoRoot, ".chronus", "config.yaml");
+
+  try {
+    const config = readFileSync(configPath, "utf-8");
+    const patterns: string[] = [];
+    let inChangedFiles = false;
+
+    for (const line of config.split(/\r?\n/)) {
+      if (!inChangedFiles) {
+        if (line.trim() === "changedFiles:") {
+          inChangedFiles = true;
+        }
+        continue;
+      }
+
+      const match = /^\s*-\s*"?(![^"#]+)"?\s*$/.exec(line);
+      if (!match) {
+        if (/^\S/.test(line)) {
+          break;
+        }
+        continue;
+      }
+
+      patterns.push(match[1]);
+    }
+
+    return patterns.map(globToRegExp);
+  } catch {
+    return [/\.md$/i, /\.test\.ts$/i, /\.e2e\.ts$/i];
+  }
+}
+
+function globToRegExp(pattern: string): RegExp {
+  const normalized = normalizePath(pattern.replace(/^!/, ""));
+  const escaped = normalized.replace(/[.+^${}()|[\]\\]/g, "\\$&");
+  const regexSource = escaped
+    .replace(/\*\*\//g, "(?:.*/)?")
+    .replace(/\*\*/g, ".*")
+    .replace(/\*/g, "[^/]*")
+    .replace(/\?/g, ".");
+  return new RegExp(`^${regexSource}$`, "i");
+}
+
+function matchesExcludedFile(file: string): boolean {
+  return changedFilesExclusions.some((pattern) => pattern.test(file));
+}
+
+function runCommand(command: string, args: string[]): CommandResult {
+  const display = formatCommand(command, args);
+
+  if (options.verbose) {
+    console.log(`${CYAN}$ ${display}${RESET}`);
+  }
+
+  const result = spawnSync(command, args, {
+    cwd: repoRoot,
+    shell: true,
+    encoding: "utf-8",
+    maxBuffer: 50 * 1024 * 1024,
+  });
+
+  const stdout = (result.stdout ?? "").trimEnd();
+  const stderr = (result.stderr ?? "").trimEnd();
+
+  if (options.verbose) {
+    if (stdout) {
+      console.log(stdout);
+    }
+    if (stderr) {
+      console.error(stderr);
+    }
+  }
+
+  return { command, args, result, stdout, stderr };
+}
+
+function isSuccess(result: SpawnSyncReturns<string>): boolean {
+  return !result.error && result.status === 0;
+}
+
+function failFromCommand(command: CommandResult, message: string): Omit<StepResult, "label" | "durationMs"> {
+  return {
+    status: "failed",
+    details: [message, ...commandOutput(command)],
+  };
+}
+
+function commandOutput(command: CommandResult): string[] {
+  const lines = [`Command: ${formatCommand(command.command, command.args)}`];
+
+  if (command.result.error) {
+    lines.push(`Error: ${command.result.error.message}`);
+  }
+  if (command.stderr) {
+    lines.push(command.stderr);
+  }
+  if (command.stdout) {
+    lines.push(command.stdout);
+  }
+  if (!command.stderr && !command.stdout && typeof command.result.status === "number") {
+    lines.push(`Exit code: ${command.result.status}`);
+  }
+
+  return lines;
+}
+
+function formatCommand(command: string, args: string[]): string {
+  return [command, ...args]
+    .map((part) => (/\s/.test(part) ? `"${part}"` : part))
+    .join(" ");
+}
+
+function splitLines(text: string): string[] {
+  return text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function normalizePath(file: string): string {
+  return file.replace(/\\/g, "/");
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "deps": "tsx eng/scripts/sync-deps.ts",
     "check:eng": "tsc -p ./tsconfig.eng.json --noEmit",
     "change": "chronus",
+    "create:linter-rule": "tsx eng/scripts/create-linter-rule.ts",
+    "validate:pr": "tsx eng/scripts/validate-pr.ts",
     "clean": "pnpm run-all clean",
     "cspell": "cspell --no-progress .",
     "dogfood": "pnpm install && pnpm build && pnpm run-all dogfood",


### PR DESCRIPTION
## Summary

Adds three components to improve AI agent performance when creating linter rules:

### 1. \ng/scripts/create-linter-rule.ts\ (scaffold script)
Generates all required files for a new linter rule:
- Rule source file with correct template
- Test file with valid/invalid test stubs
- Documentation page with correct structure
- Automatically registers the rule in \linter.ts\

Usage: \pnpm create:linter-rule <name> --package <azure-core|azure-resource-manager> --severity <warning|error>\

### 2. \ng/scripts/validate-pr.ts\ (pre-PR validation)
General validation script for any code change (not linter-rule-specific):
- Branch up to date check
- Build, test, lint, format, cspell checks
- Regen-docs freshness check
- Changeset existence check
- Diff cleanliness check

Usage: \pnpm validate:pr [--fix] [--skip-build] [--skip-test]\

### 3. \.github/skills/create-linter-rule/SKILL.md\
9-step TDD workflow skill for Copilot agents creating linter rules. Covers identification, scaffolding, test-first development, implementation, ruleset registration, documentation, changeset creation, and final validation.

## Testing
- Both scripts syntax-check cleanly (\
ode --check\)
- \create-linter-rule --dry-run\ produces expected output
- \alidate:pr --help\ shows usage

Full integration testing requires \pnpm install\ (not run in this environment).
