### PR TITLE
ci: upload code coverage on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ jobs:
   build:
     name: "Build (${{ matrix.os }}, Node ${{ matrix.node-version }})"
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      code-quality: write
+      pull-requests: read
     strategy:
       fail-fast: false
       matrix:
@@ -55,6 +59,15 @@ jobs:
 
       - name: Test
         run: pnpm vitest run --config ./vitest.config.fast.ts --coverage --reporter=github-actions --reporter=default
+
+      - name: Upload code coverage
+        if: matrix.os == 'ubuntu-latest' && matrix.node-version == '26.x'
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: ./coverage/cobertura-coverage.xml
+          language: TypeScript
+          label: code-coverage/vitest
+          fail-on-error: false
 
       - name: Regen samples
         run: pnpm run regen-samples


### PR DESCRIPTION
Wires up [`actions/upload-code-coverage@v1`](https://github.com/actions/upload-code-coverage) into the CI workflow so that the Cobertura report produced by the existing `vitest --coverage` run is uploaded to GitHub's code coverage API for each PR.

## Changes

- Grant `code-quality: write` and `pull-requests: read` permissions to the `build` job (required by the action).
- After the `Test` step, upload `./coverage/cobertura-coverage.xml` (the merged report produced by the vitest workspace run, configured via `core/vitest.config.ts`).
- Gated to `ubuntu-latest` + Node `22.x` only, so a single report is uploaded per PR run instead of one per matrix combination.
- `fail-on-error: false` so a transient upload failure doesn't break CI.