### PR TITLE
[TCGC] Fix orphan type ordering to restore stable naming for anonymous model variants

### DIFF
--- a/.chronus/changes/fix-orphan-type-naming-order-2026-5-27-14-24-0.md
+++ b/.chronus/changes/fix-orphan-type-naming-order-2026-5-27-14-24-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Fix orphan type ordering so that models are always processed before unions, ensuring anonymous model variants inside unions get their generated name from the model property context rather than the union context. This restores the naming behavior from 0.68.0 that was inadvertently changed in 0.68.1.

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -1349,15 +1349,25 @@ export function isTypeNeedsHandling(context: TCGCContext, type: Type): boolean {
 
 export function listOrphanTypes(context: TCGCContext): (Model | Enum | Union)[] {
   if (context.__orphanTypesCache) return context.__orphanTypesCache;
-  const result: (Model | Enum | Union)[] = [];
   const seen = new Set<Model | Enum | Union>();
+
+  // Collect types into separate buckets to maintain a stable ordering:
+  // models first, then enums, then unions. This ordering matters because
+  // anonymous types (e.g. anonymous model variants inside unions) get their
+  // generated name from the first context that processes them. Models must
+  // come first so their property-context names win over union-context names.
+  const models: Model[] = [];
+  const enums: Enum[] = [];
+  const unions: Union[] = [];
 
   function addType(type: Model | Enum | Union) {
     if (seen.has(type)) return;
     if ((type.kind === "Model" || type.kind === "Union") && isTemplateDeclaration(type)) return;
     if (!isTypeNeedsHandling(context, type)) return;
     seen.add(type);
-    result.push(type);
+    if (type.kind === "Model") models.push(type);
+    else if (type.kind === "Enum") enums.push(type);
+    else unions.push(type);
   }
 
   function addNamespace(namespace: Namespace) {
@@ -1402,6 +1412,7 @@ export function listOrphanTypes(context: TCGCContext): (Model | Enum | Union)[] 
     }
   }
 
+  const result: (Model | Enum | Union)[] = [...models, ...enums, ...unions];
   context.__orphanTypesCache = result;
   return result;
 }

--- a/packages/typespec-client-generator-core/test/public-utils/get-generated-name.test.ts
+++ b/packages/typespec-client-generator-core/test/public-utils/get-generated-name.test.ts
@@ -737,6 +737,46 @@ describe("orphan model with anonymous model", () => {
     const eouEnum = context.sdkPackage.enums.find((e) => e.name === "EouDetectionModel");
     ok(eouEnum, "Enum should be named 'EouDetectionModel' without numeric suffix");
   });
+
+  it("orphan union anonymous variant should be named from model property context", async () => {
+    // Regression test: when @@usage on the union appears before @@usage on the
+    // model that references it, the anonymous model variant of the union should
+    // still get its generated name from the model property context (e.g.
+    // "OuterWithNullableValue"), not from the union context (e.g.
+    // "RecursiveNullableType1").
+    const { program } = await SimpleTesterWithService.compile(`
+      union RecursiveNullableType {
+        null,
+        {
+          inner?: RecursiveNullableType,
+        },
+      }
+
+      model OuterWithNullable {
+        value?: RecursiveNullableType;
+      }
+
+      @@access(TestService.RecursiveNullableType, Access.public);
+      @@usage(TestService.RecursiveNullableType, Usage.output);
+      @@access(TestService.OuterWithNullable, Access.public);
+      @@usage(TestService.OuterWithNullable, Usage.output);
+    `);
+    const context = await createSdkContextForTester(program);
+    const models = context.sdkPackage.models;
+
+    const outerModel = models.find((m) => m.name === "OuterWithNullable");
+    ok(outerModel, "Should find OuterWithNullable model");
+
+    // The anonymous model variant should be named from the model property
+    // context, not the union context.
+    const anonModel = models.find((m) => m.isGeneratedName);
+    ok(anonModel, "Should find the anonymous model variant");
+    strictEqual(
+      anonModel.name,
+      "OuterWithNullableValue",
+      "Anonymous model should be named from model property context, not union context",
+    );
+  });
 });
 
 describe("corner case", () => {


### PR DESCRIPTION
## Problem

PR #4440 rewrote `listOrphanTypes` to iterate via `listScopedDecoratorData(context, usageKey)`, which follows **decorator application order**. The old code walked namespaces and iterated **models first, then enums, then unions**.

This ordering matters because anonymous types (e.g. anonymous model variants inside unions) get their generated name from whichever context processes them first. When `@@usage` on a union appears before `@@usage` on a model that references it, the anonymous variant gets named from the union context (e.g. `RecursiveNullableType1`) instead of the model property context (e.g. `OuterWithNullableValue`).

Reported via https://github.com/Azure/typespec-rust/pull/969 — upgrading from TCGC 0.68.0 to 0.68.2 renamed `OuterWithNullableValue` → `RecursiveNullableType1`.

## Fix

Collect orphan types into three separate buckets (models, enums, unions) and concatenate them at the end: `[...models, ...enums, ...unions]`. This restores the models-first ordering while preserving the #4440 improvement of discovering types from imported libraries.

## Testing

Added a regression test that reproduces the exact scenario from the typespec-rust spec.