### PR TITLE
Bump version for hotfix: @azure-tools/typespec-ts@0.54.1

### DIFF
--- a/.chronus/changes/fix-rlc-binary-node-readable-stream-2026-6-3-8-0-0.md
+++ b/.chronus/changes/fix-rlc-binary-node-readable-stream-2026-6-3-8-0-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Replace `NodeJS.ReadableStream` with the platform-conditional `NodeReadableStream` helper in RLC binary request body unions so generated browser builds no longer fail with TS2503 when `@types/node` is excluded.

--- a/.chronus/changes/move-typespec-ts-2026-5-1-10-12-8.md
+++ b/.chronus/changes/move-typespec-ts-2026-5-1-10-12-8.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Initial move of typespec-ts package from autorest.typescript repo

--- a/.chronus/changes/remove-lodash-typespec-ts-2026-6-3-11-5-0.md
+++ b/.chronus/changes/remove-lodash-typespec-ts-2026-6-3-11-5-0.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Replace lodash usage with built-in ESM equivalents

--- a/.chronus/changes/replace-js-yaml-with-yaml-2026-5-3-12-25-59.md
+++ b/.chronus/changes/replace-js-yaml-with-yaml-2026-5-3-12-25-59.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Replace js-yaml with yaml package in typespec-ts

--- a/.chronus/changes/sync-typespec-ts-0.54.0-metadata-2026-6-4-10-15-0.md
+++ b/.chronus/changes/sync-typespec-ts-0.54.0-metadata-2026-6-4-10-15-0.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Sync `@azure-tools/typespec-ts` `package.json` `version` and `CHANGELOG.md` with the `0.54.0` release published from `Azure/autorest.typescript`. All `0.54.0` source changes were already captured in the migration commit; this PR only reconciles the version metadata so subsequent releases from this repo bump from a baseline that matches npm.

--- a/.chronus/changes/typespec-ts-format-2026-5-3-10-8-24.md
+++ b/.chronus/changes/typespec-ts-format-2026-5-3-10-8-24.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Migrate to use monorepo formatting

--- a/packages/typespec-ts/CHANGELOG.md
+++ b/packages/typespec-ts/CHANGELOG.md
@@ -1,13 +1,28 @@
-## 0.54.0 (2026-06-01)
+# Change Log - @azure-tools/typespec-ts
 
-- [Feature] Bump TypeSpec dependencies to latest stable and next pre-release versions. Please refer to [#4012](https://github.com/Azure/autorest.typescript/pull/4012)
-- [Bugfix] Fix config/script gaps between JS emitter and SDK libraries. Please refer to [#4006](https://github.com/Azure/autorest.typescript/pull/4006)
-- [Feature] Bump turbo from 2.6.3 to 2.9.14. Please refer to [#3989](https://github.com/Azure/autorest.typescript/pull/3989)
-- [Feature] Remove `head-as-boolean` emitter flag (superseded by TCGC `@responseAsBool`). Please refer to [#3986](https://github.com/Azure/autorest.typescript/pull/3986)
-- [Feature] Improve resolveReferences performance. Please refer to [#4004](https://github.com/Azure/autorest.typescript/pull/4004)
-- [Bugfix] Fix deserializer throwing on empty response body (success and error paths). Please refer to [#3948](https://github.com/Azure/autorest.typescript/pull/3948)
-- [Feature] Decouple typespec-ts from rlc-common. Please refer to [#3926](https://github.com/Azure/autorest.typescript/pull/3926)
-- [Feature] Update naming terminology: cadl-ranch → spector, HLC → AutoRest. Please refer to [#3957](https://github.com/Azure/autorest.typescript/pull/3957)
+## 0.54.1
+
+### Bug Fixes
+
+- [#4542](https://github.com/Azure/typespec-azure/pull/4542) Replace `NodeJS.ReadableStream` with the platform-conditional `NodeReadableStream` helper in RLC binary request body unions so generated browser builds no longer fail with TS2503 when `@types/node` is excluded.
+
+
+## 0.54.0
+
+### Features
+
+- [#4012](https://github.com/Azure/autorest.typescript/pull/4012) Bump TypeSpec dependencies to latest stable and next pre-release versions.
+- [#3989](https://github.com/Azure/autorest.typescript/pull/3989) Bump turbo from 2.6.3 to 2.9.14.
+- [#3986](https://github.com/Azure/autorest.typescript/pull/3986) Remove `head-as-boolean` emitter flag (superseded by TCGC `@responseAsBool`).
+- [#4004](https://github.com/Azure/autorest.typescript/pull/4004) Improve resolveReferences performance.
+- [#3926](https://github.com/Azure/autorest.typescript/pull/3926) Decouple typespec-ts from rlc-common.
+- [#3957](https://github.com/Azure/autorest.typescript/pull/3957) Update naming terminology: cadl-ranch → spector, HLC → AutoRest.
+
+### Bug Fixes
+
+- [#4006](https://github.com/Azure/autorest.typescript/pull/4006) Fix config/script gaps between JS emitter and SDK libraries.
+- [#3948](https://github.com/Azure/autorest.typescript/pull/3948) Fix deserializer throwing on empty response body (success and error paths).
+
 
 ## 0.53.3 (2026-05-25)
 

--- a/packages/typespec-ts/package.json
+++ b/packages/typespec-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-ts",
-  "version": "0.54.0",
+  "version": "0.54.1",
   "description": "An experimental TypeSpec emitter for TypeScript RLC",
   "main": "dist/src/index.js",
   "type": "module",


### PR DESCRIPTION
Bump version for hotfix: `@azure-tools/typespec-ts@0.54.1`

## Summary

Patch release of `@azure-tools/typespec-ts` containing the RLC binary body fix from #4542.

## Changes consumed

- `fix`: #4542 Replace `NodeJS.ReadableStream` with platform-conditional `NodeReadableStream` helper in RLC binary request body unions → drives the `0.54.0 → 0.54.1` patch bump.
- `internal` / `dependencies` (no version impact): #4526 (migration), #4545 (yaml replacement), #4546 (lodash removal), #4548 (formatting), #4558 (metadata sync).

## Verification

Generated with:
```
pnpm chronus version --ignore-policies --only @azure-tools/typespec-ts
```

- `packages/typespec-ts/package.json`: 0.54.0 → 0.54.1
- `packages/typespec-ts/CHANGELOG.md`: prepend 0.54.1 section
- 6 consumed `.chronus/changes/*.md` entries deleted
- No other package touched