### PR TITLE
Add emitter:typescript label

### DIFF
--- a/eng/config/labels.ts
+++ b/eng/config/labels.ts
@@ -31,6 +31,10 @@ export const AreaLabels = defineLabels({
     color: "957300",
     description: "Issues for @azure-tools/typespec-python emitter",
   },
+  "emitter:typescript": {
+    color: "957300",
+    description: "Issues for @azure-tools/typespec-ts emitter",
+  },
   "emitter:client:all": {
     color: "957300",
     description:
@@ -63,6 +67,7 @@ export const AreaPaths: Record<keyof typeof AreaLabels, string[]> = {
   "lib:azure-resource-manager": ["packages/typespec-azure-resource-manager/"],
   "emitter:autorest": ["packages/typespec-autorest/"],
   "emitter:python": ["packages/typespec-python/"],
+  "emitter:typescript": ["packages/typespec-ts/"],
   "lib:tcgc": ["packages/typespec-client-generator-core/"],
   "lib:azure-http-specs": ["packages/azure-http-specs/"],
   ide: [],


### PR DESCRIPTION
Adds an `emitter:typescript` area label for the `@azure-tools/typespec-ts` emitter (analogous to the existing `emitter:python` label), and maps it to `packages/typespec-ts/`.