### PR TITLE
docs: add release process to typespec-python CONTRIBUTING.md

### DIFF
--- a/packages/typespec-python/CONTRIBUTING.md
+++ b/packages/typespec-python/CONTRIBUTING.md
@@ -33,7 +33,7 @@ Once a new version of the unbranded emitter has been released, follow these step
 3. **Regenerate `emitter-package-lock.yaml`**: Run the following command to update the lock file, making sure it points to your local `typespec-azure` repo where you updated the catalog version in step 1:
 
    ```bash
-   tsp-client generate-config-files --package-json=<path-to-your-local-typespec-azure-repo>/packages/typespec-python/package.json --use-npm-pinning
+   tsp-client generate-config-files --package-json= --use-npm-pinning < path-to-your-local-typespec-azure-repo > /packages/typespec-python/package.json
    ```
 
 4. **Check in the changes**: The updated `emitter-package.json` and regenerated `emitter-package-lock.yaml` should both be committed and submitted as part of the release PR.

--- a/packages/typespec-python/CONTRIBUTING.md
+++ b/packages/typespec-python/CONTRIBUTING.md
@@ -18,6 +18,26 @@ Make sure to run the following commands:
 
 - `pnpm format`
 
+## Release Process
+
+The branded Python emitter (`@azure-tools/typespec-python`) wraps the unbranded emitter (`@typespec/http-client-python`). There is no separate release of the branded emitter; instead, the release process involves updating the dependency on the unbranded emitter.
+
+For the unbranded emitter release process, see the [http-client-python CONTRIBUTING.md](https://github.com/microsoft/typespec/blob/main/packages/http-client-python/CONTRIBUTING.md#release-process).
+
+Once a new version of the unbranded emitter has been released, follow these steps to update the branded emitter:
+
+1. **Update the catalog version in `typespec-azure`**: Bump the version of `@typespec/http-client-python` in [`pnpm-workspace.yaml`](https://github.com/Azure/typespec-azure/blob/main/pnpm-workspace.yaml) to the latest released version.
+
+2. **Update `emitter-package.json` in `azure-sdk-for-python`**: Bump the dependency of `@typespec/http-client-python` to the latest released version in [`eng/emitter-package.json`](https://github.com/Azure/azure-sdk-for-python/blob/main/eng/emitter-package.json).
+
+3. **Regenerate `emitter-package-lock.yaml`**: Run the following command to update the lock file, making sure it points to your local `typespec-azure` repo where you updated the catalog version in step 1:
+
+   ```bash
+   tsp-client generate-config-files --package-json=<path-to-your-local-typespec-azure-repo>/packages/typespec-python/package.json --use-npm-pinning
+   ```
+
+4. **Check in the changes**: The updated `emitter-package.json` and regenerated `emitter-package-lock.yaml` should both be committed and submitted as part of the release PR.
+
 ## Trademarks
 
 This project may contain trademarks or logos for projects, products, or services. Authorized use of Microsoft


### PR DESCRIPTION
Document the branded Python emitter release process, which involves updating the unbranded emitter dependency rather than a separate release. Links to the unbranded emitter's release process and describes the steps for updating catalog version, emitter-package.json, and regenerating emitter-package-lock.yaml.