### PR TITLE
Bump version for hotfix: tcgc@0.68.1

### DIFF
--- a/.chronus/changes/fix-tcgc-usage-access-library-models-2026-5-19-3-40-0.md
+++ b/.chronus/changes/fix-tcgc-usage-access-library-models-2026-5-19-3-40-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-client-generator-core"
----
-
-Fix `@@usage` and `@@access` augment decorators being silently dropped when targeting models from imported libraries (npm packages) whose namespaces are not user-defined. Explicitly-tagged models are now honored regardless of which namespace they live in.

--- a/packages/typespec-client-generator-core/CHANGELOG.md
+++ b/packages/typespec-client-generator-core/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-client-generator-core
 
+## 0.68.1
+
+### Bug Fixes
+
+- [#4440](https://github.com/Azure/typespec-azure/pull/4440) Fix `@@usage` and `@@access` augment decorators being silently dropped when targeting models from imported libraries (npm packages) whose namespaces are not user-defined. Explicitly-tagged models are now honored regardless of which namespace they live in.
+
+
 ## 0.68.0
 
 ### Breaking Changes

--- a/packages/typespec-client-generator-core/package.json
+++ b/packages/typespec-client-generator-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-core",
-  "version": "0.68.0",
+  "version": "0.68.1",
   "author": "Microsoft Corporation",
   "description": "TypeSpec Data Plane Generation library",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
Hotfix release for @azure-tools/typespec-client-generator-core 0.68.1

## Changes
- [TCGC] Honor @@usage/@@access on models from imported libraries (#4440)

## Checklist
- [x] Version bump via `pnpm chronus version --ignore-policies`
- [x] Only TCGC package changed
- [x] Core submodule pointer unchanged