### PR TITLE
Add python emitter to azure playground

### DIFF
--- a/eng/scripts/upload-bundler-packages.js
+++ b/eng/scripts/upload-bundler-packages.js
@@ -4,6 +4,7 @@ import {
   getPackageVersion,
 } from "../../core/packages/bundle-uploader/dist/src/index.js";
 import { repoRoot } from "./helpers.js";
+import { uploadPythonEmitterAssets } from "./upload-python-emitter-assets.js";
 
 await bundleAndUploadPackages({
   repoRoot: repoRoot,
@@ -27,5 +28,8 @@ await bundleAndUploadPackages({
     "@azure-tools/typespec-client-generator-core",
     "@azure-tools/typespec-azure-resource-manager",
     "@azure-tools/typespec-azure-rulesets",
+    "@azure-tools/typespec-python",
   ],
 });
+
+await uploadPythonEmitterAssets(repoRoot);

--- a/eng/scripts/upload-python-emitter-assets.js
+++ b/eng/scripts/upload-python-emitter-assets.js
@@ -1,0 +1,28 @@
+// @ts-check
+import { createRequire } from "module";
+import { dirname, resolve } from "path";
+import { uploadStandalonePackageAssets } from "../../core/packages/bundle-uploader/dist/src/index.js";
+
+/**
+ * Upload the pygen wheel from the installed @typespec/http-client-python package.
+ * The wheel is fetched at runtime in the browser by the inlined http-client-python code.
+ *
+ * @param {string} repoRoot
+ */
+export async function uploadPythonEmitterAssets(repoRoot) {
+  const typespecPythonRequire = createRequire(
+    resolve(repoRoot, "packages/typespec-python/package.json"),
+  );
+  const httpClientPythonEntry = typespecPythonRequire.resolve("@typespec/http-client-python");
+  const httpClientPythonPath = resolve(dirname(httpClientPythonEntry), "../..");
+
+  await uploadStandalonePackageAssets({
+    packagePath: httpClientPythonPath,
+    assets: [
+      {
+        path: "generator/dist/pygen-*.whl",
+        contentType: "application/zip",
+      },
+    ],
+  });
+}

--- a/packages/typespec-azure-playground-website/src/index.ts
+++ b/packages/typespec-azure-playground-website/src/index.ts
@@ -20,6 +20,7 @@ export const TypeSpecPlaygroundConfig = {
     "@azure-tools/typespec-autorest",
     "@azure-tools/typespec-client-generator-core",
     "@azure-tools/typespec-azure-rulesets",
+    "@azure-tools/typespec-python",
   ],
   samples,
 } as const;


### PR DESCRIPTION
depends on https://github.com/microsoft/typespec/pull/10775 

## Reason for this change:

- `typespec-python` has an inline dependency on `http-client-python`
- Making the Python emitter work in the website requires installing the `pygen` wheel from storage blob
- The `pygen` wheel was uploaded to storage blob by the `typespec/http-client-python` pipeline BUT it gets stamped with an alpha version ? and the `pygen` url is resolved based on the version in the package.json. So the wheel was uploaded to a url like `.../pkgs/@typespec/http-client-python/0.28.3-alpha.20260429.3/generator/dist/pygen-0.1.0-py3-none-any.whl`

and the emitter looks for it at:

```
function getBrowserPygenWheelUrl(): string {
  return `${BLOB_STORAGE_BASE_URL}/${PACKAGE_NAME}/${pkgJson.version}/generator/dist/${PYGEN_WHEEL_FILENAME}`;
}
```

- Problem: the `typespec-python` emitter uploaded from this repo wouldn't stamp the alpha version, meaning the emitter would look for the pygen wheel at a URL which doesn't exist (e.g. `http-client-python/0.28.3/generator/...`)

## Proposed solution here

- Reupload the pygen wheel from this repo's publish pipeline, which uses the installed inline http-client-python without an alpha version, so that there is a pygen wheel at the URL it loads