### PR TITLE
Replace js-yaml with yaml package in typespec-ts

### DIFF
--- a/.chronus/changes/replace-js-yaml-with-yaml-2026-5-3-12-25-59.md
+++ b/.chronus/changes/replace-js-yaml-with-yaml-2026-5-3-12-25-59.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Replace js-yaml with yaml package in typespec-ts

--- a/packages/typespec-ts/package.json
+++ b/packages/typespec-ts/package.json
@@ -102,8 +102,7 @@
     "@vitest/coverage-v8": "catalog:",
     "@microsoft/api-extractor": "catalog:",
     "tsx": "catalog:",
-    "@types/js-yaml": "catalog:",
-    "js-yaml": "catalog:"
+    "yaml": "catalog:"
   },
   "peerDependencies": {
     "@azure-tools/typespec-azure-core": "workspace:^",

--- a/packages/typespec-ts/test/modularUnit/scenarios.spec.ts
+++ b/packages/typespec-ts/test/modularUnit/scenarios.spec.ts
@@ -14,7 +14,7 @@ import {
 import { assertEqualContent, ExampleJson } from "../util/testUtil.js";
 import { format } from "prettier";
 import { prettierTypeScriptOptions } from "../../src/lib.js";
-import { load as loadYaml } from "js-yaml";
+import { parse as loadYaml } from "yaml";
 
 const SCENARIOS_LOCATION = "./test/modularUnit/scenarios";
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,9 +174,6 @@ catalogs:
     '@types/hast':
       specifier: ^3.0.4
       version: 3.0.4
-    '@types/js-yaml':
-      specifier: ^4.0.9
-      version: 4.0.9
     '@types/lodash':
       specifier: ^4.17.4
       version: 4.17.24
@@ -390,9 +387,6 @@ catalogs:
     is-unicode-supported:
       specifier: ^2.1.0
       version: 2.1.0
-    js-yaml:
-      specifier: ^4.1.0
-      version: 4.1.1
     lodash:
       specifier: ^4.17.21
       version: 4.18.1
@@ -3965,9 +3959,6 @@ importers:
       '@microsoft/api-extractor':
         specifier: 'catalog:'
         version: 7.58.7(@types/node@25.9.1)
-      '@types/js-yaml':
-        specifier: 'catalog:'
-        version: 4.0.9
       '@types/lodash':
         specifier: 'catalog:'
         version: 4.17.24
@@ -4019,9 +4010,6 @@ importers:
       eslint-plugin-require-extensions:
         specifier: 'catalog:'
         version: 0.1.3(eslint@10.4.1)
-      js-yaml:
-        specifier: 'catalog:'
-        version: 4.1.1
       mkdirp:
         specifier: 'catalog:'
         version: 3.0.1
@@ -4037,6 +4025,9 @@ importers:
       vitest:
         specifier: 'catalog:'
         version: 4.1.7(@types/node@25.9.1)(@vitest/coverage-v8@4.1.7)(@vitest/ui@4.1.7)(happy-dom@20.9.0)(jsdom@25.0.1)(vite@8.0.14(@types/node@25.9.1)(esbuild@0.28.0)(tsx@4.22.3)(yaml@2.9.0))
+      yaml:
+        specifier: 'catalog:'
+        version: 2.9.0
 
   website:
     dependencies:
@@ -21065,7 +21056,7 @@ snapshots:
       algoliasearch: 4.27.0
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       diff: 5.2.2
-      ink: 3.2.0(@types/react@19.2.15)(react@19.2.6)
+      ink: 3.2.0(@types/react@19.2.15)(react@17.0.2)
       ink-text-input: 4.0.3(ink@3.2.0(@types/react@19.2.15)(react@17.0.2))(react@17.0.2)
       react: 17.0.2
       semver: 7.8.1
@@ -21215,7 +21206,7 @@ snapshots:
       '@yarnpkg/plugin-git': 3.2.0(@yarnpkg/core@4.8.0(typanion@3.14.0))(typanion@3.14.0)
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       es-toolkit: 1.47.0
-      ink: 3.2.0(@types/react@19.2.15)(react@17.0.2)
+      ink: 3.2.0(@types/react@19.2.15)(react@19.2.6)
       react: 17.0.2
       semver: 7.8.1
       tslib: 2.8.1


### PR DESCRIPTION
Replaces `js-yaml` (and `@types/js-yaml`) with the `yaml` package in `@azure-tools/typespec-ts`. The `yaml` package has built-in TypeScript types and is already available in the workspace catalog.