### PR TITLE
feat: add spector coverage upload for typespec-python

### DIFF
--- a/eng/pipelines/jobs/build-for-publish.yml
+++ b/eng/pipelines/jobs/build-for-publish.yml
@@ -19,13 +19,10 @@ jobs:
       - template: /eng/pipelines/templates/upload-coverage.yml
 
       # Python e2e tests and spector coverage upload
-      - script: |
-          curl -sSf https://mise.run | sh
-          export PATH="$HOME/.local/bin:$PATH"
-          mise install python uv
-          echo "##vso[task.prependpath]$(mise where python)/bin"
-          echo "##vso[task.prependpath]$(mise where uv)/bin"
-        displayName: "Install Python and uv via mise"
+      - task: UsePythonVersion@0
+        displayName: "Use Python 3.12"
+        inputs:
+          versionSpec: "3.12"
 
       - script: pnpm run prepare
         displayName: "Prepare Python environment"

--- a/eng/pipelines/jobs/build-for-publish.yml
+++ b/eng/pipelines/jobs/build-for-publish.yml
@@ -19,10 +19,13 @@ jobs:
       - template: /eng/pipelines/templates/upload-coverage.yml
 
       # Python e2e tests and spector coverage upload
-      - task: UsePythonVersion@0
-        displayName: "Use Python 3.11"
-        inputs:
-          versionSpec: "3.11"
+      - script: |
+          curl -sSf https://mise.run | sh
+          export PATH="$HOME/.local/bin:$PATH"
+          mise install python uv
+          echo "##vso[task.prependpath]$(mise where python)/bin"
+          echo "##vso[task.prependpath]$(mise where uv)/bin"
+        displayName: "Install Python and uv via mise"
 
       - script: pnpm run prepare
         displayName: "Prepare Python environment"

--- a/eng/pipelines/jobs/build-for-publish.yml
+++ b/eng/pipelines/jobs/build-for-publish.yml
@@ -17,6 +17,30 @@ jobs:
         displayName: Test
 
       - template: /eng/pipelines/templates/upload-coverage.yml
+
+      # Python e2e tests and spector coverage upload
+      - task: UsePythonVersion@0
+        displayName: "Use Python 3.11"
+        inputs:
+          versionSpec: "3.11"
+
+      - script: pnpm run prepare
+        displayName: "Prepare Python environment"
+        workingDirectory: packages/typespec-python
+
+      - script: pnpm run regenerate
+        displayName: "Regenerate Python test code"
+        workingDirectory: packages/typespec-python
+
+      - script: pnpm run test:python:e2e
+        displayName: "Run Python e2e tests"
+        workingDirectory: packages/typespec-python
+
+      - template: /eng/pipelines/templates/upload-spector-coverage.yml
+        parameters:
+          PackagePath: packages/typespec-python
+          GeneratorName: "@azure-tools/typespec-python"
+
       - template: /eng/pipelines/templates/pack.yml
         parameters:
           artifactName: npm-packages-stable

--- a/eng/pipelines/templates/upload-spector-coverage.yml
+++ b/eng/pipelines/templates/upload-spector-coverage.yml
@@ -1,0 +1,63 @@
+# Template for uploading spector coverage reports to Azure Storage.
+# Designed to be reusable by any emitter package in typespec-azure.
+#
+# Prerequisites:
+#   - Tests must have been run against tsp-spector mock APIs, producing
+#     spec-coverage.json in the http-specs / azure-http-specs directories.
+#
+# Usage:
+#   - template: /eng/pipelines/templates/upload-spector-coverage.yml
+#     parameters:
+#       PackagePath: packages/typespec-python
+#       GeneratorName: "@azure-tools/typespec-python"
+#       UnbrandedGeneratorName: "@typespec/http-client-python"  # optional
+
+parameters:
+  # Path to the emitter package relative to repo root
+  - name: PackagePath
+    type: string
+
+  # Generator name for azure (branded) coverage upload
+  - name: GeneratorName
+    type: string
+
+  # Generator name for unbranded (standard) coverage upload. If empty, skipped.
+  - name: UnbrandedGeneratorName
+    type: string
+    default: ""
+
+steps:
+  - ${{ if ne(parameters.UnbrandedGeneratorName, '') }}:
+      - task: AzureCLI@2
+        displayName: "Upload spector coverage (standard)"
+        continueOnError: true
+        inputs:
+          azureSubscription: "TypeSpec Storage"
+          scriptType: "bash"
+          scriptLocation: "inlineScript"
+          inlineScript: >-
+            npx tsp-spector upload-coverage
+            --coverageFile ./spec-coverage.json
+            --generatorName "${{ parameters.UnbrandedGeneratorName }}"
+            --storageAccountName typespec
+            --containerName coverages
+            --generatorVersion $(node -p -e "require('$(Build.SourcesDirectory)/${{ parameters.PackagePath }}/node_modules/@typespec/http-client-python/package.json').version")
+            --generatorMode standard
+          workingDirectory: $(Build.SourcesDirectory)/${{ parameters.PackagePath }}/node_modules/@typespec/http-specs
+
+  - task: AzureCLI@2
+    displayName: "Upload spector coverage (azure)"
+    continueOnError: true
+    inputs:
+      azureSubscription: "TypeSpec Storage"
+      scriptType: "bash"
+      scriptLocation: "inlineScript"
+      inlineScript: >-
+        npx tsp-spector upload-coverage
+        --coverageFile ./spec-coverage.json
+        --generatorName "${{ parameters.GeneratorName }}"
+        --storageAccountName typespec
+        --containerName coverages
+        --generatorVersion $(node -p -e "require('$(Build.SourcesDirectory)/${{ parameters.PackagePath }}/package.json').version")
+        --generatorMode azure
+      workingDirectory: $(Build.SourcesDirectory)/${{ parameters.PackagePath }}/node_modules/@azure-tools/azure-http-specs


### PR DESCRIPTION
## Summary

Add spector coverage report upload for `@azure-tools/typespec-python` to the on-merge publish pipeline.

### Changes

1. **New template: `eng/pipelines/templates/upload-spector-coverage.yml`**
   - Reusable template for any emitter package to upload spector coverage
   - Supports both azure (branded) and standard (unbranded) modes
   - Parameters: `PackagePath`, `GeneratorName`, `UnbrandedGeneratorName` (optional)
   - Uses `TypeSpec Storage` Azure subscription and `coverages` container

2. **`eng/pipelines/jobs/build-for-publish.yml`**
   - Wires up coverage upload for `typespec-python` after test step
   - Uploads azure-mode coverage as `@azure-tools/typespec-python`

### How other emitters can adopt
Add another template call in `build-for-publish.yml`:
```yaml
- template: /eng/pipelines/templates/upload-spector-coverage.yml
  parameters:
    PackagePath: packages/<emitter-package>
    GeneratorName: "@azure-tools/<emitter-name>"
    UnbrandedGeneratorName: "@typespec/<emitter-name>"  # optional
```

### Context
This is part of moving the branded Python emitter from autorest.python to typespec-azure. The coverage upload was previously in autorest.python's `internal-ci.yml`.