### PR TITLE
Remove lodash dependency from @azure-tools/typespec-ts

### DIFF
--- a/.chronus/changes/remove-lodash-typespec-ts-2026-6-3-11-5-0.md
+++ b/.chronus/changes/remove-lodash-typespec-ts-2026-6-3-11-5-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Replace lodash usage with built-in ESM equivalents

--- a/packages/typespec-ts/package.json
+++ b/packages/typespec-ts/package.json
@@ -82,7 +82,6 @@
     "@azure/core-rest-pipeline": "catalog:",
     "@azure/core-util": "catalog:",
     "@azure/logger": "catalog:",
-    "@types/lodash": "catalog:",
     "@typescript-eslint/eslint-plugin": "catalog:",
     "@typescript-eslint/parser": "catalog:",
     "@typespec/compiler": "workspace:^",
@@ -117,7 +116,6 @@
   "dependencies": {
     "fast-xml-parser": "catalog:",
     "handlebars": "catalog:",
-    "lodash": "catalog:",
     "prettier": "catalog:",
     "ts-morph": "catalog:",
     "tslib": "catalog:"

--- a/packages/typespec-ts/src/transform/transfromRLCOptions.ts
+++ b/packages/typespec-ts/src/transform/transfromRLCOptions.ts
@@ -20,7 +20,6 @@ import { getDefaultService } from "../utils/modelUtils.js";
 import { detectModelConflicts } from "../utils/namespaceUtils.js";
 import { getOperationName } from "../utils/operationUtil.js";
 import { getSupportedHttpAuth } from "../utils/credentialUtils.js";
-import _ from "lodash";
 import { getClientParameters } from "../modular/helpers/clientHelpers.js";
 
 export function transformRLCOptions(

--- a/packages/typespec-ts/test/commands/run.ts
+++ b/packages/typespec-ts/test/commands/run.ts
@@ -10,7 +10,25 @@ import { npxCommand } from "./runCommand.js";
 import * as fs from "fs/promises";
 import { createTaskLogger } from "./logger.js";
 import { createProgram, CompilerOptions } from "typescript";
-import lodash from "lodash";
+
+function deepMerge(target: any, source: any): any {
+  const result = { ...target };
+  for (const key of Object.keys(source)) {
+    if (
+      source[key] &&
+      typeof source[key] === "object" &&
+      !Array.isArray(source[key]) &&
+      target[key] &&
+      typeof target[key] === "object" &&
+      !Array.isArray(target[key])
+    ) {
+      result[key] = deepMerge(target[key], source[key]);
+    } else {
+      result[key] = source[key];
+    }
+  }
+  return result;
+}
 
 interface GenEnv {
   readonly logger: () => any;
@@ -182,8 +200,8 @@ async function runTypespecHelper(env: GenEnv): Promise<void> {
     // Defaults are merged in api-extractor when the config file is read from disk with
     // `ExtractorConfig.loadFile`. This is derived from that method.
     // https://github.com/microsoft/rushstack/blob/1a92f17fa537b55529adbec80203bd99afd8cd24/apps/api-extractor/src/api/ExtractorConfig.ts#L624-L627
-    const configObject = lodash.merge(
-      lodash.cloneDeep((ExtractorConfig as any)._defaultConfig),
+    const configObject = deepMerge(
+      structuredClone((ExtractorConfig as any)._defaultConfig),
       baseConfigObject
     );
     ExtractorConfig.jsonSchema.validateObject(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -177,9 +177,6 @@ catalogs:
     '@types/js-yaml':
       specifier: ^4.0.9
       version: 4.0.9
-    '@types/lodash':
-      specifier: ^4.17.4
-      version: 4.17.24
     '@types/micromatch':
       specifier: ^4.0.10
       version: 4.0.10
@@ -393,9 +390,6 @@ catalogs:
     js-yaml:
       specifier: ^4.1.0
       version: 4.1.1
-    lodash:
-      specifier: ^4.17.21
-      version: 4.18.1
     log-symbols:
       specifier: ^7.0.1
       version: 7.0.1
@@ -3910,9 +3904,6 @@ importers:
       handlebars:
         specifier: 'catalog:'
         version: 4.7.9
-      lodash:
-        specifier: 'catalog:'
-        version: 4.18.1
       prettier:
         specifier: 'catalog:'
         version: 3.8.3
@@ -3968,9 +3959,6 @@ importers:
       '@types/js-yaml':
         specifier: 'catalog:'
         version: 4.0.9
-      '@types/lodash':
-        specifier: 'catalog:'
-        version: 4.17.24
       '@typescript-eslint/eslint-plugin':
         specifier: 'catalog:'
         version: 8.60.0(@typescript-eslint/parser@8.60.0(eslint@10.4.1)(typescript@6.0.3))(eslint@10.4.1)(typescript@6.0.3)
@@ -8092,9 +8080,6 @@ packages:
 
   '@types/keyv@3.1.4':
     resolution: {integrity: sha512-BQ5aZNSCpj7D6K2ksrRCTmKRLEpnPvWDiLPfoGyhZ++8YtiK9d/3DBKPJgry359X/P1PfruyYwvnvwFjuEiEIg==}
-
-  '@types/lodash@4.17.24':
-    resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
 
   '@types/mdast@4.0.4':
     resolution: {integrity: sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==}
@@ -20292,8 +20277,6 @@ snapshots:
     dependencies:
       '@types/node': 25.9.1
 
-  '@types/lodash@4.17.24': {}
-
   '@types/mdast@4.0.4':
     dependencies:
       '@types/unist': 3.0.3
@@ -21065,7 +21048,7 @@ snapshots:
       algoliasearch: 4.27.0
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       diff: 5.2.2
-      ink: 3.2.0(@types/react@19.2.15)(react@19.2.6)
+      ink: 3.2.0(@types/react@19.2.15)(react@17.0.2)
       ink-text-input: 4.0.3(ink@3.2.0(@types/react@19.2.15)(react@17.0.2))(react@17.0.2)
       react: 17.0.2
       semver: 7.8.1
@@ -21215,7 +21198,7 @@ snapshots:
       '@yarnpkg/plugin-git': 3.2.0(@yarnpkg/core@4.8.0(typanion@3.14.0))(typanion@3.14.0)
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       es-toolkit: 1.47.0
-      ink: 3.2.0(@types/react@19.2.15)(react@17.0.2)
+      ink: 3.2.0(@types/react@19.2.15)(react@19.2.6)
       react: 17.0.2
       semver: 7.8.1
       tslib: 2.8.1


### PR DESCRIPTION
Replace lodash usage with built-in ESM equivalents:

- Removed unused `import _ from 'lodash'` in `transfromRLCOptions.ts`
- Replaced `lodash.cloneDeep` with `structuredClone()` and `lodash.merge` with a local `deepMerge()` helper in test code
- Removed `lodash` and `@types/lodash` from package.json