### PR TITLE
feat(typespec-autorest): add @scope TCGC decorator support

### DIFF
--- a/.chronus/changes/autorest-scope-decorator-support-2026-6-4-15-27-0.md
+++ b/.chronus/changes/autorest-scope-decorator-support-2026-6-4-15-27-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Add support for the `@scope` TCGC decorator. Operations, model properties, and parameters that are scoped out of the autorest emitter are now omitted from the generated swagger output.

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -29,6 +29,7 @@ import {
   getClientNameOverride,
   getLegacyHierarchyBuilding,
   getMarkAsLro,
+  isInScope,
   shouldFlattenProperty,
 } from "@azure-tools/typespec-client-generator-core";
 import {
@@ -335,12 +336,16 @@ export async function getOpenAPIForService(
   program.reportDiagnostics(diagnostics);
 
   const routes = httpService.operations;
-  reportIfNoRoutes(program, routes);
+  // Filter routes to only include operations in scope for this emitter
+  const inScopeRoutes = routes.filter((route) =>
+    isInScope(context.tcgcSdkContext, route.operation),
+  );
+  reportIfNoRoutes(program, inScopeRoutes);
 
   const xmlEnabled = xmlStrategy !== "none";
 
   // The set of produces/consumes values found in all operations
-  let allResponseContentTypes = routes
+  let allResponseContentTypes = inScopeRoutes
     .flatMap((route) => route.responses)
     .flatMap((res) => res.responses)
     .flatMap((res) => res.body?.contentTypes ?? [])
@@ -353,7 +358,7 @@ export async function getOpenAPIForService(
   if (allResponseContentTypes.length === 0) allResponseContentTypes = ["application/json"];
   const globalProduces = new Set<string>(allResponseContentTypes);
 
-  let allRequestContentTypes = routes
+  let allRequestContentTypes = inScopeRoutes
     .flatMap((route) => route.parameters)
     .flatMap((param) => param.body?.contentTypes ?? [])
     .filter(
@@ -371,7 +376,7 @@ export async function getOpenAPIForService(
     globalConsumes.size === 1 &&
     globalConsumes.has("application/xml");
 
-  routes.forEach(emitOperation);
+  inScopeRoutes.forEach(emitOperation);
 
   emitParameters();
   emitSchemas(service.type);
@@ -1012,6 +1017,9 @@ export async function getOpenAPIForService(
     const consumes: string[] = methodParams.body?.contentTypes ?? [];
 
     for (const httpProperty of methodParams.properties) {
+      if (!isInScope(context.tcgcSdkContext, httpProperty.property)) {
+        continue;
+      }
       const shared = params.get(httpProperty.property);
       if (shared) {
         currentEndpoint.parameters.push(shared);
@@ -1921,6 +1929,9 @@ export async function getOpenAPIForService(
     applyExternalDocs(model, modelSchema);
 
     for (const prop of model.properties.values()) {
+      if (!isInScope(context.tcgcSdkContext, prop)) {
+        continue;
+      }
       if (rawBaseModel && rawBaseModel.properties.has(prop.name)) {
         const baseProp = rawBaseModel.properties.get(prop.name);
         if (baseProp?.name === prop.name && baseProp.type === prop.type) {

--- a/packages/typespec-autorest/test/scope.test.ts
+++ b/packages/typespec-autorest/test/scope.test.ts
@@ -1,0 +1,168 @@
+import { describe, expect, it } from "vitest";
+import { compileOpenAPI } from "./test-host.js";
+
+describe("@scope decorator", () => {
+  describe("operations", () => {
+    it("omits operations scoped to a different emitter", async () => {
+      const res = await compileOpenAPI(
+        `
+        @service namespace MyService;
+        @route("/included") op included(): void;
+        @route("/excluded") @scope("python") op excluded(): void;
+        `,
+        { preset: "azure" },
+      );
+
+      expect(res.paths["/included"]).toBeDefined();
+      expect(res.paths["/excluded"]).toBeUndefined();
+    });
+
+    it("includes operations scoped to autorest emitter", async () => {
+      const res = await compileOpenAPI(
+        `
+        @service namespace MyService;
+        @route("/included") @scope("autorest") op included(): void;
+        `,
+        { preset: "azure" },
+      );
+
+      expect(res.paths["/included"]).toBeDefined();
+    });
+
+    it("includes operations with no scope (default behavior)", async () => {
+      const res = await compileOpenAPI(
+        `
+        @service namespace MyService;
+        @route("/no-scope") op noScope(): void;
+        `,
+        { preset: "azure" },
+      );
+
+      expect(res.paths["/no-scope"]).toBeDefined();
+    });
+
+    it("omits operations with negation scope matching autorest", async () => {
+      const res = await compileOpenAPI(
+        `
+        @service namespace MyService;
+        @route("/included") op included(): void;
+        @route("/excluded") @scope("!autorest") op excluded(): void;
+        `,
+        { preset: "azure" },
+      );
+
+      expect(res.paths["/included"]).toBeDefined();
+      expect(res.paths["/excluded"]).toBeUndefined();
+    });
+  });
+
+  describe("model properties", () => {
+    it("omits model properties scoped to a different emitter", async () => {
+      const res = await compileOpenAPI(
+        `
+        @service namespace MyService;
+        model Foo {
+          included: string;
+          @scope("python") excluded: string;
+        }
+        @route("/test") op test(): Foo;
+        `,
+        { preset: "azure" },
+      );
+
+      const fooDef = res.definitions?.["Foo"];
+      expect(fooDef).toBeDefined();
+      expect(fooDef!.properties?.["included"]).toBeDefined();
+      expect(fooDef!.properties?.["excluded"]).toBeUndefined();
+    });
+
+    it("includes model properties scoped to autorest emitter", async () => {
+      const res = await compileOpenAPI(
+        `
+        @service namespace MyService;
+        model Foo {
+          included: string;
+          @scope("autorest") alsoIncluded: string;
+        }
+        @route("/test") op test(): Foo;
+        `,
+        { preset: "azure" },
+      );
+
+      const fooDef = res.definitions?.["Foo"];
+      expect(fooDef).toBeDefined();
+      expect(fooDef!.properties?.["included"]).toBeDefined();
+      expect(fooDef!.properties?.["alsoIncluded"]).toBeDefined();
+    });
+
+    it("includes model properties with no scope (default behavior)", async () => {
+      const res = await compileOpenAPI(
+        `
+        @service namespace MyService;
+        model Foo {
+          prop1: string;
+          prop2: int32;
+        }
+        @route("/test") op test(): Foo;
+        `,
+        { preset: "azure" },
+      );
+
+      const fooDef = res.definitions?.["Foo"];
+      expect(fooDef).toBeDefined();
+      expect(fooDef!.properties?.["prop1"]).toBeDefined();
+      expect(fooDef!.properties?.["prop2"]).toBeDefined();
+    });
+
+    it("scoped-out property is not in required list", async () => {
+      const res = await compileOpenAPI(
+        `
+        @service namespace MyService;
+        model Foo {
+          included: string;
+          @scope("python") excluded: string;
+        }
+        @route("/test") op test(): Foo;
+        `,
+        { preset: "azure" },
+      );
+
+      const fooDef = res.definitions?.["Foo"];
+      expect(fooDef).toBeDefined();
+      expect(fooDef!.required).toEqual(["included"]);
+    });
+  });
+
+  describe("operation parameters", () => {
+    it("omits query parameters scoped to a different emitter", async () => {
+      const res = await compileOpenAPI(
+        `
+        @service namespace MyService;
+        @route("/test") op test(@query included: string, @query @scope("python") excluded: string): void;
+        `,
+        { preset: "azure" },
+      );
+
+      const params = res.paths["/test"].get?.parameters;
+      expect(params).toBeDefined();
+      const paramNames = params!.map((p: any) => p.name);
+      expect(paramNames).toContain("included");
+      expect(paramNames).not.toContain("excluded");
+    });
+
+    it("includes parameters scoped to autorest emitter", async () => {
+      const res = await compileOpenAPI(
+        `
+        @service namespace MyService;
+        @route("/test") op test(@query @scope("autorest") included: string): void;
+        `,
+        { preset: "azure" },
+      );
+
+      const params = res.paths["/test"].get?.parameters;
+      expect(params).toBeDefined();
+      const paramNames = params!.map((p: any) => p.name);
+      expect(paramNames).toContain("included");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Add support for the `@scope` TCGC decorator in the autorest emitter. Operations, model properties, and parameters that are scoped out of autorest are now omitted from the generated swagger output.

## Changes

- Import `isInScope` from `@azure-tools/typespec-client-generator-core`
- Filter operations by scope before emission (scoped-out operations omitted entirely)
- Filter model properties by scope in schema emission
- Filter endpoint parameters by scope
- Added 10 test cases covering all filtering scenarios

## How it works

The `@scope` decorator uses short language names (e.g., `"autorest"`, `"python"`, `"csharp"`). When an operation or property is decorated with `@scope("python")`, it will be excluded from the autorest swagger output. When decorated with `@scope("autorest")`, it will only appear in autorest output.