### PR TITLE
[Automated][tcgc] Document `@usage` on namespaces and update orphan type description

### DIFF
--- a/.chronus/changes/add-usage-namespace-spector-spec-2026-5-25-10-37-0.md
+++ b/.chronus/changes/add-usage-namespace-spector-spec-2026-5-25-10-37-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Add Spector scenario for `@usage` applied to a namespace, demonstrating recursive propagation to nested models.

--- a/eng/scripts/doc-updater/knowledge/tcgc.md
+++ b/eng/scripts/doc-updater/knowledge/tcgc.md
@@ -17,7 +17,7 @@
 3. `@protocolAPI(target, flag?, scope?)` — control protocol method generation
 4. `@client(target, options?, scope?)` — define explicit client; ClientOptions has service, name, autoMergeService
 5. `@operationGroup(target, scope?)` — DEPRECATED, use @client
-6. `@usage(target, value, scope?)` — mark model/enum/union usage (input/output/json/xml)
+6. `@usage(target, value, scope?)` — mark model/enum/union/namespace usage (input/output/json/xml); on namespace, propagates recursively to all contained types
 7. `@access(target, value, scope?)` — public/internal visibility
 8. `@override(target, override, scope?)` — customize method signatures
 9. `@useSystemTextJsonConverter(target, scope?)` — C# backward compat only
