### PR TITLE
Bump version for hotfix: tcgc@0.69.0

### DIFF
--- a/.chronus/changes/fix-reorder-parameters-validate-op-2026-5-21-3-39-0.md
+++ b/.chronus/changes/fix-reorder-parameters-validate-op-2026-5-21-3-39-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-client-generator-core"
----
-
-Fix `reorderParameters`, `addParameter`, `removeParameter`, and `replaceParameter` so that decorators copied to cloned model properties and cloned operations are applied (by calling `finishType` after cloning). This fixes scenarios such as parameters with `@typeChangedFrom` under a `@versioned` service.

--- a/.chronus/changes/fix-tcgc-decimal-example-2026-5-25-3-9-0.md
+++ b/.chronus/changes/fix-tcgc-decimal-example-2026-5-25-3-9-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-client-generator-core"
----
-
-Fix example value matching for `decimal` and `decimal128` typed properties. JSON `number` values in example files are now correctly recognized as matching `decimal` / `decimal128` typed properties.

--- a/.chronus/changes/fix-tcgc-discriminator-example-value-2026-5-22-2-0-0.md
+++ b/.chronus/changes/fix-tcgc-discriminator-example-value-2026-5-22-2-0-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-client-generator-core"
----
-
-Fix example values being dropped on subtypes added via `@hierarchyBuilding` by propagating serialization options from the nearest ancestor to the newly added subtype

--- a/.chronus/changes/tcgc-extend-isexactname-2026-5-21-7-57-0.md
+++ b/.chronus/changes/tcgc-extend-isexactname-2026-5-21-7-57-0.md
@@ -1,7 +1,0 @@
----
-changeKind: feature
-packages:
-  - "@azure-tools/typespec-client-generator-core"
----
-
-Extend `isExactName` to additional SDK types whose names can be changed by `@clientName`: `SdkClientType`, `SdkServiceMethodBase` (and its derived method kinds), and `SdkEnumValueType`. Also fixed `SdkClientType.name` to strip the internal `exact()` marker.

--- a/packages/typespec-client-generator-core/CHANGELOG.md
+++ b/packages/typespec-client-generator-core/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log - @azure-tools/typespec-client-generator-core
 
+## 0.69.0
+
+### Features
+
+- [#4480](https://github.com/Azure/typespec-azure/pull/4480) Extend `isExactName` to additional SDK types whose names can be changed by `@clientName`: `SdkClientType`, `SdkServiceMethodBase` (and its derived method kinds), and `SdkEnumValueType`. Also fixed `SdkClientType.name` to strip the internal `exact()` marker.
+
+### Bug Fixes
+
+- [#4477](https://github.com/Azure/typespec-azure/pull/4477) Fix `reorderParameters`, `addParameter`, `removeParameter`, and `replaceParameter` so that decorators copied to cloned model properties and cloned operations are applied (by calling `finishType` after cloning). This fixes scenarios such as parameters with `@typeChangedFrom` under a `@versioned` service.
+- [#4487](https://github.com/Azure/typespec-azure/pull/4487) Fix example value matching for `decimal` and `decimal128` typed properties. JSON `number` values in example files are now correctly recognized as matching `decimal` / `decimal128` typed properties.
+- [#4484](https://github.com/Azure/typespec-azure/pull/4484) Fix example values being dropped on subtypes added via `@hierarchyBuilding` by propagating serialization options from the nearest ancestor to the newly added subtype
+
+
 ## 0.68.1
 
 ### Bug Fixes

--- a/packages/typespec-client-generator-core/CHANGELOG.md
+++ b/packages/typespec-client-generator-core/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change Log - @azure-tools/typespec-client-generator-core
 
-## 0.69.0
+## 0.68.2
 
 ### Features
 

--- a/packages/typespec-client-generator-core/package.json
+++ b/packages/typespec-client-generator-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-core",
-  "version": "0.69.0",
+  "version": "0.68.2",
   "author": "Microsoft Corporation",
   "description": "TypeSpec Data Plane Generation library",
   "homepage": "https://azure.github.io/typespec-azure",

--- a/packages/typespec-client-generator-core/package.json
+++ b/packages/typespec-client-generator-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-core",
-  "version": "0.68.1",
+  "version": "0.69.0",
   "author": "Microsoft Corporation",
   "description": "TypeSpec Data Plane Generation library",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
Hotfix release for `@azure-tools/typespec-client-generator-core` 0.69.0

## Changes
- [#4480] Extend `isExactName` to clients, methods, and enum values
- [#4477] Fix `reorderParameters`/`addParameter`/`removeParameter`/`replaceParameter` decorator application on cloned types
- [#4487] Fix example value matching for `decimal`/`decimal128` properties
- [#4484] Fix example values dropped on subtypes added via `@hierarchyBuilding`

## Checklist
- [x] Version bump via `pnpm chronus version --ignore-policies`
- [x] Only TCGC package changed
- [x] Core submodule pointer unchanged