### PR TITLE
fix(tcgc): move EXACT_NAME_PREFIX to internal-utils and remove from public exports

### DIFF
--- a/.chronus/changes/fix-tcgc-internal-export-2026-6-5-11-54-0.md
+++ b/.chronus/changes/fix-tcgc-internal-export-2026-6-5-11-54-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Move internal `EXACT_NAME_PREFIX` constant out of public exports to fix build failures when `skipLibCheck` is disabled.

--- a/eng/scripts/doc-updater/knowledge/tcgc.md
+++ b/eng/scripts/doc-updater/knowledge/tcgc.md
@@ -184,7 +184,7 @@ namespace (@clientNamespace), naming (@clientName), overload, structure (@client
 - The `isExactName: boolean` property was added to many SDK type interfaces: SdkModelType, SdkEnumType, SdkUnionType, SdkConstantType, SdkNullableType, SdkClientInitializationType, SdkModelPropertyTypeBase (base for all property types), SdkClientType, SdkEnumValueType, and SdkServiceMethodBase.
 - Set to `true` when a name is wrapped with the `exact()` function in `@clientName`.
 - The `exact()` function internally prepends `_exact_:` prefix which is stripped by `normalizeExactName()` before the name reaches the type graph.
-- Exported helpers: `EXACT_NAME_PREFIX`, `hasExactNameMarker()`, `normalizeExactName()` from the TCGC package index.
+- Exported helpers: `hasExactNameMarker()`, `normalizeExactName()` from the TCGC package index. `EXACT_NAME_PREFIX` is internal (defined in `internal-utils.ts`).
 - Public utility: `isExactClientName(context, type)` checks whether a type has exact name override.
 - Documented in guideline.md under Common Properties and in 09renaming.mdx under "Preserving exact casing".
 

--- a/packages/typespec-client-generator-core/src/functions.ts
+++ b/packages/typespec-client-generator-core/src/functions.ts
@@ -1,5 +1,6 @@
 import { FunctionContext, ModelProperty, Operation, Type } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
+import { EXACT_NAME_PREFIX } from "./internal-utils.js";
 import { reportDiagnostic } from "./lib.js";
 
 // Helper function to clone an operation with new parameters and/or return type
@@ -238,12 +239,6 @@ export function reorderParameters(
 
   return cloneOperation(tk, operation, { parameters: newProperties });
 }
-
-/**
- * Internal prefix used to mark a client name as exact.
- * @internal
- */
-export const EXACT_NAME_PREFIX = "_exact_:";
 
 /**
  * Mark a client name as exact, preventing language emitters from applying

--- a/packages/typespec-client-generator-core/src/index.ts
+++ b/packages/typespec-client-generator-core/src/index.ts
@@ -1,6 +1,6 @@
 export * from "./context.js";
 export * from "./decorators.js";
-export { EXACT_NAME_PREFIX, hasExactNameMarker, normalizeExactName } from "./functions.js";
+export { hasExactNameMarker, normalizeExactName } from "./functions.js";
 export * from "./interfaces.js";
 export * from "./lib.js";
 export { $linter } from "./linter.js";

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -1418,7 +1418,6 @@ export function listOrphanTypes(context: TCGCContext): (Model | Enum | Union)[] 
 }
 
 /**
- * Internal prefix used to mark a client name as exact.
- * @internal
+ * Prefix used to mark a client name as exact.
  */
 export const EXACT_NAME_PREFIX = "_exact_:";

--- a/packages/typespec-client-generator-core/src/internal-utils.ts
+++ b/packages/typespec-client-generator-core/src/internal-utils.ts
@@ -1416,3 +1416,9 @@ export function listOrphanTypes(context: TCGCContext): (Model | Enum | Union)[] 
   context.__orphanTypesCache = result;
   return result;
 }
+
+/**
+ * Internal prefix used to mark a client name as exact.
+ * @internal
+ */
+export const EXACT_NAME_PREFIX = "_exact_:";


### PR DESCRIPTION
## Problem

`EXACT_NAME_PREFIX` in `functions.ts` is marked `@internal`, which causes it to be stripped from `functions.d.ts`. However, `index.ts` re-exported it without the `@internal` marker, so `index.d.ts` still referenced a symbol that no longer exists in `functions.d.ts`. This breaks builds with `skipLibCheck: false`.

## Fix

- Move `EXACT_NAME_PREFIX` to `internal-utils.ts` (where other internal helpers live)
- Import it in `functions.ts` from `internal-utils.ts`
- Remove the re-export from `index.ts` entirely
- `hasExactNameMarker()` and `normalizeExactName()` remain public exports

Fixes #4519