@@ -181,7 +181,7 @@ namespace (@clientNamespace), naming (@clientName), overload, structure (@client
 
 ## isExactName Property (May 2026)
 
-- The `isExactName: boolean` property was added to many SDK type interfaces: SdkModelType, SdkEnumType, SdkUnionType, SdkConstantType, SdkNullableType, SdkClientInitializationType, and SdkModelPropertyTypeBase (base for all property types).
+- The `isExactName: boolean` property was added to many SDK type interfaces: SdkModelType, SdkEnumType, SdkUnionType, SdkConstantType, SdkNullableType, SdkClientInitializationType, SdkModelPropertyTypeBase (base for all property types), SdkClientType, SdkEnumValueType, and SdkServiceMethodBase.
 - Set to `true` when a name is wrapped with the `exact()` function in `@clientName`.
 - The `exact()` function internally prepends `_exact_:` prefix which is stripped by `normalizeExactName()` before the name reaches the type graph.
 - Exported helpers: `EXACT_NAME_PREFIX`, `hasExactNameMarker()`, `normalizeExactName()` from the TCGC package index.
@@ -191,3 +191,17 @@ namespace (@clientNamespace), naming (@clientName), overload, structure (@client
 ## Feedback Lessons (PR #4416)
 
 - In TypeScript code examples, keep method signatures on a single line when they fit within ~120 characters. Don't use multi-line formatting for short method signatures.
+
+## Feedback Lessons (PR #4481)
+
+- For exact-name Spector specs: use per-language underscore-prefixed names (e.g., `_my_name`, `_myName`, `_MyName`) to truly verify that language naming logic does not strip or recase the name. Simple camelCase/snake_case names don't prove exactness because they'd survive normal casing rules.
+- `@clientName` description in docs: say it "allows emitters to apply language-specific casing transformations to the provided name." The `exact()` function "prevents this and preserves the name exactly as specified."
+- guideline.md formatting: do NOT add extra blank lines between numbered list items and their sub-items (keep `  -` sub-items immediately after the numbered item).
+- Keep exact() doc examples simple: prefer showing only scoped renames (per-language). Don't combine global rename + scoped rename in the same example.
+- Language tabs for exact() should show `# not supported` / `// not supported` since no emitter supports `isExactName` yet.
+
+## Orphan Type Detection (May 2026 Refactoring)
+
+- `listOrphanTypes` no longer iterates only user-defined namespaces. It now uses `listScopedDecoratorData` to find all types and namespaces with an explicit `@usage` decorator, including types in imported libraries (e.g., `@@usage(Azure.Core.Foundations.Error, Usage.input)`).
+- When `@usage` is applied to a namespace, the function recursively descends into sub-namespaces to collect all models, enums, and unions.
+- Types with `@hierarchyBuilding` are also collected separately (only when legacy hierarchy building is enabled).

--- a/eng/scripts/doc-updater/knowledge/tcgc.meta.json
+++ b/eng/scripts/doc-updater/knowledge/tcgc.meta.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "4e0c41b8c199deff9f2797e943aa568a2500cfb6",
-  "lastUpdated": "2026-05-18T06:28:16.451Z",
+  "lastCommit": "b166149c75cfcf8b63e8205fad4bee05a98aef1a",
+  "lastUpdated": "2026-05-25T10:51:38.701Z",
   "analyzedPaths": [
     "packages/typespec-client-generator-core/src",
     "packages/typespec-client-generator-core/lib",

--- a/packages/azure-http-specs/spec-summary.md
+++ b/packages/azure-http-specs/spec-summary.md
@@ -912,8 +912,15 @@ Expected response body:
 - Endpoint: `post /azure/client-generator-core/exact-name/property`
 
 This scenario tests the exact() function applied to a model property with language scoping.
-The property 'name' on ScopedModel is renamed to 'my_name' using exact() scoped to Python only.
-Python should preserve the exact name 'my_name' as-is. Other languages use the default name 'name'.
+The property 'name' on ScopedModel is renamed using exact() scoped to each language,
+with names that include an underscore prefix to verify that language naming logic does not apply:
+
+- Python: '\_my_name' (should not be converted to 'my_name' or other casing)
+- Java: '\_myName' (should not be converted to remove the underscore prefix)
+- C#: '\_MyName' (should not be converted to remove the underscore prefix)
+- JavaScript: '\_myName' (should not be converted to remove the underscore prefix)
+- Go: '\_MyName' (should not be converted to remove the underscore prefix)
+  Each language should preserve the specified exact name as-is without any further casing conversion.
 
 Expected request body:
 
@@ -1309,6 +1316,16 @@ Expected calls:
 This scenario contains 4 public operations. All should be generated and exported.
 'OrphanModel' is not used but specified as 'public' and 'input', so it should be generated in SDK. The 'orphanModelSerializable' operation verifies that the model can be serialized to JSON.
 The other models' usage is additive to roundtrip, so they should be generated and exported as well.
+
+### Azure_ClientGenerator_Core_Usage_NamespaceUsage
+
+- Endpoint: `put /azure/client-generator-core/usage/namespaceModelSerializable`
+
+This scenario tests @usage applied to a namespace.
+All models within the namespace (including nested sub-namespaces) inherit the usage.
+'NamespaceModel' and 'NestedNamespaceModel' are orphan models that should be generated
+because their parent namespace has @usage(Usage.input | Usage.json) applied.
+The 'namespaceModelSerializable' operation verifies that models from the namespace can be serialized.
 
 ### Azure_Core_Basic_createOrReplace
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/usage/main.tsp
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/usage/main.tsp
@@ -120,3 +120,45 @@ model OrphanModel {
   @encodedName("application/json", "desc")
   description: string;
 }
+
+@scenario
+@scenarioDoc("""
+  This scenario tests @usage applied to a namespace.
+  All models within the namespace (including nested sub-namespaces) inherit the usage.
+  'NamespaceModel' and 'NestedNamespaceModel' are orphan models that should be generated
+  because their parent namespace has @usage(Usage.input | Usage.json) applied.
+  The 'namespaceModelSerializable' operation verifies that models from the namespace can be serialized.
+  """)
+@global.Azure.ClientGenerator.Core.clientNamespace("azure.clientgenerator.core.usage", "java")
+namespace NamespaceUsage {
+  @route("/namespaceModelSerializable")
+  @put
+  @global.Azure.ClientGenerator.Core.convenientAPI(false)
+  @doc("""
+    Serialize the 'NamespaceModel' as request body.
+    
+    Expected body parameter:
+    ```json
+    {
+      "name": "test"
+    }
+    ```
+    """)
+  op namespaceModelSerializable(@body body: unknown): NoContentResponse;
+}
+
+@global.Azure.ClientGenerator.Core.usage(
+  global.Azure.ClientGenerator.Core.Usage.input | global.Azure.ClientGenerator.Core.Usage.json
+)
+@global.Azure.ClientGenerator.Core.access(global.Azure.ClientGenerator.Core.Access.public)
+namespace Models {
+  model NamespaceModel {
+    name: string;
+  }
+
+  namespace Nested {
+    model NestedNamespaceModel {
+      value: string;
+    }
+  }
+}

--- a/packages/azure-http-specs/specs/azure/client-generator-core/usage/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/usage/mockapi.ts
@@ -51,3 +51,19 @@ Scenarios.Azure_ClientGenerator_Core_Usage_ModelInOperation = passOnSuccess([
     kind: "MockApiDefinition",
   },
 ]);
+
+Scenarios.Azure_ClientGenerator_Core_Usage_NamespaceUsage = passOnSuccess([
+  {
+    uri: "/azure/client-generator-core/usage/namespaceModelSerializable",
+    method: "put",
+    request: {
+      body: json({
+        name: "test",
+      }),
+    },
+    response: {
+      status: 204,
+    },
+    kind: "MockApiDefinition",
+  },
+]);

--- a/website/src/content/docs/docs/howtos/Generate client libraries/04method.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/04method.mdx
@@ -252,8 +252,18 @@ Models can be used for input, output, or both at the same time. In some language
 changes the way the API is exposed for those models.
 
 By default, the code generator will infer the usage based on the TypeSpec. If this inference doesn't
-correspond to expectation, this can be customized with the `usage` decorator. Possible values are
-`input` and `output`, and can be combined with `Usage.input | Usage.output`.
+correspond to expectation, this can be customized with the `usage` decorator.
+
+Possible values are:
+
+- `Usage.input`: type is used in request payloads.
+- `Usage.output`: type is used in response payloads.
+- `Usage.json`: type is used in JSON payloads.
+- `Usage.xml`: type is used in XML payloads.
+
+Values can be combined with bitwise OR (`|`) to express all applicable contexts. For example,
+`Usage.input | Usage.output | Usage.json` means the type is round-trip (both request and response)
+and JSON-based.
 
 The `@usage` decorator can be applied to individual models, enums, or unions. It can also be applied to a **namespace**, in which case the usage propagates recursively to all models, enums, and unions defined within that namespace and its nested sub-namespaces. This includes types in imported libraries when using augment decorators (`@@usage`).
 

--- a/website/src/content/docs/docs/howtos/Generate client libraries/04method.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/04method.mdx
@@ -255,6 +255,8 @@ By default, the code generator will infer the usage based on the TypeSpec. If th
 correspond to expectation, this can be customized with the `usage` decorator. Possible values are
 `input` and `output`, and can be combined with `Usage.input | Usage.output`.
 
+The `@usage` decorator can be applied to individual models, enums, or unions. It can also be applied to a **namespace**, in which case the usage propagates recursively to all models, enums, and unions defined within that namespace and its nested sub-namespaces. This includes types in imported libraries when using augment decorators (`@@usage`).
+
 > **NOTE:** If a model is never used, it will not be generated. Assigning a usage will force generation.
 
 <ClientTabs>

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
@@ -346,7 +346,7 @@ TCGC uses the following steps to detect all the types in one spec:
 9. If type is an `EnumMember`, finds types for the enum the member belongs to.
 10. If type is a `UnionVariant`, finds types for the union the variant belongs to.
 11. Iterates parameters defined in `@server` and finds types.
-12. Iterates user-defined namespace for `Model`, `Enum` and `Union` to find orphan types (not referred by `Operation`).
+12. Finds orphan types (`Model`, `Enum`, and `Union` not referred by any `Operation`) by scanning all types and namespaces that have an explicit `@usage` decorator, including types in imported libraries.
 13. Handles API version `Enum` used in `@versioned`.
 
 ### Access Calculation


### PR DESCRIPTION
- Document @usage decorator namespace target with recursive propagation in 04method.mdx user docs
- Update guideline.md orphan type detection description to reflect new implementation using listScopedDecoratorData (including imported libs)
- Add Spector scenario for namespace-level @usage with nested sub-namespaces
- Update knowledge base with feedback lessons and new behavior notes

Resolve: https://github.com/Azure/typespec-azure/issues/4490