### PR TITLE
[Automated][azure-resource-manager] Add ExtendedLocationProperty to envelope properties documentation

### DIFF
--- a/eng/scripts/doc-updater/knowledge/azure-resource-manager.md
+++ b/eng/scripts/doc-updater/knowledge/azure-resource-manager.md
@@ -93,6 +93,14 @@ Old paths like `dynatrace/`, `tenantResource/`, `arm-scenarios/singleton/`, `ope
 
 The `@service` decorator should NOT include a `version` parameter (version comes from `@versioned` when used). The guide uses `ArmCustomPatchSync` (not ArmTagsPatch) because that is the recommendation, based on the requirements of the ARM RPC (Resource Provider Contract).
 
+## Envelope Properties Placement
+
+All standard envelope properties (`EntityTagProperty`, `ExtendedLocationProperty`, `ManagedByProperty`, `ManagedServiceIdentityProperty`, `ResourceKindProperty`, `ResourcePlanProperty`, `ResourceSkuProperty`) must be spread on the **resource model** itself — NOT inside the properties bag model. The canonical sample `resource-common-properties/common-properties/main.tsp` demonstrates this pattern with all seven properties on the resource model.
+
+## ResourceNameParameter NamePattern
+
+`ResourceNameParameter` has a `NamePattern` template parameter with default value `"^[a-zA-Z0-9-]{3,24}$"`. In documentation examples, omit `NamePattern` when the value equals the default. Only show it when demonstrating a custom pattern.
+
 ## Feedback Corrections Applied
 
 - `step03.md`: Use `...ResourceNameParameter<AddressResource, KeyName = "addressName", SegmentName = "addresses">` instead of manual `@key/@segment name` fields for child resources.
@@ -100,3 +108,4 @@ The `@service` decorator should NOT include a `version` parameter (version comes
 - `step05.md`: Remove `version` from `@service` decorator; use `...ResourceNameParameter<User>` instead of manual key/segment/path.
 - `deprecation.tsp`: The ExtensionResourceBase deprecation message must say "Foundations.ExtensionResource" (not "ProxyResource").
 - `arm-legacy-operations-discourage` rule was removed from linter registration; its rule doc file and linter.md entry should not exist.
+- Knowledge base: The reason for using `ArmCustomPatchSync` in docs is "because that is the recommendation, based on the requirements of the ARM RPC" — NOT "to avoid the suppress complexity".

--- a/eng/scripts/doc-updater/knowledge/azure-resource-manager.meta.json
+++ b/eng/scripts/doc-updater/knowledge/azure-resource-manager.meta.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "1eb05cd5d698c92f92a0c468276e87b26bc6a718",
-  "lastUpdated": "2026-05-18T11:02:47.905Z",
+  "lastCommit": "d0d2d7c83897ad72314d55ebae0dcbc28e62ee61",
+  "lastUpdated": "2026-06-01T11:07:13.329Z",
   "analyzedPaths": [
     "packages/typespec-azure-resource-manager/src",
     "packages/typespec-azure-resource-manager/lib",

--- a/website/src/content/docs/docs/howtos/ARM/resource-type.md
+++ b/website/src/content/docs/docs/howtos/ARM/resource-type.md
@@ -469,6 +469,8 @@ In addition to the resource-specific property bag, a resource may configure on o
 - **Plan**: A standard mechanism for configuring MarketPlace billing plans for a resource.
 - **ETags**: A standard mechanism for managing concurrent operations over the resource.
 - **ResourceKind**: A standard mechanism for specifying a type of user experience in the portal.
+- **ManagedBy**: Indicating that this resource is managed by another Azure resource.
+- **ExtendedLocation**: Enabling deployment to custom locations such as Azure Arc-connected environments.
 
 ### Managed Identity
 
@@ -558,6 +560,17 @@ model Employee is TrackedResource<EmployeeProperties> {
 ```
 
 For more information on supporting 'ManagedBy', see [ManagedBy API Contract](https://eng.ms/docs/products/arm/api_contracts/managedby)
+
+### ExtendedLocation
+
+Support for deploying a resource to custom locations, such as Azure Arc-connected environments. To enable extended location support, add the `ExtendedLocationProperty` envelope property to the resource definition:
+
+```typespec
+model Employee is TrackedResource<EmployeeProperties> {
+  ...ResourceNameParameter<Employee>;
+  ...ExtendedLocationProperty;
+}
+```
 
 ## Reference
 


### PR DESCRIPTION
…e properties guide

Add missing ExtendedLocationProperty documentation to the envelope properties section of the resource-type how-to guide, matching the updated canonical sample that now demonstrates all recommended envelope properties.

Also update the knowledge base with lessons from feedback and new envelope property placement conventions.