### PR TITLE
Sync @azure-tools/typespec-ts metadata with npm 0.54.0

### DIFF
--- a/.chronus/changes/sync-typespec-ts-0.54.0-metadata-2026-6-4-10-15-0.md
+++ b/.chronus/changes/sync-typespec-ts-0.54.0-metadata-2026-6-4-10-15-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Sync `@azure-tools/typespec-ts` `package.json` `version` and `CHANGELOG.md` with the `0.54.0` release published from `Azure/autorest.typescript`. All `0.54.0` source changes were already captured in the migration commit; this PR only reconciles the version metadata so subsequent releases from this repo bump from a baseline that matches npm.

--- a/packages/typespec-ts/CHANGELOG.md
+++ b/packages/typespec-ts/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.54.0 (2026-06-01)
+
+- [Feature] Bump TypeSpec dependencies to latest stable and next pre-release versions. Please refer to [#4012](https://github.com/Azure/autorest.typescript/pull/4012)
+- [Bugfix] Fix config/script gaps between JS emitter and SDK libraries. Please refer to [#4006](https://github.com/Azure/autorest.typescript/pull/4006)
+- [Feature] Bump turbo from 2.6.3 to 2.9.14. Please refer to [#3989](https://github.com/Azure/autorest.typescript/pull/3989)
+- [Feature] Remove `head-as-boolean` emitter flag (superseded by TCGC `@responseAsBool`). Please refer to [#3986](https://github.com/Azure/autorest.typescript/pull/3986)
+- [Feature] Improve resolveReferences performance. Please refer to [#4004](https://github.com/Azure/autorest.typescript/pull/4004)
+- [Bugfix] Fix deserializer throwing on empty response body (success and error paths). Please refer to [#3948](https://github.com/Azure/autorest.typescript/pull/3948)
+- [Feature] Decouple typespec-ts from rlc-common. Please refer to [#3926](https://github.com/Azure/autorest.typescript/pull/3926)
+- [Feature] Update naming terminology: cadl-ranch → spector, HLC → AutoRest. Please refer to [#3957](https://github.com/Azure/autorest.typescript/pull/3957)
+
 ## 0.53.3 (2026-05-25)
 
 - [Feature] Bump TypeSpec dependencies to latest stable. Please refer to [#4002](https://github.com/Azure/autorest.typescript/pull/4002)

--- a/packages/typespec-ts/package.json
+++ b/packages/typespec-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-ts",
-  "version": "0.53.3",
+  "version": "0.54.0",
   "description": "An experimental TypeSpec emitter for TypeScript RLC",
   "main": "dist/src/index.js",
   "type": "module",


### PR DESCRIPTION
## What

Reconciles `@azure-tools/typespec-ts` `package.json` `version` and `CHANGELOG.md` with the `0.54.0` release published from [`Azure/autorest.typescript`](https://github.com/Azure/autorest.typescript/blob/main/packages/typespec-ts/CHANGELOG.md) on 2026-06-01.


## Verification

Audit confirmed via cross-repo PR-level and file-level diff that no `src/**` or `static/**` content from autorest.typescript `0.54.0` is missing in this repo. Only the metadata is out of sync. This PR is metadata-only — no runtime code change.

- `packages/typespec-ts/package.json`: `0.53.3` → `0.54.0`
- `packages/typespec-ts/CHANGELOG.md`: prepend `## 0.54.0 (2026-06-01)` section copied verbatim from autorest.typescript
- `.chronus/changes/sync-typespec-ts-0.54.0-metadata-…md`: `internal` change entry so consistency check passes