### PR TITLE
Bump version for hotfix: tcgc@0.68.4

### DIFF
--- a/.chronus/changes/fix-tcgc-example-matching-per-language-client-location-2026-5-29-2-40-0.md
+++ b/.chronus/changes/fix-tcgc-example-matching-per-language-client-location-2026-5-29-2-40-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-client-generator-core"
----
-
-Fix example matching when `@clientLocation` (or `@clientName`) is applied with per-language scope. Example files coming from the swagger/autorest output carry a single canonical `operationId`, but per-language `@clientLocation` overrides previously caused TCGC to resolve a different operation id per emitter, silently breaking example linkage for all languages whose group name didn't match the example file. Example matching now resolves operation ids under the `autorest` scope so a single example file links successfully across all language emitters.

--- a/.chronus/changes/fix-tcgc-file-content-type-enum-mismatch-2026-5-29-2-44-0.md
+++ b/.chronus/changes/fix-tcgc-file-content-type-enum-mismatch-2026-5-29-2-44-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-client-generator-core"
----
-
-Fix mismatched enum type names for `Http.File` bodies with multiple content types. The synthetic `contentType` header/method parameter now reuses the `File` model's `contentType` property type, so the enum referenced by the parameter and the enum present in `sdkPackage.enums` are the same instance (and share the same name).

--- a/packages/typespec-client-generator-core/CHANGELOG.md
+++ b/packages/typespec-client-generator-core/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log - @azure-tools/typespec-client-generator-core
 
+## 0.68.4
+
+### Bug Fixes
+
+- [#4515](https://github.com/Azure/typespec-azure/pull/4515) Fix example matching when `@clientLocation` (or `@clientName`) is applied with per-language scope. Example files coming from the swagger/autorest output carry a single canonical `operationId`, but per-language `@clientLocation` overrides previously caused TCGC to resolve a different operation id per emitter, silently breaking example linkage for all languages whose group name didn't match the example file. Example matching now resolves operation ids under the `autorest` scope so a single example file links successfully across all language emitters.
+- [#4514](https://github.com/Azure/typespec-azure/pull/4514) Fix mismatched enum type names for `Http.File` bodies with multiple content types. The synthetic `contentType` header/method parameter now reuses the `File` model's `contentType` property type, so the enum referenced by the parameter and the enum present in `sdkPackage.enums` are the same instance (and share the same name).
+
+
 ## 0.68.3
 
 ### Bug Fixes

--- a/packages/typespec-client-generator-core/package.json
+++ b/packages/typespec-client-generator-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-client-generator-core",
-  "version": "0.68.3",
+  "version": "0.68.4",
   "author": "Microsoft Corporation",
   "description": "TypeSpec Data Plane Generation library",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
Hotfix release for `@azure-tools/typespec-client-generator-core` 0.68.4

## Changes
- [#4515] Fix TCGC example matching for per-language `@clientLocation`
- [#4514] Fix mismatched enum for `Http.File` body with multiple content types

## Checklist
- [x] Version bump via `pnpm chronus version --ignore-policies`
- [x] Only TCGC package changed
- [x] Core submodule pointer unchanged