### PR TITLE
Regenerate label policies to include emitter:typescript

### DIFF
--- a/.github/policies/issues.triage.generated.yml
+++ b/.github/policies/issues.triage.generated.yml
@@ -30,6 +30,8 @@ configuration:
                 - hasLabel:
                     label: emitter:python
                 - hasLabel:
+                    label: emitter:typescript
+                - hasLabel:
                     label: emitter:client:all
                 - hasLabel:
                     label: eng
@@ -61,6 +63,8 @@ configuration:
                   label: emitter:autorest
               - labelAdded:
                   label: emitter:python
+              - labelAdded:
+                  label: emitter:typescript
               - labelAdded:
                   label: emitter:client:all
               - labelAdded:
@@ -95,6 +99,8 @@ configuration:
               - labelRemoved:
                   label: emitter:python
               - labelRemoved:
+                  label: emitter:typescript
+              - labelRemoved:
                   label: emitter:client:all
               - labelRemoved:
                   label: eng
@@ -118,6 +124,8 @@ configuration:
                     label: emitter:autorest
                 - hasLabel:
                     label: emitter:python
+                - hasLabel:
+                    label: emitter:typescript
                 - hasLabel:
                     label: emitter:client:all
                 - hasLabel:

--- a/.github/policies/prs.triage.generated.yml
+++ b/.github/policies/prs.triage.generated.yml
@@ -49,6 +49,13 @@ configuration:
           - if:
               - includesModifiedFiles:
                   files:
+                    - packages/typespec-ts/**/*
+            then:
+              - addLabel:
+                  label: emitter:typescript
+          - if:
+              - includesModifiedFiles:
+                  files:
                     - packages/typespec-client-generator-core/**/*
             then:
               - addLabel:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -438,6 +438,7 @@ Area of the codebase
 | `lib:azure-http-specs`       | #c7aee6 | For issues/prs related to the @azure-tools/typespec-azure-http-specs package        |
 | `emitter:autorest`           | #957300 | Issues for @azure-tools/typespec-autorest emitter                                   |
 | `emitter:python`             | #957300 | Issues for @azure-tools/typespec-python emitter                                     |
+| `emitter:typescript`         | #957300 | Issues for @azure-tools/typespec-ts emitter                                         |
 | `emitter:client:all`         | #957300 | General client emitter issues that do not involve TCGC or typespec-azure-http-specs |
 | `eng`                        | #65bfff |                                                                                     |
 | `ide`                        | #846da1 | Issues for Azure specific ide features                                              |


### PR DESCRIPTION
## Summary

Regenerates `.github/policies/*.generated.yml` and the `CONTRIBUTING.md` labels table so the `emitter:typescript` area label is actually applied to PRs and issues.

## Why

When `packages/typespec-ts` was migrated into this repo via #4526, `eng/config/labels.ts` was updated to declare:

```ts
"emitter:typescript": ["packages/typespec-ts/"],
```

but `pnpm sync-labels` was not re-run to regenerate the policy YAML and `CONTRIBUTING.md`. As a result, the policy bot has no rule that maps `packages/typespec-ts/**` to the `emitter:typescript` label, so PRs touching that package (e.g. #4542, #4558, #4559) were never auto-labeled.

This PR regenerates the files. After merge, the bot will auto-apply `emitter:typescript` to all future typespec-ts PRs/issues.

## Files changed

- `.github/policies/prs.triage.generated.yml` — add the `packages/typespec-ts/**/*` → `emitter:typescript` rule.
- `.github/policies/issues.triage.generated.yml` — add `emitter:typescript` to the area-label gating logic (4 occurrences).
- `CONTRIBUTING.md` — add the `emitter:typescript` row to the labels reference table.

## Verification

Generated by re-running `pnpm sync-labels` against `eng/config/labels.ts`. Diff is limited to the missing `emitter:typescript` entries — no other label drift.