### PR TITLE
Remove redundant top-level describe blocks from test files

### DIFF
--- a/packages/typespec-autorest/test/additional-properties.test.ts
+++ b/packages/typespec-autorest/test/additional-properties.test.ts
@@ -2,79 +2,77 @@ import { deepStrictEqual, ok } from "assert";
 import { describe, it } from "vitest";
 import { oapiForModel } from "./test-host.js";
 
-describe("typespec-autorest: Additional properties", () => {
-  describe("extends Record<T>", () => {
-    it("doesn't set additionalProperties on model itself", async () => {
-      const res = await oapiForModel("Pet", `model Pet extends Record<unknown> {name: string};`);
-      deepStrictEqual(res.defs.Pet.additionalProperties, undefined);
-    });
+describe("extends Record<T>", () => {
+  it("doesn't set additionalProperties on model itself", async () => {
+    const res = await oapiForModel("Pet", `model Pet extends Record<unknown> {name: string};`);
+    deepStrictEqual(res.defs.Pet.additionalProperties, undefined);
+  });
 
-    it("links to an allOf of the Record<unknown> schema", async () => {
-      const res = await oapiForModel("Pet", `model Pet extends Record<unknown> {name: string};`);
-      deepStrictEqual(res.defs.Pet.allOf, [{ type: "object", additionalProperties: {} }]);
-    });
+  it("links to an allOf of the Record<unknown> schema", async () => {
+    const res = await oapiForModel("Pet", `model Pet extends Record<unknown> {name: string};`);
+    deepStrictEqual(res.defs.Pet.allOf, [{ type: "object", additionalProperties: {} }]);
+  });
 
-    it("include model properties", async () => {
-      const res = await oapiForModel("Pet", `model Pet extends Record<unknown> { name: string };`);
-      deepStrictEqual(res.defs.Pet.properties, {
-        name: { type: "string" },
-      });
+  it("include model properties", async () => {
+    const res = await oapiForModel("Pet", `model Pet extends Record<unknown> { name: string };`);
+    deepStrictEqual(res.defs.Pet.properties, {
+      name: { type: "string" },
+    });
+  });
+});
+
+describe("is Record<T>", () => {
+  it("set additionalProperties on model itself", async () => {
+    const res = await oapiForModel("Pet", `model Pet is Record<unknown> {};`);
+    deepStrictEqual(res.defs.Pet.additionalProperties, {});
+  });
+
+  it("set additional properties type", async () => {
+    const res = await oapiForModel("Pet", `model Pet is Record<string> {};`);
+    deepStrictEqual(res.defs.Pet.additionalProperties, {
+      type: "string",
     });
   });
 
-  describe("is Record<T>", () => {
-    it("set additionalProperties on model itself", async () => {
-      const res = await oapiForModel("Pet", `model Pet is Record<unknown> {};`);
-      deepStrictEqual(res.defs.Pet.additionalProperties, {});
-    });
-
-    it("set additional properties type", async () => {
-      const res = await oapiForModel("Pet", `model Pet is Record<string> {};`);
-      deepStrictEqual(res.defs.Pet.additionalProperties, {
-        type: "string",
-      });
-    });
-
-    it("include model properties", async () => {
-      const res = await oapiForModel("Pet", `model Pet is Record<unknown> { name: string };`);
-      deepStrictEqual(res.defs.Pet.properties, {
-        name: { type: "string" },
-      });
+  it("include model properties", async () => {
+    const res = await oapiForModel("Pet", `model Pet is Record<unknown> { name: string };`);
+    deepStrictEqual(res.defs.Pet.properties, {
+      name: { type: "string" },
     });
   });
+});
 
-  describe("referencing Record<T>", () => {
-    it("add additionalProperties inline for property of type Record<unknown>", async () => {
-      const res = await oapiForModel(
-        "Pet",
-        `
-        model Pet { details: Record<unknown> };
-        `,
-      );
-
-      ok(res.isRef);
-      ok(res.defs.Pet, "expected definition named Pet");
-      deepStrictEqual(res.defs.Pet.properties.details, {
-        type: "object",
-        additionalProperties: {},
-      });
-    });
-  });
-
-  it("set additionalProperties if model extends Record with leaf type", async () => {
+describe("referencing Record<T>", () => {
+  it("add additionalProperties inline for property of type Record<unknown>", async () => {
     const res = await oapiForModel(
       "Pet",
       `
-      
-      scalar Value;
-      model Pet is Record<Value> {};
+      model Pet { details: Record<unknown> };
       `,
     );
 
     ok(res.isRef);
     ok(res.defs.Pet, "expected definition named Pet");
-    deepStrictEqual(res.defs.Pet.additionalProperties, {
-      $ref: "#/definitions/Value",
+    deepStrictEqual(res.defs.Pet.properties.details, {
+      type: "object",
+      additionalProperties: {},
     });
+  });
+});
+
+it("set additionalProperties if model extends Record with leaf type", async () => {
+  const res = await oapiForModel(
+    "Pet",
+    `
+    
+    scalar Value;
+    model Pet is Record<Value> {};
+    `,
+  );
+
+  ok(res.isRef);
+  ok(res.defs.Pet, "expected definition named Pet");
+  deepStrictEqual(res.defs.Pet.additionalProperties, {
+    $ref: "#/definitions/Value",
   });
 });

--- a/packages/typespec-autorest/test/array.test.ts
+++ b/packages/typespec-autorest/test/array.test.ts
@@ -1,121 +1,119 @@
 import { deepStrictEqual, ok } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { oapiForModel } from "./test-host.js";
 
-describe("typespec-autorest: Array", () => {
-  it("defines array inline", async () => {
-    const res = await oapiForModel(
-      "Pet",
-      `
-      model Pet { names: string[] };
-      `,
-    );
+it("defines array inline", async () => {
+  const res = await oapiForModel(
+    "Pet",
+    `
+    model Pet { names: string[] };
+    `,
+  );
 
-    ok(res.isRef);
-    ok(res.defs.Pet, "expected definition named Pet");
-    deepStrictEqual(res.defs.Pet.properties.names, {
-      type: "array",
-      items: { type: "string" },
-    });
+  ok(res.isRef);
+  ok(res.defs.Pet, "expected definition named Pet");
+  deepStrictEqual(res.defs.Pet.properties.names, {
+    type: "array",
+    items: { type: "string" },
   });
+});
 
-  it("define a named array using model is", async () => {
-    const res = await oapiForModel(
-      "Pet",
-      `
-      model PetNames is string[] {}
-      model Pet { names: PetNames };
-      `,
-    );
+it("define a named array using model is", async () => {
+  const res = await oapiForModel(
+    "Pet",
+    `
+    model PetNames is string[] {}
+    model Pet { names: PetNames };
+    `,
+  );
 
-    ok(res.isRef);
-    ok(res.defs.PetNames, "expected definition named myArray");
-    ok(res.defs.Pet, "expected definition named Pet");
-    deepStrictEqual(res.defs.PetNames, {
-      type: "array",
-      items: { type: "string" },
-    });
+  ok(res.isRef);
+  ok(res.defs.PetNames, "expected definition named myArray");
+  ok(res.defs.Pet, "expected definition named Pet");
+  deepStrictEqual(res.defs.PetNames, {
+    type: "array",
+    items: { type: "string" },
   });
+});
 
-  it("named array applies doc", async () => {
-    const res = await oapiForModel(
-      "Pet",
-      `
-      @doc("This is a doc for PetNames")
-      model PetNames is string[] {}
-      model Pet { names: PetNames };
-      `,
-    );
-    deepStrictEqual(res.defs.PetNames.description, "This is a doc for PetNames");
-  });
+it("named array applies doc", async () => {
+  const res = await oapiForModel(
+    "Pet",
+    `
+    @doc("This is a doc for PetNames")
+    model PetNames is string[] {}
+    model Pet { names: PetNames };
+    `,
+  );
+  deepStrictEqual(res.defs.PetNames.description, "This is a doc for PetNames");
+});
 
-  it("can specify minItems using @minItems decorator", async () => {
-    const res = await oapiForModel(
-      "Pet",
-      `
-      model Pet {
-        @minItems(1)
-        names: string[]
-      };
-      `,
-    );
-
-    ok(res.defs.Pet, "expected definition named Pet");
-    deepStrictEqual(res.defs.Pet.properties.names, {
-      type: "array",
-      minItems: 1,
-      items: { type: "string" },
-    });
-  });
-
-  it("can specify maxItems using @maxItems decorator", async () => {
-    const res = await oapiForModel(
-      "Pet",
-      `
-      model Pet {
-        @maxItems(3)
-        names: string[]
-      };
-      `,
-    );
-
-    ok(res.defs.Pet, "expected definition named Pet");
-    deepStrictEqual(res.defs.Pet.properties.names, {
-      type: "array",
-      maxItems: 3,
-      items: { type: "string" },
-    });
-  });
-
-  it("can specify minItems using @minItems decorator (on array model)", async () => {
-    const res = await oapiForModel(
-      "Names",
-      `
+it("can specify minItems using @minItems decorator", async () => {
+  const res = await oapiForModel(
+    "Pet",
+    `
+    model Pet {
       @minItems(1)
-      model Names is string[];
-      `,
-    );
+      names: string[]
+    };
+    `,
+  );
 
-    deepStrictEqual(res.defs.Names, {
-      type: "array",
-      minItems: 1,
-      items: { type: "string" },
-    });
+  ok(res.defs.Pet, "expected definition named Pet");
+  deepStrictEqual(res.defs.Pet.properties.names, {
+    type: "array",
+    minItems: 1,
+    items: { type: "string" },
   });
+});
 
-  it("can specify maxItems using @maxItems decorator  (on array model)", async () => {
-    const res = await oapiForModel(
-      "Names",
-      `
+it("can specify maxItems using @maxItems decorator", async () => {
+  const res = await oapiForModel(
+    "Pet",
+    `
+    model Pet {
       @maxItems(3)
-      model Names is string[];
-      `,
-    );
+      names: string[]
+    };
+    `,
+  );
 
-    deepStrictEqual(res.defs.Names, {
-      type: "array",
-      maxItems: 3,
-      items: { type: "string" },
-    });
+  ok(res.defs.Pet, "expected definition named Pet");
+  deepStrictEqual(res.defs.Pet.properties.names, {
+    type: "array",
+    maxItems: 3,
+    items: { type: "string" },
+  });
+});
+
+it("can specify minItems using @minItems decorator (on array model)", async () => {
+  const res = await oapiForModel(
+    "Names",
+    `
+    @minItems(1)
+    model Names is string[];
+    `,
+  );
+
+  deepStrictEqual(res.defs.Names, {
+    type: "array",
+    minItems: 1,
+    items: { type: "string" },
+  });
+});
+
+it("can specify maxItems using @maxItems decorator  (on array model)", async () => {
+  const res = await oapiForModel(
+    "Names",
+    `
+    @maxItems(3)
+    model Names is string[];
+    `,
+  );
+
+  deepStrictEqual(res.defs.Names, {
+    type: "array",
+    maxItems: 3,
+    items: { type: "string" },
   });
 });

--- a/packages/typespec-autorest/test/azure-core-operations.test.ts
+++ b/packages/typespec-autorest/test/azure-core-operations.test.ts
@@ -1,5 +1,5 @@
 import { deepStrictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { compileOpenAPI } from "./test-host.js";
 
 const wrapperCode = `
@@ -33,44 +33,11 @@ SupportsClientRequestId;
 alias Operations = Azure.Core.ResourceOperations<ServiceTraits>;
 `;
 
-describe("typespec-autorest: Azure.Core.ResourceOperations", () => {
-  it("ensure properties with 'create' visibility are included in the ResourceCreateOrUpdate body", async () => {
-    const result = await compileOpenAPI(
-      `
-        ${wrapperCode}
-    
-        
-        @resource("widgets")
-        model Widget {
-          @key("widgetName")
-          
-          @visibility(Lifecycle.Read)
-          name: string;
-        
-          
-          @visibility(Lifecycle.Create, Lifecycle.Read)
-          modality: string;
-        
-          
-          color: string;
-        }
-        
-        
-        @test
-        #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-        op createOrUpdateWidget is Operations.ResourceCreateOrUpdate<Widget>;
-      `,
-      { preset: "azure" },
-    );
-    const propKeys = Object.keys(result.definitions?.["WidgetCreateOrUpdate"].properties!);
-    deepStrictEqual(propKeys, ["modality", "color"]);
-  });
-
-  it("ensure properties with 'create' visibility are included in the LongRunningResourceCreateOrUpdate body", async () => {
-    const result = await compileOpenAPI(
-      `
+it("ensure properties with 'create' visibility are included in the ResourceCreateOrUpdate body", async () => {
+  const result = await compileOpenAPI(
+    `
       ${wrapperCode}
-
+  
       
       @resource("widgets")
       model Widget {
@@ -90,57 +57,88 @@ describe("typespec-autorest: Azure.Core.ResourceOperations", () => {
       
       @test
       #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-      op createOrUpdateWidget is Operations.LongRunningResourceCreateOrUpdate<Widget>;
+      op createOrUpdateWidget is Operations.ResourceCreateOrUpdate<Widget>;
     `,
-      { preset: "azure" },
-    );
+    { preset: "azure" },
+  );
+  const propKeys = Object.keys(result.definitions?.["WidgetCreateOrUpdate"].properties!);
+  deepStrictEqual(propKeys, ["modality", "color"]);
+});
 
-    const propKeys = Object.keys(result.definitions!["WidgetCreateOrUpdate"].properties!);
-    deepStrictEqual(propKeys, ["modality", "color"]);
-  });
+it("ensure properties with 'create' visibility are included in the LongRunningResourceCreateOrUpdate body", async () => {
+  const result = await compileOpenAPI(
+    `
+    ${wrapperCode}
 
-  it("ensure ConditionalRequestHeaders does not appear on Action or List operations", async () => {
-    function checkParams(params: any, path: string) {
-      params.forEach((param: { $ref?: string }) => {
-        if (param.$ref) {
-          const hasConditionalRequestHeaders = param.$ref.indexOf("ConditionalRequestHeaders") > -1;
-          if (hasConditionalRequestHeaders) {
-            throw new Error(`ConditionalRequestHeaders should not appear in ${path}`);
-          }
+    
+    @resource("widgets")
+    model Widget {
+      @key("widgetName")
+      
+      @visibility(Lifecycle.Read)
+      name: string;
+    
+      
+      @visibility(Lifecycle.Create, Lifecycle.Read)
+      modality: string;
+    
+      
+      color: string;
+    }
+    
+    
+    @test
+    #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    op createOrUpdateWidget is Operations.LongRunningResourceCreateOrUpdate<Widget>;
+  `,
+    { preset: "azure" },
+  );
+
+  const propKeys = Object.keys(result.definitions!["WidgetCreateOrUpdate"].properties!);
+  deepStrictEqual(propKeys, ["modality", "color"]);
+});
+
+it("ensure ConditionalRequestHeaders does not appear on Action or List operations", async () => {
+  function checkParams(params: any, path: string) {
+    params.forEach((param: { $ref?: string }) => {
+      if (param.$ref) {
+        const hasConditionalRequestHeaders = param.$ref.indexOf("ConditionalRequestHeaders") > -1;
+        if (hasConditionalRequestHeaders) {
+          throw new Error(`ConditionalRequestHeaders should not appear in ${path}`);
         }
-      });
+      }
+    });
+  }
+
+  const result = await compileOpenAPI(
+    `
+    ${wrapperCode}
+
+    
+    @resource("widgets")
+    model Widget {
+      @key("widgetName")
+      
+      name: string;
     }
 
-    const result = await compileOpenAPI(
-      `
-      ${wrapperCode}
+    
+    @test
+    op listWidgets is Operations.ResourceList<
+      Widget,
+      ListQueryParametersTrait<StandardListQueryParameters & SelectQueryParameter>
+    >;
 
-      
-      @resource("widgets")
-      model Widget {
-        @key("widgetName")
-        
-        name: string;
-      }
+    
+    @test
+    op actionWidget is Operations.ResourceAction<Widget, {}, {}>;
+  `,
+    { preset: "azure" },
+  );
 
-      
-      @test
-      op listWidgets is Operations.ResourceList<
-        Widget,
-        ListQueryParametersTrait<StandardListQueryParameters & SelectQueryParameter>
-      >;
+  let params = result.paths["/widgets/{widgetName}:actionWidget"].post!.parameters;
+  checkParams(params, "/widgets/{widgetName}:actionWidget");
 
-      
-      @test
-      op actionWidget is Operations.ResourceAction<Widget, {}, {}>;
-    `,
-      { preset: "azure" },
-    );
-
-    let params = result.paths["/widgets/{widgetName}:actionWidget"].post!.parameters;
-    checkParams(params, "/widgets/{widgetName}:actionWidget");
-
-    params = result.paths["/widgets"].get!.parameters;
-    checkParams(params, "/widgets");
-  });
+  params = result.paths["/widgets"].get!.parameters;
+  checkParams(params, "/widgets");
 });

--- a/packages/typespec-autorest/test/decorators.test.ts
+++ b/packages/typespec-autorest/test/decorators.test.ts
@@ -9,118 +9,113 @@ import { describe, it } from "vitest";
 import { getRef } from "../src/decorators.js";
 import { BasicTester, ignoreDiagnostics, ignoreUseStandardOps, openApiFor } from "./test-host.js";
 
-describe("typespec-autorest: decorators", () => {
-  describe("@useRef", () => {
-    it("emit diagnostic if use on non model or property", async () => {
-      const diagnostics = await BasicTester.diagnose(`
-        @useRef("foo")
-        op foo(): string;
-      `);
-      expectDiagnostics(ignoreUseStandardOps(diagnostics), {
-        code: "decorator-wrong-target",
-        message:
-          "Cannot apply @useRef decorator to foo since it is not assignable to Model | ModelProperty",
-      });
+describe("@useRef", () => {
+  it("emit diagnostic if use on non model or property", async () => {
+    const diagnostics = await BasicTester.diagnose(`
+      @useRef("foo")
+      op foo(): string;
+    `);
+    expectDiagnostics(ignoreUseStandardOps(diagnostics), {
+      code: "decorator-wrong-target",
+      message:
+        "Cannot apply @useRef decorator to foo since it is not assignable to Model | ModelProperty",
     });
+  });
 
-    it("emit diagnostic if ref is not a string", async () => {
-      const diagnostics = await BasicTester.diagnose(`
-        @useRef(123)
-        model Foo {}
-      `);
-      expectDiagnostics(ignoreUseStandardOps(diagnostics), {
-        code: "invalid-argument",
-      });
+  it("emit diagnostic if ref is not a string", async () => {
+    const diagnostics = await BasicTester.diagnose(`
+      @useRef(123)
+      model Foo {}
+    `);
+    expectDiagnostics(ignoreUseStandardOps(diagnostics), {
+      code: "invalid-argument",
     });
+  });
 
-    it("emit diagnostic if ref is not passed", async () => {
-      const diagnostics = await BasicTester.diagnose(`
-        @useRef
+  it("emit diagnostic if ref is not passed", async () => {
+    const diagnostics = await BasicTester.diagnose(`
+      @useRef
+      model Foo {}
+    `);
+    expectDiagnostics(ignoreUseStandardOps(diagnostics), [
+      {
+        code: "invalid-argument-count",
+        message: "Expected 1 arguments, but got 0.",
+      },
+    ]);
+  });
+
+  it("set external reference", async () => {
+    const [{ Foo, program }, diagnostics] = await BasicTester.compileAndDiagnose(t.code`
+      @useRef("../common.json#/definitions/Foo")
+      model ${t.model("Foo")} {}
+    `);
+    expectDiagnosticEmpty(
+      ignoreDiagnostics(diagnostics, [
+        "@azure-tools/typespec-azure-core/use-standard-operations",
+        "@typespec/http/no-service-found",
+      ]),
+    );
+    strictEqual(getRef(program, Foo), "../common.json#/definitions/Foo");
+  });
+
+  describe("interpolate arm-types-dir", () => {
+    async function testArmTypesDir(options?: any) {
+      const code = `
+        @useRef("{arm-types-dir}/common.json#/definitions/Foo")
         model Foo {}
-      `);
-      expectDiagnostics(ignoreUseStandardOps(diagnostics), [
-        {
-          code: "invalid-argument-count",
-          message: "Expected 1 arguments, but got 0.",
+
+        model Bar {
+          foo: Foo;
+        }
+      `;
+      const outputDir = resolveVirtualPath(`specification/org/service/output`);
+      const [{ outputs }, diagnostics] = await BasicTester.emit("@azure-tools/typespec-autorest", {
+        ...options,
+        "emitter-output-dir": outputDir,
+      }).compileAndDiagnose(code, {
+        compilerOptions: {
+          config: resolveVirtualPath("specification/org/service/tspconfig.json"),
         },
-      ]);
-    });
-
-    it("set external reference", async () => {
-      const [{ Foo, program }, diagnostics] = await BasicTester.compileAndDiagnose(t.code`
-        @useRef("../common.json#/definitions/Foo")
-        model ${t.model("Foo")} {}
-      `);
+      });
       expectDiagnosticEmpty(
         ignoreDiagnostics(diagnostics, [
           "@azure-tools/typespec-azure-core/use-standard-operations",
           "@typespec/http/no-service-found",
         ]),
       );
-      strictEqual(getRef(program, Foo), "../common.json#/definitions/Foo");
+      const openAPI = JSON.parse(outputs["openapi.json"]);
+      return openAPI.definitions.Bar.properties.foo.$ref;
+    }
+    // project-root resolve to "" in test
+    it("To ${project-root}../../ by default", async () => {
+      const ref = await testArmTypesDir();
+      strictEqual(ref, "../../../common-types/resource-management/common.json#/definitions/Foo");
     });
 
-    describe("interpolate arm-types-dir", () => {
-      async function testArmTypesDir(options?: any) {
-        const code = `
-          @useRef("{arm-types-dir}/common.json#/definitions/Foo")
-          model Foo {}
-
-          model Bar {
-            foo: Foo;
-          }
-        `;
-        const outputDir = resolveVirtualPath(`specification/org/service/output`);
-        const [{ outputs }, diagnostics] = await BasicTester.emit(
-          "@azure-tools/typespec-autorest",
-          {
-            ...options,
-            "emitter-output-dir": outputDir,
-          },
-        ).compileAndDiagnose(code, {
-          compilerOptions: {
-            config: resolveVirtualPath("specification/org/service/tspconfig.json"),
-          },
-        });
-        expectDiagnosticEmpty(
-          ignoreDiagnostics(diagnostics, [
-            "@azure-tools/typespec-azure-core/use-standard-operations",
-            "@typespec/http/no-service-found",
-          ]),
-        );
-        const openAPI = JSON.parse(outputs["openapi.json"]);
-        return openAPI.definitions.Bar.properties.foo.$ref;
-      }
-      // project-root resolve to "" in test
-      it("To ${project-root}../../ by default", async () => {
-        const ref = await testArmTypesDir();
-        strictEqual(ref, "../../../common-types/resource-management/common.json#/definitions/Foo");
+    it("configure a new absolute value", async () => {
+      const ref = await testArmTypesDir({
+        "arm-types-dir": "{project-root}/../other/path",
       });
+      strictEqual(ref, "../../other/path/common.json#/definitions/Foo");
+    });
 
-      it("configure a new absolute value", async () => {
-        const ref = await testArmTypesDir({
-          "arm-types-dir": "{project-root}/../other/path",
-        });
-        strictEqual(ref, "../../other/path/common.json#/definitions/Foo");
+    it("keeps relative value as it is", async () => {
+      const ref = await testArmTypesDir({
+        "arm-types-dir": "../other/path",
       });
-
-      it("keeps relative value as it is", async () => {
-        const ref = await testArmTypesDir({
-          "arm-types-dir": "../other/path",
-        });
-        strictEqual(ref, "../other/path/common.json#/definitions/Foo");
-      });
+      strictEqual(ref, "../other/path/common.json#/definitions/Foo");
     });
   });
+});
 
-  describe("@operationId", () => {
-    it("preserves casing of explicit @operationId decorator", async () => {
-      const openapi = await openApiFor(`
-        @get
-        @operationId("Pets_GET")
-        op read(): string;
-      `);
-      deepStrictEqual(openapi.paths["/"].get.operationId, "Pets_GET");
-    });
+describe("@operationId", () => {
+  it("preserves casing of explicit @operationId decorator", async () => {
+    const openapi = await openApiFor(`
+      @get
+      @operationId("Pets_GET")
+      op read(): string;
+    `);
+    deepStrictEqual(openapi.paths["/"].get.operationId, "Pets_GET");
   });
 });

--- a/packages/typespec-autorest/test/discriminator.test.ts
+++ b/packages/typespec-autorest/test/discriminator.test.ts
@@ -3,460 +3,458 @@ import { deepStrictEqual, ok, strictEqual } from "assert";
 import { describe, it } from "vitest";
 import { compileOpenAPI, openApiFor, Tester } from "./test-host.js";
 
-describe("typespec-autorest: polymorphic model inheritance with discriminator", () => {
-  it("discriminator can be a simple string literal", async () => {
-    const openApi = await openApiFor(`
-      @discriminator("kind")
-      model Pet { }
-      model Cat extends Pet {
-        kind: "cat";
-        meow: int32;
-      }
-      model Dog extends Pet {
-        kind: "dog";
-        bark: string;
-      }
-      `);
-    deepStrictEqual(openApi.definitions.Pet, {
-      type: "object",
-      properties: { kind: { type: "string", description: "Discriminator property for Pet." } },
-      required: ["kind"],
-      discriminator: "kind",
-    });
-    deepStrictEqual(openApi.definitions.Cat.allOf, [{ $ref: "#/definitions/Pet" }]);
-    deepStrictEqual(openApi.definitions.Dog.allOf, [{ $ref: "#/definitions/Pet" }]);
+it("discriminator can be a simple string literal", async () => {
+  const openApi = await openApiFor(`
+    @discriminator("kind")
+    model Pet { }
+    model Cat extends Pet {
+      kind: "cat";
+      meow: int32;
+    }
+    model Dog extends Pet {
+      kind: "dog";
+      bark: string;
+    }
+    `);
+  deepStrictEqual(openApi.definitions.Pet, {
+    type: "object",
+    properties: { kind: { type: "string", description: "Discriminator property for Pet." } },
+    required: ["kind"],
+    discriminator: "kind",
   });
+  deepStrictEqual(openApi.definitions.Cat.allOf, [{ $ref: "#/definitions/Pet" }]);
+  deepStrictEqual(openApi.definitions.Dog.allOf, [{ $ref: "#/definitions/Pet" }]);
+});
 
-  it("discriminator can be a union", async () => {
-    const openApi = await openApiFor(`
-      union PetKind {cat: "cat-kind", dog: "dog-kind" }
-      @discriminator("kind")
-      model Pet { kind: PetKind }
-      model Cat extends Pet {
-        kind: PetKind.cat;
-        meow: int32;
-      }
-      model Dog extends Pet {
-        kind: PetKind.dog;
-        bark: string;
-      }
-      `);
-    deepStrictEqual(openApi.definitions.Pet, {
-      type: "object",
-      properties: {
-        kind: {
-          $ref: "#/definitions/PetKind",
-        },
+it("discriminator can be a union", async () => {
+  const openApi = await openApiFor(`
+    union PetKind {cat: "cat-kind", dog: "dog-kind" }
+    @discriminator("kind")
+    model Pet { kind: PetKind }
+    model Cat extends Pet {
+      kind: PetKind.cat;
+      meow: int32;
+    }
+    model Dog extends Pet {
+      kind: PetKind.dog;
+      bark: string;
+    }
+    `);
+  deepStrictEqual(openApi.definitions.Pet, {
+    type: "object",
+    properties: {
+      kind: {
+        $ref: "#/definitions/PetKind",
       },
-      required: ["kind"],
-      discriminator: "kind",
-    });
-    deepStrictEqual(openApi.definitions.Cat["x-ms-discriminator-value"], "cat-kind");
-    deepStrictEqual(openApi.definitions.Dog["x-ms-discriminator-value"], "dog-kind");
+    },
+    required: ["kind"],
+    discriminator: "kind",
   });
+  deepStrictEqual(openApi.definitions.Cat["x-ms-discriminator-value"], "cat-kind");
+  deepStrictEqual(openApi.definitions.Dog["x-ms-discriminator-value"], "dog-kind");
+});
 
-  it("defines discriminated unions with non-empty base type", async () => {
-    const openApi = await openApiFor(`
-      @discriminator("kind")
-      model Pet {
-        name: string;
-        weight?: float32;
-      }
-      model Cat extends Pet {
-        kind: "cat";
-        meow: int32;
-      }
-      model Dog extends Pet {
-        kind: "dog";
-        bark: string;
-      }
+it("defines discriminated unions with non-empty base type", async () => {
+  const openApi = await openApiFor(`
+    @discriminator("kind")
+    model Pet {
+      name: string;
+      weight?: float32;
+    }
+    model Cat extends Pet {
+      kind: "cat";
+      meow: int32;
+    }
+    model Dog extends Pet {
+      kind: "dog";
+      bark: string;
+    }
 
-      op read(): { @body body: Pet };
-      `);
-    ok(openApi.definitions.Pet, "expected definition named Pet");
-    ok(openApi.definitions.Cat, "expected definition named Cat");
-    ok(openApi.definitions.Dog, "expected definition named Dog");
-    deepStrictEqual(openApi.paths["/"].get.responses["200"].schema, {
-      $ref: "#/definitions/Pet",
-    });
-    deepStrictEqual(openApi.definitions.Pet, {
-      type: "object",
-      properties: {
-        kind: { type: "string", description: "Discriminator property for Pet." },
-        name: { type: "string" },
-        weight: { type: "number", format: "float" },
-      },
-      required: ["kind", "name"],
-      discriminator: "kind",
-    });
-    deepStrictEqual(openApi.definitions.Cat.allOf, [{ $ref: "#/definitions/Pet" }]);
-    deepStrictEqual(openApi.definitions.Dog.allOf, [{ $ref: "#/definitions/Pet" }]);
+    op read(): { @body body: Pet };
+    `);
+  ok(openApi.definitions.Pet, "expected definition named Pet");
+  ok(openApi.definitions.Cat, "expected definition named Cat");
+  ok(openApi.definitions.Dog, "expected definition named Dog");
+  deepStrictEqual(openApi.paths["/"].get.responses["200"].schema, {
+    $ref: "#/definitions/Pet",
   });
-
-  // https://github.com/Azure/typespec-azure/issues/3802
-  it("referencing a child model keeps the `x-ms-discriminator-value", async () => {
-    const openApi = await openApiFor(`
-      @discriminator("kind")
-      model Pet { }
-      model CatCls extends Pet {
-        kind: "cat";
-        meow: int32;
-      }
-
-      op read(): CatCls;
-      `);
-    ok(openApi.definitions.Pet, "expected definition named Pet");
-    ok(openApi.definitions.CatCls, "expected definition named Cat");
-    strictEqual(openApi.definitions.CatCls["x-ms-discriminator-value"], "cat");
-    deepStrictEqual(openApi.definitions.CatCls.allOf, [{ $ref: "#/definitions/Pet" }]);
+  deepStrictEqual(openApi.definitions.Pet, {
+    type: "object",
+    properties: {
+      kind: { type: "string", description: "Discriminator property for Pet." },
+      name: { type: "string" },
+      weight: { type: "number", format: "float" },
+    },
+    required: ["kind", "name"],
+    discriminator: "kind",
   });
+  deepStrictEqual(openApi.definitions.Cat.allOf, [{ $ref: "#/definitions/Pet" }]);
+  deepStrictEqual(openApi.definitions.Dog.allOf, [{ $ref: "#/definitions/Pet" }]);
+});
 
-  it("defines discriminated inheritance with extra non discriminated leaf types", async () => {
-    const openApi = await openApiFor(`
-      @discriminator("kind")
-      model Pet {
-        kind: string;
-      }
-      model Cat extends Pet {
-        kind: "cat";
-      }
-      model Dog extends Pet {
-        kind: "dog";
-      }
-      model Beagle extends Dog {
-        purebred: boolean;
-      }
-      `);
-    deepStrictEqual(openApi.definitions.Pet, {
-      type: "object",
-      properties: {
-        kind: { type: "string" },
-      },
-      required: ["kind"],
-      discriminator: "kind",
-    });
-    deepStrictEqual(openApi.definitions.Cat.allOf, [{ $ref: "#/definitions/Pet" }]);
-    deepStrictEqual(openApi.definitions.Dog.allOf, [{ $ref: "#/definitions/Pet" }]);
-    deepStrictEqual(openApi.definitions.Beagle.allOf, [{ $ref: "#/definitions/Dog" }]);
+// https://github.com/Azure/typespec-azure/issues/3802
+it("referencing a child model keeps the `x-ms-discriminator-value", async () => {
+  const openApi = await openApiFor(`
+    @discriminator("kind")
+    model Pet { }
+    model CatCls extends Pet {
+      kind: "cat";
+      meow: int32;
+    }
+
+    op read(): CatCls;
+    `);
+  ok(openApi.definitions.Pet, "expected definition named Pet");
+  ok(openApi.definitions.CatCls, "expected definition named Cat");
+  strictEqual(openApi.definitions.CatCls["x-ms-discriminator-value"], "cat");
+  deepStrictEqual(openApi.definitions.CatCls.allOf, [{ $ref: "#/definitions/Pet" }]);
+});
+
+it("defines discriminated inheritance with extra non discriminated leaf types", async () => {
+  const openApi = await openApiFor(`
+    @discriminator("kind")
+    model Pet {
+      kind: string;
+    }
+    model Cat extends Pet {
+      kind: "cat";
+    }
+    model Dog extends Pet {
+      kind: "dog";
+    }
+    model Beagle extends Dog {
+      purebred: boolean;
+    }
+    `);
+  deepStrictEqual(openApi.definitions.Pet, {
+    type: "object",
+    properties: {
+      kind: { type: "string" },
+    },
+    required: ["kind"],
+    discriminator: "kind",
   });
+  deepStrictEqual(openApi.definitions.Cat.allOf, [{ $ref: "#/definitions/Pet" }]);
+  deepStrictEqual(openApi.definitions.Dog.allOf, [{ $ref: "#/definitions/Pet" }]);
+  deepStrictEqual(openApi.definitions.Beagle.allOf, [{ $ref: "#/definitions/Dog" }]);
+});
 
-  it("defines discriminated inheritance with intermediate non discriminated model", async () => {
-    const openApi = await openApiFor(`
-      @discriminator("kind")
-      model Pet {
-        kind: string;
-      }
-      
-      model CommonPet extends Pet {
-        name: string;
-      }
-      
-      model Dog extends CommonPet {
-        kind: "dog-kind";
-      }
-      `);
-    deepStrictEqual(openApi.definitions.Pet, {
-      type: "object",
-      properties: {
-        kind: { type: "string" },
-      },
-      required: ["kind"],
-      discriminator: "kind",
-    });
-    deepStrictEqual(openApi.definitions.Dog.allOf, [{ $ref: "#/definitions/CommonPet" }]);
-    strictEqual(openApi.definitions.Dog["x-ms-discriminator-value"], "dog-kind");
-    deepStrictEqual(openApi.definitions.CommonPet.allOf, [{ $ref: "#/definitions/Pet" }]);
-    strictEqual(openApi.definitions.CommonPet["x-ms-discriminator-value"], undefined);
+it("defines discriminated inheritance with intermediate non discriminated model", async () => {
+  const openApi = await openApiFor(`
+    @discriminator("kind")
+    model Pet {
+      kind: string;
+    }
+    
+    model CommonPet extends Pet {
+      name: string;
+    }
+    
+    model Dog extends CommonPet {
+      kind: "dog-kind";
+    }
+    `);
+  deepStrictEqual(openApi.definitions.Pet, {
+    type: "object",
+    properties: {
+      kind: { type: "string" },
+    },
+    required: ["kind"],
+    discriminator: "kind",
   });
+  deepStrictEqual(openApi.definitions.Dog.allOf, [{ $ref: "#/definitions/CommonPet" }]);
+  strictEqual(openApi.definitions.Dog["x-ms-discriminator-value"], "dog-kind");
+  deepStrictEqual(openApi.definitions.CommonPet.allOf, [{ $ref: "#/definitions/Pet" }]);
+  strictEqual(openApi.definitions.CommonPet["x-ms-discriminator-value"], undefined);
+});
 
-  it("defines nested discriminated unions", async () => {
-    const openApi = await openApiFor(`
-      @discriminator("kind")
-      model Pet {
-        name: string;
-        weight?: float32;
-      }
-      model Cat extends Pet {
-        kind: "cat";
-        meow: int32;
-      }
-      @discriminator("breed")
-      model Dog extends Pet {
-        kind: "dog";
-        bark: string;
-      }
-      #suppress "@typespec/openapi3/discriminator-value" "kind defined in parent"
-      model Beagle extends Dog {
-        breed: "beagle";
-      }
-      #suppress "@typespec/openapi3/discriminator-value" "kind defined in parent"
-      model Poodle extends Dog {
-        breed: "poodle";
-      }
+it("defines nested discriminated unions", async () => {
+  const openApi = await openApiFor(`
+    @discriminator("kind")
+    model Pet {
+      name: string;
+      weight?: float32;
+    }
+    model Cat extends Pet {
+      kind: "cat";
+      meow: int32;
+    }
+    @discriminator("breed")
+    model Dog extends Pet {
+      kind: "dog";
+      bark: string;
+    }
+    #suppress "@typespec/openapi3/discriminator-value" "kind defined in parent"
+    model Beagle extends Dog {
+      breed: "beagle";
+    }
+    #suppress "@typespec/openapi3/discriminator-value" "kind defined in parent"
+    model Poodle extends Dog {
+      breed: "poodle";
+    }
 
-      op read(): { @body body: Pet };
-      `);
-    ok(openApi);
-    ok(openApi.definitions);
-    ok(openApi.definitions.Pet, "expected definition named Pet");
-    ok(openApi.definitions.Cat, "expected definition named Cat");
-    ok(openApi.definitions.Dog, "expected definition named Dog");
-    ok(openApi.definitions.Beagle, "expected definition named Beagle");
-    ok(openApi.definitions.Poodle, "expected definition named Poodle");
-    deepStrictEqual(openApi.paths["/"].get.responses["200"].schema, {
-      $ref: "#/definitions/Pet",
-    });
-    deepStrictEqual(openApi.definitions.Pet, {
-      type: "object",
-      properties: {
-        kind: { type: "string", description: "Discriminator property for Pet." },
-        name: { type: "string" },
-        weight: { type: "number", format: "float" },
-      },
-      required: ["kind", "name"],
-      discriminator: "kind",
-    });
-    deepStrictEqual(openApi.definitions.Dog, {
-      type: "object",
-      properties: {
-        breed: { type: "string", description: "Discriminator property for Dog." },
-        bark: { type: "string" },
-      },
-      required: ["breed", "bark"],
-      allOf: [{ $ref: "#/definitions/Pet" }],
-      discriminator: "breed",
-      "x-ms-discriminator-value": "dog",
-    });
-    deepStrictEqual(openApi.definitions.Beagle.allOf, [{ $ref: "#/definitions/Dog" }]);
-    deepStrictEqual(openApi.definitions.Poodle.allOf, [{ $ref: "#/definitions/Dog" }]);
+    op read(): { @body body: Pet };
+    `);
+  ok(openApi);
+  ok(openApi.definitions);
+  ok(openApi.definitions.Pet, "expected definition named Pet");
+  ok(openApi.definitions.Cat, "expected definition named Cat");
+  ok(openApi.definitions.Dog, "expected definition named Dog");
+  ok(openApi.definitions.Beagle, "expected definition named Beagle");
+  ok(openApi.definitions.Poodle, "expected definition named Poodle");
+  deepStrictEqual(openApi.paths["/"].get.responses["200"].schema, {
+    $ref: "#/definitions/Pet",
   });
-
-  it("defines multi-level single discriminator hierarchy", async () => {
-    const openApi = await compileOpenAPI(
-      `
-      @discriminator("kind")
-      model Pet {
-        name: string;
-        weight?: float32;
-      }
-      model Cat extends Pet {
-        kind: "cat";
-        meow: int32;
-      }
-      alias DogProperties = {
-        bark: string;
-      };
-
-      model Dog extends Pet {
-        kind: "dog";
-        ...DogProperties;
-      }
-
-      @Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(Dog)
-      model Beagle extends Pet {
-        kind: "beagle";
-        ...DogProperties;
-      }
-      
-      @Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(Dog)
-      model Poodle extends Pet {
-        kind: "poodle";
-        ...DogProperties;
-      }
-
-      op read(): { @body body: Pet };
-      `,
-      { preset: "azure" },
-    );
-    ok(openApi.definitions);
-    ok(openApi.definitions.Cat, "expected definition named Cat");
-    ok(openApi.definitions.Beagle, "expected definition named Beagle");
-    ok(openApi.definitions.Poodle, "expected definition named Poodle");
-    deepStrictEqual(openApi.definitions.Pet, {
-      type: "object",
-      properties: {
-        kind: { type: "string", description: "Discriminator property for Pet." },
-        name: { type: "string" },
-        weight: { type: "number", format: "float" },
-      },
-      required: ["kind", "name"],
-      discriminator: "kind",
-    });
-    deepStrictEqual(openApi.definitions.Dog, {
-      type: "object",
-      properties: {
-        bark: { type: "string" },
-      },
-      required: ["bark"],
-      allOf: [{ $ref: "#/definitions/Pet" }],
-      "x-ms-discriminator-value": "dog",
-    });
-    deepStrictEqual(openApi.definitions.Beagle, {
-      type: "object",
-      allOf: [{ $ref: "#/definitions/Dog" }],
-      "x-ms-discriminator-value": "beagle",
-    });
-    deepStrictEqual(openApi.definitions.Poodle, {
-      type: "object",
-      allOf: [{ $ref: "#/definitions/Dog" }],
-      "x-ms-discriminator-value": "poodle",
-    });
+  deepStrictEqual(openApi.definitions.Pet, {
+    type: "object",
+    properties: {
+      kind: { type: "string", description: "Discriminator property for Pet." },
+      name: { type: "string" },
+      weight: { type: "number", format: "float" },
+    },
+    required: ["kind", "name"],
+    discriminator: "kind",
   });
+  deepStrictEqual(openApi.definitions.Dog, {
+    type: "object",
+    properties: {
+      breed: { type: "string", description: "Discriminator property for Dog." },
+      bark: { type: "string" },
+    },
+    required: ["breed", "bark"],
+    allOf: [{ $ref: "#/definitions/Pet" }],
+    discriminator: "breed",
+    "x-ms-discriminator-value": "dog",
+  });
+  deepStrictEqual(openApi.definitions.Beagle.allOf, [{ $ref: "#/definitions/Dog" }]);
+  deepStrictEqual(openApi.definitions.Poodle.allOf, [{ $ref: "#/definitions/Dog" }]);
+});
 
-  it("defines discriminated union with enum", async () => {
+it("defines multi-level single discriminator hierarchy", async () => {
+  const openApi = await compileOpenAPI(
+    `
+    @discriminator("kind")
+    model Pet {
+      name: string;
+      weight?: float32;
+    }
+    model Cat extends Pet {
+      kind: "cat";
+      meow: int32;
+    }
+    alias DogProperties = {
+      bark: string;
+    };
+
+    model Dog extends Pet {
+      kind: "dog";
+      ...DogProperties;
+    }
+
+    @Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(Dog)
+    model Beagle extends Pet {
+      kind: "beagle";
+      ...DogProperties;
+    }
+    
+    @Azure.ClientGenerator.Core.Legacy.hierarchyBuilding(Dog)
+    model Poodle extends Pet {
+      kind: "poodle";
+      ...DogProperties;
+    }
+
+    op read(): { @body body: Pet };
+    `,
+    { preset: "azure" },
+  );
+  ok(openApi.definitions);
+  ok(openApi.definitions.Cat, "expected definition named Cat");
+  ok(openApi.definitions.Beagle, "expected definition named Beagle");
+  ok(openApi.definitions.Poodle, "expected definition named Poodle");
+  deepStrictEqual(openApi.definitions.Pet, {
+    type: "object",
+    properties: {
+      kind: { type: "string", description: "Discriminator property for Pet." },
+      name: { type: "string" },
+      weight: { type: "number", format: "float" },
+    },
+    required: ["kind", "name"],
+    discriminator: "kind",
+  });
+  deepStrictEqual(openApi.definitions.Dog, {
+    type: "object",
+    properties: {
+      bark: { type: "string" },
+    },
+    required: ["bark"],
+    allOf: [{ $ref: "#/definitions/Pet" }],
+    "x-ms-discriminator-value": "dog",
+  });
+  deepStrictEqual(openApi.definitions.Beagle, {
+    type: "object",
+    allOf: [{ $ref: "#/definitions/Dog" }],
+    "x-ms-discriminator-value": "beagle",
+  });
+  deepStrictEqual(openApi.definitions.Poodle, {
+    type: "object",
+    allOf: [{ $ref: "#/definitions/Dog" }],
+    "x-ms-discriminator-value": "poodle",
+  });
+});
+
+it("defines discriminated union with enum", async () => {
+  const openApi = await openApiFor(`
+    enum PetKind {cat, dog}
+    @discriminator("kind")
+    model Pet {
+      kind: PetKind;
+    }
+    model Cat extends Pet {
+      kind: PetKind.cat;
+      meow: int32;
+    }
+    model Dog extends Pet {
+      kind: PetKind.dog;
+      bark: string;
+    }
+    
+
+    op read(): Pet;
+    `);
+  ok(openApi.definitions.Pet, "expected definition named Pet");
+  ok(openApi.definitions.Cat, "expected definition named Cat");
+  ok(openApi.definitions.Dog, "expected definition named Dog");
+  deepStrictEqual(openApi.definitions.Pet, {
+    type: "object",
+    properties: {
+      kind: { $ref: "#/definitions/PetKind" },
+    },
+    required: ["kind"],
+    discriminator: "kind",
+  });
+  deepStrictEqual(openApi.definitions.Cat["x-ms-discriminator-value"], "cat");
+  deepStrictEqual(openApi.definitions.Dog["x-ms-discriminator-value"], "dog");
+});
+
+describe("discriminator property MUST be required", () => {
+  it("force the property as required even if marked optional", async () => {
     const openApi = await openApiFor(`
-      enum PetKind {cat, dog}
-      @discriminator("kind")
-      model Pet {
-        kind: PetKind;
-      }
-      model Cat extends Pet {
-        kind: PetKind.cat;
-        meow: int32;
-      }
-      model Dog extends Pet {
-        kind: PetKind.dog;
-        bark: string;
-      }
-      
+      @discriminator("kind") model Pet { kind?: string; }
 
       op read(): Pet;
-      `);
-    ok(openApi.definitions.Pet, "expected definition named Pet");
-    ok(openApi.definitions.Cat, "expected definition named Cat");
-    ok(openApi.definitions.Dog, "expected definition named Dog");
-    deepStrictEqual(openApi.definitions.Pet, {
-      type: "object",
-      properties: {
-        kind: { $ref: "#/definitions/PetKind" },
-      },
-      required: ["kind"],
-      discriminator: "kind",
-    });
-    deepStrictEqual(openApi.definitions.Cat["x-ms-discriminator-value"], "cat");
-    deepStrictEqual(openApi.definitions.Dog["x-ms-discriminator-value"], "dog");
+    `);
+
+    deepStrictEqual(openApi.definitions.Pet.required, ["kind"]);
   });
 
-  describe("discriminator property MUST be required", () => {
-    it("force the property as required even if marked optional", async () => {
-      const openApi = await openApiFor(`
-        @discriminator("kind") model Pet { kind?: string; }
-  
-        op read(): Pet;
-      `);
-
-      deepStrictEqual(openApi.definitions.Pet.required, ["kind"]);
-    });
-
-    it("force it as required in a patch request", async () => {
-      const openApi = await openApiFor(`
-        @discriminator("kind")
-        model Pet { kind: string; }
-        model Cat extends Pet { kind: "cat"; meow: int32; }
-        model Dog extends Pet { kind: "dog"; bark: string; }
-        
-        #suppress "@typespec/http/deprecated-implicit-optionality" "For testing"
-        @patch(#{implicitOptionality: true}) op read(...Pet): Pet;
-      `);
-
-      deepStrictEqual(openApi.definitions.PetUpdate.required, ["kind"]);
-    });
-  });
-
-  it("issues diagnostics for errors in a discriminated union", async () => {
-    const diagnostics = await Tester.diagnose(
-      `
+  it("force it as required in a patch request", async () => {
+    const openApi = await openApiFor(`
       @discriminator("kind")
-      model Pet {
-        name: string;
-        weight?: float32;
-      }
-      model Cat extends Pet {
-        kind: "cat";
-        meow: int32;
-      }
-      model Dog extends Pet {
-        petType: "dog";
-        bark: string;
-      }
-      model Pig extends Pet {
-        kind: int32;
-        oink: float32;
-      }
-      model Tiger extends Pet {
-        kind?: "tiger";
-        claws: float32;
-      }
-      model Lizard extends Pet {
-        kind: string;
-        tail: float64;
-      }
+      model Pet { kind: string; }
+      model Cat extends Pet { kind: "cat"; meow: int32; }
+      model Dog extends Pet { kind: "dog"; bark: string; }
+      
+      #suppress "@typespec/http/deprecated-implicit-optionality" "For testing"
+      @patch(#{implicitOptionality: true}) op read(...Pet): Pet;
+    `);
 
-      #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
-      op read(): { @body body: Pet };
-      `,
-    );
-    expectDiagnostics(diagnostics, [
-      {
-        code: "missing-discriminator-property",
-        message:
-          /Each derived model of a discriminated model type should have set the discriminator property/,
-      },
-      {
-        code: "invalid-discriminator-value",
-        message: `Discriminator value should be a string, union of string or string enum but was Scalar.`,
-      },
-      {
-        code: "invalid-discriminator-value",
-        message: `The discriminator property must be a required property.`,
-      },
-      {
-        code: "invalid-discriminator-value",
-        message: `Discriminator value should be a string, union of string or string enum but was Scalar.`,
-      },
-    ]);
+    deepStrictEqual(openApi.definitions.PetUpdate.required, ["kind"]);
   });
+});
 
-  it("issues diagnostics for duplicate discriminator values", async () => {
-    const diagnostics = await Tester.diagnose(
-      `
-      @discriminator("kind")
-      model Pet {
-      }
-      model Cat extends Pet {
-        kind: "cat" | "feline" | "housepet";
-        meow: int32;
-      }
-      model Dog extends Pet {
-        kind: "dog" | "housepet";
-        bark: string;
-      }
-      model Beagle extends Pet {
-        kind: "dog";
-        bark: string;
-      }
+it("issues diagnostics for errors in a discriminated union", async () => {
+  const diagnostics = await Tester.diagnose(
+    `
+    @discriminator("kind")
+    model Pet {
+      name: string;
+      weight?: float32;
+    }
+    model Cat extends Pet {
+      kind: "cat";
+      meow: int32;
+    }
+    model Dog extends Pet {
+      petType: "dog";
+      bark: string;
+    }
+    model Pig extends Pet {
+      kind: int32;
+      oink: float32;
+    }
+    model Tiger extends Pet {
+      kind?: "tiger";
+      claws: float32;
+    }
+    model Lizard extends Pet {
+      kind: string;
+      tail: float64;
+    }
 
-      #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
-      op read(): { @body body: Pet };
-      `,
-    );
-    expectDiagnostics(diagnostics, [
-      {
-        code: "invalid-discriminator-value",
-        message: `Discriminator value "housepet" is already used in another variant.`,
-      },
-      {
-        code: "invalid-discriminator-value",
-        message: `Discriminator value "housepet" is already used in another variant.`,
-      },
-      {
-        code: "invalid-discriminator-value",
-        message: `Discriminator value "dog" is already used in another variant.`,
-      },
-      {
-        code: "invalid-discriminator-value",
-        message: `Discriminator value "dog" is already used in another variant.`,
-      },
-    ]);
-  });
+    #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
+    op read(): { @body body: Pet };
+    `,
+  );
+  expectDiagnostics(diagnostics, [
+    {
+      code: "missing-discriminator-property",
+      message:
+        /Each derived model of a discriminated model type should have set the discriminator property/,
+    },
+    {
+      code: "invalid-discriminator-value",
+      message: `Discriminator value should be a string, union of string or string enum but was Scalar.`,
+    },
+    {
+      code: "invalid-discriminator-value",
+      message: `The discriminator property must be a required property.`,
+    },
+    {
+      code: "invalid-discriminator-value",
+      message: `Discriminator value should be a string, union of string or string enum but was Scalar.`,
+    },
+  ]);
+});
+
+it("issues diagnostics for duplicate discriminator values", async () => {
+  const diagnostics = await Tester.diagnose(
+    `
+    @discriminator("kind")
+    model Pet {
+    }
+    model Cat extends Pet {
+      kind: "cat" | "feline" | "housepet";
+      meow: int32;
+    }
+    model Dog extends Pet {
+      kind: "dog" | "housepet";
+      bark: string;
+    }
+    model Beagle extends Pet {
+      kind: "dog";
+      bark: string;
+    }
+
+    #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
+    op read(): { @body body: Pet };
+    `,
+  );
+  expectDiagnostics(diagnostics, [
+    {
+      code: "invalid-discriminator-value",
+      message: `Discriminator value "housepet" is already used in another variant.`,
+    },
+    {
+      code: "invalid-discriminator-value",
+      message: `Discriminator value "housepet" is already used in another variant.`,
+    },
+    {
+      code: "invalid-discriminator-value",
+      message: `Discriminator value "dog" is already used in another variant.`,
+    },
+    {
+      code: "invalid-discriminator-value",
+      message: `Discriminator value "dog" is already used in another variant.`,
+    },
+  ]);
 });

--- a/packages/typespec-autorest/test/formats.test.ts
+++ b/packages/typespec-autorest/test/formats.test.ts
@@ -1,6 +1,6 @@
 import { expectDiagnosticEmpty, expectDiagnostics } from "@typespec/compiler/testing";
 import { deepStrictEqual } from "assert";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import {
   AzureTester,
   diagnoseOpenApiFor,
@@ -8,83 +8,81 @@ import {
   openApiFor,
 } from "./test-host.js";
 
-describe("typespec-autorest: format", () => {
-  it("allows supported formats", async () => {
-    const res = await openApiFor(
-      `
-      @service
-      namespace Test;
+it("allows supported formats", async () => {
+  const res = await openApiFor(
+    `
+    @service
+    namespace Test;
 
-      model Widget {
-        @format("uuid")
-        prop: string;
-      }
+    model Widget {
+      @format("uuid")
+      prop: string;
+    }
 
-      op get(): void;
-      `,
-    );
-    const model = res.definitions["Widget"]!;
-    deepStrictEqual(model, {
-      properties: {
-        prop: {
-          format: "uuid",
-          type: "string",
-        },
+    op get(): void;
+    `,
+  );
+  const model = res.definitions["Widget"]!;
+  deepStrictEqual(model, {
+    properties: {
+      prop: {
+        format: "uuid",
+        type: "string",
       },
-      required: ["prop"],
-      type: "object",
-    });
+    },
+    required: ["prop"],
+    type: "object",
   });
+});
 
-  it("emits diagnostic for unsupported formats", async () => {
-    const diagnostics = await diagnoseOpenApiFor(
-      `
-      model Widget {
-        @format("fake")
-        prop: string;
-      }
-      `,
-    );
-    expectDiagnostics(diagnostics, {
-      code: "@azure-tools/typespec-autorest/unknown-format",
-      message: "'string' format 'fake' is not supported in Autorest. It will not be emitted.",
-    });
+it("emits diagnostic for unsupported formats", async () => {
+  const diagnostics = await diagnoseOpenApiFor(
+    `
+    model Widget {
+      @format("fake")
+      prop: string;
+    }
+    `,
+  );
+  expectDiagnostics(diagnostics, {
+    code: "@azure-tools/typespec-autorest/unknown-format",
+    message: "'string' format 'fake' is not supported in Autorest. It will not be emitted.",
   });
+});
 
-  it("emits diagnostic for unsupported encoding and update type to string", async () => {
-    const [openapi, diagnostics] = await emitOpenApiWithDiagnostics(
-      `
-      model Widget {
-        @encode(ArrayEncoding.commaDelimited)
-        prop: string[];
-      }
-      `,
-    );
-    expectDiagnostics(diagnostics, {
-      code: "@azure-tools/typespec-autorest/unknown-format",
-      message:
-        "'string' encoding format 'ArrayEncoding.commaDelimited' is not supported in Autorest. It will not be emitted.",
-    });
-    expect(openapi.definitions?.Widget?.properties?.prop).toEqual({
-      type: "string",
-    });
+it("emits diagnostic for unsupported encoding and update type to string", async () => {
+  const [openapi, diagnostics] = await emitOpenApiWithDiagnostics(
+    `
+    model Widget {
+      @encode(ArrayEncoding.commaDelimited)
+      prop: string[];
+    }
+    `,
+  );
+  expectDiagnostics(diagnostics, {
+    code: "@azure-tools/typespec-autorest/unknown-format",
+    message:
+      "'string' encoding format 'ArrayEncoding.commaDelimited' is not supported in Autorest. It will not be emitted.",
   });
-
-  it("does not emit diagnostic for Azure.Core scalars", async () => {
-    const diagnostics = await AzureTester.diagnose(
-      `
-      @service
-          namespace Test;
-
-      model Widget {
-        eTag: eTag;
-        ipv4Address: ipV4Address;
-        ipv6Address: ipV6Address;
-      }
-
-      op get(): void;
-      `,
-    );
-    expectDiagnosticEmpty(diagnostics);
+  expect(openapi.definitions?.Widget?.properties?.prop).toEqual({
+    type: "string",
   });
+});
+
+it("does not emit diagnostic for Azure.Core scalars", async () => {
+  const diagnostics = await AzureTester.diagnose(
+    `
+    @service
+        namespace Test;
+
+    model Widget {
+      eTag: eTag;
+      ipv4Address: ipV4Address;
+      ipv6Address: ipV6Address;
+    }
+
+    op get(): void;
+    `,
+  );
+  expectDiagnosticEmpty(diagnostics);
 });

--- a/packages/typespec-autorest/test/host.test.ts
+++ b/packages/typespec-autorest/test/host.test.ts
@@ -1,191 +1,189 @@
 import { deepStrictEqual, strictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { openApiFor } from "./test-host.js";
 
-describe("typespec-autorest: host/x-ms-parameterized-host", () => {
-  it("set a basic server", async () => {
-    const res = await openApiFor(
-      `
-      @service(#{title: "My service"})
-      @server("https://example.com", "Main server")
-      namespace MyService {}
-      `,
-    );
-    strictEqual(res.host, "example.com");
-    strictEqual(res["x-ms-parameterized-host"], undefined);
-    deepStrictEqual(res.schemes, ["https"]);
-  });
+it("set a basic server", async () => {
+  const res = await openApiFor(
+    `
+    @service(#{title: "My service"})
+    @server("https://example.com", "Main server")
+    namespace MyService {}
+    `,
+  );
+  strictEqual(res.host, "example.com");
+  strictEqual(res["x-ms-parameterized-host"], undefined);
+  deepStrictEqual(res.schemes, ["https"]);
+});
 
-  it("set a server with base url parameter", async () => {
-    const res = await openApiFor(
-      `
-      @service(#{title: "My service"})
-      @server("{endpoint}/v2", "Regional account endpoint", {endpoint: url})
-      namespace MyService {}
-      `,
-    );
-    strictEqual(res.host, undefined);
-    deepStrictEqual(res["x-ms-parameterized-host"], {
-      hostTemplate: "{endpoint}/v2",
-      useSchemePrefix: false,
-      parameters: [
-        {
-          in: "path",
-          name: "endpoint",
-          required: true,
-          type: "string",
-          format: "uri",
-          "x-ms-skip-url-encoding": true,
+it("set a server with base url parameter", async () => {
+  const res = await openApiFor(
+    `
+    @service(#{title: "My service"})
+    @server("{endpoint}/v2", "Regional account endpoint", {endpoint: url})
+    namespace MyService {}
+    `,
+  );
+  strictEqual(res.host, undefined);
+  deepStrictEqual(res["x-ms-parameterized-host"], {
+    hostTemplate: "{endpoint}/v2",
+    useSchemePrefix: false,
+    parameters: [
+      {
+        in: "path",
+        name: "endpoint",
+        required: true,
+        type: "string",
+        format: "uri",
+        "x-ms-skip-url-encoding": true,
+      },
+    ],
+  });
+});
+
+it("set a server with parameters", async () => {
+  const res = await openApiFor(
+    `
+    @service(#{title: "My service"})
+    @server("https://{account}.{region}.example.com", "Regional account endpoint", {region: string, account: string})
+    namespace MyService {}
+    `,
+  );
+  strictEqual(res.host, undefined);
+  deepStrictEqual(res["x-ms-parameterized-host"], {
+    hostTemplate: "https://{account}.{region}.example.com",
+    useSchemePrefix: false,
+    parameters: [
+      { in: "path", name: "region", required: true, type: "string" },
+      { in: "path", name: "account", required: true, type: "string" },
+    ],
+  });
+});
+
+it("set a server with parameters with defaults", async () => {
+  const res = await openApiFor(
+    `
+    @service(#{title: "My service"})
+    @server("https://{account}.{region}.example.com", "Regional account endpoint", {
+      region: string = "westus", 
+      account: string = "default",
+    })
+    namespace MyService {}
+    `,
+  );
+  strictEqual(res.host, undefined);
+  deepStrictEqual(res["x-ms-parameterized-host"], {
+    hostTemplate: "https://{account}.{region}.example.com",
+    useSchemePrefix: false,
+    parameters: [
+      { in: "path", name: "region", required: true, type: "string", default: "westus" },
+      { in: "path", name: "account", required: true, type: "string", default: "default" },
+    ],
+  });
+});
+
+it("set a server with parameters with doc", async () => {
+  const res = await openApiFor(
+    `
+    @service(#{title: "My service"})
+    @server("https://{region}.example.com", "Regional account endpoint", {
+      @doc("Region name")
+      region: string,
+    })
+    namespace MyService {}
+    `,
+  );
+  strictEqual(res.host, undefined);
+  deepStrictEqual(res["x-ms-parameterized-host"], {
+    hostTemplate: "https://{region}.example.com",
+    useSchemePrefix: false,
+    parameters: [
+      { in: "path", name: "region", required: true, type: "string", description: "Region name" },
+    ],
+  });
+});
+
+it("set a server with enum properties", async () => {
+  const res = await openApiFor(
+    `
+    enum Region { westus, eastus }
+    @service(#{title: "My service"})
+    @server("https://{region}.example.com", "Regional account endpoint", {
+      region: Region, 
+    })
+    namespace MyService {}
+    `,
+  );
+  strictEqual(res.host, undefined);
+  deepStrictEqual(res["x-ms-parameterized-host"], {
+    hostTemplate: "https://{region}.example.com",
+    useSchemePrefix: false,
+    parameters: [
+      {
+        in: "path",
+        name: "region",
+        required: true,
+        type: "string",
+        enum: ["westus", "eastus"],
+        "x-ms-enum": { modelAsString: false, name: "Region" },
+      },
+    ],
+  });
+});
+
+it("set a server with string literal", async () => {
+  const res = await openApiFor(
+    `
+    enum Region {  }
+    @service(#{title: "My service"})
+    @server("https://{region}.example.com", "Regional account endpoint", {
+      region: "westus", 
+    })
+    namespace MyService {}
+    `,
+  );
+  strictEqual(res.host, undefined);
+  deepStrictEqual(res["x-ms-parameterized-host"], {
+    hostTemplate: "https://{region}.example.com",
+    useSchemePrefix: false,
+    parameters: [
+      {
+        in: "path",
+        name: "region",
+        required: true,
+        type: "string",
+        enum: ["westus"],
+        "x-ms-enum": { modelAsString: false },
+      },
+    ],
+  });
+});
+
+it("set a server with unions type", async () => {
+  const res = await openApiFor(
+    `
+    enum Region {  }
+    @service(#{title: "My service"})
+    @server("https://{region}.example.com", "Regional account endpoint", {
+      region: "westus" | "eastus", 
+    })
+    namespace MyService {}
+    `,
+  );
+  strictEqual(res.host, undefined);
+  deepStrictEqual(res["x-ms-parameterized-host"], {
+    hostTemplate: "https://{region}.example.com",
+    useSchemePrefix: false,
+    parameters: [
+      {
+        in: "path",
+        name: "region",
+        required: true,
+        type: "string",
+        enum: ["westus", "eastus"],
+        "x-ms-enum": {
+          modelAsString: false,
         },
-      ],
-    });
-  });
-
-  it("set a server with parameters", async () => {
-    const res = await openApiFor(
-      `
-      @service(#{title: "My service"})
-      @server("https://{account}.{region}.example.com", "Regional account endpoint", {region: string, account: string})
-      namespace MyService {}
-      `,
-    );
-    strictEqual(res.host, undefined);
-    deepStrictEqual(res["x-ms-parameterized-host"], {
-      hostTemplate: "https://{account}.{region}.example.com",
-      useSchemePrefix: false,
-      parameters: [
-        { in: "path", name: "region", required: true, type: "string" },
-        { in: "path", name: "account", required: true, type: "string" },
-      ],
-    });
-  });
-
-  it("set a server with parameters with defaults", async () => {
-    const res = await openApiFor(
-      `
-      @service(#{title: "My service"})
-      @server("https://{account}.{region}.example.com", "Regional account endpoint", {
-        region: string = "westus", 
-        account: string = "default",
-      })
-      namespace MyService {}
-      `,
-    );
-    strictEqual(res.host, undefined);
-    deepStrictEqual(res["x-ms-parameterized-host"], {
-      hostTemplate: "https://{account}.{region}.example.com",
-      useSchemePrefix: false,
-      parameters: [
-        { in: "path", name: "region", required: true, type: "string", default: "westus" },
-        { in: "path", name: "account", required: true, type: "string", default: "default" },
-      ],
-    });
-  });
-
-  it("set a server with parameters with doc", async () => {
-    const res = await openApiFor(
-      `
-      @service(#{title: "My service"})
-      @server("https://{region}.example.com", "Regional account endpoint", {
-        @doc("Region name")
-        region: string,
-      })
-      namespace MyService {}
-      `,
-    );
-    strictEqual(res.host, undefined);
-    deepStrictEqual(res["x-ms-parameterized-host"], {
-      hostTemplate: "https://{region}.example.com",
-      useSchemePrefix: false,
-      parameters: [
-        { in: "path", name: "region", required: true, type: "string", description: "Region name" },
-      ],
-    });
-  });
-
-  it("set a server with enum properties", async () => {
-    const res = await openApiFor(
-      `
-      enum Region { westus, eastus }
-      @service(#{title: "My service"})
-      @server("https://{region}.example.com", "Regional account endpoint", {
-        region: Region, 
-      })
-      namespace MyService {}
-      `,
-    );
-    strictEqual(res.host, undefined);
-    deepStrictEqual(res["x-ms-parameterized-host"], {
-      hostTemplate: "https://{region}.example.com",
-      useSchemePrefix: false,
-      parameters: [
-        {
-          in: "path",
-          name: "region",
-          required: true,
-          type: "string",
-          enum: ["westus", "eastus"],
-          "x-ms-enum": { modelAsString: false, name: "Region" },
-        },
-      ],
-    });
-  });
-
-  it("set a server with string literal", async () => {
-    const res = await openApiFor(
-      `
-      enum Region {  }
-      @service(#{title: "My service"})
-      @server("https://{region}.example.com", "Regional account endpoint", {
-        region: "westus", 
-      })
-      namespace MyService {}
-      `,
-    );
-    strictEqual(res.host, undefined);
-    deepStrictEqual(res["x-ms-parameterized-host"], {
-      hostTemplate: "https://{region}.example.com",
-      useSchemePrefix: false,
-      parameters: [
-        {
-          in: "path",
-          name: "region",
-          required: true,
-          type: "string",
-          enum: ["westus"],
-          "x-ms-enum": { modelAsString: false },
-        },
-      ],
-    });
-  });
-
-  it("set a server with unions type", async () => {
-    const res = await openApiFor(
-      `
-      enum Region {  }
-      @service(#{title: "My service"})
-      @server("https://{region}.example.com", "Regional account endpoint", {
-        region: "westus" | "eastus", 
-      })
-      namespace MyService {}
-      `,
-    );
-    strictEqual(res.host, undefined);
-    deepStrictEqual(res["x-ms-parameterized-host"], {
-      hostTemplate: "https://{region}.example.com",
-      useSchemePrefix: false,
-      parameters: [
-        {
-          in: "path",
-          name: "region",
-          required: true,
-          type: "string",
-          enum: ["westus", "eastus"],
-          "x-ms-enum": {
-            modelAsString: false,
-          },
-        },
-      ],
-    });
+      },
+    ],
   });
 });

--- a/packages/typespec-autorest/test/info.test.ts
+++ b/packages/typespec-autorest/test/info.test.ts
@@ -1,90 +1,88 @@
 import { deepStrictEqual, strictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { openApiFor } from "./test-host.js";
 
-describe("typespec-autorest: info", () => {
-  it("set the service title with @service", async () => {
-    const res = await openApiFor(
-      `
-      @service(#{title: "My Service"})
-      namespace Foo {}
-      `,
-    );
-    strictEqual(res.info.title, "My Service");
-  });
+it("set the service title with @service", async () => {
+  const res = await openApiFor(
+    `
+    @service(#{title: "My Service"})
+    namespace Foo {}
+    `,
+  );
+  strictEqual(res.info.title, "My Service");
+});
 
-  it("set the service description with @doc", async () => {
-    const res = await openApiFor(
-      `
-      @doc("My service description")
-      @service(#{title: "My Service"})
-      namespace Foo {}
-      `,
-    );
-    strictEqual(res.info.description, "My service description");
-  });
+it("set the service description with @doc", async () => {
+  const res = await openApiFor(
+    `
+    @doc("My service description")
+    @service(#{title: "My Service"})
+    namespace Foo {}
+    `,
+  );
+  strictEqual(res.info.description, "My service description");
+});
 
-  it("set the service externalDocs with @externalDocs", async () => {
-    const res = await openApiFor(
-      `
-      @externalDocs("https://example.com", "more info")
-      @service(#{title: "My Service"})
-      namespace Foo {}
-      `,
-    );
-    deepStrictEqual(res.externalDocs, {
-      url: "https://example.com",
-      description: "more info",
-    });
+it("set the service externalDocs with @externalDocs", async () => {
+  const res = await openApiFor(
+    `
+    @externalDocs("https://example.com", "more info")
+    @service(#{title: "My Service"})
+    namespace Foo {}
+    `,
+  );
+  deepStrictEqual(res.externalDocs, {
+    url: "https://example.com",
+    description: "more info",
   });
-  it("lists the emitters used in the info section", async () => {
-    const res = await openApiFor(
-      `
-      @doc("My service description")
-      @service(#{title: "My Service"})
-      namespace Foo {}
-      `,
-    );
-    deepStrictEqual(res.info["x-typespec-generated"], [
-      { emitter: "@azure-tools/typespec-autorest" },
-    ]);
-  });
+});
+it("lists the emitters used in the info section", async () => {
+  const res = await openApiFor(
+    `
+    @doc("My service description")
+    @service(#{title: "My Service"})
+    namespace Foo {}
+    `,
+  );
+  deepStrictEqual(res.info["x-typespec-generated"], [
+    { emitter: "@azure-tools/typespec-autorest" },
+  ]);
+});
 
-  it("set the additional information with @info decorator", async () => {
-    const res = await openApiFor(
-      `
-      @service
-      @info(#{
-        termsOfService: "http://example.com/terms/",
-        contact: #{
-          name: "API Support",
-          url: "http://www.example.com/support",
-          email: "support@example.com"
-        },
-        license: #{
-          name: "Apache 2.0",
-          url: "http://www.apache.org/licenses/LICENSE-2.0.html"
-        },
-      })
-      namespace Foo {
-        op test(): string;
-      }
-      `,
-    );
-    deepStrictEqual(res.info, {
-      title: "(title)",
-      version: "0000-00-00",
+it("set the additional information with @info decorator", async () => {
+  const res = await openApiFor(
+    `
+    @service
+    @info(#{
       termsOfService: "http://example.com/terms/",
-      contact: {
+      contact: #{
         name: "API Support",
         url: "http://www.example.com/support",
-        email: "support@example.com",
+        email: "support@example.com"
       },
-      license: {
+      license: #{
         name: "Apache 2.0",
-        url: "http://www.apache.org/licenses/LICENSE-2.0.html",
+        url: "http://www.apache.org/licenses/LICENSE-2.0.html"
       },
-      "x-typespec-generated": [{ emitter: "@azure-tools/typespec-autorest" }],
-    });
+    })
+    namespace Foo {
+      op test(): string;
+    }
+    `,
+  );
+  deepStrictEqual(res.info, {
+    title: "(title)",
+    version: "0000-00-00",
+    termsOfService: "http://example.com/terms/",
+    contact: {
+      name: "API Support",
+      url: "http://www.example.com/support",
+      email: "support@example.com",
+    },
+    license: {
+      name: "Apache 2.0",
+      url: "http://www.apache.org/licenses/LICENSE-2.0.html",
+    },
+    "x-typespec-generated": [{ emitter: "@azure-tools/typespec-autorest" }],
   });
 });

--- a/packages/typespec-autorest/test/lro.test.ts
+++ b/packages/typespec-autorest/test/lro.test.ts
@@ -1,590 +1,588 @@
 import { paramMessage } from "@typespec/compiler";
 import { deepStrictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { compileOpenAPI } from "./test-host.js";
 
-describe("typespec-autorest: Long-running Operations", () => {
-  it("includes x-ms-long-running-operation", async () => {
-    const openapi = await compileOpenAPI(
-      `
-      using Azure.Core.Traits;
+it("includes x-ms-long-running-operation", async () => {
+  const openapi = await compileOpenAPI(
+    `
+    using Azure.Core.Traits;
 
-      @useAuth(
-        ApiKeyAuth<ApiKeyLocation.header, "api-key"> | OAuth2Auth<[
-          {
-            type: OAuth2FlowType.implicit,
-            authorizationUrl: "https://login.contoso.com/common/oauth2/v2.0/authorize",
-            scopes: ["https://widget.contoso.com/.default"],
-          }
-        ]>
-      )
-      @service(#{
-        title: "Contoso Widget Manager",
-      })
-      @server(
-        "{endpoint}/widget",
-        "Contoso Widget APIs",
+    @useAuth(
+      ApiKeyAuth<ApiKeyLocation.header, "api-key"> | OAuth2Auth<[
         {
-          endpoint: string,
+          type: OAuth2FlowType.implicit,
+          authorizationUrl: "https://login.contoso.com/common/oauth2/v2.0/authorize",
+          scopes: ["https://widget.contoso.com/.default"],
         }
-      )
-          namespace Test;
-
-      alias ServiceTraits = SupportsRepeatableRequests & SupportsConditionalRequests & SupportsClientRequestId;
-
-      alias Operations = Azure.Core.ResourceOperations<ServiceTraits>;
-
-      @resource("widgets")
-      
-      model Widget {
-        @key("widgetName")
-        
-        @visibility(Lifecycle.Read)
-        name: string;
-        
-        manufacturerId: string;
-      
-      ...EtagProperty;
-      }
-
-      op getWidgetOperationStatus is Operations.GetResourceOperationStatus<Widget>;
-    
-      @pollingOperation(getWidgetOperationStatus)
-      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-      op createOrUpdateWidget is Operations.LongRunningResourceCreateOrUpdate<Widget>;
-      `,
-      { preset: "azure", options: { "emit-lro-options": "all" } },
-    );
-
-    deepStrictEqual(
-      openapi.paths["/widgets/{widgetName}"].patch?.["x-ms-long-running-operation"],
-      true,
-    );
-    deepStrictEqual(
-      openapi.paths["/widgets/{widgetName}"].patch["x-ms-long-running-operation-options"],
+      ]>
+    )
+    @service(#{
+      title: "Contoso Widget Manager",
+    })
+    @server(
+      "{endpoint}/widget",
+      "Contoso Widget APIs",
       {
-        "final-state-via": "operation-location",
-        "final-state-schema": "#/definitions/Widget",
-      },
-    );
-    deepStrictEqual(
-      openapi.paths["/widgets/{widgetName}/operations/{operationId}"].get?.[
-        "x-ms-long-running-operation"
-      ],
-      undefined,
-    );
-  });
-
-  it("includes x-ms-long-running-operation for lro get", async () => {
-    const openapi = await compileOpenAPI(
-      `
-      using Azure.Core.Traits;
-
-      @service(#{
-        title: "Contoso Widget Manager",
-      })
-      namespace Test;
-
-      alias ServiceTraits = SupportsRepeatableRequests & SupportsConditionalRequests & SupportsClientRequestId;
-
-      alias Operations = Azure.Core.ResourceOperations<ServiceTraits>;
-
-      @resource("widgets")
-      model Widget {
-        @key("widgetName")
-        @visibility(Lifecycle.Read)
-        name: string;
-        manufacturerId: string;
-      
-      ...EtagProperty;
+        endpoint: string,
       }
+    )
+        namespace Test;
 
-      @Azure.ClientGenerator.Core.Legacy.markAsLro
-      op getWidgetOperationStatus is Operations.GetResourceOperationStatus<Widget>;
+    alias ServiceTraits = SupportsRepeatableRequests & SupportsConditionalRequests & SupportsClientRequestId;
+
+    alias Operations = Azure.Core.ResourceOperations<ServiceTraits>;
+
+    @resource("widgets")
     
-      @pollingOperation(getWidgetOperationStatus)
+    model Widget {
+      @key("widgetName")
+      
+      @visibility(Lifecycle.Read)
+      name: string;
+      
+      manufacturerId: string;
+    
+    ...EtagProperty;
+    }
+
+    op getWidgetOperationStatus is Operations.GetResourceOperationStatus<Widget>;
+  
+    @pollingOperation(getWidgetOperationStatus)
+    #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    op createOrUpdateWidget is Operations.LongRunningResourceCreateOrUpdate<Widget>;
+    `,
+    { preset: "azure", options: { "emit-lro-options": "all" } },
+  );
+
+  deepStrictEqual(
+    openapi.paths["/widgets/{widgetName}"].patch?.["x-ms-long-running-operation"],
+    true,
+  );
+  deepStrictEqual(
+    openapi.paths["/widgets/{widgetName}"].patch["x-ms-long-running-operation-options"],
+    {
+      "final-state-via": "operation-location",
+      "final-state-schema": "#/definitions/Widget",
+    },
+  );
+  deepStrictEqual(
+    openapi.paths["/widgets/{widgetName}/operations/{operationId}"].get?.[
+      "x-ms-long-running-operation"
+    ],
+    undefined,
+  );
+});
+
+it("includes x-ms-long-running-operation for lro get", async () => {
+  const openapi = await compileOpenAPI(
+    `
+    using Azure.Core.Traits;
+
+    @service(#{
+      title: "Contoso Widget Manager",
+    })
+    namespace Test;
+
+    alias ServiceTraits = SupportsRepeatableRequests & SupportsConditionalRequests & SupportsClientRequestId;
+
+    alias Operations = Azure.Core.ResourceOperations<ServiceTraits>;
+
+    @resource("widgets")
+    model Widget {
+      @key("widgetName")
+      @visibility(Lifecycle.Read)
+      name: string;
+      manufacturerId: string;
+    
+    ...EtagProperty;
+    }
+
+    @Azure.ClientGenerator.Core.Legacy.markAsLro
+    op getWidgetOperationStatus is Operations.GetResourceOperationStatus<Widget>;
+  
+    @pollingOperation(getWidgetOperationStatus)
+    #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    op createOrUpdateWidget is Operations.LongRunningResourceCreateOrUpdate<Widget>;
+    `,
+    { preset: "azure", options: { "emit-lro-options": "all" } },
+  );
+
+  deepStrictEqual(
+    openapi.paths["/widgets/{widgetName}/operations/{operationId}"].get?.[
+      "x-ms-long-running-operation"
+    ],
+    true,
+  );
+});
+
+const armCode = paramMessage`
+    @armProviderNamespace
+            namespace Microsoft.Test;
+
+    interface Operations extends Azure.ResourceManager.Operations {}
+
+    
+    enum ResourceState {
+     Succeeded,
+     Canceled,
+     Failed
+   }
+
+    
+    model WidgetProperties {
+      
+      simpleArmId: Azure.Core.armResourceIdentifier;
+
+      
+      provisioningState: ResourceState;
+    }
+
+    
+    model Widget is TrackedResource<WidgetProperties> {
+      
+      @key("widgetName")
+      @segment("widgets")
+      @path
+      name: string;
+    }
+    @armResourceOperations(Widget)
+    interface Widgets {
+      get is ArmResourceRead<Widget>;
+      ${"putOp"}
       #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-      op createOrUpdateWidget is Operations.LongRunningResourceCreateOrUpdate<Widget>;
-      `,
-      { preset: "azure", options: { "emit-lro-options": "all" } },
-    );
+      update is ArmResourcePatchAsync<Widget, WidgetProperties>;
+      delete is ArmResourceDeleteWithoutOkAsync<Widget>;
+      restart is ArmResourceActionAsync<Widget, void, never>;
+      munge is ArmResourceActionAsync<Widget, void, Widget>;
+      alter is ArmResourceActionAsync<Widget, void, void, LroHeaders=ArmAsyncOperationHeader<FinalResult = void>>;
+      listByResourceGroup is ArmResourceListByParent<Widget>;
+      listBySubscription is ArmListBySubscription<Widget>;
+    }
+    `;
+it("includes x-ms-long-running-operation-options for ARM operations", async () => {
+  const openapi = await compileOpenAPI(
+    armCode.apply(armCode, [
+      { putOp: "createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget>;" },
+    ]),
+    { preset: "azure", options: { "emit-lro-options": "all" } },
+  );
 
-    deepStrictEqual(
-      openapi.paths["/widgets/{widgetName}/operations/{operationId}"].get?.[
-        "x-ms-long-running-operation"
-      ],
-      true,
-    );
+  const itemPath =
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
+  deepStrictEqual(openapi.paths[itemPath].put?.["x-ms-long-running-operation"], true);
+  deepStrictEqual(openapi.paths[itemPath].put["x-ms-long-running-operation-options"], {
+    "final-state-via": "azure-async-operation",
+    "final-state-schema": "#/definitions/Widget",
   });
 
-  const armCode = paramMessage`
-      @armProviderNamespace
-              namespace Microsoft.Test;
+  deepStrictEqual(openapi.paths[itemPath].patch?.["x-ms-long-running-operation"], true);
+  deepStrictEqual(openapi.paths[itemPath].patch["x-ms-long-running-operation-options"], {
+    "final-state-via": "location",
+    "final-state-schema": "#/definitions/Widget",
+  });
 
-      interface Operations extends Azure.ResourceManager.Operations {}
+  deepStrictEqual(openapi.paths[itemPath].delete?.["x-ms-long-running-operation"], true);
+  deepStrictEqual(openapi.paths[itemPath].delete["x-ms-long-running-operation-options"], {
+    "final-state-via": "location",
+  });
+  const restartPath = `${itemPath}/restart`;
+  deepStrictEqual(openapi.paths[restartPath].post?.["x-ms-long-running-operation"], true);
+  deepStrictEqual(openapi.paths[restartPath].post["x-ms-long-running-operation-options"], {
+    "final-state-via": "location",
+  });
+  const mungePath = `${itemPath}/munge`;
+  deepStrictEqual(openapi.paths[mungePath].post?.["x-ms-long-running-operation"], true);
+  deepStrictEqual(openapi.paths[mungePath].post["x-ms-long-running-operation-options"], {
+    "final-state-via": "location",
+    "final-state-schema": "#/definitions/Widget",
+  });
+  const alterPath = `${itemPath}/alter`;
+  deepStrictEqual(openapi.paths[alterPath].post?.["x-ms-long-running-operation"], true);
+  deepStrictEqual(openapi.paths[alterPath].post["x-ms-long-running-operation-options"], {
+    "final-state-via": "azure-async-operation",
+  });
+});
+it("Uses final-state-via: location when location is provided for ARM PUT", async () => {
+  const openapi = await compileOpenAPI(
+    armCode.apply(armCode, [
+      {
+        putOp:
+          "createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget, LroHeaders = ArmLroLocationHeader<FinalResult = Widget> & Azure.Core.Foundations.RetryAfterHeader>;",
+      },
+    ]),
+    { preset: "azure", options: { "emit-lro-options": "all" } },
+  );
+
+  const itemPath =
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
+  deepStrictEqual(openapi.paths[itemPath].put?.["x-ms-long-running-operation"], true);
+  deepStrictEqual(openapi.paths[itemPath].put["x-ms-long-running-operation-options"], {
+    "final-state-via": "location",
+    "final-state-schema": "#/definitions/Widget",
+  });
+});
+it("Uses final-state-via: original-uri when no lro headers are provided for ARM PUT", async () => {
+  const openapi = await compileOpenAPI(
+    armCode.apply(armCode, [
+      {
+        putOp:
+          "createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget, LroHeaders = Azure.Core.Foundations.RetryAfterHeader>;",
+      },
+    ]),
+    { preset: "azure", options: { "emit-lro-options": "all" } },
+  );
+
+  const itemPath =
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
+  deepStrictEqual(openapi.paths[itemPath].put?.["x-ms-long-running-operation"], true);
+  deepStrictEqual(openapi.paths[itemPath].put["x-ms-long-running-operation-options"], {
+    "final-state-via": "original-uri",
+    "final-state-schema": "#/definitions/Widget",
+  });
+});
+
+it("Creates a final state schema for array types", async () => {
+  const openapi = await compileOpenAPI(
+    armCode.apply(armCode, [
+      {
+        putOp: "getProcessedWidgets is ArmResourceActionAsync<Widget, void, Widget[]>;",
+      },
+    ]),
+    { preset: "azure", options: { "emit-lro-options": "all" } },
+  );
+
+  const itemPath =
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/getProcessedWidgets";
+  deepStrictEqual(openapi.paths[itemPath].post?.["x-ms-long-running-operation"], true);
+  deepStrictEqual(openapi.paths[itemPath].post["x-ms-long-running-operation-options"], {
+    "final-state-via": "location",
+    "final-state-schema": "#/definitions/WidgetArray",
+  });
+});
+
+it("Creates a final state schema for unknown types", async () => {
+  const openapi = await compileOpenAPI(
+    armCode.apply(armCode, [
+      {
+        putOp: "getProcessedWidgets is ArmResourceActionAsync<Widget, void, unknown>;",
+      },
+    ]),
+    { preset: "azure", options: { "emit-lro-options": "all" } },
+  );
+
+  const itemPath =
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/getProcessedWidgets";
+  deepStrictEqual(openapi.paths[itemPath].post?.["x-ms-long-running-operation"], true);
+  deepStrictEqual(openapi.paths[itemPath].post["x-ms-long-running-operation-options"], {
+    "final-state-via": "location",
+    "final-state-schema": "#/definitions/unknown",
+  });
+});
+
+it("Allows azure-async-operation override without headers for ARM PUT", async () => {
+  const openapi = await compileOpenAPI(
+    armCode.apply(armCode, [
+      {
+        putOp: `#suppress "@azure-tools/typespec-azure-core/invalid-final-state" "test"
+        @useFinalStateVia("azure-async-operation")
+        createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget, LroHeaders = Azure.Core.Foundations.RetryAfterHeader>;
+        `,
+      },
+    ]),
+    { preset: "azure", options: { "emit-lro-options": "all" } },
+  );
+
+  const itemPath =
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
+  deepStrictEqual(openapi.paths[itemPath].put?.["x-ms-long-running-operation"], true);
+  deepStrictEqual(openapi.paths[itemPath].put["x-ms-long-running-operation-options"], {
+    "final-state-via": "azure-async-operation",
+    "final-state-schema": "#/definitions/Widget",
+  });
+});
+
+it("Creates a named final-state-schema definition for scalar final results", async () => {
+  const openapi = (await compileOpenAPI(
+    armCode.apply(armCode, [
+      {
+        putOp: "move is ArmResourceActionAsync<Widget, void, string>;",
+      },
+    ]),
+    { preset: "azure", options: { "emit-lro-options": "all" } },
+  )) as any;
+
+  const itemPath =
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/move";
+  deepStrictEqual(openapi.paths[itemPath].post?.["x-ms-long-running-operation"], true);
+  deepStrictEqual(openapi.paths[itemPath].post["x-ms-long-running-operation-options"], {
+    "final-state-via": "location",
+    "final-state-schema": "#/definitions/String",
+  });
+  // Verify the schema definition is created
+  deepStrictEqual(openapi.definitions["String"], { type: "string" });
+});
+
+it("Reuses the same schema when string is the finalResult in two operations", async () => {
+  const openapi = (await compileOpenAPI(
+    `
+    @armProviderNamespace
+    namespace Microsoft.Test;
+
+    interface Operations extends Azure.ResourceManager.Operations {}
+
+    
+    enum ResourceState {
+      Succeeded,
+      Canceled,
+      Failed
+    }
+
+    
+    model WidgetProperties {
+      
+      simpleArmId: Azure.Core.armResourceIdentifier;
 
       
-      enum ResourceState {
-       Succeeded,
-       Canceled,
-       Failed
-     }
+      provisioningState: ResourceState;
+    }
 
+    
+    model Widget is TrackedResource<WidgetProperties> {
       
-      model WidgetProperties {
-        
-        simpleArmId: Azure.Core.armResourceIdentifier;
+      @key("widgetName")
+      @segment("widgets")
+      @path
+      name: string;
+    }
 
-        
-        provisioningState: ResourceState;
-      }
+    @armResourceOperations(Widget)
+    interface Widgets {
+      get is ArmResourceRead<Widget>;
+      createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget>;
+      move is ArmResourceActionAsync<Widget, void, string>;
+      transfer is ArmResourceActionAsync<Widget, void, string>;
+    }
+    `,
+    { preset: "azure", options: { "emit-lro-options": "all" } },
+  )) as any;
 
-      
-      model Widget is TrackedResource<WidgetProperties> {
-        
-        @key("widgetName")
-        @segment("widgets")
-        @path
-        name: string;
-      }
-      @armResourceOperations(Widget)
-      interface Widgets {
-        get is ArmResourceRead<Widget>;
-        ${"putOp"}
-        #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-        update is ArmResourcePatchAsync<Widget, WidgetProperties>;
-        delete is ArmResourceDeleteWithoutOkAsync<Widget>;
-        restart is ArmResourceActionAsync<Widget, void, never>;
-        munge is ArmResourceActionAsync<Widget, void, Widget>;
-        alter is ArmResourceActionAsync<Widget, void, void, LroHeaders=ArmAsyncOperationHeader<FinalResult = void>>;
-        listByResourceGroup is ArmResourceListByParent<Widget>;
-        listBySubscription is ArmListBySubscription<Widget>;
-      }
-      `;
-  it("includes x-ms-long-running-operation-options for ARM operations", async () => {
-    const openapi = await compileOpenAPI(
-      armCode.apply(armCode, [
-        { putOp: "createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget>;" },
-      ]),
-      { preset: "azure", options: { "emit-lro-options": "all" } },
-    );
-
-    const itemPath =
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
-    deepStrictEqual(openapi.paths[itemPath].put?.["x-ms-long-running-operation"], true);
-    deepStrictEqual(openapi.paths[itemPath].put["x-ms-long-running-operation-options"], {
-      "final-state-via": "azure-async-operation",
-      "final-state-schema": "#/definitions/Widget",
-    });
-
-    deepStrictEqual(openapi.paths[itemPath].patch?.["x-ms-long-running-operation"], true);
-    deepStrictEqual(openapi.paths[itemPath].patch["x-ms-long-running-operation-options"], {
-      "final-state-via": "location",
-      "final-state-schema": "#/definitions/Widget",
-    });
-
-    deepStrictEqual(openapi.paths[itemPath].delete?.["x-ms-long-running-operation"], true);
-    deepStrictEqual(openapi.paths[itemPath].delete["x-ms-long-running-operation-options"], {
-      "final-state-via": "location",
-    });
-    const restartPath = `${itemPath}/restart`;
-    deepStrictEqual(openapi.paths[restartPath].post?.["x-ms-long-running-operation"], true);
-    deepStrictEqual(openapi.paths[restartPath].post["x-ms-long-running-operation-options"], {
-      "final-state-via": "location",
-    });
-    const mungePath = `${itemPath}/munge`;
-    deepStrictEqual(openapi.paths[mungePath].post?.["x-ms-long-running-operation"], true);
-    deepStrictEqual(openapi.paths[mungePath].post["x-ms-long-running-operation-options"], {
-      "final-state-via": "location",
-      "final-state-schema": "#/definitions/Widget",
-    });
-    const alterPath = `${itemPath}/alter`;
-    deepStrictEqual(openapi.paths[alterPath].post?.["x-ms-long-running-operation"], true);
-    deepStrictEqual(openapi.paths[alterPath].post["x-ms-long-running-operation-options"], {
-      "final-state-via": "azure-async-operation",
-    });
+  const basePath =
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
+  // Both operations should reference the same schema
+  deepStrictEqual(openapi.paths[`${basePath}/move`].post["x-ms-long-running-operation-options"], {
+    "final-state-via": "location",
+    "final-state-schema": "#/definitions/String",
   });
-  it("Uses final-state-via: location when location is provided for ARM PUT", async () => {
-    const openapi = await compileOpenAPI(
-      armCode.apply(armCode, [
-        {
-          putOp:
-            "createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget, LroHeaders = ArmLroLocationHeader<FinalResult = Widget> & Azure.Core.Foundations.RetryAfterHeader>;",
-        },
-      ]),
-      { preset: "azure", options: { "emit-lro-options": "all" } },
-    );
-
-    const itemPath =
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
-    deepStrictEqual(openapi.paths[itemPath].put?.["x-ms-long-running-operation"], true);
-    deepStrictEqual(openapi.paths[itemPath].put["x-ms-long-running-operation-options"], {
-      "final-state-via": "location",
-      "final-state-schema": "#/definitions/Widget",
-    });
-  });
-  it("Uses final-state-via: original-uri when no lro headers are provided for ARM PUT", async () => {
-    const openapi = await compileOpenAPI(
-      armCode.apply(armCode, [
-        {
-          putOp:
-            "createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget, LroHeaders = Azure.Core.Foundations.RetryAfterHeader>;",
-        },
-      ]),
-      { preset: "azure", options: { "emit-lro-options": "all" } },
-    );
-
-    const itemPath =
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
-    deepStrictEqual(openapi.paths[itemPath].put?.["x-ms-long-running-operation"], true);
-    deepStrictEqual(openapi.paths[itemPath].put["x-ms-long-running-operation-options"], {
-      "final-state-via": "original-uri",
-      "final-state-schema": "#/definitions/Widget",
-    });
-  });
-
-  it("Creates a final state schema for array types", async () => {
-    const openapi = await compileOpenAPI(
-      armCode.apply(armCode, [
-        {
-          putOp: "getProcessedWidgets is ArmResourceActionAsync<Widget, void, Widget[]>;",
-        },
-      ]),
-      { preset: "azure", options: { "emit-lro-options": "all" } },
-    );
-
-    const itemPath =
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/getProcessedWidgets";
-    deepStrictEqual(openapi.paths[itemPath].post?.["x-ms-long-running-operation"], true);
-    deepStrictEqual(openapi.paths[itemPath].post["x-ms-long-running-operation-options"], {
-      "final-state-via": "location",
-      "final-state-schema": "#/definitions/WidgetArray",
-    });
-  });
-
-  it("Creates a final state schema for unknown types", async () => {
-    const openapi = await compileOpenAPI(
-      armCode.apply(armCode, [
-        {
-          putOp: "getProcessedWidgets is ArmResourceActionAsync<Widget, void, unknown>;",
-        },
-      ]),
-      { preset: "azure", options: { "emit-lro-options": "all" } },
-    );
-
-    const itemPath =
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/getProcessedWidgets";
-    deepStrictEqual(openapi.paths[itemPath].post?.["x-ms-long-running-operation"], true);
-    deepStrictEqual(openapi.paths[itemPath].post["x-ms-long-running-operation-options"], {
-      "final-state-via": "location",
-      "final-state-schema": "#/definitions/unknown",
-    });
-  });
-
-  it("Allows azure-async-operation override without headers for ARM PUT", async () => {
-    const openapi = await compileOpenAPI(
-      armCode.apply(armCode, [
-        {
-          putOp: `#suppress "@azure-tools/typespec-azure-core/invalid-final-state" "test"
-          @useFinalStateVia("azure-async-operation")
-          createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget, LroHeaders = Azure.Core.Foundations.RetryAfterHeader>;
-          `,
-        },
-      ]),
-      { preset: "azure", options: { "emit-lro-options": "all" } },
-    );
-
-    const itemPath =
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
-    deepStrictEqual(openapi.paths[itemPath].put?.["x-ms-long-running-operation"], true);
-    deepStrictEqual(openapi.paths[itemPath].put["x-ms-long-running-operation-options"], {
-      "final-state-via": "azure-async-operation",
-      "final-state-schema": "#/definitions/Widget",
-    });
-  });
-
-  it("Creates a named final-state-schema definition for scalar final results", async () => {
-    const openapi = (await compileOpenAPI(
-      armCode.apply(armCode, [
-        {
-          putOp: "move is ArmResourceActionAsync<Widget, void, string>;",
-        },
-      ]),
-      { preset: "azure", options: { "emit-lro-options": "all" } },
-    )) as any;
-
-    const itemPath =
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}/move";
-    deepStrictEqual(openapi.paths[itemPath].post?.["x-ms-long-running-operation"], true);
-    deepStrictEqual(openapi.paths[itemPath].post["x-ms-long-running-operation-options"], {
+  deepStrictEqual(
+    openapi.paths[`${basePath}/transfer`].post["x-ms-long-running-operation-options"],
+    {
       "final-state-via": "location",
       "final-state-schema": "#/definitions/String",
-    });
-    // Verify the schema definition is created
-    deepStrictEqual(openapi.definitions["String"], { type: "string" });
+    },
+  );
+  // Only one String schema should exist
+  deepStrictEqual(openapi.definitions["String"], { type: "string" });
+});
+
+it("Creates separate schemas for two custom scalars with different names", async () => {
+  const openapi = (await compileOpenAPI(
+    `
+    @armProviderNamespace
+    namespace Microsoft.Test;
+
+    interface Operations extends Azure.ResourceManager.Operations {}
+
+    
+    enum ResourceState {
+      Succeeded,
+      Canceled,
+      Failed
+    }
+
+    
+    model WidgetProperties {
+      
+      simpleArmId: Azure.Core.armResourceIdentifier;
+
+      
+      provisioningState: ResourceState;
+    }
+
+    
+    model Widget is TrackedResource<WidgetProperties> {
+      
+      @key("widgetName")
+      @segment("widgets")
+      @path
+      name: string;
+    }
+
+    scalar widgetId extends string;
+    scalar widgetTag extends string;
+
+    @armResourceOperations(Widget)
+    interface Widgets {
+      get is ArmResourceRead<Widget>;
+      createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget>;
+      move is ArmResourceActionAsync<Widget, void, widgetId>;
+      transfer is ArmResourceActionAsync<Widget, void, widgetTag>;
+    }
+    `,
+    { preset: "azure", options: { "emit-lro-options": "all" } },
+  )) as any;
+
+  const basePath =
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
+  deepStrictEqual(openapi.paths[`${basePath}/move`].post["x-ms-long-running-operation-options"], {
+    "final-state-via": "location",
+    "final-state-schema": "#/definitions/widgetId",
   });
-
-  it("Reuses the same schema when string is the finalResult in two operations", async () => {
-    const openapi = (await compileOpenAPI(
-      `
-      @armProviderNamespace
-      namespace Microsoft.Test;
-
-      interface Operations extends Azure.ResourceManager.Operations {}
-
-      
-      enum ResourceState {
-        Succeeded,
-        Canceled,
-        Failed
-      }
-
-      
-      model WidgetProperties {
-        
-        simpleArmId: Azure.Core.armResourceIdentifier;
-
-        
-        provisioningState: ResourceState;
-      }
-
-      
-      model Widget is TrackedResource<WidgetProperties> {
-        
-        @key("widgetName")
-        @segment("widgets")
-        @path
-        name: string;
-      }
-
-      @armResourceOperations(Widget)
-      interface Widgets {
-        get is ArmResourceRead<Widget>;
-        createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget>;
-        move is ArmResourceActionAsync<Widget, void, string>;
-        transfer is ArmResourceActionAsync<Widget, void, string>;
-      }
-      `,
-      { preset: "azure", options: { "emit-lro-options": "all" } },
-    )) as any;
-
-    const basePath =
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
-    // Both operations should reference the same schema
-    deepStrictEqual(openapi.paths[`${basePath}/move`].post["x-ms-long-running-operation-options"], {
+  deepStrictEqual(
+    openapi.paths[`${basePath}/transfer`].post["x-ms-long-running-operation-options"],
+    {
       "final-state-via": "location",
-      "final-state-schema": "#/definitions/String",
-    });
-    deepStrictEqual(
-      openapi.paths[`${basePath}/transfer`].post["x-ms-long-running-operation-options"],
-      {
-        "final-state-via": "location",
-        "final-state-schema": "#/definitions/String",
-      },
-    );
-    // Only one String schema should exist
-    deepStrictEqual(openapi.definitions["String"], { type: "string" });
+      "final-state-schema": "#/definitions/widgetTag",
+    },
+  );
+  // Both schemas should exist separately
+  deepStrictEqual(openapi.definitions["widgetId"], { type: "string" });
+  deepStrictEqual(openapi.definitions["widgetTag"], { type: "string" });
+});
+
+it("Preserves camelCase in custom scalar names for final-state-schema", async () => {
+  const openapi = (await compileOpenAPI(
+    `
+    @armProviderNamespace
+    namespace Microsoft.Test;
+
+    interface Operations extends Azure.ResourceManager.Operations {}
+
+    
+    enum ResourceState {
+      Succeeded,
+      Canceled,
+      Failed
+    }
+
+    
+    model WidgetProperties {
+      
+      simpleArmId: Azure.Core.armResourceIdentifier;
+
+      
+      provisioningState: ResourceState;
+    }
+
+    
+    model Widget is TrackedResource<WidgetProperties> {
+      
+      @key("widgetName")
+      @segment("widgets")
+      @path
+      name: string;
+    }
+
+    scalar myCustomResult extends string;
+
+    @armResourceOperations(Widget)
+    interface Widgets {
+      get is ArmResourceRead<Widget>;
+      createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget>;
+      move is ArmResourceActionAsync<Widget, void, myCustomResult>;
+    }
+    `,
+    { preset: "azure", options: { "emit-lro-options": "all" } },
+  )) as any;
+
+  const basePath =
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
+  deepStrictEqual(openapi.paths[`${basePath}/move`].post["x-ms-long-running-operation-options"], {
+    "final-state-via": "location",
+    "final-state-schema": "#/definitions/myCustomResult",
   });
+  // Verify the schema definition preserves the camelCase name
+  deepStrictEqual(openapi.definitions["myCustomResult"], { type: "string" });
+});
 
-  it("Creates separate schemas for two custom scalars with different names", async () => {
-    const openapi = (await compileOpenAPI(
-      `
-      @armProviderNamespace
-      namespace Microsoft.Test;
+it("Creates separate schemas for custom scalars with the same name in different namespaces", async () => {
+  const openapi = (await compileOpenAPI(
+    `
+    @armProviderNamespace
+    namespace Microsoft.Test;
 
-      interface Operations extends Azure.ResourceManager.Operations {}
+    interface Operations extends Azure.ResourceManager.Operations {}
+
+    
+    enum ResourceState {
+      Succeeded,
+      Canceled,
+      Failed
+    }
+
+    
+    model WidgetProperties {
+      
+      simpleArmId: Azure.Core.armResourceIdentifier;
 
       
-      enum ResourceState {
-        Succeeded,
-        Canceled,
-        Failed
-      }
+      provisioningState: ResourceState;
+    }
 
+    
+    model Widget is TrackedResource<WidgetProperties> {
       
-      model WidgetProperties {
-        
-        simpleArmId: Azure.Core.armResourceIdentifier;
+      @key("widgetName")
+      @segment("widgets")
+      @path
+      name: string;
+    }
 
-        
-        provisioningState: ResourceState;
-      }
+    namespace Ns1 {
+      scalar customResult extends string;
+    }
+    namespace Ns2 {
+      scalar customResult extends int32;
+    }
 
-      
-      model Widget is TrackedResource<WidgetProperties> {
-        
-        @key("widgetName")
-        @segment("widgets")
-        @path
-        name: string;
-      }
+    @armResourceOperations(Widget)
+    interface Widgets {
+      get is ArmResourceRead<Widget>;
+      createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget>;
+      move is ArmResourceActionAsync<Widget, void, Ns1.customResult>;
+      transfer is ArmResourceActionAsync<Widget, void, Ns2.customResult>;
+    }
+    `,
+    { preset: "azure", options: { "emit-lro-options": "all" } },
+  )) as any;
 
-      scalar widgetId extends string;
-      scalar widgetTag extends string;
-
-      @armResourceOperations(Widget)
-      interface Widgets {
-        get is ArmResourceRead<Widget>;
-        createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget>;
-        move is ArmResourceActionAsync<Widget, void, widgetId>;
-        transfer is ArmResourceActionAsync<Widget, void, widgetTag>;
-      }
-      `,
-      { preset: "azure", options: { "emit-lro-options": "all" } },
-    )) as any;
-
-    const basePath =
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
-    deepStrictEqual(openapi.paths[`${basePath}/move`].post["x-ms-long-running-operation-options"], {
-      "final-state-via": "location",
-      "final-state-schema": "#/definitions/widgetId",
-    });
-    deepStrictEqual(
-      openapi.paths[`${basePath}/transfer`].post["x-ms-long-running-operation-options"],
-      {
-        "final-state-via": "location",
-        "final-state-schema": "#/definitions/widgetTag",
-      },
-    );
-    // Both schemas should exist separately
-    deepStrictEqual(openapi.definitions["widgetId"], { type: "string" });
-    deepStrictEqual(openapi.definitions["widgetTag"], { type: "string" });
-  });
-
-  it("Preserves camelCase in custom scalar names for final-state-schema", async () => {
-    const openapi = (await compileOpenAPI(
-      `
-      @armProviderNamespace
-      namespace Microsoft.Test;
-
-      interface Operations extends Azure.ResourceManager.Operations {}
-
-      
-      enum ResourceState {
-        Succeeded,
-        Canceled,
-        Failed
-      }
-
-      
-      model WidgetProperties {
-        
-        simpleArmId: Azure.Core.armResourceIdentifier;
-
-        
-        provisioningState: ResourceState;
-      }
-
-      
-      model Widget is TrackedResource<WidgetProperties> {
-        
-        @key("widgetName")
-        @segment("widgets")
-        @path
-        name: string;
-      }
-
-      scalar myCustomResult extends string;
-
-      @armResourceOperations(Widget)
-      interface Widgets {
-        get is ArmResourceRead<Widget>;
-        createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget>;
-        move is ArmResourceActionAsync<Widget, void, myCustomResult>;
-      }
-      `,
-      { preset: "azure", options: { "emit-lro-options": "all" } },
-    )) as any;
-
-    const basePath =
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
-    deepStrictEqual(openapi.paths[`${basePath}/move`].post["x-ms-long-running-operation-options"], {
-      "final-state-via": "location",
-      "final-state-schema": "#/definitions/myCustomResult",
-    });
-    // Verify the schema definition preserves the camelCase name
-    deepStrictEqual(openapi.definitions["myCustomResult"], { type: "string" });
-  });
-
-  it("Creates separate schemas for custom scalars with the same name in different namespaces", async () => {
-    const openapi = (await compileOpenAPI(
-      `
-      @armProviderNamespace
-      namespace Microsoft.Test;
-
-      interface Operations extends Azure.ResourceManager.Operations {}
-
-      
-      enum ResourceState {
-        Succeeded,
-        Canceled,
-        Failed
-      }
-
-      
-      model WidgetProperties {
-        
-        simpleArmId: Azure.Core.armResourceIdentifier;
-
-        
-        provisioningState: ResourceState;
-      }
-
-      
-      model Widget is TrackedResource<WidgetProperties> {
-        
-        @key("widgetName")
-        @segment("widgets")
-        @path
-        name: string;
-      }
-
-      namespace Ns1 {
-        scalar customResult extends string;
-      }
-      namespace Ns2 {
-        scalar customResult extends int32;
-      }
-
-      @armResourceOperations(Widget)
-      interface Widgets {
-        get is ArmResourceRead<Widget>;
-        createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget>;
-        move is ArmResourceActionAsync<Widget, void, Ns1.customResult>;
-        transfer is ArmResourceActionAsync<Widget, void, Ns2.customResult>;
-      }
-      `,
-      { preset: "azure", options: { "emit-lro-options": "all" } },
-    )) as any;
-
-    const basePath =
-      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
-    deepStrictEqual(
-      openapi.paths[`${basePath}/move`].post["x-ms-long-running-operation-options"][
-        "final-state-via"
-      ],
-      "location",
-    );
-    deepStrictEqual(
-      openapi.paths[`${basePath}/transfer`].post["x-ms-long-running-operation-options"][
-        "final-state-via"
-      ],
-      "location",
-    );
-    // Both should have distinct final-state-schema references
-    const moveSchema =
-      openapi.paths[`${basePath}/move`].post["x-ms-long-running-operation-options"][
-        "final-state-schema"
-      ];
-    const transferSchema =
-      openapi.paths[`${basePath}/transfer`].post["x-ms-long-running-operation-options"][
-        "final-state-schema"
-      ];
-    // Both should have distinct, specifically-named schema references
-    deepStrictEqual(moveSchema, "#/definitions/Ns1.customResult");
-    deepStrictEqual(transferSchema, "#/definitions/Ns2.customResult");
-    // Both schemas should exist with correct types
-    deepStrictEqual(openapi.definitions["Ns1.customResult"], { type: "string" });
-    deepStrictEqual(openapi.definitions["Ns2.customResult"], { type: "integer", format: "int32" });
-  });
+  const basePath =
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
+  deepStrictEqual(
+    openapi.paths[`${basePath}/move`].post["x-ms-long-running-operation-options"][
+      "final-state-via"
+    ],
+    "location",
+  );
+  deepStrictEqual(
+    openapi.paths[`${basePath}/transfer`].post["x-ms-long-running-operation-options"][
+      "final-state-via"
+    ],
+    "location",
+  );
+  // Both should have distinct final-state-schema references
+  const moveSchema =
+    openapi.paths[`${basePath}/move`].post["x-ms-long-running-operation-options"][
+      "final-state-schema"
+    ];
+  const transferSchema =
+    openapi.paths[`${basePath}/transfer`].post["x-ms-long-running-operation-options"][
+      "final-state-schema"
+    ];
+  // Both should have distinct, specifically-named schema references
+  deepStrictEqual(moveSchema, "#/definitions/Ns1.customResult");
+  deepStrictEqual(transferSchema, "#/definitions/Ns2.customResult");
+  // Both schemas should exist with correct types
+  deepStrictEqual(openapi.definitions["Ns1.customResult"], { type: "string" });
+  deepStrictEqual(openapi.definitions["Ns2.customResult"], { type: "integer", format: "int32" });
 });

--- a/packages/typespec-autorest/test/metadata.test.ts
+++ b/packages/typespec-autorest/test/metadata.test.ts
@@ -2,671 +2,669 @@ import { deepStrictEqual, strictEqual } from "assert";
 import { describe, it } from "vitest";
 import { openApiFor } from "./test-host.js";
 
-describe("typespec-autorest: metadata", () => {
-  it("will expose create visibility properties on PATCH model using @requestVisibility", async () => {
-    const res = await openApiFor(`
-      model M {
-        @visibility(Lifecycle.Read) r: string;
-        @visibility(Lifecycle.Read, Lifecycle.Create) rc?: string;
-        @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create) ruc?: string;
-      }
-      @parameterVisibility(Lifecycle.Create, Lifecycle.Update)
-      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-      @route("/") @patch(#{implicitOptionality: true}) op createOrUpdate(...M): M; 
-    `);
-
-    const response = res.paths["/"].patch.responses["200"].schema;
-    const request = res.paths["/"].patch.parameters[0].schema;
-
-    deepStrictEqual(response, { $ref: "#/definitions/M" });
-    deepStrictEqual(request, { $ref: "#/definitions/MCreateOrUpdate" });
-    deepStrictEqual(res.definitions, {
-      M: {
-        type: "object",
-        properties: {
-          r: { type: "string", readOnly: true },
-          rc: { type: "string", "x-ms-mutability": ["read", "create"] },
-          ruc: { type: "string", "x-ms-mutability": ["read", "update", "create"] },
-        },
-        required: ["r"],
-      },
-      MCreateOrUpdate: {
-        type: "object",
-        properties: {
-          rc: { type: "string", "x-ms-mutability": ["read", "create"] },
-          ruc: { type: "string", "x-ms-mutability": ["read", "update", "create"] },
-        },
-      },
-    });
-  });
-
-  it("will expose create visibility properties on PUT model", async () => {
-    const res = await openApiFor(`
-      model M {
-        @visibility(Lifecycle.Read) r: string;
-        @visibility(Lifecycle.Read, Lifecycle.Create) rc?: string;
-        @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create) ruc?: string;
-      }
-      @route("/") @put op createOrUpdate(...M): M; 
-    `);
-
-    const response = res.paths["/"].put.responses["200"].schema;
-    const request = res.paths["/"].put.parameters[0].schema;
-
-    deepStrictEqual(response, { $ref: "#/definitions/M" });
-    deepStrictEqual(request, { $ref: "#/definitions/M" });
-    deepStrictEqual(res.definitions, {
-      M: {
-        type: "object",
-        properties: {
-          r: { type: "string", readOnly: true },
-          rc: { type: "string", "x-ms-mutability": ["read", "create"] },
-          ruc: { type: "string", "x-ms-mutability": ["read", "update", "create"] },
-        },
-        required: ["r"],
-      },
-    });
-  });
-
-  it("ensures properties are required for array updates", async () => {
-    const res = await openApiFor(`
-      model Person {
-        @visibility(Lifecycle.Read) id: string;
-        @visibility(Lifecycle.Create) secret: string;
-        name: string;
-      
-        @visibility(Lifecycle.Read, Lifecycle.Create)
-        test: string;
-      
-        @visibility(Lifecycle.Read, Lifecycle.Update)
-        other: string;
-      
-        @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
-        relatives: PersonRelative[];
-      }
-      
-      model PersonRelative {
-        person: Person;
-        relationship: string;
-      }
-      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-      @route("/") @patch(#{implicitOptionality: true}) op update(...Person): Person; 
-    `);
-
-    const response = res.paths["/"].patch.responses["200"].schema;
-    const request = res.paths["/"].patch.parameters[0].schema;
-
-    deepStrictEqual(response, { $ref: "#/definitions/Person" });
-    deepStrictEqual(request, { $ref: "#/definitions/PersonUpdate" });
-    deepStrictEqual(res.definitions.PersonUpdate, {
-      type: "object",
-      properties: {
-        name: { type: "string" },
-        other: { type: "string", "x-ms-mutability": ["read", "update"] },
-        relatives: {
-          type: "array",
-          "x-ms-mutability": ["read", "update", "create"],
-          items: { $ref: "#/definitions/PersonRelative" },
-        },
-      },
-    });
-    deepStrictEqual(res.definitions.PersonRelative, {
-      type: "object",
-      properties: {
-        person: { $ref: "#/definitions/Person" },
-        relationship: { type: "string" },
-      },
-      required: ["person", "relationship"],
-    });
-    deepStrictEqual(res.definitions.Person, {
-      type: "object",
-      properties: {
-        id: { type: "string", readOnly: true },
-        name: { type: "string" },
-        other: { type: "string", "x-ms-mutability": ["read", "update"] },
-        relatives: {
-          type: "array",
-          "x-ms-mutability": ["read", "update", "create"],
-          items: { $ref: "#/definitions/PersonRelative" },
-        },
-        secret: { type: "string", "x-ms-mutability": ["create"] },
-        test: { type: "string", "x-ms-mutability": ["read", "create"] },
-      },
-      required: ["id", "secret", "name", "test", "other", "relatives"],
-    });
-  });
-
-  it("can share read, update, create visibility via x-ms-mutability or readonly", async () => {
-    const res = await openApiFor(`
+it("will expose create visibility properties on PATCH model using @requestVisibility", async () => {
+  const res = await openApiFor(`
     model M {
-      @visibility(Lifecycle.Read) r?: string;
-      @visibility(Lifecycle.Create) c?: string;
-      @visibility(Lifecycle.Update) u?: string;
-      @visibility(Lifecycle.Update, Lifecycle.Create) uc?: string;
+      @visibility(Lifecycle.Read) r: string;
+      @visibility(Lifecycle.Read, Lifecycle.Create) rc?: string;
       @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create) ruc?: string;
-      
     }
-    @route("/") @post op create(...M): M; 
+    @parameterVisibility(Lifecycle.Create, Lifecycle.Update)
+    #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    @route("/") @patch(#{implicitOptionality: true}) op createOrUpdate(...M): M; 
   `);
 
-    const request = res.paths["/"].post.parameters[0].schema;
-    deepStrictEqual(request, { $ref: "#/definitions/M" });
+  const response = res.paths["/"].patch.responses["200"].schema;
+  const request = res.paths["/"].patch.parameters[0].schema;
 
-    const response = res.paths["/"].post.responses["200"].schema;
-    deepStrictEqual(response, { $ref: "#/definitions/M" });
-
-    deepStrictEqual(res.definitions, {
-      M: {
-        type: "object",
-        properties: {
-          r: { type: "string", readOnly: true }, // x-ms-mutability: ["read"] not used when readOnly: true can suffice
-          c: { type: "string", "x-ms-mutability": ["create"] },
-          u: { type: "string", "x-ms-mutability": ["update"] },
-          uc: { type: "string", "x-ms-mutability": ["update", "create"] },
-          ruc: { type: "string", "x-ms-mutability": ["read", "update", "create"] },
-        },
+  deepStrictEqual(response, { $ref: "#/definitions/M" });
+  deepStrictEqual(request, { $ref: "#/definitions/MCreateOrUpdate" });
+  deepStrictEqual(res.definitions, {
+    M: {
+      type: "object",
+      properties: {
+        r: { type: "string", readOnly: true },
+        rc: { type: "string", "x-ms-mutability": ["read", "create"] },
+        ruc: { type: "string", "x-ms-mutability": ["read", "update", "create"] },
       },
-    });
+      required: ["r"],
+    },
+    MCreateOrUpdate: {
+      type: "object",
+      properties: {
+        rc: { type: "string", "x-ms-mutability": ["read", "create"] },
+        ruc: { type: "string", "x-ms-mutability": ["read", "update", "create"] },
+      },
+    },
   });
+});
 
-  it("does not emit invisible, unshared readonly properties", async () => {
-    const res = await openApiFor(`
+it("will expose create visibility properties on PUT model", async () => {
+  const res = await openApiFor(`
     model M {
-      @visibility(Lifecycle.Read) r?: string;
-      @visibility(Lifecycle.Query) q?: string;
-      @visibility(Lifecycle.Delete) d?: string;
+      @visibility(Lifecycle.Read) r: string;
+      @visibility(Lifecycle.Read, Lifecycle.Create) rc?: string;
+      @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create) ruc?: string;
     }
-    @route("/") @get op get(...M): M; 
+    @route("/") @put op createOrUpdate(...M): M; 
   `);
 
-    const request = res.paths["/"].get.parameters[0].schema;
-    deepStrictEqual(request, { $ref: "#/definitions/MQuery" });
+  const response = res.paths["/"].put.responses["200"].schema;
+  const request = res.paths["/"].put.parameters[0].schema;
 
-    const response = res.paths["/"].get.responses["200"].schema;
-    deepStrictEqual(response, { $ref: "#/definitions/M" });
-
-    deepStrictEqual(res.definitions, {
-      MQuery: {
-        type: "object",
-        properties: {
-          q: { type: "string" },
-        },
+  deepStrictEqual(response, { $ref: "#/definitions/M" });
+  deepStrictEqual(request, { $ref: "#/definitions/M" });
+  deepStrictEqual(res.definitions, {
+    M: {
+      type: "object",
+      properties: {
+        r: { type: "string", readOnly: true },
+        rc: { type: "string", "x-ms-mutability": ["read", "create"] },
+        ruc: { type: "string", "x-ms-mutability": ["read", "update", "create"] },
       },
-      M: {
-        type: "object",
-        properties: {
-          r: { type: "string", readOnly: true },
-        },
-      },
-    });
+      required: ["r"],
+    },
   });
+});
 
-  it("bubbles up visibility changes to referencers", async () => {
-    const res = await openApiFor(
-      `
-    model M {
-      @visibility(Lifecycle.Read) r?: string;
-      @visibility(Lifecycle.Create) c?: string;
-      @visibility(Lifecycle.Update) u?: string;
-      @visibility(Lifecycle.Delete) d?: string;
-      @visibility(Lifecycle.Query) q?: string;
-    }
-
-    // base model
-    model D extends M {}
+it("ensures properties are required for array updates", async () => {
+  const res = await openApiFor(`
+    model Person {
+      @visibility(Lifecycle.Read) id: string;
+      @visibility(Lifecycle.Create) secret: string;
+      name: string;
     
-    // property type
-    model R {
-      m?: M; 
+      @visibility(Lifecycle.Read, Lifecycle.Create)
+      test: string;
+    
+      @visibility(Lifecycle.Read, Lifecycle.Update)
+      other: string;
+    
+      @visibility(Lifecycle.Read, Lifecycle.Create, Lifecycle.Update)
+      relatives: PersonRelative[];
     }
-    // array element type
-    model A {
-      a?: M[];
+    
+    model PersonRelative {
+      person: Person;
+      relationship: string;
     }
+    #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    @route("/") @patch(#{implicitOptionality: true}) op update(...Person): Person; 
+  `);
 
-    @route("/M")
-    interface IM {
-      @get get(...M): M;
-      @post create(...M): M;
-      @put createOrUpdate(...M): M;
-      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-      @patch(#{implicitOptionality: true}) update(...M): M;
-      @delete delete(...M): void; 
-    }
+  const response = res.paths["/"].patch.responses["200"].schema;
+  const request = res.paths["/"].patch.parameters[0].schema;
 
-    @route("/D")
-    interface ID {
-      @get get(...D): D;
-      @post create(...D): D;
-      @put createOrUpdate(...D): D;
-      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-      @patch(#{implicitOptionality: true}) update(...D): D;
-      @delete delete(...D): void; 
-    }
+  deepStrictEqual(response, { $ref: "#/definitions/Person" });
+  deepStrictEqual(request, { $ref: "#/definitions/PersonUpdate" });
+  deepStrictEqual(res.definitions.PersonUpdate, {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      other: { type: "string", "x-ms-mutability": ["read", "update"] },
+      relatives: {
+        type: "array",
+        "x-ms-mutability": ["read", "update", "create"],
+        items: { $ref: "#/definitions/PersonRelative" },
+      },
+    },
+  });
+  deepStrictEqual(res.definitions.PersonRelative, {
+    type: "object",
+    properties: {
+      person: { $ref: "#/definitions/Person" },
+      relationship: { type: "string" },
+    },
+    required: ["person", "relationship"],
+  });
+  deepStrictEqual(res.definitions.Person, {
+    type: "object",
+    properties: {
+      id: { type: "string", readOnly: true },
+      name: { type: "string" },
+      other: { type: "string", "x-ms-mutability": ["read", "update"] },
+      relatives: {
+        type: "array",
+        "x-ms-mutability": ["read", "update", "create"],
+        items: { $ref: "#/definitions/PersonRelative" },
+      },
+      secret: { type: "string", "x-ms-mutability": ["create"] },
+      test: { type: "string", "x-ms-mutability": ["read", "create"] },
+    },
+    required: ["id", "secret", "name", "test", "other", "relatives"],
+  });
+});
+
+it("can share read, update, create visibility via x-ms-mutability or readonly", async () => {
+  const res = await openApiFor(`
+  model M {
+    @visibility(Lifecycle.Read) r?: string;
+    @visibility(Lifecycle.Create) c?: string;
+    @visibility(Lifecycle.Update) u?: string;
+    @visibility(Lifecycle.Update, Lifecycle.Create) uc?: string;
+    @visibility(Lifecycle.Read, Lifecycle.Update, Lifecycle.Create) ruc?: string;
+    
+  }
+  @route("/") @post op create(...M): M; 
+`);
+
+  const request = res.paths["/"].post.parameters[0].schema;
+  deepStrictEqual(request, { $ref: "#/definitions/M" });
+
+  const response = res.paths["/"].post.responses["200"].schema;
+  deepStrictEqual(response, { $ref: "#/definitions/M" });
+
+  deepStrictEqual(res.definitions, {
+    M: {
+      type: "object",
+      properties: {
+        r: { type: "string", readOnly: true }, // x-ms-mutability: ["read"] not used when readOnly: true can suffice
+        c: { type: "string", "x-ms-mutability": ["create"] },
+        u: { type: "string", "x-ms-mutability": ["update"] },
+        uc: { type: "string", "x-ms-mutability": ["update", "create"] },
+        ruc: { type: "string", "x-ms-mutability": ["read", "update", "create"] },
+      },
+    },
+  });
+});
+
+it("does not emit invisible, unshared readonly properties", async () => {
+  const res = await openApiFor(`
+  model M {
+    @visibility(Lifecycle.Read) r?: string;
+    @visibility(Lifecycle.Query) q?: string;
+    @visibility(Lifecycle.Delete) d?: string;
+  }
+  @route("/") @get op get(...M): M; 
+`);
+
+  const request = res.paths["/"].get.parameters[0].schema;
+  deepStrictEqual(request, { $ref: "#/definitions/MQuery" });
+
+  const response = res.paths["/"].get.responses["200"].schema;
+  deepStrictEqual(response, { $ref: "#/definitions/M" });
+
+  deepStrictEqual(res.definitions, {
+    MQuery: {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+      },
+    },
+    M: {
+      type: "object",
+      properties: {
+        r: { type: "string", readOnly: true },
+      },
+    },
+  });
+});
+
+it("bubbles up visibility changes to referencers", async () => {
+  const res = await openApiFor(
+    `
+  model M {
+    @visibility(Lifecycle.Read) r?: string;
+    @visibility(Lifecycle.Create) c?: string;
+    @visibility(Lifecycle.Update) u?: string;
+    @visibility(Lifecycle.Delete) d?: string;
+    @visibility(Lifecycle.Query) q?: string;
+  }
+
+  // base model
+  model D extends M {}
   
-    @route("/R") 
-    interface IR {
-      @get op get(id: string): R;
-      @post op create(...R): R;
-      @put op createOrUpdate(...R): R;
-      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-      @patch(#{implicitOptionality: true}) op update(...R): R;
-      @delete op delete(...D): void; 
+  // property type
+  model R {
+    m?: M; 
+  }
+  // array element type
+  model A {
+    a?: M[];
+  }
+
+  @route("/M")
+  interface IM {
+    @get get(...M): M;
+    @post create(...M): M;
+    @put createOrUpdate(...M): M;
+    #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    @patch(#{implicitOptionality: true}) update(...M): M;
+    @delete delete(...M): void; 
+  }
+
+  @route("/D")
+  interface ID {
+    @get get(...D): D;
+    @post create(...D): D;
+    @put createOrUpdate(...D): D;
+    #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    @patch(#{implicitOptionality: true}) update(...D): D;
+    @delete delete(...D): void; 
+  }
+
+  @route("/R") 
+  interface IR {
+    @get op get(id: string): R;
+    @post op create(...R): R;
+    @put op createOrUpdate(...R): R;
+    #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    @patch(#{implicitOptionality: true}) op update(...R): R;
+    @delete op delete(...D): void; 
+  }
+
+  `,
+    undefined,
+    { "omit-unreachable-types": true },
+  );
+
+  deepStrictEqual(res.definitions, {
+    M: {
+      type: "object",
+      properties: {
+        r: {
+          type: "string",
+          readOnly: true,
+        },
+        c: {
+          type: "string",
+          "x-ms-mutability": ["create"],
+        },
+        u: {
+          type: "string",
+          "x-ms-mutability": ["update"],
+        },
+      },
+    },
+    MDelete: {
+      type: "object",
+      properties: {
+        d: {
+          type: "string",
+        },
+      },
+    },
+    MQuery: {
+      type: "object",
+      properties: {
+        q: {
+          type: "string",
+        },
+      },
+    },
+    D: {
+      type: "object",
+      allOf: [
+        {
+          $ref: "#/definitions/M",
+        },
+      ],
+    },
+    DDelete: {
+      type: "object",
+      allOf: [
+        {
+          $ref: "#/definitions/MDelete",
+        },
+      ],
+    },
+    DQuery: {
+      type: "object",
+      allOf: [
+        {
+          $ref: "#/definitions/MQuery",
+        },
+      ],
+    },
+    R: {
+      type: "object",
+      properties: {
+        m: {
+          $ref: "#/definitions/M",
+        },
+      },
+    },
+  });
+});
+
+it("puts inapplicable metadata in schema", async () => {
+  const res = await openApiFor(
+    `
+    model Parameters {
+     @query q: string;
+     @path p: string;
+     @header h: string;
+    }
+    @route("/single") @get op single(...Parameters): string;
+    @route("/batch") @get op batch(@bodyRoot body: Parameters[]): string;
+    `,
+  );
+  deepStrictEqual(res.paths, {
+    "/single/{p}": {
+      get: {
+        operationId: "Single",
+        produces: ["text/plain"],
+        parameters: [
+          { $ref: "#/parameters/Parameters.q" },
+          { $ref: "#/parameters/Parameters.p" },
+          { $ref: "#/parameters/Parameters.h" },
+        ],
+        responses: {
+          "200": {
+            description: "The request has succeeded.",
+            schema: { type: "string" },
+          },
+        },
+      },
+    },
+    "/batch": {
+      get: {
+        operationId: "Batch",
+        produces: ["text/plain"],
+        responses: {
+          "200": {
+            description: "The request has succeeded.",
+            schema: { type: "string" },
+          },
+        },
+        parameters: [
+          {
+            in: "body",
+            name: "body",
+            required: true,
+            schema: {
+              type: "array",
+              items: { $ref: "#/definitions/Parameters" },
+            },
+          },
+        ],
+      },
+    },
+  });
+  deepStrictEqual(res.parameters, {
+    "Parameters.q": {
+      name: "q",
+      in: "query",
+      required: true,
+      type: "string",
+      "x-ms-parameter-location": "method",
+    },
+    "Parameters.p": {
+      name: "p",
+      in: "path",
+      required: true,
+      type: "string",
+      "x-ms-parameter-location": "method",
+    },
+    "Parameters.h": {
+      name: "h",
+      in: "header",
+      required: true,
+      type: "string",
+      "x-ms-parameter-location": "method",
+    },
+  });
+
+  deepStrictEqual(res.definitions, {
+    Parameters: {
+      properties: {
+        h: {
+          type: "string",
+        },
+        p: {
+          type: "string",
+        },
+        q: {
+          type: "string",
+        },
+      },
+      required: ["q", "p", "h"],
+      type: "object",
+    },
+  });
+});
+
+it("uses item suffix if array element has inapplicable metadata and is used with more than one visibility.", async () => {
+  const res = await openApiFor(
+    `
+    model Thing {
+      @header etag: string;
+      name: string;
+      @visibility(Lifecycle.Delete) d: string;
+    }
+    @route("/") @post op createMultiple(...Thing): Thing[];
+    `,
+  );
+
+  const request = res.paths["/"].post.parameters[1].schema;
+  deepStrictEqual(request, { $ref: "#/definitions/Thing" });
+
+  const response = res.paths["/"].post.responses["200"].schema;
+  deepStrictEqual(response, {
+    type: "array",
+    items: { $ref: "#/definitions/ThingItem" },
+  });
+
+  deepStrictEqual(res.parameters, {
+    "Thing.etag": {
+      name: "etag",
+      in: "header",
+      required: true,
+      type: "string",
+      "x-ms-parameter-location": "method",
+    },
+  });
+
+  deepStrictEqual(res.definitions, {
+    Thing: {
+      type: "object",
+      properties: {
+        name: { type: "string" },
+      },
+      required: ["name"],
+    },
+    ThingItem: {
+      type: "object",
+      properties: {
+        etag: { type: "string" },
+        name: { type: "string" },
+      },
+      required: ["etag", "name"],
+    },
+  });
+});
+
+it("handles cycle in untransformed model", async () => {
+  const res = await openApiFor(
+    `
+    model Thing {
+     inner?: Thing;
+    }
+    @route("/") @get op get(): Thing;
+    `,
+  );
+
+  const response = res.paths["/"].get.responses["200"].schema;
+  deepStrictEqual(response, { $ref: "#/definitions/Thing" });
+
+  deepStrictEqual(res.definitions, {
+    Thing: {
+      type: "object",
+      properties: {
+        inner: {
+          $ref: "#/definitions/Thing",
+        },
+      },
+    },
+  });
+});
+
+it("handles cycle in transformed model", async () => {
+  const res = await openApiFor(
+    `
+    model Thing {
+      @visibility(Lifecycle.Delete) d?: string;
+      @visibility(Lifecycle.Query) q?: string;
+      inner?: Thing;
     }
 
+    @route("/") @get op get(...Thing): Thing;
     `,
-      undefined,
-      { "omit-unreachable-types": true },
-    );
+  );
 
-    deepStrictEqual(res.definitions, {
-      M: {
-        type: "object",
-        properties: {
-          r: {
-            type: "string",
-            readOnly: true,
-          },
-          c: {
-            type: "string",
-            "x-ms-mutability": ["create"],
-          },
-          u: {
-            type: "string",
-            "x-ms-mutability": ["update"],
-          },
-        },
+  const request = res.paths["/"].get.parameters[0].schema;
+  deepStrictEqual(request, { $ref: "#/definitions/ThingQuery" });
+
+  const response = res.paths["/"].get.responses["200"].schema;
+  deepStrictEqual(response, { $ref: "#/definitions/Thing" });
+
+  deepStrictEqual(res.definitions, {
+    Thing: {
+      type: "object",
+      properties: {
+        inner: { $ref: "#/definitions/Thing" },
       },
-      MDelete: {
-        type: "object",
-        properties: {
-          d: {
-            type: "string",
-          },
-        },
+    },
+    ThingQuery: {
+      type: "object",
+      properties: {
+        q: { type: "string" },
+        inner: { $ref: "#/definitions/ThingQuery" },
       },
-      MQuery: {
-        type: "object",
-        properties: {
-          q: {
-            type: "string",
-          },
-        },
-      },
-      D: {
-        type: "object",
-        allOf: [
+    },
+  });
+});
+
+it("supports nested metadata and removes properties with @bodyIgnore ", async () => {
+  const res = await openApiFor(
+    `
+    model Pet {
+      @bodyIgnore  headers: {
+        @header h1: string;
+        moreHeaders: {
+          @header h2: string;
+        }
+      };
+
+      @path
+      id: string;
+      name: string;
+    }
+    
+    @route("/pets")
+    @post op create(...Pet): Pet;
+    `,
+  );
+
+  deepStrictEqual(res.paths, {
+    "/pets/{id}": {
+      post: {
+        operationId: "Create",
+        parameters: [
           {
-            $ref: "#/definitions/M",
+            name: "h1",
+            in: "header",
+            required: true,
+            type: "string",
+          },
+          {
+            name: "h2",
+            in: "header",
+            required: true,
+            type: "string",
+          },
+          {
+            $ref: "#/parameters/Pet.id",
+          },
+          {
+            name: "body",
+            in: "body",
+            schema: { $ref: "#/definitions/PetCreate" },
+            required: true,
           },
         ],
-      },
-      DDelete: {
-        type: "object",
-        allOf: [
-          {
-            $ref: "#/definitions/MDelete",
-          },
-        ],
-      },
-      DQuery: {
-        type: "object",
-        allOf: [
-          {
-            $ref: "#/definitions/MQuery",
-          },
-        ],
-      },
-      R: {
-        type: "object",
-        properties: {
-          m: {
-            $ref: "#/definitions/M",
-          },
-        },
-      },
-    });
-  });
-
-  it("puts inapplicable metadata in schema", async () => {
-    const res = await openApiFor(
-      `
-      model Parameters {
-       @query q: string;
-       @path p: string;
-       @header h: string;
-      }
-      @route("/single") @get op single(...Parameters): string;
-      @route("/batch") @get op batch(@bodyRoot body: Parameters[]): string;
-      `,
-    );
-    deepStrictEqual(res.paths, {
-      "/single/{p}": {
-        get: {
-          operationId: "Single",
-          produces: ["text/plain"],
-          parameters: [
-            { $ref: "#/parameters/Parameters.q" },
-            { $ref: "#/parameters/Parameters.p" },
-            { $ref: "#/parameters/Parameters.h" },
-          ],
-          responses: {
-            "200": {
-              description: "The request has succeeded.",
-              schema: { type: "string" },
-            },
-          },
-        },
-      },
-      "/batch": {
-        get: {
-          operationId: "Batch",
-          produces: ["text/plain"],
-          responses: {
-            "200": {
-              description: "The request has succeeded.",
-              schema: { type: "string" },
-            },
-          },
-          parameters: [
-            {
-              in: "body",
-              name: "body",
-              required: true,
-              schema: {
-                type: "array",
-                items: { $ref: "#/definitions/Parameters" },
+        responses: {
+          "200": {
+            description: "The request has succeeded.",
+            headers: {
+              h1: {
+                type: "string",
+              },
+              h2: {
+                type: "string",
               },
             },
-          ],
-        },
-      },
-    });
-    deepStrictEqual(res.parameters, {
-      "Parameters.q": {
-        name: "q",
-        in: "query",
-        required: true,
-        type: "string",
-        "x-ms-parameter-location": "method",
-      },
-      "Parameters.p": {
-        name: "p",
-        in: "path",
-        required: true,
-        type: "string",
-        "x-ms-parameter-location": "method",
-      },
-      "Parameters.h": {
-        name: "h",
-        in: "header",
-        required: true,
-        type: "string",
-        "x-ms-parameter-location": "method",
-      },
-    });
-
-    deepStrictEqual(res.definitions, {
-      Parameters: {
-        properties: {
-          h: {
-            type: "string",
-          },
-          p: {
-            type: "string",
-          },
-          q: {
-            type: "string",
+            schema: {
+              $ref: "#/definitions/Pet",
+            },
           },
         },
-        required: ["q", "p", "h"],
-        type: "object",
       },
-    });
+    },
   });
 
-  it("uses item suffix if array element has inapplicable metadata and is used with more than one visibility.", async () => {
+  deepStrictEqual(res.definitions, {
+    PetCreate: {
+      type: "object",
+      properties: {
+        name: {
+          type: "string",
+        },
+      },
+      required: ["name"],
+    },
+    Pet: {
+      type: "object",
+      properties: {
+        id: {
+          type: "string",
+        },
+        name: {
+          type: "string",
+        },
+      },
+      required: ["id", "name"],
+    },
+  });
+});
+
+describe("body required", () => {
+  it("implicit body is marked as required", async () => {
     const res = await openApiFor(
       `
-      model Thing {
-        @header etag: string;
-        name: string;
-        @visibility(Lifecycle.Delete) d: string;
-      }
-      @route("/") @post op createMultiple(...Thing): Thing[];
-      `,
+    model Pet {
+      name: string;
+      age: int32;
+    }
+    op single(...Pet): void;
+    `,
     );
-
-    const request = res.paths["/"].post.parameters[1].schema;
-    deepStrictEqual(request, { $ref: "#/definitions/Thing" });
-
-    const response = res.paths["/"].post.responses["200"].schema;
-    deepStrictEqual(response, {
-      type: "array",
-      items: { $ref: "#/definitions/ThingItem" },
-    });
-
-    deepStrictEqual(res.parameters, {
-      "Thing.etag": {
-        name: "etag",
-        in: "header",
-        required: true,
-        type: "string",
-        "x-ms-parameter-location": "method",
-      },
-    });
-
-    deepStrictEqual(res.definitions, {
-      Thing: {
-        type: "object",
-        properties: {
-          name: { type: "string" },
-        },
-        required: ["name"],
-      },
-      ThingItem: {
-        type: "object",
-        properties: {
-          etag: { type: "string" },
-          name: { type: "string" },
-        },
-        required: ["etag", "name"],
-      },
-    });
+    strictEqual(res.paths["/"].post.parameters[0].required, true);
   });
 
-  it("handles cycle in untransformed model", async () => {
+  it("explicit body is marked as required if property is required", async () => {
     const res = await openApiFor(
       `
-      model Thing {
-       inner?: Thing;
-      }
-      @route("/") @get op get(): Thing;
-      `,
+    model Pet {
+      name: string;
+      age: int32;
+    }
+    op single(@body pet: Pet): void;
+    `,
     );
-
-    const response = res.paths["/"].get.responses["200"].schema;
-    deepStrictEqual(response, { $ref: "#/definitions/Thing" });
-
-    deepStrictEqual(res.definitions, {
-      Thing: {
-        type: "object",
-        properties: {
-          inner: {
-            $ref: "#/definitions/Thing",
-          },
-        },
-      },
-    });
+    strictEqual(res.paths["/"].post.parameters[0].required, true);
   });
 
-  it("handles cycle in transformed model", async () => {
+  it("explicit body is marked as optional if property is optional", async () => {
     const res = await openApiFor(
       `
-      model Thing {
-        @visibility(Lifecycle.Delete) d?: string;
-        @visibility(Lifecycle.Query) q?: string;
-        inner?: Thing;
-      }
-
-      @route("/") @get op get(...Thing): Thing;
-      `,
+    model Pet {
+      name: string;
+      age: int32;
+    }
+    op single(@body pet?: Pet): void;
+    `,
     );
-
-    const request = res.paths["/"].get.parameters[0].schema;
-    deepStrictEqual(request, { $ref: "#/definitions/ThingQuery" });
-
-    const response = res.paths["/"].get.responses["200"].schema;
-    deepStrictEqual(response, { $ref: "#/definitions/Thing" });
-
-    deepStrictEqual(res.definitions, {
-      Thing: {
-        type: "object",
-        properties: {
-          inner: { $ref: "#/definitions/Thing" },
-        },
-      },
-      ThingQuery: {
-        type: "object",
-        properties: {
-          q: { type: "string" },
-          inner: { $ref: "#/definitions/ThingQuery" },
-        },
-      },
-    });
-  });
-
-  it("supports nested metadata and removes properties with @bodyIgnore ", async () => {
-    const res = await openApiFor(
-      `
-      model Pet {
-        @bodyIgnore  headers: {
-          @header h1: string;
-          moreHeaders: {
-            @header h2: string;
-          }
-        };
-
-        @path
-        id: string;
-        name: string;
-      }
-      
-      @route("/pets")
-      @post op create(...Pet): Pet;
-      `,
-    );
-
-    deepStrictEqual(res.paths, {
-      "/pets/{id}": {
-        post: {
-          operationId: "Create",
-          parameters: [
-            {
-              name: "h1",
-              in: "header",
-              required: true,
-              type: "string",
-            },
-            {
-              name: "h2",
-              in: "header",
-              required: true,
-              type: "string",
-            },
-            {
-              $ref: "#/parameters/Pet.id",
-            },
-            {
-              name: "body",
-              in: "body",
-              schema: { $ref: "#/definitions/PetCreate" },
-              required: true,
-            },
-          ],
-          responses: {
-            "200": {
-              description: "The request has succeeded.",
-              headers: {
-                h1: {
-                  type: "string",
-                },
-                h2: {
-                  type: "string",
-                },
-              },
-              schema: {
-                $ref: "#/definitions/Pet",
-              },
-            },
-          },
-        },
-      },
-    });
-
-    deepStrictEqual(res.definitions, {
-      PetCreate: {
-        type: "object",
-        properties: {
-          name: {
-            type: "string",
-          },
-        },
-        required: ["name"],
-      },
-      Pet: {
-        type: "object",
-        properties: {
-          id: {
-            type: "string",
-          },
-          name: {
-            type: "string",
-          },
-        },
-        required: ["id", "name"],
-      },
-    });
-  });
-
-  describe("body required", () => {
-    it("implicit body is marked as required", async () => {
-      const res = await openApiFor(
-        `
-      model Pet {
-        name: string;
-        age: int32;
-      }
-      op single(...Pet): void;
-      `,
-      );
-      strictEqual(res.paths["/"].post.parameters[0].required, true);
-    });
-
-    it("explicit body is marked as required if property is required", async () => {
-      const res = await openApiFor(
-        `
-      model Pet {
-        name: string;
-        age: int32;
-      }
-      op single(@body pet: Pet): void;
-      `,
-      );
-      strictEqual(res.paths["/"].post.parameters[0].required, true);
-    });
-
-    it("explicit body is marked as optional if property is optional", async () => {
-      const res = await openApiFor(
-        `
-      model Pet {
-        name: string;
-        age: int32;
-      }
-      op single(@body pet?: Pet): void;
-      `,
-      );
-      strictEqual(res.paths["/"].post.parameters[0].required, false);
-    });
+    strictEqual(res.paths["/"].post.parameters[0].required, false);
   });
 });

--- a/packages/typespec-autorest/test/models.test.ts
+++ b/packages/typespec-autorest/test/models.test.ts
@@ -3,749 +3,747 @@ import { deepStrictEqual, ok, strictEqual } from "assert";
 import { describe, expect, it } from "vitest";
 import { compileOpenAPI, diagnoseOpenApiFor, oapiForModel } from "./test-host.js";
 
-describe("typespec-autorest: model definitions", () => {
-  it("defines models", async () => {
-    const res = await oapiForModel(
-      "Foo",
-      `model Foo {
-        x: int32;
-      };`,
-    );
+it("defines models", async () => {
+  const res = await oapiForModel(
+    "Foo",
+    `model Foo {
+      x: int32;
+    };`,
+  );
 
-    ok(res.isRef);
-    deepStrictEqual(res.defs.Foo, {
-      type: "object",
-      properties: {
-        x: { type: "integer", format: "int32" },
+  ok(res.isRef);
+  deepStrictEqual(res.defs.Foo, {
+    type: "object",
+    properties: {
+      x: { type: "integer", format: "int32" },
+    },
+    required: ["x"],
+  });
+});
+
+it("allows secrets on models", async () => {
+  const res = await oapiForModel(
+    "Foo",
+    `@secret
+     model Foo {
+      x: int32;
+    };`,
+  );
+
+  deepStrictEqual(res.defs.Foo, {
+    type: "object",
+    properties: {
+      x: { type: "integer", format: "int32" },
+    },
+    required: ["x"],
+    "x-ms-secret": true,
+  });
+});
+
+it("change definition name with @clientName", async () => {
+  const res = await compileOpenAPI(`@clientName("ClientFoo") model Foo {};`, { preset: "azure" });
+  expect(res.definitions).toHaveProperty("ClientFoo");
+  expect(res.definitions).not.toHaveProperty("Foo");
+});
+
+it("using @summary sets the title on definitions and properties", async () => {
+  const res = await oapiForModel(
+    "Foo",
+    `
+    @summary("FooModel")
+    model Foo {
+      @summary("YProp")
+      y: int32;
+    };
+    `,
+  );
+  strictEqual(res.defs.Foo.title, "FooModel");
+  strictEqual(res.defs.Foo.properties.y.title, "YProp");
+});
+
+it("emits property-level @example", async () => {
+  const res = await oapiForModel(
+    "Test",
+    `
+    model Test {
+      @TypeSpec.example("core.windows.net")
+      abcd: string;
+    };
+    `,
+  );
+
+  expect(res.defs.Test.properties.abcd.example).toEqual("core.windows.net");
+});
+
+it("uses json name specified via @encodedName", async () => {
+  const res = await oapiForModel(
+    "Foo",
+    `model Foo {
+      @encodedName("application/json", "xJson")
+      x: int32;
+    };`,
+  );
+
+  expect(res.defs.Foo).toMatchObject({
+    properties: {
+      xJson: { type: "integer", format: "int32", "x-ms-client-name": "x" },
+    },
+  });
+});
+
+it("errors on duplicate model names", async () => {
+  const diagnostics = await diagnoseOpenApiFor(
+    `
+    model P {
+      p: string;
+    }
+
+    @friendlyName("P")
+    model Q {
+      q: string;
+    }
+
+    #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
+    @route("/test1")
+    @get
+    op test1(p: P): Q;
+    `,
+  );
+
+  expectDiagnostics(diagnostics, [
+    {
+      code: "@typespec/openapi/duplicate-type-name",
+      message: /type/,
+    },
+  ]);
+});
+
+it("doesn't define anonymous or unconnected models", async () => {
+  const res = await oapiForModel(
+    "{ ... Foo }",
+    `model Foo {
+      x: int32;
+    };`,
+  );
+
+  ok(res.isRef);
+  strictEqual(Object.keys(res.defs).length, 1);
+  deepStrictEqual(res.useSchema, {
+    $ref: "#/definitions/Foo",
+  });
+});
+
+it("defines templated models", async () => {
+  const res = await oapiForModel(
+    "Foo<int32>",
+    `model Foo<T> {
+      x: T;
+    };`,
+  );
+
+  ok(!res.isRef);
+  deepStrictEqual(res.useSchema, {
+    type: "object",
+    properties: {
+      x: { type: "integer", format: "int32" },
+    },
+    required: ["x"],
+  });
+});
+
+it("defines templated models when template param is in a namespace", async () => {
+  const res = await oapiForModel(
+    "Foo<Test.M>",
+    `
+    namespace Test {
+      model M {}
+    }
+    model Foo<T> {
+      x: T;
+    };`,
+  );
+
+  ok(!res.isRef);
+  deepStrictEqual(res.useSchema, {
+    type: "object",
+    properties: {
+      x: { $ref: "#/definitions/Test.M" },
+    },
+    required: ["x"],
+  });
+});
+
+it("defines models extended from models", async () => {
+  const res = await oapiForModel(
+    "Bar",
+    `
+    model Foo {
+      y: int32;
+    };
+    model Bar extends Foo {}`,
+  );
+
+  ok(res.isRef);
+  ok(res.defs.Foo, "expected definition named Foo");
+  ok(res.defs.Bar, "expected definition named Bar");
+  deepStrictEqual(res.defs.Bar, {
+    type: "object",
+    allOf: [{ $ref: "#/definitions/Foo" }],
+  });
+
+  deepStrictEqual(res.defs.Foo, {
+    type: "object",
+    properties: { y: { type: "integer", format: "int32" } },
+    required: ["y"],
+  });
+});
+
+it("emits models extended from models when parent is emitted", async () => {
+  const res = await compileOpenAPI(
+    `
+    model Parent {
+      x?: int32;
+    };
+    model Child extends Parent {
+      y?: int32;
+    }
+    @route("/") op test(): Parent;
+    `,
+  );
+  deepStrictEqual(res.definitions?.Parent, {
+    type: "object",
+    properties: { x: { type: "integer", format: "int32" } },
+  });
+  deepStrictEqual(res.definitions.Child, {
+    type: "object",
+    allOf: [{ $ref: "#/definitions/Parent" }],
+    properties: { y: { type: "integer", format: "int32" } },
+  });
+});
+
+it("specify default value on enum property inline the enum", async () => {
+  const res = await oapiForModel(
+    "Foo",
+    `
+    model Foo {
+      optionalEnum?: MyEnum = MyEnum.a;
+    };
+    
+    enum MyEnum {
+      a: "a-value",
+      b,
+    }
+    `,
+  );
+  deepStrictEqual(res.defs.Foo, {
+    type: "object",
+    properties: {
+      optionalEnum: {
+        type: "string",
+        enum: ["a-value", "b"],
+        "x-ms-enum": {
+          name: "MyEnum",
+          modelAsString: false,
+          values: [
+            { name: "a", value: "a-value" },
+            { name: "b", value: "b" },
+          ],
+        },
+        default: "a-value",
       },
-      required: ["x"],
-    });
+    },
   });
+});
 
-  it("allows secrets on models", async () => {
-    const res = await oapiForModel(
-      "Foo",
-      `@secret
-       model Foo {
-        x: int32;
-      };`,
-    );
+it("specify default value on union with variant", async () => {
+  const res = await oapiForModel(
+    "Foo",
+    `
+    model Foo {
+      optionalUnion?: MyUnion = MyUnion.a;
+    };
+    
+    union MyUnion {
+      a: "a-value",
+      b: "b-value",
+    }
+    `,
+  );
 
-    deepStrictEqual(res.defs.Foo, {
-      type: "object",
-      properties: {
-        x: { type: "integer", format: "int32" },
+  deepStrictEqual(res.defs.Foo, {
+    type: "object",
+    properties: {
+      optionalUnion: {
+        type: "string",
+        enum: ["a-value", "b-value"],
+        "x-ms-enum": {
+          values: [
+            { name: "a", value: "a-value" },
+            { name: "b", value: "b-value" },
+          ],
+          modelAsString: false,
+          name: "MyUnion",
+        },
+        default: "a-value",
       },
-      required: ["x"],
-      "x-ms-secret": true,
-    });
+    },
+  });
+});
+
+it("errors on empty enum", async () => {
+  const diagnostics = await diagnoseOpenApiFor(
+    `
+    model Foo {
+      optionalEnum?: MyEnum;
+    };
+    
+    enum MyEnum {}
+
+    @route("/")
+    op foo(): Foo;
+    `,
+  );
+
+  expectDiagnostics(diagnostics, [
+    {
+      code: "@azure-tools/typespec-autorest/union-unsupported",
+      message:
+        "Empty unions are not supported for OpenAPI v2 - enums must have at least one value.",
+      severity: "warning",
+    },
+  ]);
+});
+
+it("ignore uninstantiated template types", async () => {
+  const res = await compileOpenAPI(
+    `
+    model Parent {
+      x?: int32;
+    };
+    @friendlyName("TParent_{name}", T)
+    model TParent<T> extends Parent {
+      t: T;
+    }
+    model Child extends TParent<string> {
+      y?: int32;
+    }
+    @route("/") op test(): Parent;
+    `,
+  );
+  ok(res.definitions);
+  ok(!("TParent" in res.definitions), "Parent templated type shouldn't be included in OpenAPI");
+  deepStrictEqual(res.definitions.Parent, {
+    type: "object",
+    properties: { x: { type: "integer", format: "int32" } },
+  });
+  deepStrictEqual(res.definitions.TParent_string, {
+    type: "object",
+    properties: { t: { type: "string" } },
+    required: ["t"],
+    allOf: [{ $ref: "#/definitions/Parent" }],
+  });
+  deepStrictEqual(res.definitions.Child, {
+    type: "object",
+    allOf: [{ $ref: "#/definitions/TParent_string" }],
+    properties: { y: { type: "integer", format: "int32" } },
+  });
+});
+
+it("shouldn't emit instantiated template child types that are only used in is", async () => {
+  const res = await compileOpenAPI(
+    `
+    model Parent {
+      x?: int32;
+    };
+    model TParent<T> extends Parent {
+      t: T;
+    }
+    model Child is TParent<string> {
+      y?: int32;
+    }
+    @route("/") op test(): Parent;
+    `,
+  );
+  ok(
+    !("TParent_string" in res.definitions!),
+    "Parent instantiated templated type shouldn't be included in OpenAPI",
+  );
+});
+
+it("defines models with properties extended from models", async () => {
+  const res = await oapiForModel(
+    "Bar",
+    `
+    model Foo {
+      y: int32;
+    };
+    model Bar extends Foo {
+      x: int32;
+    }`,
+  );
+
+  ok(res.isRef);
+  ok(res.defs.Foo, "expected definition named Foo");
+  ok(res.defs.Bar, "expected definition named Bar");
+  deepStrictEqual(res.defs.Bar, {
+    type: "object",
+    properties: { x: { type: "integer", format: "int32" } },
+    allOf: [{ $ref: "#/definitions/Foo" }],
+    required: ["x"],
   });
 
-  it("change definition name with @clientName", async () => {
-    const res = await compileOpenAPI(`@clientName("ClientFoo") model Foo {};`, { preset: "azure" });
-    expect(res.definitions).toHaveProperty("ClientFoo");
-    expect(res.definitions).not.toHaveProperty("Foo");
+  deepStrictEqual(res.defs.Foo, {
+    type: "object",
+    properties: { y: { type: "integer", format: "int32" } },
+    required: ["y"],
   });
+});
 
-  it("using @summary sets the title on definitions and properties", async () => {
-    const res = await oapiForModel(
-      "Foo",
-      `
-      @summary("FooModel")
-      model Foo {
-        @summary("YProp")
-        y: int32;
-      };
-      `,
-    );
-    strictEqual(res.defs.Foo.title, "FooModel");
-    strictEqual(res.defs.Foo.properties.y.title, "YProp");
+it("defines models extended from templated models", async () => {
+  const res = await oapiForModel(
+    "Bar",
+    `
+    model Foo<T> {
+      y: T;
+    };
+    model Bar extends Foo<int32> {}`,
+  );
+
+  ok(res.isRef);
+  ok(res.defs["Foo_int32"] === undefined, "no definition named Foo_int32");
+  ok(res.defs.Bar, "expected definition named Bar");
+  deepStrictEqual(res.defs.Bar, {
+    type: "object",
+    properties: { y: { type: "integer", format: "int32" } },
+    required: ["y"],
   });
+});
 
-  it("emits property-level @example", async () => {
-    const res = await oapiForModel(
-      "Test",
-      `
-      model Test {
-        @TypeSpec.example("core.windows.net")
-        abcd: string;
-      };
-      `,
-    );
+it("defines models with properties extended from templated models", async () => {
+  const res = await oapiForModel(
+    "Bar",
+    `
+    model Foo<T> {
+      y: T;
+    };
+    model Bar extends Foo<int32> {
+      x: int32
+    }`,
+  );
 
-    expect(res.defs.Test.properties.abcd.example).toEqual("core.windows.net");
-  });
-
-  it("uses json name specified via @encodedName", async () => {
-    const res = await oapiForModel(
-      "Foo",
-      `model Foo {
-        @encodedName("application/json", "xJson")
-        x: int32;
-      };`,
-    );
-
-    expect(res.defs.Foo).toMatchObject({
-      properties: {
-        xJson: { type: "integer", format: "int32", "x-ms-client-name": "x" },
-      },
-    });
-  });
-
-  it("errors on duplicate model names", async () => {
-    const diagnostics = await diagnoseOpenApiFor(
-      `
-      model P {
-        p: string;
-      }
-
-      @friendlyName("P")
-      model Q {
-        q: string;
-      }
-
-      #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
-      @route("/test1")
-      @get
-      op test1(p: P): Q;
-      `,
-    );
-
-    expectDiagnostics(diagnostics, [
+  ok(res.isRef);
+  ok(res.defs.Bar, "expected definition named Bar");
+  deepStrictEqual(res.defs.Bar, {
+    type: "object",
+    properties: { x: { type: "integer", format: "int32" } },
+    required: ["x"],
+    allOf: [
       {
-        code: "@typespec/openapi/duplicate-type-name",
-        message: /type/,
+        type: "object",
+        properties: { y: { type: "integer", format: "int32" } },
+        required: ["y"],
       },
-    ]);
+    ],
+  });
+});
+
+it("defines templated models with properties extended from templated models", async () => {
+  const res = await oapiForModel(
+    "Bar<int32>",
+    `
+    @friendlyName("Foo_{name}", T)
+    model Foo<T> {
+      y: T;
+    };
+    @friendlyName("Bar_{name}", T)
+    model Bar<T> extends Foo<T> {
+      x: T
+    }`,
+  );
+
+  ok(res.isRef);
+  ok(res.defs.Foo_int32, "expected definition named Foo_int32");
+  ok(res.defs.Bar_int32, "expected definition named Bar_int32");
+  deepStrictEqual(res.defs.Bar_int32, {
+    type: "object",
+    properties: { x: { type: "integer", format: "int32" } },
+    allOf: [{ $ref: "#/definitions/Foo_int32" }],
+    required: ["x"],
   });
 
-  it("doesn't define anonymous or unconnected models", async () => {
-    const res = await oapiForModel(
-      "{ ... Foo }",
-      `model Foo {
-        x: int32;
-      };`,
-    );
+  deepStrictEqual(res.defs.Foo_int32, {
+    type: "object",
+    properties: { y: { type: "integer", format: "int32" } },
+    required: ["y"],
+  });
+});
 
-    ok(res.isRef);
-    strictEqual(Object.keys(res.defs).length, 1);
-    deepStrictEqual(res.useSchema, {
-      $ref: "#/definitions/Foo",
-    });
+it("excludes response models with only headers", async () => {
+  const res = await oapiForModel(
+    "Foo",
+    `
+    model Foo { @statusCode code: 200, @header x: string};`,
+  );
+
+  ok(!res.isRef);
+  deepStrictEqual(res.defs, {});
+  deepStrictEqual(res.response, {
+    description: "The request has succeeded.",
+    headers: { x: { type: "string" } },
+  });
+});
+
+it("defines models with no properties extended", async () => {
+  const res = await oapiForModel(
+    "Bar",
+    `
+    model Foo { x?: string};
+    model Bar extends Foo {};`,
+  );
+
+  ok(res.isRef);
+  ok(res.defs.Foo, "expected definition named Foo");
+  ok(res.defs.Bar, "expected definition named Bar");
+  deepStrictEqual(res.defs.Bar, {
+    type: "object",
+    allOf: [{ $ref: "#/definitions/Foo" }],
   });
 
-  it("defines templated models", async () => {
-    const res = await oapiForModel(
-      "Foo<int32>",
-      `model Foo<T> {
-        x: T;
-      };`,
-    );
+  deepStrictEqual(res.defs.Foo, {
+    type: "object",
+    properties: { x: { type: "string" } },
+  });
+});
 
-    ok(!res.isRef);
-    deepStrictEqual(res.useSchema, {
-      type: "object",
-      properties: {
-        x: { type: "integer", format: "int32" },
+it("defines models with no properties extended twice", async () => {
+  const res = await oapiForModel(
+    "Baz",
+    `
+    model Foo { x: int32 };
+    model Bar extends Foo {};
+    model Baz extends Bar {};`,
+  );
+
+  ok(res.isRef);
+  ok(res.defs.Foo, "expected definition named Foo");
+  ok(res.defs.Bar, "expected definition named Bar");
+  ok(res.defs.Baz, "expected definition named Baz");
+  deepStrictEqual(res.defs.Baz, {
+    type: "object",
+    allOf: [{ $ref: "#/definitions/Bar" }],
+  });
+
+  deepStrictEqual(res.defs.Bar, {
+    type: "object",
+    allOf: [{ $ref: "#/definitions/Foo" }],
+  });
+
+  deepStrictEqual(res.defs.Foo, {
+    type: "object",
+    properties: {
+      x: {
+        format: "int32",
+        type: "integer",
       },
-      required: ["x"],
-    });
+    },
+    required: ["x"],
   });
+});
 
-  it("defines templated models when template param is in a namespace", async () => {
-    const res = await oapiForModel(
-      "Foo<Test.M>",
-      `
-      namespace Test {
-        model M {}
-      }
-      model Foo<T> {
-        x: T;
-      };`,
-    );
+it("defines models with default properties", async () => {
+  const res = await oapiForModel(
+    "Pet",
+    `
+    model Pet {
+      someString?: string = "withDefault"
+    }
+    `,
+  );
 
-    ok(!res.isRef);
-    deepStrictEqual(res.useSchema, {
-      type: "object",
-      properties: {
-        x: { $ref: "#/definitions/Test.M" },
+  ok(res.isRef);
+  ok(res.defs.Pet, "expected definition named Pet");
+  deepStrictEqual(res.defs.Pet.properties.someString.default, "withDefault");
+});
+
+it("recovers logical type name", async () => {
+  const oapi: any = await compileOpenAPI(
+    `
+    model Thing {
+      name?: string;
+    }
+
+    @route("/things/{id}")
+    @get
+    op get(@path id: string, @query test: string, ...Thing): Thing & { @header test: string; };
+    `,
+  );
+
+  deepStrictEqual(oapi.definitions?.Thing, {
+    type: "object",
+    properties: {
+      name: {
+        type: "string",
       },
-      required: ["x"],
-    });
+    },
   });
 
-  it("defines models extended from models", async () => {
-    const res = await oapiForModel(
-      "Bar",
-      `
-      model Foo {
-        y: int32;
-      };
-      model Bar extends Foo {}`,
-    );
-
-    ok(res.isRef);
-    ok(res.defs.Foo, "expected definition named Foo");
-    ok(res.defs.Bar, "expected definition named Bar");
-    deepStrictEqual(res.defs.Bar, {
-      type: "object",
-      allOf: [{ $ref: "#/definitions/Foo" }],
-    });
-
-    deepStrictEqual(res.defs.Foo, {
-      type: "object",
-      properties: { y: { type: "integer", format: "int32" } },
-      required: ["y"],
-    });
-  });
-
-  it("emits models extended from models when parent is emitted", async () => {
-    const res = await compileOpenAPI(
-      `
-      model Parent {
-        x?: int32;
-      };
-      model Child extends Parent {
-        y?: int32;
-      }
-      @route("/") op test(): Parent;
-      `,
-    );
-    deepStrictEqual(res.definitions?.Parent, {
-      type: "object",
-      properties: { x: { type: "integer", format: "int32" } },
-    });
-    deepStrictEqual(res.definitions.Child, {
-      type: "object",
-      allOf: [{ $ref: "#/definitions/Parent" }],
-      properties: { y: { type: "integer", format: "int32" } },
-    });
-  });
-
-  it("specify default value on enum property inline the enum", async () => {
-    const res = await oapiForModel(
-      "Foo",
-      `
-      model Foo {
-        optionalEnum?: MyEnum = MyEnum.a;
-      };
-      
-      enum MyEnum {
-        a: "a-value",
-        b,
-      }
-      `,
-    );
-    deepStrictEqual(res.defs.Foo, {
-      type: "object",
-      properties: {
-        optionalEnum: {
-          type: "string",
-          enum: ["a-value", "b"],
-          "x-ms-enum": {
-            name: "MyEnum",
-            modelAsString: false,
-            values: [
-              { name: "a", value: "a-value" },
-              { name: "b", value: "b" },
-            ],
-          },
-          default: "a-value",
-        },
-      },
-    });
-  });
-
-  it("specify default value on union with variant", async () => {
-    const res = await oapiForModel(
-      "Foo",
-      `
-      model Foo {
-        optionalUnion?: MyUnion = MyUnion.a;
-      };
-      
-      union MyUnion {
-        a: "a-value",
-        b: "b-value",
-      }
-      `,
-    );
-
-    deepStrictEqual(res.defs.Foo, {
-      type: "object",
-      properties: {
-        optionalUnion: {
-          type: "string",
-          enum: ["a-value", "b-value"],
-          "x-ms-enum": {
-            values: [
-              { name: "a", value: "a-value" },
-              { name: "b", value: "b-value" },
-            ],
-            modelAsString: false,
-            name: "MyUnion",
-          },
-          default: "a-value",
-        },
-      },
-    });
-  });
-
-  it("errors on empty enum", async () => {
-    const diagnostics = await diagnoseOpenApiFor(
-      `
-      model Foo {
-        optionalEnum?: MyEnum;
-      };
-      
-      enum MyEnum {}
-
-      @route("/")
-      op foo(): Foo;
-      `,
-    );
-
-    expectDiagnostics(diagnostics, [
-      {
-        code: "@azure-tools/typespec-autorest/union-unsupported",
-        message:
-          "Empty unions are not supported for OpenAPI v2 - enums must have at least one value.",
-        severity: "warning",
-      },
-    ]);
-  });
-
-  it("ignore uninstantiated template types", async () => {
-    const res = await compileOpenAPI(
-      `
-      model Parent {
-        x?: int32;
-      };
-      @friendlyName("TParent_{name}", T)
-      model TParent<T> extends Parent {
-        t: T;
-      }
-      model Child extends TParent<string> {
-        y?: int32;
-      }
-      @route("/") op test(): Parent;
-      `,
-    );
-    ok(res.definitions);
-    ok(!("TParent" in res.definitions), "Parent templated type shouldn't be included in OpenAPI");
-    deepStrictEqual(res.definitions.Parent, {
-      type: "object",
-      properties: { x: { type: "integer", format: "int32" } },
-    });
-    deepStrictEqual(res.definitions.TParent_string, {
-      type: "object",
-      properties: { t: { type: "string" } },
-      required: ["t"],
-      allOf: [{ $ref: "#/definitions/Parent" }],
-    });
-    deepStrictEqual(res.definitions.Child, {
-      type: "object",
-      allOf: [{ $ref: "#/definitions/TParent_string" }],
-      properties: { y: { type: "integer", format: "int32" } },
-    });
-  });
-
-  it("shouldn't emit instantiated template child types that are only used in is", async () => {
-    const res = await compileOpenAPI(
-      `
-      model Parent {
-        x?: int32;
-      };
-      model TParent<T> extends Parent {
-        t: T;
-      }
-      model Child is TParent<string> {
-        y?: int32;
-      }
-      @route("/") op test(): Parent;
-      `,
-    );
-    ok(
-      !("TParent_string" in res.definitions!),
-      "Parent instantiated templated type shouldn't be included in OpenAPI",
-    );
-  });
-
-  it("defines models with properties extended from models", async () => {
-    const res = await oapiForModel(
-      "Bar",
-      `
-      model Foo {
-        y: int32;
-      };
-      model Bar extends Foo {
-        x: int32;
-      }`,
-    );
-
-    ok(res.isRef);
-    ok(res.defs.Foo, "expected definition named Foo");
-    ok(res.defs.Bar, "expected definition named Bar");
-    deepStrictEqual(res.defs.Bar, {
-      type: "object",
-      properties: { x: { type: "integer", format: "int32" } },
-      allOf: [{ $ref: "#/definitions/Foo" }],
-      required: ["x"],
-    });
-
-    deepStrictEqual(res.defs.Foo, {
-      type: "object",
-      properties: { y: { type: "integer", format: "int32" } },
-      required: ["y"],
-    });
-  });
-
-  it("defines models extended from templated models", async () => {
-    const res = await oapiForModel(
-      "Bar",
-      `
-      model Foo<T> {
-        y: T;
-      };
-      model Bar extends Foo<int32> {}`,
-    );
-
-    ok(res.isRef);
-    ok(res.defs["Foo_int32"] === undefined, "no definition named Foo_int32");
-    ok(res.defs.Bar, "expected definition named Bar");
-    deepStrictEqual(res.defs.Bar, {
-      type: "object",
-      properties: { y: { type: "integer", format: "int32" } },
-      required: ["y"],
-    });
-  });
-
-  it("defines models with properties extended from templated models", async () => {
-    const res = await oapiForModel(
-      "Bar",
-      `
-      model Foo<T> {
-        y: T;
-      };
-      model Bar extends Foo<int32> {
-        x: int32
-      }`,
-    );
-
-    ok(res.isRef);
-    ok(res.defs.Bar, "expected definition named Bar");
-    deepStrictEqual(res.defs.Bar, {
-      type: "object",
-      properties: { x: { type: "integer", format: "int32" } },
-      required: ["x"],
-      allOf: [
-        {
-          type: "object",
-          properties: { y: { type: "integer", format: "int32" } },
-          required: ["y"],
-        },
-      ],
-    });
-  });
-
-  it("defines templated models with properties extended from templated models", async () => {
-    const res = await oapiForModel(
-      "Bar<int32>",
-      `
-      @friendlyName("Foo_{name}", T)
-      model Foo<T> {
-        y: T;
-      };
-      @friendlyName("Bar_{name}", T)
-      model Bar<T> extends Foo<T> {
-        x: T
-      }`,
-    );
-
-    ok(res.isRef);
-    ok(res.defs.Foo_int32, "expected definition named Foo_int32");
-    ok(res.defs.Bar_int32, "expected definition named Bar_int32");
-    deepStrictEqual(res.defs.Bar_int32, {
-      type: "object",
-      properties: { x: { type: "integer", format: "int32" } },
-      allOf: [{ $ref: "#/definitions/Foo_int32" }],
-      required: ["x"],
-    });
-
-    deepStrictEqual(res.defs.Foo_int32, {
-      type: "object",
-      properties: { y: { type: "integer", format: "int32" } },
-      required: ["y"],
-    });
-  });
-
-  it("excludes response models with only headers", async () => {
-    const res = await oapiForModel(
-      "Foo",
-      `
-      model Foo { @statusCode code: 200, @header x: string};`,
-    );
-
-    ok(!res.isRef);
-    deepStrictEqual(res.defs, {});
-    deepStrictEqual(res.response, {
-      description: "The request has succeeded.",
-      headers: { x: { type: "string" } },
-    });
-  });
-
-  it("defines models with no properties extended", async () => {
-    const res = await oapiForModel(
-      "Bar",
-      `
-      model Foo { x?: string};
-      model Bar extends Foo {};`,
-    );
-
-    ok(res.isRef);
-    ok(res.defs.Foo, "expected definition named Foo");
-    ok(res.defs.Bar, "expected definition named Bar");
-    deepStrictEqual(res.defs.Bar, {
-      type: "object",
-      allOf: [{ $ref: "#/definitions/Foo" }],
-    });
-
-    deepStrictEqual(res.defs.Foo, {
-      type: "object",
-      properties: { x: { type: "string" } },
-    });
-  });
-
-  it("defines models with no properties extended twice", async () => {
-    const res = await oapiForModel(
-      "Baz",
-      `
-      model Foo { x: int32 };
-      model Bar extends Foo {};
-      model Baz extends Bar {};`,
-    );
-
-    ok(res.isRef);
-    ok(res.defs.Foo, "expected definition named Foo");
-    ok(res.defs.Bar, "expected definition named Bar");
-    ok(res.defs.Baz, "expected definition named Baz");
-    deepStrictEqual(res.defs.Baz, {
-      type: "object",
-      allOf: [{ $ref: "#/definitions/Bar" }],
-    });
-
-    deepStrictEqual(res.defs.Bar, {
-      type: "object",
-      allOf: [{ $ref: "#/definitions/Foo" }],
-    });
-
-    deepStrictEqual(res.defs.Foo, {
-      type: "object",
-      properties: {
-        x: {
-          format: "int32",
-          type: "integer",
-        },
-      },
-      required: ["x"],
-    });
-  });
-
-  it("defines models with default properties", async () => {
-    const res = await oapiForModel(
-      "Pet",
-      `
-      model Pet {
-        someString?: string = "withDefault"
-      }
-      `,
-    );
-
-    ok(res.isRef);
-    ok(res.defs.Pet, "expected definition named Pet");
-    deepStrictEqual(res.defs.Pet.properties.someString.default, "withDefault");
-  });
-
-  it("recovers logical type name", async () => {
-    const oapi: any = await compileOpenAPI(
-      `
-      model Thing {
-        name?: string;
-      }
-
-      @route("/things/{id}")
-      @get
-      op get(@path id: string, @query test: string, ...Thing): Thing & { @header test: string; };
-      `,
-    );
-
-    deepStrictEqual(oapi.definitions?.Thing, {
-      type: "object",
-      properties: {
-        name: {
-          type: "string",
-        },
-      },
-    });
-
-    deepStrictEqual(
-      oapi.paths["/things/{id}"].get.parameters.find((p: any) => p.in === "body").schema,
-      {
-        $ref: "#/definitions/Thing",
-      },
-    );
-
-    deepStrictEqual(oapi.paths["/things/{id}"].get?.responses["200"].schema!, {
+  deepStrictEqual(
+    oapi.paths["/things/{id}"].get.parameters.find((p: any) => p.in === "body").schema,
+    {
       $ref: "#/definitions/Thing",
-    });
+    },
+  );
+
+  deepStrictEqual(oapi.paths["/things/{id}"].get?.responses["200"].schema!, {
+    $ref: "#/definitions/Thing",
+  });
+});
+
+it("detects cycles in inline type", async () => {
+  const diagnostics = await diagnoseOpenApiFor(
+    `
+    model Thing<T> { inner?: Thing<T>; }
+
+    #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
+    op get(): Thing<string>;
+    `,
+    { "omit-unreachable-types": true },
+  );
+
+  expectDiagnostics(diagnostics, [{ code: "@azure-tools/typespec-autorest/inline-cycle" }]);
+});
+
+it("excludes properties with type 'never'", async () => {
+  const res = await oapiForModel(
+    "Bar",
+    `
+    model Foo {
+      y: int32;
+      nope: never;
+    };
+    model Bar extends Foo {
+      x: int32;
+    }`,
+  );
+
+  ok(res.isRef);
+  ok(res.defs.Foo, "expected definition named Foo");
+  ok(res.defs.Bar, "expected definition named Bar");
+  deepStrictEqual(res.defs.Bar, {
+    type: "object",
+    properties: { x: { type: "integer", format: "int32" } },
+    allOf: [{ $ref: "#/definitions/Foo" }],
+    required: ["x"],
   });
 
-  it("detects cycles in inline type", async () => {
-    const diagnostics = await diagnoseOpenApiFor(
-      `
-      model Thing<T> { inner?: Thing<T>; }
-
-      #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
-      op get(): Thing<string>;
-      `,
-      { "omit-unreachable-types": true },
-    );
-
-    expectDiagnostics(diagnostics, [{ code: "@azure-tools/typespec-autorest/inline-cycle" }]);
+  deepStrictEqual(res.defs.Foo, {
+    type: "object",
+    properties: { y: { type: "integer", format: "int32" } },
+    required: ["y"],
   });
+});
 
-  it("excludes properties with type 'never'", async () => {
+describe("referencing another property as type", () => {
+  it("use the type of the other property", async () => {
     const res = await oapiForModel(
       "Bar",
       `
       model Foo {
-        y: int32;
-        nope: never;
-      };
-      model Bar extends Foo {
-        x: int32;
+        name: string;
+      }
+      model Bar {
+        x: Foo.name
       }`,
     );
 
-    ok(res.isRef);
-    ok(res.defs.Foo, "expected definition named Foo");
     ok(res.defs.Bar, "expected definition named Bar");
-    deepStrictEqual(res.defs.Bar, {
-      type: "object",
-      properties: { x: { type: "integer", format: "int32" } },
-      allOf: [{ $ref: "#/definitions/Foo" }],
-      required: ["x"],
-    });
-
-    deepStrictEqual(res.defs.Foo, {
-      type: "object",
-      properties: { y: { type: "integer", format: "int32" } },
-      required: ["y"],
+    deepStrictEqual(res.defs.Bar.properties.x, {
+      type: "string",
     });
   });
 
-  describe("referencing another property as type", () => {
-    it("use the type of the other property", async () => {
-      const res = await oapiForModel(
-        "Bar",
-        `
-        model Foo {
-          name: string;
-        }
-        model Bar {
-          x: Foo.name
-        }`,
-      );
-
-      ok(res.defs.Bar, "expected definition named Bar");
-      deepStrictEqual(res.defs.Bar.properties.x, {
-        type: "string",
-      });
-    });
-
-    it("use the type of the other property with ref", async () => {
-      const res = await oapiForModel(
-        "Bar",
-        `
-        model Name {first: string}
-        model Foo {
-          name: Name;
-        }
-        model Bar {
-          x: Foo.name
-        }`,
-      );
-
-      ok(res.defs.Bar, "expected definition named Bar");
-      deepStrictEqual(res.defs.Bar.properties.x, {
-        $ref: "#/definitions/Name",
-      });
-    });
-
-    it("should include decorators on both referenced property and source property itself", async () => {
-      const res = await oapiForModel(
-        "Bar",
-        `
-        model Foo {
-          @format("uri")
-          name: string;
-        }
-        model Bar {
-          @doc("My doc")
-          x: Foo.name
-        }`,
-      );
-
-      ok(res.defs.Bar, "expected definition named Bar");
-      deepStrictEqual(res.defs.Bar.properties.x, {
-        type: "string",
-        format: "uri",
-        description: "My doc",
-      });
-    });
-
-    it("decorators on the property should override the value of referenced property", async () => {
-      const res = await oapiForModel(
-        "Bar",
-        `
-        model Foo {
-          @doc("Default doc")
-          name: string;
-        }
-        model Bar {
-          @doc("My doc override")
-          x: Foo.name
-        }`,
-      );
-
-      ok(res.defs.Bar, "expected definition named Bar");
-      deepStrictEqual(res.defs.Bar.properties.x, {
-        type: "string",
-        description: "My doc override",
-      });
-    });
-  });
-
-  it("encode know scalar as a default value", async () => {
+  it("use the type of the other property with ref", async () => {
     const res = await oapiForModel(
-      "Test",
+      "Bar",
       `
-        model Test { @encode("rfc7231") minDate: utcDateTime = utcDateTime.fromISO("2024-01-01T11:32:00Z"); }
-      `,
+      model Name {first: string}
+      model Foo {
+        name: Name;
+      }
+      model Bar {
+        x: Foo.name
+      }`,
     );
 
-    expect(res.defs.Test.properties.minDate.default).toEqual("Mon, 01 Jan 2024 11:32:00 GMT");
+    ok(res.defs.Bar, "expected definition named Bar");
+    deepStrictEqual(res.defs.Bar.properties.x, {
+      $ref: "#/definitions/Name",
+    });
   });
 
-  it("object value used as a default value", async () => {
+  it("should include decorators on both referenced property and source property itself", async () => {
     const res = await oapiForModel(
-      "Test",
+      "Bar",
       `
-        model Test { Pet: {name: string;  @encode("rfc7231")birthday: utcDateTime} = #{ name: "Dog", birthday:utcDateTime.fromISO("2024-01-01T11:32:00Z")}}
-      `,
+      model Foo {
+        @format("uri")
+        name: string;
+      }
+      model Bar {
+        @doc("My doc")
+        x: Foo.name
+      }`,
     );
 
-    expect(res.defs.Test.properties.Pet.default.name).toEqual("Dog");
-    expect(res.defs.Test.properties.Pet.default.birthday).toEqual("Mon, 01 Jan 2024 11:32:00 GMT");
+    ok(res.defs.Bar, "expected definition named Bar");
+    deepStrictEqual(res.defs.Bar.properties.x, {
+      type: "string",
+      format: "uri",
+      description: "My doc",
+    });
   });
+
+  it("decorators on the property should override the value of referenced property", async () => {
+    const res = await oapiForModel(
+      "Bar",
+      `
+      model Foo {
+        @doc("Default doc")
+        name: string;
+      }
+      model Bar {
+        @doc("My doc override")
+        x: Foo.name
+      }`,
+    );
+
+    ok(res.defs.Bar, "expected definition named Bar");
+    deepStrictEqual(res.defs.Bar.properties.x, {
+      type: "string",
+      description: "My doc override",
+    });
+  });
+});
+
+it("encode know scalar as a default value", async () => {
+  const res = await oapiForModel(
+    "Test",
+    `
+      model Test { @encode("rfc7231") minDate: utcDateTime = utcDateTime.fromISO("2024-01-01T11:32:00Z"); }
+    `,
+  );
+
+  expect(res.defs.Test.properties.minDate.default).toEqual("Mon, 01 Jan 2024 11:32:00 GMT");
+});
+
+it("object value used as a default value", async () => {
+  const res = await oapiForModel(
+    "Test",
+    `
+      model Test { Pet: {name: string;  @encode("rfc7231")birthday: utcDateTime} = #{ name: "Dog", birthday:utcDateTime.fromISO("2024-01-01T11:32:00Z")}}
+    `,
+  );
+
+  expect(res.defs.Test.properties.Pet.default.name).toEqual("Dog");
+  expect(res.defs.Test.properties.Pet.default.birthday).toEqual("Mon, 01 Jan 2024 11:32:00 GMT");
 });

--- a/packages/typespec-autorest/test/openapi-output.test.ts
+++ b/packages/typespec-autorest/test/openapi-output.test.ts
@@ -3,7 +3,7 @@ import { deepStrictEqual, notStrictEqual, ok, strictEqual } from "assert";
 import { describe, it } from "vitest";
 import { compileOpenAPI, diagnoseOpenApiFor, oapiForModel } from "./test-host.js";
 
-describe("typespec-autorest: definitions", () => {
+describe("definitions", () => {
   it("defines models", async () => {
     const res: any = await oapiForModel(
       "Foo",
@@ -437,7 +437,7 @@ describe("typespec-autorest: definitions", () => {
   });
 });
 
-describe("typespec-autorest: literals", () => {
+describe("literals", () => {
   const cases = [
     ["1", { type: "number", enum: [1] }],
     ['"hello"', { type: "string", enum: ["hello"], "x-ms-enum": { modelAsString: false } }],
@@ -460,7 +460,7 @@ describe("typespec-autorest: literals", () => {
   }
 });
 
-describe("typespec-autorest: operations", () => {
+describe("operations", () => {
   it("define operations with param with defaults", async () => {
     const res: any = await compileOpenAPI(`
       @get op read(@query queryWithDefault?: string = "defaultValue"): string;
@@ -653,7 +653,7 @@ describe("typespec-autorest: operations", () => {
   });
 });
 
-describe("typespec-autorest: request", () => {
+describe("request", () => {
   describe("binary request", () => {
     it("bytes request should produce byte format with application/json", async () => {
       const res: any = await compileOpenAPI(`
@@ -682,7 +682,7 @@ describe("typespec-autorest: request", () => {
   });
 });
 
-describe("typespec-autorest: extension decorator", () => {
+describe("extension decorator", () => {
   it("adds an arbitrary extension to a model", async () => {
     const oapi: any = await compileOpenAPI(`
       @extension("x-model-extension", "foobar")

--- a/packages/typespec-autorest/test/options.test.ts
+++ b/packages/typespec-autorest/test/options.test.ts
@@ -24,424 +24,422 @@ function compileOpenAPIWithOptions(code: string, options: AutorestEmitterOptions
   });
 }
 
-describe("typespec-autorest: options", () => {
-  describe("'new-line' option", () => {
-    async function rawOpenApiFor(code: string, options: AutorestEmitterOptions): Promise<string> {
-      const [{ outputs }, diagnostics] = await runner.compileAndDiagnose(code, {
-        compilerOptions: {
-          options: {
-            "@azure-tools/typespec-autorest": { ...options },
-          },
+describe("'new-line' option", () => {
+  async function rawOpenApiFor(code: string, options: AutorestEmitterOptions): Promise<string> {
+    const [{ outputs }, diagnostics] = await runner.compileAndDiagnose(code, {
+      compilerOptions: {
+        options: {
+          "@azure-tools/typespec-autorest": { ...options },
         },
-      });
-
-      expectDiagnosticEmpty(
-        ignoreDiagnostics(diagnostics, [
-          "@typespec/http/no-service-found",
-          "@azure-tools/typespec-azure-core/use-standard-operations",
-        ]),
-      );
-
-      return outputs["openapi.json"];
-    }
-
-    // Content of an empty spec
-    const expectedEmptySpec = [
-      "{",
-      `  "swagger": "2.0",`,
-      `  "info": {`,
-      `    "title": "(title)",`,
-      `    "version": "0000-00-00",`,
-      `    "x-typespec-generated": [`,
-      `      {`,
-      `        "emitter": "@azure-tools/typespec-autorest"`,
-      `      }`,
-      `    ]`,
-      `  },`,
-      `  "schemes": [`,
-      `    "https"`,
-      `  ],`,
-      `  "produces": [`,
-      `    "application/json"`,
-      `  ],`,
-      `  "consumes": [`,
-      `    "application/json"`,
-      `  ],`,
-      `  "tags": [],`,
-      `  "paths": {},`,
-      `  "definitions": {},`,
-      `  "parameters": {}`,
-      "}",
-      "",
-    ];
-
-    it("emit LF line endings by default", async () => {
-      const output = await rawOpenApiFor("", {});
-      strictEqual(output, expectedEmptySpec.join("\n"));
+      },
     });
 
-    it("emit CRLF when configured", async () => {
-      const output = await rawOpenApiFor("", { "new-line": "crlf" });
-      strictEqual(output, expectedEmptySpec.join("\r\n"));
-    });
+    expectDiagnosticEmpty(
+      ignoreDiagnostics(diagnostics, [
+        "@typespec/http/no-service-found",
+        "@azure-tools/typespec-azure-core/use-standard-operations",
+      ]),
+    );
+
+    return outputs["openapi.json"];
+  }
+
+  // Content of an empty spec
+  const expectedEmptySpec = [
+    "{",
+    `  "swagger": "2.0",`,
+    `  "info": {`,
+    `    "title": "(title)",`,
+    `    "version": "0000-00-00",`,
+    `    "x-typespec-generated": [`,
+    `      {`,
+    `        "emitter": "@azure-tools/typespec-autorest"`,
+    `      }`,
+    `    ]`,
+    `  },`,
+    `  "schemes": [`,
+    `    "https"`,
+    `  ],`,
+    `  "produces": [`,
+    `    "application/json"`,
+    `  ],`,
+    `  "consumes": [`,
+    `    "application/json"`,
+    `  ],`,
+    `  "tags": [],`,
+    `  "paths": {},`,
+    `  "definitions": {},`,
+    `  "parameters": {}`,
+    "}",
+    "",
+  ];
+
+  it("emit LF line endings by default", async () => {
+    const output = await rawOpenApiFor("", {});
+    strictEqual(output, expectedEmptySpec.join("\n"));
   });
 
-  describe("'output-file' option", () => {
-    const emitterOutputDir = resolveVirtualPath("./my-output");
-    it("emit to {emitter-output-dir}/openapi.json if not provided", async () => {
-      await runner.compile(
-        `
-        #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
-        op test(): void;`,
-        {
-          compilerOptions: {
-            options: {
-              "@azure-tools/typespec-autorest": { "emitter-output-dir": emitterOutputDir },
+  it("emit CRLF when configured", async () => {
+    const output = await rawOpenApiFor("", { "new-line": "crlf" });
+    strictEqual(output, expectedEmptySpec.join("\r\n"));
+  });
+});
+
+describe("'output-file' option", () => {
+  const emitterOutputDir = resolveVirtualPath("./my-output");
+  it("emit to {emitter-output-dir}/openapi.json if not provided", async () => {
+    await runner.compile(
+      `
+      #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
+      op test(): void;`,
+      {
+        compilerOptions: {
+          options: {
+            "@azure-tools/typespec-autorest": { "emitter-output-dir": emitterOutputDir },
+          },
+        },
+      },
+    );
+    ok(runner.fs.fs.has(resolvePath(emitterOutputDir, "openapi.json")));
+  });
+
+  it("emit to {emitter-output-dir}/{output-file} if provided", async () => {
+    await runner.compile(
+      `
+      #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
+      op test(): void;`,
+      {
+        compilerOptions: {
+          outputDir: "./my-output",
+          options: {
+            "@azure-tools/typespec-autorest": {
+              "emitter-output-dir": emitterOutputDir,
             },
           },
         },
-      );
-      ok(runner.fs.fs.has(resolvePath(emitterOutputDir, "openapi.json")));
-    });
+      },
+    );
+    ok(runner.fs.fs.has(resolveVirtualPath("./my-output/openapi.json")));
+  });
 
-    it("emit to {emitter-output-dir}/{output-file} if provided", async () => {
-      await runner.compile(
-        `
-        #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
-        op test(): void;`,
-        {
-          compilerOptions: {
-            outputDir: "./my-output",
-            options: {
-              "@azure-tools/typespec-autorest": {
-                "emitter-output-dir": emitterOutputDir,
-              },
-            },
-          },
-        },
-      );
-      ok(runner.fs.fs.has(resolveVirtualPath("./my-output/openapi.json")));
-    });
-
-    it("emit to {emitter-output-dir}/{version-status}/{version}/{output-file} if spec contains versioning", async () => {
-      const versionedRunner = await Tester.createInstance();
-      await versionedRunner.compile(
-        `
+  it("emit to {emitter-output-dir}/{version-status}/{version}/{output-file} if spec contains versioning", async () => {
+    const versionedRunner = await Tester.createInstance();
+    await versionedRunner.compile(
+      `
 @TypeSpec.Versioning.versioned(Versions)
 @service(#{title: "Widget Service"})
 namespace DemoService;
 enum Versions {v1, v2}
 
 op test(): void;
-      `,
-        {
-          compilerOptions: {
-            outputDir: "./my-output",
-            options: {
-              "@azure-tools/typespec-autorest": {
-                "emitter-output-dir": emitterOutputDir,
-              },
+    `,
+      {
+        compilerOptions: {
+          outputDir: "./my-output",
+          options: {
+            "@azure-tools/typespec-autorest": {
+              "emitter-output-dir": emitterOutputDir,
             },
           },
         },
-      );
-      ok(
-        !versionedRunner.fs.fs.has(resolveVirtualPath("./my-output/openapi.json")),
-        "Shouldn't have created the non versioned file name",
-      );
-      ok(versionedRunner.fs.fs.has(resolveVirtualPath("./my-output/stable/v1/openapi.json")));
-      ok(versionedRunner.fs.fs.has(resolveVirtualPath("./my-output/stable/v2/openapi.json")));
-    });
+      },
+    );
+    ok(
+      !versionedRunner.fs.fs.has(resolveVirtualPath("./my-output/openapi.json")),
+      "Shouldn't have created the non versioned file name",
+    );
+    ok(versionedRunner.fs.fs.has(resolveVirtualPath("./my-output/stable/v1/openapi.json")));
+    ok(versionedRunner.fs.fs.has(resolveVirtualPath("./my-output/stable/v2/openapi.json")));
+  });
+});
+
+describe("omit-unreachable-types", () => {
+  it("emit unreferenced types by default", async () => {
+    const output = await compileOpenAPIWithOptions(
+      `
+      model NotReferenced {name: string}
+      model Referenced {name: string}
+      op test(): Referenced;
+    `,
+      {},
+    );
+    deepStrictEqual(Object.keys(output.definitions!), ["NotReferenced", "Referenced"]);
   });
 
-  describe("omit-unreachable-types", () => {
-    it("emit unreferenced types by default", async () => {
-      const output = await compileOpenAPIWithOptions(
-        `
-        model NotReferenced {name: string}
-        model Referenced {name: string}
-        op test(): Referenced;
-      `,
-        {},
-      );
-      deepStrictEqual(Object.keys(output.definitions!), ["NotReferenced", "Referenced"]);
-    });
+  it("emit only referenced types when using omit-unreachable-types", async () => {
+    const output = await compileOpenAPIWithOptions(
+      `
+      model NotReferenced {name: string}
+      model Referenced {name: string}
+      op test(): Referenced;
+    `,
+      {
+        "omit-unreachable-types": true,
+      },
+    );
+    deepStrictEqual(Object.keys(output.definitions!), ["Referenced"]);
+  });
+});
 
-    it("emit only referenced types when using omit-unreachable-types", async () => {
-      const output = await compileOpenAPIWithOptions(
-        `
-        model NotReferenced {name: string}
-        model Referenced {name: string}
-        op test(): Referenced;
-      `,
-        {
-          "omit-unreachable-types": true,
-        },
-      );
-      deepStrictEqual(Object.keys(output.definitions!), ["Referenced"]);
-    });
+describe("version-enum-strategy", () => {
+  const code = `
+    @service
+    @versioned(Versions)
+    namespace My {
+      enum Versions {v1, v2}
+      model NotReferenced {}
+    }
+  `;
+  it("doesn't include version enum by default", async () => {
+    const output = await compileOpenAPIWithOptions(code, {});
+    deepStrictEqual(Object.keys(output.definitions!), ["NotReferenced"]);
   });
 
-  describe("version-enum-strategy", () => {
-    const code = `
-      @service
+  it("include version enum when set to 'include'", async () => {
+    const output = await compileOpenAPIWithOptions(code, {
+      "version-enum-strategy": "include",
+    });
+    deepStrictEqual(Object.keys(output.definitions!), ["NotReferenced", "Versions"]);
+  });
+
+  it("doesn't omit other enums", async () => {
+    const output = await compileOpenAPIWithOptions(
+      `@service
       @versioned(Versions)
       namespace My {
         enum Versions {v1, v2}
-        model NotReferenced {}
-      }
+        enum NotReferenced {a, b}
+      }`,
+      {},
+    );
+    deepStrictEqual(Object.keys(output.definitions!), ["NotReferenced"]);
+  });
+});
+
+describe("include-x-typespec-name", () => {
+  it("doesn't include x-typespec-name by default", async () => {
+    const output = await compileOpenAPIWithOptions(
+      `
+      model Foo {names: string[]}
+    `,
+      {},
+    );
+    ok(!("x-typespec-name" in output.definitions!.Foo.properties!.names));
+  });
+
+  it(`doesn't include x-typespec-name when option include-x-typespec-name: "never"`, async () => {
+    const output = await compileOpenAPIWithOptions(
+      `
+      model Foo {names: string[]}
+    `,
+      { "include-x-typespec-name": "never" },
+    );
+    ok(!("x-typespec-name" in output.definitions!.Foo.properties!.names));
+  });
+
+  it(`include x-typespec-name when option include-x-typespec-name: "inline-only"`, async () => {
+    const output = await compileOpenAPIWithOptions(
+      `
+      model Foo {names: string[]}
+    `,
+      { "include-x-typespec-name": "inline-only" },
+    );
+    const prop: any = output.definitions!.Foo.properties!.names;
+    strictEqual(prop["x-typespec-name"], `string[]`);
+  });
+});
+
+describe("'emit-lro-options' option", () => {
+  const lroCode = `
+    @armProviderNamespace
+            namespace Microsoft.Test;
+
+    interface Operations extends Azure.ResourceManager.Operations {}
+
+    
+    enum ResourceState {
+     Succeeded,
+     Canceled,
+     Failed
+   }
+
+    
+    model WidgetProperties {
+      
+      simpleArmId: Azure.Core.armResourceIdentifier;
+
+      
+      provisioningState: ResourceState;
+    }
+
+    
+    model Widget is TrackedResource<WidgetProperties> {
+      
+      @key("widgetName")
+      @segment("widgets")
+      @path
+      name: string;
+    }
+    @armResourceOperations(Widget)
+    interface Widgets {
+      get is ArmResourceRead<Widget>;
+      @Azure.Core.useFinalStateVia("azure-async-operation")
+      createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget, LroHeaders = Azure.Core.Foundations.RetryAfterHeader & ArmAsyncOperationHeader>;
+      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+      update is ArmResourcePatchSync<Widget, WidgetProperties>;
+      delete is ArmResourceDeleteSync<Widget>;
+      listByResourceGroup is ArmResourceListByParent<Widget>;
+      listBySubscription is ArmListBySubscription<Widget>;
+    }
     `;
-    it("doesn't include version enum by default", async () => {
-      const output = await compileOpenAPIWithOptions(code, {});
-      deepStrictEqual(Object.keys(output.definitions!), ["NotReferenced"]);
-    });
 
-    it("include version enum when set to 'include'", async () => {
-      const output = await compileOpenAPIWithOptions(code, {
-        "version-enum-strategy": "include",
-      });
-      deepStrictEqual(Object.keys(output.definitions!), ["NotReferenced", "Versions"]);
-    });
-
-    it("doesn't omit other enums", async () => {
-      const output = await compileOpenAPIWithOptions(
-        `@service
-        @versioned(Versions)
-        namespace My {
-          enum Versions {v1, v2}
-          enum NotReferenced {a, b}
-        }`,
-        {},
-      );
-      deepStrictEqual(Object.keys(output.definitions!), ["NotReferenced"]);
+  it("emits all x-ms-long-running-operation-options", async () => {
+    const output = await compileOpenAPIWithOptions(lroCode, { "emit-lro-options": "all" });
+    const itemPath =
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
+    ok(output.paths[itemPath]);
+    ok(output.paths[itemPath].put);
+    deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation"], true);
+    deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation-options"], {
+      "final-state-via": "azure-async-operation",
+      "final-state-schema": "#/definitions/Widget",
     });
   });
 
-  describe("include-x-typespec-name", () => {
-    it("doesn't include x-typespec-name by default", async () => {
-      const output = await compileOpenAPIWithOptions(
-        `
-        model Foo {names: string[]}
-      `,
-        {},
-      );
-      ok(!("x-typespec-name" in output.definitions!.Foo.properties!.names));
-    });
-
-    it(`doesn't include x-typespec-name when option include-x-typespec-name: "never"`, async () => {
-      const output = await compileOpenAPIWithOptions(
-        `
-        model Foo {names: string[]}
-      `,
-        { "include-x-typespec-name": "never" },
-      );
-      ok(!("x-typespec-name" in output.definitions!.Foo.properties!.names));
-    });
-
-    it(`include x-typespec-name when option include-x-typespec-name: "inline-only"`, async () => {
-      const output = await compileOpenAPIWithOptions(
-        `
-        model Foo {names: string[]}
-      `,
-        { "include-x-typespec-name": "inline-only" },
-      );
-      const prop: any = output.definitions!.Foo.properties!.names;
-      strictEqual(prop["x-typespec-name"], `string[]`);
+  it("emits final-state-via by default", async () => {
+    const output = await compileOpenAPIWithOptions(lroCode, {});
+    const itemPath =
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
+    ok(output.paths[itemPath]);
+    ok(output.paths[itemPath].put);
+    deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation"], true);
+    deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation-options"], {
+      "final-state-via": "azure-async-operation",
     });
   });
 
-  describe("'emit-lro-options' option", () => {
-    const lroCode = `
-      @armProviderNamespace
-              namespace Microsoft.Test;
-
-      interface Operations extends Azure.ResourceManager.Operations {}
-
-      
-      enum ResourceState {
-       Succeeded,
-       Canceled,
-       Failed
-     }
-
-      
-      model WidgetProperties {
-        
-        simpleArmId: Azure.Core.armResourceIdentifier;
-
-        
-        provisioningState: ResourceState;
-      }
-
-      
-      model Widget is TrackedResource<WidgetProperties> {
-        
-        @key("widgetName")
-        @segment("widgets")
-        @path
-        name: string;
-      }
-      @armResourceOperations(Widget)
-      interface Widgets {
-        get is ArmResourceRead<Widget>;
-        @Azure.Core.useFinalStateVia("azure-async-operation")
-        createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget, LroHeaders = Azure.Core.Foundations.RetryAfterHeader & ArmAsyncOperationHeader>;
-        #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-        update is ArmResourcePatchSync<Widget, WidgetProperties>;
-        delete is ArmResourceDeleteSync<Widget>;
-        listByResourceGroup is ArmResourceListByParent<Widget>;
-        listBySubscription is ArmListBySubscription<Widget>;
-      }
-      `;
-
-    it("emits all x-ms-long-running-operation-options", async () => {
-      const output = await compileOpenAPIWithOptions(lroCode, { "emit-lro-options": "all" });
-      const itemPath =
-        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
-      ok(output.paths[itemPath]);
-      ok(output.paths[itemPath].put);
-      deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation"], true);
-      deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation-options"], {
-        "final-state-via": "azure-async-operation",
-        "final-state-schema": "#/definitions/Widget",
-      });
+  it("emits final-state-via when configured", async () => {
+    const output = await compileOpenAPIWithOptions(lroCode, {
+      "emit-lro-options": "final-state-only",
     });
-
-    it("emits final-state-via by default", async () => {
-      const output = await compileOpenAPIWithOptions(lroCode, {});
-      const itemPath =
-        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
-      ok(output.paths[itemPath]);
-      ok(output.paths[itemPath].put);
-      deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation"], true);
-      deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation-options"], {
-        "final-state-via": "azure-async-operation",
-      });
-    });
-
-    it("emits final-state-via when configured", async () => {
-      const output = await compileOpenAPIWithOptions(lroCode, {
-        "emit-lro-options": "final-state-only",
-      });
-      const itemPath =
-        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
-      ok(output.paths[itemPath]);
-      ok(output.paths[itemPath].put);
-      deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation"], true);
-      deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation-options"], {
-        "final-state-via": "azure-async-operation",
-      });
-    });
-
-    it("suppress x-ms-long-running operation options when configured", async () => {
-      const output = await compileOpenAPIWithOptions(lroCode, { "emit-lro-options": "none" });
-      const itemPath =
-        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
-      ok(output.paths[itemPath]);
-      ok(output.paths[itemPath].put);
-      deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation"], true);
-      deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation-options"], undefined);
+    const itemPath =
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
+    ok(output.paths[itemPath]);
+    ok(output.paths[itemPath].put);
+    deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation"], true);
+    deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation-options"], {
+      "final-state-via": "azure-async-operation",
     });
   });
 
-  describe("'emit-common-types-schema' option", () => {
-    const commonTypesFolder = resolveVirtualPath("common-types/resource-management");
-    const commonTypesPath = "../common-types/resource-management/v3/types.json";
-    const commonCode = `
-      @armProviderNamespace
-              namespace Microsoft.Test;
+  it("suppress x-ms-long-running operation options when configured", async () => {
+    const output = await compileOpenAPIWithOptions(lroCode, { "emit-lro-options": "none" });
+    const itemPath =
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/widgets/{widgetName}";
+    ok(output.paths[itemPath]);
+    ok(output.paths[itemPath].put);
+    deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation"], true);
+    deepStrictEqual(output.paths[itemPath].put["x-ms-long-running-operation-options"], undefined);
+  });
+});
 
-      interface Operations extends Azure.ResourceManager.Operations {}
+describe("'emit-common-types-schema' option", () => {
+  const commonTypesFolder = resolveVirtualPath("common-types/resource-management");
+  const commonTypesPath = "../common-types/resource-management/v3/types.json";
+  const commonCode = `
+    @armProviderNamespace
+            namespace Microsoft.Test;
+
+    interface Operations extends Azure.ResourceManager.Operations {}
+
+    
+    enum ResourceState {
+     Succeeded,
+     Canceled,
+     Failed
+   }
+
+    
+    model WidgetProperties {
+      
+      simpleArmId: Azure.Core.armResourceIdentifier;
 
       
-      enum ResourceState {
-       Succeeded,
-       Canceled,
-       Failed
-     }
+      provisioningState: ResourceState;
+    }
 
+    
+    model Widget is TrackedResource<WidgetProperties> {
       
-      model WidgetProperties {
-        
-        simpleArmId: Azure.Core.armResourceIdentifier;
+      @key("widgetName")
+      @segment("widgets")
+      @path
+      name: string;
+    }
+    @armResourceOperations(Widget)
+    interface Widgets {
+      get is ArmResourceRead<Widget>;
+      @Azure.Core.useFinalStateVia("azure-async-operation")
+      createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget, LroHeaders = Azure.Core.Foundations.RetryAfterHeader & ArmAsyncOperationHeader>;
+      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+      update is ArmResourcePatchSync<Widget, WidgetProperties>;
+      delete is ArmResourceDeleteSync<Widget>;
+      listByResourceGroup is ArmResourceListByParent<Widget>;
+      listBySubscription is ArmListBySubscription<Widget>;
+    }
+    `;
 
-        
-        provisioningState: ResourceState;
-      }
-
-      
-      model Widget is TrackedResource<WidgetProperties> {
-        
-        @key("widgetName")
-        @segment("widgets")
-        @path
-        name: string;
-      }
-      @armResourceOperations(Widget)
-      interface Widgets {
-        get is ArmResourceRead<Widget>;
-        @Azure.Core.useFinalStateVia("azure-async-operation")
-        createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget, LroHeaders = Azure.Core.Foundations.RetryAfterHeader & ArmAsyncOperationHeader>;
-        #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-        update is ArmResourcePatchSync<Widget, WidgetProperties>;
-        delete is ArmResourceDeleteSync<Widget>;
-        listByResourceGroup is ArmResourceListByParent<Widget>;
-        listBySubscription is ArmListBySubscription<Widget>;
-      }
-      `;
-
-    it("emits only schema references with 'never' setting", async () => {
-      const output = await compileOpenAPIWithOptions(commonCode, {
-        "emit-common-types-schema": "never",
-        "arm-types-dir": commonTypesFolder,
-      });
-      ok(output.definitions);
-      ok(output.definitions["WidgetUpdate"]);
-      deepStrictEqual(output.definitions["WidgetUpdate"].allOf, [
-        {
-          $ref: `${commonTypesPath}#/definitions/TrackedResource`,
-        },
-      ]);
+  it("emits only schema references with 'never' setting", async () => {
+    const output = await compileOpenAPIWithOptions(commonCode, {
+      "emit-common-types-schema": "never",
+      "arm-types-dir": commonTypesFolder,
     });
-
-    it("emits an update schema for TrackedResource by default", async () => {
-      const output = await compileOpenAPIWithOptions(commonCode, {
-        "arm-types-dir": commonTypesFolder,
-      });
-      ok(output.definitions);
-      ok(output.definitions["WidgetUpdate"]);
-      deepStrictEqual(output.definitions["WidgetUpdate"].allOf, [
-        {
-          $ref: `#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate`,
-        },
-      ]);
-    });
-
-    it("emits update schema when set to `for-visibility-changes`", async () => {
-      const output = await compileOpenAPIWithOptions(commonCode, {
-        "emit-common-types-schema": "for-visibility-changes",
-        "arm-types-dir": commonTypesFolder,
-      });
-      ok(output.definitions);
-      ok(output.definitions["WidgetUpdate"]);
-      deepStrictEqual(output.definitions["WidgetUpdate"].allOf, [
-        {
-          $ref: `#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate`,
-        },
-      ]);
-    });
+    ok(output.definitions);
+    ok(output.definitions["WidgetUpdate"]);
+    deepStrictEqual(output.definitions["WidgetUpdate"].allOf, [
+      {
+        $ref: `${commonTypesPath}#/definitions/TrackedResource`,
+      },
+    ]);
   });
 
-  describe("'examples-dir'", () => {
-    it("emit diagnostic if examples-dir is not absolute", async () => {
-      const runner = await ApiTester.emit("@azure-tools/typespec-autorest", {
-        "examples-dir": "./examples",
-      });
+  it("emits an update schema for TrackedResource by default", async () => {
+    const output = await compileOpenAPIWithOptions(commonCode, {
+      "arm-types-dir": commonTypesFolder,
+    });
+    ok(output.definitions);
+    ok(output.definitions["WidgetUpdate"]);
+    deepStrictEqual(output.definitions["WidgetUpdate"].allOf, [
+      {
+        $ref: `#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate`,
+      },
+    ]);
+  });
 
-      const diagnostics = await runner.diagnose("op test(): void;");
-      expectDiagnostics(diagnostics, {
-        code: "config-path-absolute",
-      });
+  it("emits update schema when set to `for-visibility-changes`", async () => {
+    const output = await compileOpenAPIWithOptions(commonCode, {
+      "emit-common-types-schema": "for-visibility-changes",
+      "arm-types-dir": commonTypesFolder,
+    });
+    ok(output.definitions);
+    ok(output.definitions["WidgetUpdate"]);
+    deepStrictEqual(output.definitions["WidgetUpdate"].allOf, [
+      {
+        $ref: `#/definitions/Azure.ResourceManager.CommonTypes.TrackedResourceUpdate`,
+      },
+    ]);
+  });
+});
+
+describe("'examples-dir'", () => {
+  it("emit diagnostic if examples-dir is not absolute", async () => {
+    const runner = await ApiTester.emit("@azure-tools/typespec-autorest", {
+      "examples-dir": "./examples",
+    });
+
+    const diagnostics = await runner.diagnose("op test(): void;");
+    expectDiagnostics(diagnostics, {
+      code: "config-path-absolute",
     });
   });
 });

--- a/packages/typespec-autorest/test/primitive-types.test.ts
+++ b/packages/typespec-autorest/test/primitive-types.test.ts
@@ -4,305 +4,303 @@ import { describe, it } from "vitest";
 import { OpenAPI2Parameter, OpenAPI2Schema } from "../src/openapi2-document.js";
 import { diagnoseOpenApiFor, oapiForModel, openApiFor } from "./test-host.js";
 
-describe("typespec-autorest: primitives", () => {
-  describe("handle typespec intrinsic types", () => {
-    const cases = [
-      ["unknown", {}],
-      ["int8", { type: "integer", format: "int8" }],
-      ["int16", { type: "integer", format: "int16" }],
-      ["int32", { type: "integer", format: "int32" }],
-      ["int64", { type: "integer", format: "int64" }],
-      ["safeint", { type: "integer", format: "int64" }],
-      ["uint8", { type: "integer", format: "uint8" }],
-      ["uint16", { type: "integer", format: "uint16" }],
-      ["uint32", { type: "integer", format: "uint32" }],
-      ["uint64", { type: "integer", format: "uint64" }],
-      ["float32", { type: "number", format: "float" }],
-      ["float64", { type: "number", format: "double" }],
-      ["string", { type: "string" }],
-      ["boolean", { type: "boolean" }],
-      ["plainDate", { type: "string", format: "date" }],
-      ["utcDateTime", { type: "string", format: "date-time" }],
-      ["offsetDateTime", { type: "string", format: "date-time" }],
-      ["plainTime", { type: "string", format: "time" }],
-      ["duration", { type: "string", format: "duration" }],
-      ["bytes", { type: "string", format: "byte" }],
-      ["decimal", { type: "number", format: "decimal" }],
-      ["decimal128", { type: "number", format: "decimal" }],
-    ];
+describe("handle typespec intrinsic types", () => {
+  const cases = [
+    ["unknown", {}],
+    ["int8", { type: "integer", format: "int8" }],
+    ["int16", { type: "integer", format: "int16" }],
+    ["int32", { type: "integer", format: "int32" }],
+    ["int64", { type: "integer", format: "int64" }],
+    ["safeint", { type: "integer", format: "int64" }],
+    ["uint8", { type: "integer", format: "uint8" }],
+    ["uint16", { type: "integer", format: "uint16" }],
+    ["uint32", { type: "integer", format: "uint32" }],
+    ["uint64", { type: "integer", format: "uint64" }],
+    ["float32", { type: "number", format: "float" }],
+    ["float64", { type: "number", format: "double" }],
+    ["string", { type: "string" }],
+    ["boolean", { type: "boolean" }],
+    ["plainDate", { type: "string", format: "date" }],
+    ["utcDateTime", { type: "string", format: "date-time" }],
+    ["offsetDateTime", { type: "string", format: "date-time" }],
+    ["plainTime", { type: "string", format: "time" }],
+    ["duration", { type: "string", format: "duration" }],
+    ["bytes", { type: "string", format: "byte" }],
+    ["decimal", { type: "number", format: "decimal" }],
+    ["decimal128", { type: "number", format: "decimal" }],
+  ];
 
-    for (const test of cases) {
-      it("knows schema for " + test[0], async () => {
-        const res = await oapiForModel(
-          "Pet",
-          `
+  for (const test of cases) {
+    it("knows schema for " + test[0], async () => {
+      const res = await oapiForModel(
+        "Pet",
+        `
+        model Pet { name: ${test[0]} };
+        `,
+      );
+
+      const schema = res.defs.Pet.properties.name;
+      deepStrictEqual(schema, test[1]);
+    });
+  }
+});
+
+describe("handle nonspecific intrinsic types", () => {
+  const cases = [
+    [
+      "numeric",
+      "Scalar type 'numeric' is not specific enough. The more specific type 'int64' has been chosen.",
+    ],
+    [
+      "integer",
+      "Scalar type 'integer' is not specific enough. The more specific type 'int64' has been chosen.",
+    ],
+    [
+      "float",
+      "Scalar type 'float' is not specific enough. The more specific type 'float64' has been chosen.",
+    ],
+  ];
+
+  for (const test of cases) {
+    it("reports nonspecific scalar for " + test[0], async () => {
+      const res = await diagnoseOpenApiFor(
+        `
+        @service(#{title: "Testing model"})
+        @route("/")
+        namespace root {
+          #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
+          op read(): void;
+
           model Pet { name: ${test[0]} };
-          `,
-        );
+        }
+        `,
+      );
 
-        const schema = res.defs.Pet.properties.name;
-        deepStrictEqual(schema, test[1]);
+      expectDiagnostics(res, {
+        code: "@azure-tools/typespec-autorest/nonspecific-scalar",
+        message: test[1],
       });
-    }
-  });
-
-  describe("handle nonspecific intrinsic types", () => {
-    const cases = [
-      [
-        "numeric",
-        "Scalar type 'numeric' is not specific enough. The more specific type 'int64' has been chosen.",
-      ],
-      [
-        "integer",
-        "Scalar type 'integer' is not specific enough. The more specific type 'int64' has been chosen.",
-      ],
-      [
-        "float",
-        "Scalar type 'float' is not specific enough. The more specific type 'float64' has been chosen.",
-      ],
-    ];
-
-    for (const test of cases) {
-      it("reports nonspecific scalar for " + test[0], async () => {
-        const res = await diagnoseOpenApiFor(
-          `
-          @service(#{title: "Testing model"})
-          @route("/")
-          namespace root {
-            #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
-            op read(): void;
-
-            model Pet { name: ${test[0]} };
-          }
-          `,
-        );
-
-        expectDiagnostics(res, {
-          code: "@azure-tools/typespec-autorest/nonspecific-scalar",
-          message: test[1],
-        });
-      });
-    }
-  });
-
-  it("defines models extended from primitives", async () => {
-    const res = await oapiForModel(
-      "Pet",
-      `
-      scalar shortString extends string;
-      model Pet { name: shortString };
-      `,
-    );
-
-    ok(res.isRef);
-    ok(res.defs.shortString, "expected definition named shortString");
-    ok(res.defs.Pet, "expected definition named Pet");
-    deepStrictEqual(res.defs.shortString, {
-      type: "string",
     });
+  }
+});
+
+it("defines models extended from primitives", async () => {
+  const res = await oapiForModel(
+    "Pet",
+    `
+    scalar shortString extends string;
+    model Pet { name: shortString };
+    `,
+  );
+
+  ok(res.isRef);
+  ok(res.defs.shortString, "expected definition named shortString");
+  ok(res.defs.Pet, "expected definition named Pet");
+  deepStrictEqual(res.defs.shortString, {
+    type: "string",
   });
+});
 
-  it("apply description on extended primitive (string)", async () => {
-    const res = await oapiForModel(
-      "shortString",
-      `
-      @doc("My custom description")
-      scalar shortString extends string;
-      `,
-    );
-
-    ok(res.isRef);
-    deepStrictEqual(res.defs.shortString, {
-      type: "string",
-      description: "My custom description",
-    });
-  });
-
-  it("apply description on extended primitive (int32)", async () => {
-    const res = await oapiForModel(
-      "specialInt",
-      `
-      @doc("My custom description")
-      scalar specialInt extends int32;
-      `,
-    );
-
-    ok(res.isRef);
-    deepStrictEqual(res.defs.specialInt, {
-      type: "integer",
-      format: "int32",
-      description: "My custom description",
-    });
-  });
-
-  it("apply description on extended custom scalars", async () => {
-    const res = await oapiForModel(
-      "superSpecialint",
-      `
+it("apply description on extended primitive (string)", async () => {
+  const res = await oapiForModel(
+    "shortString",
+    `
     @doc("My custom description")
-    scalar specialint extends int32;
-    @doc("Override specialint description")
-    scalar superSpecialint extends specialint;
+    scalar shortString extends string;
     `,
-    );
+  );
 
-    ok(res.isRef);
-    deepStrictEqual(res.defs.superSpecialint, {
-      type: "integer",
-      format: "int32",
-      description: "Override specialint description",
-    });
+  ok(res.isRef);
+  deepStrictEqual(res.defs.shortString, {
+    type: "string",
+    description: "My custom description",
   });
+});
 
-  it("defines scalar extended from primitives with attrs", async () => {
-    const res = await oapiForModel(
-      "Pet",
-      `
-      @maxLength(10) @minLength(10)
-      scalar shortString extends string;
-      model Pet { name: shortString };
-      `,
-    );
-
-    ok(res.isRef);
-    ok(res.defs.shortString, "expected definition named shortString");
-    ok(res.defs.Pet, "expected definition named Pet");
-    deepStrictEqual(res.defs.shortString, {
-      type: "string",
-      minLength: 10,
-      maxLength: 10,
-    });
-  });
-
-  it("defines scalar extended from primitives with new attrs", async () => {
-    const res = await oapiForModel(
-      "Pet",
-      `
-      @maxLength(10)
-      scalar shortString extends string;
-      @minLength(1)
-      scalar shortButNotEmptyString extends shortString;
-      model Pet { name: shortButNotEmptyString, breed: shortString };
-      `,
-    );
-    ok(res.isRef);
-    ok(res.defs.shortString, "expected definition named shortString");
-    ok(res.defs.shortButNotEmptyString, "expected definition named shortButNotEmptyString");
-    ok(res.defs.Pet, "expected definition named Pet");
-
-    deepStrictEqual(res.defs.shortString, {
-      type: "string",
-      maxLength: 10,
-    });
-    deepStrictEqual(res.defs.shortButNotEmptyString, {
-      type: "string",
-      minLength: 1,
-      maxLength: 10,
-    });
-  });
-
-  it("includes extensions passed on the scalar", async () => {
-    const res = await oapiForModel(
-      "Pet",
-      `
-    @extension("x-custom", "my-value")
-    scalar Pet extends string;
+it("apply description on extended primitive (int32)", async () => {
+  const res = await oapiForModel(
+    "specialInt",
+    `
+    @doc("My custom description")
+    scalar specialInt extends int32;
     `,
-    );
+  );
 
-    ok(res.defs.Pet, "expected definition named Pet");
-    deepStrictEqual(res.defs.Pet, {
-      type: "string",
-      "x-custom": "my-value",
+  ok(res.isRef);
+  deepStrictEqual(res.defs.specialInt, {
+    type: "integer",
+    format: "int32",
+    description: "My custom description",
+  });
+});
+
+it("apply description on extended custom scalars", async () => {
+  const res = await oapiForModel(
+    "superSpecialint",
+    `
+  @doc("My custom description")
+  scalar specialint extends int32;
+  @doc("Override specialint description")
+  scalar superSpecialint extends specialint;
+  `,
+  );
+
+  ok(res.isRef);
+  deepStrictEqual(res.defs.superSpecialint, {
+    type: "integer",
+    format: "int32",
+    description: "Override specialint description",
+  });
+});
+
+it("defines scalar extended from primitives with attrs", async () => {
+  const res = await oapiForModel(
+    "Pet",
+    `
+    @maxLength(10) @minLength(10)
+    scalar shortString extends string;
+    model Pet { name: shortString };
+    `,
+  );
+
+  ok(res.isRef);
+  ok(res.defs.shortString, "expected definition named shortString");
+  ok(res.defs.Pet, "expected definition named Pet");
+  deepStrictEqual(res.defs.shortString, {
+    type: "string",
+    minLength: 10,
+    maxLength: 10,
+  });
+});
+
+it("defines scalar extended from primitives with new attrs", async () => {
+  const res = await oapiForModel(
+    "Pet",
+    `
+    @maxLength(10)
+    scalar shortString extends string;
+    @minLength(1)
+    scalar shortButNotEmptyString extends shortString;
+    model Pet { name: shortButNotEmptyString, breed: shortString };
+    `,
+  );
+  ok(res.isRef);
+  ok(res.defs.shortString, "expected definition named shortString");
+  ok(res.defs.shortButNotEmptyString, "expected definition named shortButNotEmptyString");
+  ok(res.defs.Pet, "expected definition named Pet");
+
+  deepStrictEqual(res.defs.shortString, {
+    type: "string",
+    maxLength: 10,
+  });
+  deepStrictEqual(res.defs.shortButNotEmptyString, {
+    type: "string",
+    minLength: 1,
+    maxLength: 10,
+  });
+});
+
+it("includes extensions passed on the scalar", async () => {
+  const res = await oapiForModel(
+    "Pet",
+    `
+  @extension("x-custom", "my-value")
+  scalar Pet extends string;
+  `,
+  );
+
+  ok(res.defs.Pet, "expected definition named Pet");
+  deepStrictEqual(res.defs.Pet, {
+    type: "string",
+    "x-custom": "my-value",
+  });
+});
+
+describe("using @encode decorator", () => {
+  async function testEncode(
+    scalar: string,
+    expectedOpenApi: OpenAPI2Schema,
+    encoding?: string | null,
+    encodeAs?: string,
+  ) {
+    const encodeAsParam = encodeAs ? `, ${encodeAs}` : "";
+    const encodeDecorator =
+      encoding === null
+        ? `@encode(${encodeAs})`
+        : encoding !== undefined
+          ? `@encode("${encoding}"${encodeAsParam})`
+          : "";
+    const res1 = await oapiForModel("s", `${encodeDecorator} scalar s extends ${scalar};`);
+    deepStrictEqual(res1.defs.s, expectedOpenApi);
+    const res2 = await oapiForModel("Test", `model Test {${encodeDecorator} prop: ${scalar}};`);
+    deepStrictEqual(res2.defs.Test.properties.prop, expectedOpenApi);
+  }
+
+  describe("utcDateTime", () => {
+    it("set format to 'date-time' by default", () =>
+      testEncode("utcDateTime", { type: "string", format: "date-time" }));
+    it("set format to 'date-time-rfc7231' when encoding is rfc7231", () =>
+      testEncode("utcDateTime", { type: "string", format: "date-time-rfc7231" }, "rfc7231"));
+    it("set format to 'date-time-rfc7231' for a header when encoding is rfc7231", async () => {
+      const oapi = await openApiFor(`
+          model Test {@header @encode("rfc7231") param: utcDateTime};
+         
+          #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
+          op read(...Test): void;      
+        `);
+      const expected: OpenAPI2Parameter = {
+        name: "param",
+        in: "header",
+        required: true,
+        type: "string",
+        format: "date-time-rfc7231",
+        "x-ms-parameter-location": "method",
+      };
+      deepStrictEqual(oapi.parameters.Test, expected);
+    });
+    it("set type to integer and format to 'unixtime' when encoding is unixTimestamp (unixTimestamp info is lost)", async () => {
+      const expected: OpenAPI2Schema = { type: "integer", format: "unixtime" };
+      await testEncode("utcDateTime", expected, "unixTimestamp", "int32");
+      await testEncode("utcDateTime", expected, "unixTimestamp", "int64");
+      await testEncode("utcDateTime", expected, "unixTimestamp", "int8");
+      await testEncode("utcDateTime", expected, "unixTimestamp", "uint8");
     });
   });
 
-  describe("using @encode decorator", () => {
-    async function testEncode(
-      scalar: string,
-      expectedOpenApi: OpenAPI2Schema,
-      encoding?: string | null,
-      encodeAs?: string,
-    ) {
-      const encodeAsParam = encodeAs ? `, ${encodeAs}` : "";
-      const encodeDecorator =
-        encoding === null
-          ? `@encode(${encodeAs})`
-          : encoding !== undefined
-            ? `@encode("${encoding}"${encodeAsParam})`
-            : "";
-      const res1 = await oapiForModel("s", `${encodeDecorator} scalar s extends ${scalar};`);
-      deepStrictEqual(res1.defs.s, expectedOpenApi);
-      const res2 = await oapiForModel("Test", `model Test {${encodeDecorator} prop: ${scalar}};`);
-      deepStrictEqual(res2.defs.Test.properties.prop, expectedOpenApi);
-    }
+  describe("offsetDateTime", () => {
+    it("set format to 'date-time' by default", () =>
+      testEncode("offsetDateTime", { type: "string", format: "date-time" }));
+    it("set format to 'date-time-rfc7231' when encoding is rfc7231", () =>
+      testEncode("offsetDateTime", { type: "string", format: "date-time-rfc7231" }, "rfc7231"));
+  });
 
-    describe("utcDateTime", () => {
-      it("set format to 'date-time' by default", () =>
-        testEncode("utcDateTime", { type: "string", format: "date-time" }));
-      it("set format to 'date-time-rfc7231' when encoding is rfc7231", () =>
-        testEncode("utcDateTime", { type: "string", format: "date-time-rfc7231" }, "rfc7231"));
-      it("set format to 'date-time-rfc7231' for a header when encoding is rfc7231", async () => {
-        const oapi = await openApiFor(`
-            model Test {@header @encode("rfc7231") param: utcDateTime};
-           
-            #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
-            op read(...Test): void;      
-          `);
-        const expected: OpenAPI2Parameter = {
-          name: "param",
-          in: "header",
-          required: true,
-          type: "string",
-          format: "date-time-rfc7231",
-          "x-ms-parameter-location": "method",
-        };
-        deepStrictEqual(oapi.parameters.Test, expected);
-      });
-      it("set type to integer and format to 'unixtime' when encoding is unixTimestamp (unixTimestamp info is lost)", async () => {
-        const expected: OpenAPI2Schema = { type: "integer", format: "unixtime" };
-        await testEncode("utcDateTime", expected, "unixTimestamp", "int32");
-        await testEncode("utcDateTime", expected, "unixTimestamp", "int64");
-        await testEncode("utcDateTime", expected, "unixTimestamp", "int8");
-        await testEncode("utcDateTime", expected, "unixTimestamp", "uint8");
-      });
-    });
+  describe("duration", () => {
+    it("set format to 'duration' by default", () =>
+      testEncode("duration", { type: "string", format: "duration" }));
+    it("set integer with int32 format setting duration as seconds", () =>
+      testEncode("duration", { type: "integer", format: "int32" }, "seconds", "int32"));
+  });
 
-    describe("offsetDateTime", () => {
-      it("set format to 'date-time' by default", () =>
-        testEncode("offsetDateTime", { type: "string", format: "date-time" }));
-      it("set format to 'date-time-rfc7231' when encoding is rfc7231", () =>
-        testEncode("offsetDateTime", { type: "string", format: "date-time-rfc7231" }, "rfc7231"));
-    });
+  describe("bytes", () => {
+    it("set format to 'base64' by default", () =>
+      testEncode("bytes", { type: "string", format: "byte" }));
+    it("set format to byte when encoding bytes as base64", () =>
+      testEncode("bytes", { type: "string", format: "byte" }, "base64"));
+    it("set format to base64url when encoding bytes as base64url", () =>
+      testEncode("bytes", { type: "string", format: "base64url" }, "base64url"));
+  });
 
-    describe("duration", () => {
-      it("set format to 'duration' by default", () =>
-        testEncode("duration", { type: "string", format: "duration" }));
-      it("set integer with int32 format setting duration as seconds", () =>
-        testEncode("duration", { type: "integer", format: "int32" }, "seconds", "int32"));
-    });
+  describe("int64", () => {
+    it("set type: integer and format to 'int64' by default", () =>
+      testEncode("int64", { type: "integer", format: "int64" }));
+    it("set type: string and format to int64 when @encode(string)", () =>
+      testEncode("int64", { type: "string", format: "int64" }, null, "string"));
+  });
 
-    describe("bytes", () => {
-      it("set format to 'base64' by default", () =>
-        testEncode("bytes", { type: "string", format: "byte" }));
-      it("set format to byte when encoding bytes as base64", () =>
-        testEncode("bytes", { type: "string", format: "byte" }, "base64"));
-      it("set format to base64url when encoding bytes as base64url", () =>
-        testEncode("bytes", { type: "string", format: "base64url" }, "base64url"));
-    });
-
-    describe("int64", () => {
-      it("set type: integer and format to 'int64' by default", () =>
-        testEncode("int64", { type: "integer", format: "int64" }));
-      it("set type: string and format to int64 when @encode(string)", () =>
-        testEncode("int64", { type: "string", format: "int64" }, null, "string"));
-    });
-
-    describe("decimal128", () => {
-      it("set type: integer and format to 'int64' by default", () =>
-        testEncode("decimal128", { type: "number", format: "decimal" }));
-      it("set type: string and format to int64 when @encode(string)", () =>
-        testEncode("decimal128", { type: "string", format: "decimal" }, null, "string"));
-    });
+  describe("decimal128", () => {
+    it("set type: integer and format to 'int64' by default", () =>
+      testEncode("decimal128", { type: "number", format: "decimal" }));
+    it("set type: string and format to int64 when @encode(string)", () =>
+      testEncode("decimal128", { type: "string", format: "decimal" }, null, "string"));
   });
 });

--- a/packages/typespec-autorest/test/produces-consumes.test.ts
+++ b/packages/typespec-autorest/test/produces-consumes.test.ts
@@ -1,5 +1,5 @@
 import { deepStrictEqual, strictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { openApiFor } from "./test-host.js";
 
 interface ProducesConsumes {
@@ -22,79 +22,77 @@ interface OperationResult {
   consumes?: string[];
 }
 
-describe("typespec-autorest: produces/consumes", () => {
-  it("produces global produces for simple json", async () => {
-    const result = await openApiForProducesConsumes([
-      {
-        path: "/",
-        namespace: "root",
-        type: "produces",
-        modelDef: `
-        model simple {
-          name: string;
-        }
-        `,
-        modelName: "simple",
-      },
-    ]);
+it("produces global produces for simple json", async () => {
+  const result = await openApiForProducesConsumes([
+    {
+      path: "/",
+      namespace: "root",
+      type: "produces",
+      modelDef: `
+      model simple {
+        name: string;
+      }
+      `,
+      modelName: "simple",
+    },
+  ]);
 
-    strictEqual(result.globalProduces[0], "application/json");
-    deepStrictEqual(result.operations.get("/")?.produces, undefined);
-    deepStrictEqual(result.operations.get("/")?.consumes, undefined);
-  });
-  it("produces global consumes for simple json", async () => {
-    const result = await openApiForProducesConsumes([
-      {
-        path: "/",
-        namespace: "root",
-        type: "consumes",
-        modelDef: `
-        model simple {
-          name: string;
-        }
-        `,
-        modelName: "simple",
-      },
-    ]);
+  strictEqual(result.globalProduces[0], "application/json");
+  deepStrictEqual(result.operations.get("/")?.produces, undefined);
+  deepStrictEqual(result.operations.get("/")?.consumes, undefined);
+});
+it("produces global consumes for simple json", async () => {
+  const result = await openApiForProducesConsumes([
+    {
+      path: "/",
+      namespace: "root",
+      type: "consumes",
+      modelDef: `
+      model simple {
+        name: string;
+      }
+      `,
+      modelName: "simple",
+    },
+  ]);
 
-    strictEqual(result.globalConsumes[0], "application/json");
-    deepStrictEqual(result.operations.get("/")?.produces, undefined);
-    deepStrictEqual(result.operations.get("/")?.consumes, undefined);
-  });
-  it("produces individual produces/consumes if differences in methods", async () => {
-    const result = await openApiForProducesConsumes([
-      {
-        path: "/in",
-        namespace: "input",
-        type: "consumes",
-        modelDef: `
-        model simpleParam {
-          @header "content-type": "application/json";
-          name: string;
-        }
-        `,
-        modelName: "simpleParam",
-      },
-      {
-        path: "/out",
-        namespace: "output",
-        type: "produces",
-        modelDef: `
-        model simpleOutput {
-          @header "content-type": "text/json";
-          name: string;
-        }
-        `,
-        modelName: "simpleOutput",
-      },
-    ]);
+  strictEqual(result.globalConsumes[0], "application/json");
+  deepStrictEqual(result.operations.get("/")?.produces, undefined);
+  deepStrictEqual(result.operations.get("/")?.consumes, undefined);
+});
+it("produces individual produces/consumes if differences in methods", async () => {
+  const result = await openApiForProducesConsumes([
+    {
+      path: "/in",
+      namespace: "input",
+      type: "consumes",
+      modelDef: `
+      model simpleParam {
+        @header "content-type": "application/json";
+        name: string;
+      }
+      `,
+      modelName: "simpleParam",
+    },
+    {
+      path: "/out",
+      namespace: "output",
+      type: "produces",
+      modelDef: `
+      model simpleOutput {
+        @header "content-type": "text/json";
+        name: string;
+      }
+      `,
+      modelName: "simpleOutput",
+    },
+  ]);
 
-    deepStrictEqual(result.globalConsumes, ["application/json"]);
-    deepStrictEqual(result.operations.get("/in")?.produces, undefined);
-    deepStrictEqual(result.operations.get("/in")?.consumes, undefined);
-    deepStrictEqual(result.operations.get("/out")?.produces, ["text/json"]);
-    strictEqual(result.operations.get("/out")?.consumes, undefined);
-  });
+  deepStrictEqual(result.globalConsumes, ["application/json"]);
+  deepStrictEqual(result.operations.get("/in")?.produces, undefined);
+  deepStrictEqual(result.operations.get("/in")?.consumes, undefined);
+  deepStrictEqual(result.operations.get("/out")?.produces, ["text/json"]);
+  strictEqual(result.operations.get("/out")?.consumes, undefined);
 });
 
 async function openApiForProducesConsumes(

--- a/packages/typespec-autorest/test/property-schema.test.ts
+++ b/packages/typespec-autorest/test/property-schema.test.ts
@@ -1,145 +1,143 @@
 import { deepStrictEqual, ok } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { openApiFor } from "./test-host.js";
 
-describe("typespec-autorest: Property schema tests", () => {
-  it("produces standard schema for lro status by default", async () => {
-    const result = await openApiFor(
-      `
-      @service(#{title: "Test"}) 
-      namespace Test;
+it("produces standard schema for lro status by default", async () => {
+  const result = await openApiFor(
+    `
+    @service(#{title: "Test"}) 
+    namespace Test;
 
-      model Bar {propB: int32;}
-      model Foo { prop1: string;}
+    model Bar {propB: int32;}
+    model Foo { prop1: string;}
 
-      enum FooPrime { Succeeded, Failed, Canceled}
+    enum FooPrime { Succeeded, Failed, Canceled}
 
-      @pattern("^[a-zA-Z0-9-]{3,24}$")
-      scalar BarPrime extends string;
+    @pattern("^[a-zA-Z0-9-]{3,24}$")
+    scalar BarPrime extends string;
 
-      model UsesAll {
-        @visibility(Lifecycle.Read)
-        fooProp: Foo;
-        @visibility(Lifecycle.Read)
-        primeProp: FooPrime;
-        @visibility(Lifecycle.Read)
-        barPrimeProp: BarPrime;
-      }
+    model UsesAll {
+      @visibility(Lifecycle.Read)
+      fooProp: Foo;
+      @visibility(Lifecycle.Read)
+      primeProp: FooPrime;
+      @visibility(Lifecycle.Read)
+      barPrimeProp: BarPrime;
+    }
 
-      op myOp(): void;
-
-
-      `,
-    );
-
-    ok(!result.isRef);
-    deepStrictEqual(result.definitions.FooPrime.readOnly, undefined);
-  });
-
-  it("produces normal status schema when use-read-only-status-schema is false", async () => {
-    const result = await openApiFor(
-      `
-      @service(#{title: "Test"}) 
-      namespace Test;
-
-      model Bar {propB: int32;}
-      model Foo { prop1: string;}
-
-      enum FooPrime { Succeeded, Failed, Canceled}
-
-      @pattern("^[a-zA-Z0-9-]{3,24}$")
-      scalar BarPrime extends string;
-
-      model UsesAll {
-        @visibility(Lifecycle.Read)
-        fooProp: Foo;
-        @visibility(Lifecycle.Read)
-        primeProp: FooPrime;
-        @visibility(Lifecycle.Read)
-        barPrimeProp: BarPrime;
-      }
-
-      op myOp(first: Foo, second: FooPrime, third: BarPrime): void;
+    op myOp(): void;
 
 
-      `,
-      undefined,
-      { "use-read-only-status-schema": false },
-    );
+    `,
+  );
 
-    ok(!result.isRef);
-    deepStrictEqual(result.definitions.FooPrime.readOnly, undefined);
-  });
+  ok(!result.isRef);
+  deepStrictEqual(result.definitions.FooPrime.readOnly, undefined);
+});
 
-  it("creates readOnly schema for status properties when set to 'use-read-only-status-schema': true", async () => {
-    const result = await openApiFor(
-      `
-      @service(#{title: "Test"}) 
-      namespace Test;
+it("produces normal status schema when use-read-only-status-schema is false", async () => {
+  const result = await openApiFor(
+    `
+    @service(#{title: "Test"}) 
+    namespace Test;
 
-      model Bar {propB: int32;}
-      model Foo { prop1: string;}
+    model Bar {propB: int32;}
+    model Foo { prop1: string;}
 
-      enum FooPrime { Succeeded, Failed, Canceled}
+    enum FooPrime { Succeeded, Failed, Canceled}
 
-      @pattern("^[a-zA-Z0-9-]{3,24}$")
-      scalar BarPrime extends string;
+    @pattern("^[a-zA-Z0-9-]{3,24}$")
+    scalar BarPrime extends string;
 
-      model UsesAll {
-        @visibility(Lifecycle.Read)
-        fooProp: Foo;
-        @visibility(Lifecycle.Read)
-        primeProp: FooPrime;
-        @visibility(Lifecycle.Read)
-        barPrimeProp: BarPrime;
-        otherProp: FooPrime;
-      }
+    model UsesAll {
+      @visibility(Lifecycle.Read)
+      fooProp: Foo;
+      @visibility(Lifecycle.Read)
+      primeProp: FooPrime;
+      @visibility(Lifecycle.Read)
+      barPrimeProp: BarPrime;
+    }
 
-      op myOp(): void;
+    op myOp(first: Foo, second: FooPrime, third: BarPrime): void;
 
 
-      `,
-      undefined,
-      { "use-read-only-status-schema": true },
-    );
+    `,
+    undefined,
+    { "use-read-only-status-schema": false },
+  );
 
-    ok(!result.isRef);
-    deepStrictEqual(result.definitions.FooPrime.readOnly, true);
-  });
+  ok(!result.isRef);
+  deepStrictEqual(result.definitions.FooPrime.readOnly, undefined);
+});
 
-  it("creates readOnly schema for status properties when set to 'use-read-only-status-schema': true for unions", async () => {
-    const result = await openApiFor(
-      `
-      @service(#{title: "Test"}) 
-      namespace Test;
+it("creates readOnly schema for status properties when set to 'use-read-only-status-schema': true", async () => {
+  const result = await openApiFor(
+    `
+    @service(#{title: "Test"}) 
+    namespace Test;
 
-      model Bar {propB: int32;}
-      model Foo { prop1: string;}
+    model Bar {propB: int32;}
+    model Foo { prop1: string;}
 
-      union FooPrime { "Succeeded", "Failed", "Canceled"}
+    enum FooPrime { Succeeded, Failed, Canceled}
 
-      @pattern("^[a-zA-Z0-9-]{3,24}$")
-      scalar BarPrime extends string;
+    @pattern("^[a-zA-Z0-9-]{3,24}$")
+    scalar BarPrime extends string;
 
-      model UsesAll {
-        @visibility(Lifecycle.Read)
-        fooProp: Foo;
-        @visibility(Lifecycle.Read)
-        primeProp: FooPrime;
-        @visibility(Lifecycle.Read)
-        barPrimeProp: BarPrime;
-        otherProp: FooPrime;
-      }
+    model UsesAll {
+      @visibility(Lifecycle.Read)
+      fooProp: Foo;
+      @visibility(Lifecycle.Read)
+      primeProp: FooPrime;
+      @visibility(Lifecycle.Read)
+      barPrimeProp: BarPrime;
+      otherProp: FooPrime;
+    }
 
-      op myOp(): void;
+    op myOp(): void;
 
 
-      `,
-      undefined,
-      { "use-read-only-status-schema": true },
-    );
+    `,
+    undefined,
+    { "use-read-only-status-schema": true },
+  );
 
-    ok(!result.isRef);
-    deepStrictEqual(result.definitions.FooPrime.readOnly, true);
-  });
+  ok(!result.isRef);
+  deepStrictEqual(result.definitions.FooPrime.readOnly, true);
+});
+
+it("creates readOnly schema for status properties when set to 'use-read-only-status-schema': true for unions", async () => {
+  const result = await openApiFor(
+    `
+    @service(#{title: "Test"}) 
+    namespace Test;
+
+    model Bar {propB: int32;}
+    model Foo { prop1: string;}
+
+    union FooPrime { "Succeeded", "Failed", "Canceled"}
+
+    @pattern("^[a-zA-Z0-9-]{3,24}$")
+    scalar BarPrime extends string;
+
+    model UsesAll {
+      @visibility(Lifecycle.Read)
+      fooProp: Foo;
+      @visibility(Lifecycle.Read)
+      primeProp: FooPrime;
+      @visibility(Lifecycle.Read)
+      barPrimeProp: BarPrime;
+      otherProp: FooPrime;
+    }
+
+    op myOp(): void;
+
+
+    `,
+    undefined,
+    { "use-read-only-status-schema": true },
+  );
+
+  ok(!result.isRef);
+  deepStrictEqual(result.definitions.FooPrime.readOnly, true);
 });

--- a/packages/typespec-autorest/test/return-types.test.ts
+++ b/packages/typespec-autorest/test/return-types.test.ts
@@ -3,567 +3,565 @@ import { deepStrictEqual, ok, strictEqual } from "assert";
 import { describe, expect, it } from "vitest";
 import { ignoreUseStandardOps, openApiFor, Tester } from "./test-host.js";
 
-describe("typespec-autorest: return types", () => {
-  it("model used with @body and without shouldn't conflict if it contains no metadata", async () => {
-    const res = await openApiFor(
-      `
-      model Foo {
-        name: string;
-      }
-      @route("c1") op c1(): Foo;
-      @route("c2") op c2(): {@body _: Foo};
-      `,
-    );
-    deepStrictEqual(res.paths["/c1"].get.responses["200"].schema, {
-      $ref: "#/definitions/Foo",
-    });
-    deepStrictEqual(res.paths["/c2"].get.responses["200"].schema, {
-      $ref: "#/definitions/Foo",
-    });
-  });
-
-  it("defines responses with response headers", async () => {
-    const res = await openApiFor(
-      `
-      model ETagHeader {
-        @header eTag: string;
-      }
-      model Key {
-        key: string;
-      }
-      @get op read(): Key & ETagHeader;
-      `,
-    );
-    ok(res.paths["/"].get.responses["200"].headers);
-    ok(res.paths["/"].get.responses["200"].headers["e-tag"]);
-    // Note: schema intersection produces an anonymous model.
-    deepStrictEqual(res.paths["/"].get.responses["200"].schema, {
-      $ref: "#/definitions/Key",
-    });
-  });
-
-  it("defines responses with status codes", async () => {
-    const res = await openApiFor(
-      `
-      model TestCreatedResponse {
-        @statusCode code: "201";
-      }
-      model Key {
-        key: string;
-      }
-      @put
-      op create(): TestCreatedResponse & Key;
-      `,
-    );
-    ok(res.paths["/"].put.responses["201"]);
-    deepStrictEqual(res.paths["/"].put.responses["201"].schema, {
-      $ref: "#/definitions/Key",
-    });
-  });
-
-  it("defines responses with numeric status codes", async () => {
-    const res = await openApiFor(
-      `
-      model TestCreatedResponse {
-        @statusCode code: 201;
-      }
-      model Key {
-        key: string;
-      }
-      @put
-      op create(): TestCreatedResponse & Key;
-      `,
-    );
-    ok(res.paths["/"].put.responses["201"]);
-    ok(res.paths["/"].put.responses["201"].schema);
-  });
-
-  it("defines responses with headers and status codes", async () => {
-    const res = await openApiFor(
-      `
-      model ETagHeader {
-        @header eTag: string;
-      }
-      model TestCreatedResponse {
-        @statusCode code: "201";
-      }
-      model Key {
-        key: string;
-      }
-      @put
-      op create(): { ...TestCreatedResponse, ...ETagHeader, @body body: Key};
-      `,
-    );
-    ok(res.paths["/"].put.responses["201"]);
-    ok(res.paths["/"].put.responses["201"].headers["e-tag"]);
-    deepStrictEqual(res.paths["/"].put.responses["201"].schema, {
-      $ref: "#/definitions/Key",
-    });
-  });
-
-  it("defines responses with headers and status codes in base model", async () => {
-    const res = await openApiFor(
-      `
-      model TestCreatedResponse {
-        @statusCode code: "201";
-        @header contentType: "text/html";
-        @header location: string;
-      }
-      model TestPage {
-        content: string;
-      }
-      model TestCreatePageResponse extends TestCreatedResponse {
-        @body body: TestPage;
-      }
-      @put
-      op create(): TestCreatePageResponse;
-      `,
-    );
-    ok(res.paths["/"].put.responses["201"]);
-    ok(res.paths["/"].put.responses["201"].headers["location"]);
-    deepStrictEqual(res.paths["/"].put.responses["201"].schema, {
-      $ref: "#/definitions/TestPage",
-    });
-  });
-
-  it("defines separate responses for each status code defined as a union of values", async () => {
-    const res = await openApiFor(
-      `
-      model CreatedOrUpdatedResponse {
-        @statusCode code: "200" | "201";
-      }
-      model DateHeader {
-        @header date: utcDateTime;
-      }
-      model Key {
-        key: string;
-      }
-      @put
-      op create(): CreatedOrUpdatedResponse & DateHeader & Key;
-      `,
-    );
-    ok(res.paths["/"].put.responses["200"]);
-    ok(res.paths["/"].put.responses["201"]);
-    // Note: 200 and 201 response should be equal except for description
-    deepStrictEqual(
-      res.paths["/"].put.responses["200"].headers,
-      res.paths["/"].put.responses["201"].headers,
-    );
-    deepStrictEqual(
-      res.paths["/"].put.responses["200"].schema,
-      res.paths["/"].put.responses["201"].schema,
-    );
-  });
-
-  it("defines separate responses for each variant of a union return type", async () => {
-    const res = await openApiFor(
-      `
-      
-      @error
-      model Error {
-        code: int32;
-        message: string;
-      }
-      model Key {
-        key: string;
-      }
-      @get
-      op read(): Key | Error;
-      `,
-    );
-    ok(res.paths["/"].get.responses["200"]);
-    ok(res.definitions.Key);
-    deepStrictEqual(res.paths["/"].get.responses["200"].schema, {
-      $ref: "#/definitions/Key",
-    });
-    ok(res.definitions.Error);
-    deepStrictEqual(res.paths["/"].get.responses["default"].schema, {
-      $ref: "#/definitions/Error",
-    });
-  });
-
-  it("defines the response media type from the content-type header if present", async () => {
-    const res = await openApiFor(
-      `
-      
-      @error
-      model Error {
-        code: int32;
-        message: string;
-      }
-      model TextPlain {
-        @header contentType: "text/plain";
-      }
-      model Key {
-        key: string;
-      }
-      @get
-      // Note: & takes precedence over |
-      op read(): Key & TextPlain | Error;
-      `,
-    );
-    ok(res.paths["/"].get.responses["200"]);
-    ok(res.paths["/"].get.responses["200"].schema);
-    deepStrictEqual(res.paths["/"].get.produces, ["text/plain", "application/json"]);
-    ok(res.definitions.Error);
-    deepStrictEqual(res.paths["/"].get.responses["default"].schema, {
-      $ref: "#/definitions/Error",
-    });
-  });
-
-  it("defines the multiple response media types for content-type header with union value", async () => {
-    const res = await openApiFor(
-      `
-      model TextMulti {
-        @header contentType: "text/plain" | "text/html" | "text/csv";
-      }
-      @get
-      op read(): { ...TextMulti, @body body: string };
+it("model used with @body and without shouldn't conflict if it contains no metadata", async () => {
+  const res = await openApiFor(
+    `
+    model Foo {
+      name: string;
+    }
+    @route("c1") op c1(): Foo;
+    @route("c2") op c2(): {@body _: Foo};
     `,
-    );
-    ok(res.paths["/"].get.responses["200"]);
-    deepStrictEqual(res.paths["/"].get.produces, ["text/plain", "text/html", "text/csv"]);
+  );
+  deepStrictEqual(res.paths["/c1"].get.responses["200"].schema, {
+    $ref: "#/definitions/Foo",
   });
-
-  it("issues diagnostics when there is differrent body types across content types", async () => {
-    const diagnostics = await Tester.diagnose(
-      `
-      model Foo {
-        @header contentType: "application/json";
-        foo: string;
-      }
-      model Bar {
-        @header contentType: "application/xml";
-        code: string;
-      }
-
-      op read(): Foo | Bar;
-      `,
-    );
-    expectDiagnostics(ignoreUseStandardOps(diagnostics), {
-      code: "@azure-tools/typespec-autorest/duplicate-body-types",
-      message: "Request has multiple body types",
-    });
+  deepStrictEqual(res.paths["/c2"].get.responses["200"].schema, {
+    $ref: "#/definitions/Foo",
   });
+});
 
-  it("defines responses with primitive types", async () => {
-    const res = await openApiFor(`
-      @get() op read(): string;
-    `);
-    ok(res.paths["/"].get.responses["200"]);
-    ok(res.paths["/"].get.responses["200"].schema);
-    strictEqual(res.paths["/"].get.responses["200"].schema.type, "string");
+it("defines responses with response headers", async () => {
+  const res = await openApiFor(
+    `
+    model ETagHeader {
+      @header eTag: string;
+    }
+    model Key {
+      key: string;
+    }
+    @get op read(): Key & ETagHeader;
+    `,
+  );
+  ok(res.paths["/"].get.responses["200"].headers);
+  ok(res.paths["/"].get.responses["200"].headers["e-tag"]);
+  // Note: schema intersection produces an anonymous model.
+  deepStrictEqual(res.paths["/"].get.responses["200"].schema, {
+    $ref: "#/definitions/Key",
   });
+});
 
-  it("defines responses with top-level array type", async () => {
-    const res = await openApiFor(
-      `
-      model Foo {
-        foo: string;
-      }
-
-      @get() op read(): Foo[];
-      `,
-    );
-    ok(res.paths["/"].get.responses["200"]);
-    ok(res.paths["/"].get.responses["200"].schema);
-    ok(res.paths["/"].get.produces === undefined, "operation should have no produces");
-    strictEqual(res.paths["/"].get.responses["200"].schema.type, "array");
+it("defines responses with status codes", async () => {
+  const res = await openApiFor(
+    `
+    model TestCreatedResponse {
+      @statusCode code: "201";
+    }
+    model Key {
+      key: string;
+    }
+    @put
+    op create(): TestCreatedResponse & Key;
+    `,
+  );
+  ok(res.paths["/"].put.responses["201"]);
+  deepStrictEqual(res.paths["/"].put.responses["201"].schema, {
+    $ref: "#/definitions/Key",
   });
+});
 
-  it("produce additionalProperties schema if response is Record<T>", async () => {
-    const res = await openApiFor(
-      `
-      @get op test(): Record<string>;
-      `,
-    );
+it("defines responses with numeric status codes", async () => {
+  const res = await openApiFor(
+    `
+    model TestCreatedResponse {
+      @statusCode code: 201;
+    }
+    model Key {
+      key: string;
+    }
+    @put
+    op create(): TestCreatedResponse & Key;
+    `,
+  );
+  ok(res.paths["/"].put.responses["201"]);
+  ok(res.paths["/"].put.responses["201"].schema);
+});
 
-    const responses = res.paths["/"].get.responses;
-    ok(responses["200"]);
-    deepStrictEqual(responses["200"].schema, {
-      type: "object",
-      additionalProperties: {
-        type: "string",
-      },
-    });
+it("defines responses with headers and status codes", async () => {
+  const res = await openApiFor(
+    `
+    model ETagHeader {
+      @header eTag: string;
+    }
+    model TestCreatedResponse {
+      @statusCode code: "201";
+    }
+    model Key {
+      key: string;
+    }
+    @put
+    op create(): { ...TestCreatedResponse, ...ETagHeader, @body body: Key};
+    `,
+  );
+  ok(res.paths["/"].put.responses["201"]);
+  ok(res.paths["/"].put.responses["201"].headers["e-tag"]);
+  deepStrictEqual(res.paths["/"].put.responses["201"].schema, {
+    $ref: "#/definitions/Key",
   });
+});
 
-  it("return type with only response metadata should be 200 response w/ no content", async () => {
-    const res = await openApiFor(
-      `
-      @get op delete(): {@header date: string};
-      `,
-    );
-
-    const responses = res.paths["/"].get.responses;
-    ok(responses["200"]);
-    ok(responses["200"].schema === undefined, "response should have no content");
-    ok(responses["204"] === undefined);
+it("defines responses with headers and status codes in base model", async () => {
+  const res = await openApiFor(
+    `
+    model TestCreatedResponse {
+      @statusCode code: "201";
+      @header contentType: "text/html";
+      @header location: string;
+    }
+    model TestPage {
+      content: string;
+    }
+    model TestCreatePageResponse extends TestCreatedResponse {
+      @body body: TestPage;
+    }
+    @put
+    op create(): TestCreatePageResponse;
+    `,
+  );
+  ok(res.paths["/"].put.responses["201"]);
+  ok(res.paths["/"].put.responses["201"].headers["location"]);
+  deepStrictEqual(res.paths["/"].put.responses["201"].schema, {
+    $ref: "#/definitions/TestPage",
   });
+});
 
-  it("defaults status code to default when model has @error decorator", async () => {
-    const res = await openApiFor(
-      `
-      @error
-      model Error {
-        code: string;
-      }
+it("defines separate responses for each status code defined as a union of values", async () => {
+  const res = await openApiFor(
+    `
+    model CreatedOrUpdatedResponse {
+      @statusCode code: "200" | "201";
+    }
+    model DateHeader {
+      @header date: utcDateTime;
+    }
+    model Key {
+      key: string;
+    }
+    @put
+    op create(): CreatedOrUpdatedResponse & DateHeader & Key;
+    `,
+  );
+  ok(res.paths["/"].put.responses["200"]);
+  ok(res.paths["/"].put.responses["201"]);
+  // Note: 200 and 201 response should be equal except for description
+  deepStrictEqual(
+    res.paths["/"].put.responses["200"].headers,
+    res.paths["/"].put.responses["201"].headers,
+  );
+  deepStrictEqual(
+    res.paths["/"].put.responses["200"].schema,
+    res.paths["/"].put.responses["201"].schema,
+  );
+});
 
-      model Foo {
-        foo: string;
-      }
-
-      @get
-      op get(): Foo | Error;
-      `,
-    );
-    const responses = res.paths["/"].get.responses;
-    ok(responses["200"]);
-    deepStrictEqual(responses["200"].schema, {
-      $ref: "#/definitions/Foo",
-    });
-    ok(responses["default"]);
-    deepStrictEqual(responses["default"].schema, {
-      $ref: "#/definitions/Error",
-    });
+it("defines separate responses for each variant of a union return type", async () => {
+  const res = await openApiFor(
+    `
+    
+    @error
+    model Error {
+      code: int32;
+      message: string;
+    }
+    model Key {
+      key: string;
+    }
+    @get
+    op read(): Key | Error;
+    `,
+  );
+  ok(res.paths["/"].get.responses["200"]);
+  ok(res.definitions.Key);
+  deepStrictEqual(res.paths["/"].get.responses["200"].schema, {
+    $ref: "#/definitions/Key",
   });
+  ok(res.definitions.Error);
+  deepStrictEqual(res.paths["/"].get.responses["default"].schema, {
+    $ref: "#/definitions/Error",
+  });
+});
 
-  it("defaults status code to default when model has @error decorator and explicit body", async () => {
-    const res = await openApiFor(
-      `
-      @error
-      model Error {
-        @body body: string;
-      }
+it("defines the response media type from the content-type header if present", async () => {
+  const res = await openApiFor(
+    `
+    
+    @error
+    model Error {
+      code: int32;
+      message: string;
+    }
+    model TextPlain {
+      @header contentType: "text/plain";
+    }
+    model Key {
+      key: string;
+    }
+    @get
+    // Note: & takes precedence over |
+    op read(): Key & TextPlain | Error;
+    `,
+  );
+  ok(res.paths["/"].get.responses["200"]);
+  ok(res.paths["/"].get.responses["200"].schema);
+  deepStrictEqual(res.paths["/"].get.produces, ["text/plain", "application/json"]);
+  ok(res.definitions.Error);
+  deepStrictEqual(res.paths["/"].get.responses["default"].schema, {
+    $ref: "#/definitions/Error",
+  });
+});
 
-      model Foo {
-        foo: string;
-      }
+it("defines the multiple response media types for content-type header with union value", async () => {
+  const res = await openApiFor(
+    `
+    model TextMulti {
+      @header contentType: "text/plain" | "text/html" | "text/csv";
+    }
+    @get
+    op read(): { ...TextMulti, @body body: string };
+  `,
+  );
+  ok(res.paths["/"].get.responses["200"]);
+  deepStrictEqual(res.paths["/"].get.produces, ["text/plain", "text/html", "text/csv"]);
+});
 
-        @get
-        op get(): Foo | Error;
-      `,
-    );
-    const responses = res.paths["/"].get.responses;
-    ok(responses["200"]);
-    deepStrictEqual(responses["200"].schema, {
-      $ref: "#/definitions/Foo",
-    });
-    ok(responses["default"]);
-    deepStrictEqual(responses["default"].schema, {
+it("issues diagnostics when there is differrent body types across content types", async () => {
+  const diagnostics = await Tester.diagnose(
+    `
+    model Foo {
+      @header contentType: "application/json";
+      foo: string;
+    }
+    model Bar {
+      @header contentType: "application/xml";
+      code: string;
+    }
+
+    op read(): Foo | Bar;
+    `,
+  );
+  expectDiagnostics(ignoreUseStandardOps(diagnostics), {
+    code: "@azure-tools/typespec-autorest/duplicate-body-types",
+    message: "Request has multiple body types",
+  });
+});
+
+it("defines responses with primitive types", async () => {
+  const res = await openApiFor(`
+    @get() op read(): string;
+  `);
+  ok(res.paths["/"].get.responses["200"]);
+  ok(res.paths["/"].get.responses["200"].schema);
+  strictEqual(res.paths["/"].get.responses["200"].schema.type, "string");
+});
+
+it("defines responses with top-level array type", async () => {
+  const res = await openApiFor(
+    `
+    model Foo {
+      foo: string;
+    }
+
+    @get() op read(): Foo[];
+    `,
+  );
+  ok(res.paths["/"].get.responses["200"]);
+  ok(res.paths["/"].get.responses["200"].schema);
+  ok(res.paths["/"].get.produces === undefined, "operation should have no produces");
+  strictEqual(res.paths["/"].get.responses["200"].schema.type, "array");
+});
+
+it("produce additionalProperties schema if response is Record<T>", async () => {
+  const res = await openApiFor(
+    `
+    @get op test(): Record<string>;
+    `,
+  );
+
+  const responses = res.paths["/"].get.responses;
+  ok(responses["200"]);
+  deepStrictEqual(responses["200"].schema, {
+    type: "object",
+    additionalProperties: {
       type: "string",
-    });
+    },
   });
+});
 
-  it("emit x-ms-error-response when uses explicit status code and model has @error decorator", async () => {
-    const res = await openApiFor(
-      `
-      @error
-      model Error {
-        @statusCode _: "400";
-        code: string;
-      }
+it("return type with only response metadata should be 200 response w/ no content", async () => {
+  const res = await openApiFor(
+    `
+    @get op delete(): {@header date: string};
+    `,
+  );
 
-      model Foo {
-        foo: string;
-      }
+  const responses = res.paths["/"].get.responses;
+  ok(responses["200"]);
+  ok(responses["200"].schema === undefined, "response should have no content");
+  ok(responses["204"] === undefined);
+});
+
+it("defaults status code to default when model has @error decorator", async () => {
+  const res = await openApiFor(
+    `
+    @error
+    model Error {
+      code: string;
+    }
+
+    model Foo {
+      foo: string;
+    }
+
+    @get
+    op get(): Foo | Error;
+    `,
+  );
+  const responses = res.paths["/"].get.responses;
+  ok(responses["200"]);
+  deepStrictEqual(responses["200"].schema, {
+    $ref: "#/definitions/Foo",
+  });
+  ok(responses["default"]);
+  deepStrictEqual(responses["default"].schema, {
+    $ref: "#/definitions/Error",
+  });
+});
+
+it("defaults status code to default when model has @error decorator and explicit body", async () => {
+  const res = await openApiFor(
+    `
+    @error
+    model Error {
+      @body body: string;
+    }
+
+    model Foo {
+      foo: string;
+    }
 
       @get
       op get(): Foo | Error;
-      `,
-    );
-    const responses = res.paths["/"].get.responses;
-    deepStrictEqual(responses["400"]["x-ms-error-response"], true);
-    ok(responses["default"] === undefined);
+    `,
+  );
+  const responses = res.paths["/"].get.responses;
+  ok(responses["200"]);
+  deepStrictEqual(responses["200"].schema, {
+    $ref: "#/definitions/Foo",
   });
-
-  it("emit x-ms-error-response when return type includes two union options with @error decorator", async () => {
-    const res = await openApiFor(
-      `
-      @error
-      model CustomizedErrorResponse {
-        @statusCode _: "404";
-        code: string;
-      }
-
-      @error
-      model Error {
-        @statusCode _: "400";
-        code: string;
-      }
-
-      model Foo {
-        foo: string;
-      }
-
-      @get
-      op get(): Foo | CustomizedErrorResponse | Error;
-      `,
-    );
-    const responses = res.paths["/"].get.responses;
-    deepStrictEqual(responses["400"]["x-ms-error-response"], true);
-    deepStrictEqual(responses["404"]["x-ms-error-response"], true);
-    ok(responses["default"] === undefined);
+  ok(responses["default"]);
+  deepStrictEqual(responses["default"].schema, {
+    type: "string",
   });
+});
 
-  it("uses explicit status code when model has @error decorator", async () => {
-    const res = await openApiFor(
-      `
-      @error
-      model Error {
-        @statusCode _: "400";
-        code: string;
-      }
-      model Foo {
-        foo: string;
-      }
-      @get
-      op get(): Foo | Error;
-      `,
-    );
-    const responses = res.paths["/"].get.responses;
-    ok(responses["200"]);
-    deepStrictEqual(responses["200"].schema, {
-      $ref: "#/definitions/Foo",
-    });
-    ok(responses["400"]);
-    deepStrictEqual(responses["400"].schema, {
-      $ref: "#/definitions/Error",
-    });
-    ok(responses["default"] === undefined);
+it("emit x-ms-error-response when uses explicit status code and model has @error decorator", async () => {
+  const res = await openApiFor(
+    `
+    @error
+    model Error {
+      @statusCode _: "400";
+      code: string;
+    }
+
+    model Foo {
+      foo: string;
+    }
+
+    @get
+    op get(): Foo | Error;
+    `,
+  );
+  const responses = res.paths["/"].get.responses;
+  deepStrictEqual(responses["400"]["x-ms-error-response"], true);
+  ok(responses["default"] === undefined);
+});
+
+it("emit x-ms-error-response when return type includes two union options with @error decorator", async () => {
+  const res = await openApiFor(
+    `
+    @error
+    model CustomizedErrorResponse {
+      @statusCode _: "404";
+      code: string;
+    }
+
+    @error
+    model Error {
+      @statusCode _: "400";
+      code: string;
+    }
+
+    model Foo {
+      foo: string;
+    }
+
+    @get
+    op get(): Foo | CustomizedErrorResponse | Error;
+    `,
+  );
+  const responses = res.paths["/"].get.responses;
+  deepStrictEqual(responses["400"]["x-ms-error-response"], true);
+  deepStrictEqual(responses["404"]["x-ms-error-response"], true);
+  ok(responses["default"] === undefined);
+});
+
+it("uses explicit status code when model has @error decorator", async () => {
+  const res = await openApiFor(
+    `
+    @error
+    model Error {
+      @statusCode _: "400";
+      code: string;
+    }
+    model Foo {
+      foo: string;
+    }
+    @get
+    op get(): Foo | Error;
+    `,
+  );
+  const responses = res.paths["/"].get.responses;
+  ok(responses["200"]);
+  deepStrictEqual(responses["200"].schema, {
+    $ref: "#/definitions/Foo",
   });
-
-  it("defines body schema when explicit body has no content", async () => {
-    const res = await openApiFor(
-      `
-      @delete
-      op delete(): { @header date: string, @body body: {} };
-      `,
-    );
-    const responses = res.paths["/"].delete.responses;
-    ok(responses["204"] === undefined);
-    ok(responses["200"]);
-    ok(responses["200"].headers["date"]);
-    ok(responses["200"].schema);
+  ok(responses["400"]);
+  deepStrictEqual(responses["400"].schema, {
+    $ref: "#/definitions/Error",
   });
+  ok(responses["default"] === undefined);
+});
 
-  it("return type with only statusCode should have specified status code and no content", async () => {
+it("defines body schema when explicit body has no content", async () => {
+  const res = await openApiFor(
+    `
+    @delete
+    op delete(): { @header date: string, @body body: {} };
+    `,
+  );
+  const responses = res.paths["/"].delete.responses;
+  ok(responses["204"] === undefined);
+  ok(responses["200"]);
+  ok(responses["200"].headers["date"]);
+  ok(responses["200"].schema);
+});
+
+it("return type with only statusCode should have specified status code and no content", async () => {
+  const res = await openApiFor(`
+    @get op create(): {@statusCode code: 201};
+    `);
+
+  const responses = res.paths["/"].get.responses;
+  ok(responses["201"]);
+  ok(responses["201"].schema === undefined, "response should have no content");
+  ok(responses["200"] === undefined);
+  ok(responses["204"] === undefined);
+});
+
+it("defaults to 204 no content with void response type", async () => {
+  const res = await openApiFor(`@get op read(): void;`);
+  ok(res.paths["/"].get.responses["204"]);
+});
+
+it("defaults to 204 no content with void @body", async () => {
+  const res = await openApiFor(`@get op read(): {@body body: void};`);
+  ok(res.paths["/"].get.responses["200"]);
+});
+
+it("using @body ignore any metadata property underneath", async () => {
+  const res = await openApiFor(`@get op read(): {
+    @body body: {
+      #suppress "@typespec/http/metadata-ignored"
+      @header header: string,
+      #suppress "@typespec/http/metadata-ignored"
+      @query query: string,
+      #suppress "@typespec/http/metadata-ignored"
+      @statusCode code: 201,
+    }
+  };`);
+  expect(res.paths["/"].get.responses["200"].schema).toEqual({
+    type: "object",
+    properties: {
+      header: { type: "string" },
+      query: { type: "string" },
+      code: { type: "number", enum: [201] },
+    },
+    required: ["header", "query", "code"],
+  });
+});
+
+describe("response model resolving to no property in the body produce no body", () => {
+  it.each(["{}", "{@header prop: string}", `{@invisible(Lifecycle) prop: string}`])(
+    "%s",
+    async (body) => {
+      const res = await openApiFor(`op test(): ${body};`);
+      strictEqual(res.paths["/"].get.responses["200"].schema, undefined);
+    },
+  );
+});
+
+it("property in body with only metadata properties should still be included", async () => {
+  const res = await openApiFor(`op read(): {
+      headers: {
+        @header header1: string;
+        @header header2: string;
+      };
+      name: string;
+    };`);
+  expect(res.paths["/"].get.responses["200"].schema).toEqual({
+    type: "object",
+    properties: {
+      headers: { type: "object" },
+      name: { type: "string" },
+    },
+    required: ["headers", "name"],
+  });
+});
+
+it("property in body with only metadata properties and @bodyIgnore should not be included", async () => {
+  const res = await openApiFor(`op read(): {
+      @bodyIgnore headers: {
+        @header header1: string;
+        @header header2: string;
+      };
+      name: string;
+  };`);
+  expect(res.paths["/"].get.responses["200"].schema).toEqual({
+    type: "object",
+    properties: {
+      name: { type: "string" },
+    },
+    required: ["name"],
+  });
+});
+
+describe("binary responses", () => {
+  it("bytes responses should produce application/json with byte schema", async () => {
     const res = await openApiFor(`
-      @get op create(): {@statusCode code: 201};
-      `);
-
-    const responses = res.paths["/"].get.responses;
-    ok(responses["201"]);
-    ok(responses["201"].schema === undefined, "response should have no content");
-    ok(responses["200"] === undefined);
-    ok(responses["204"] === undefined);
+      @get op read(): bytes;
+    `);
+    const operation = res.paths["/"].get;
+    deepStrictEqual(operation.produces, ["application/octet-stream"]);
+    strictEqual(operation.responses["200"].schema.type, "file");
   });
 
-  it("defaults to 204 no content with void response type", async () => {
-    const res = await openApiFor(`@get op read(): void;`);
-    ok(res.paths["/"].get.responses["204"]);
+  it("@body body: bytes responses should produce application/json with byte schema", async () => {
+    const res = await openApiFor(`
+      @get op read(): {@body body: bytes};
+    `);
+
+    const operation = res.paths["/"].get;
+    deepStrictEqual(operation.produces, ["application/octet-stream"]);
+    strictEqual(operation.responses["200"].schema.type, "file");
   });
 
-  it("defaults to 204 no content with void @body", async () => {
-    const res = await openApiFor(`@get op read(): {@body body: void};`);
-    ok(res.paths["/"].get.responses["200"]);
-  });
+  it("@header contentType should override content type and set type to file", async () => {
+    const res = await openApiFor(`
+      @get op read(): {@header contentType: "image/png", @body body: bytes};
+    `);
 
-  it("using @body ignore any metadata property underneath", async () => {
-    const res = await openApiFor(`@get op read(): {
-      @body body: {
-        #suppress "@typespec/http/metadata-ignored"
-        @header header: string,
-        #suppress "@typespec/http/metadata-ignored"
-        @query query: string,
-        #suppress "@typespec/http/metadata-ignored"
-        @statusCode code: 201,
-      }
-    };`);
-    expect(res.paths["/"].get.responses["200"].schema).toEqual({
-      type: "object",
-      properties: {
-        header: { type: "string" },
-        query: { type: "string" },
-        code: { type: "number", enum: [201] },
-      },
-      required: ["header", "query", "code"],
-    });
-  });
-
-  describe("response model resolving to no property in the body produce no body", () => {
-    it.each(["{}", "{@header prop: string}", `{@invisible(Lifecycle) prop: string}`])(
-      "%s",
-      async (body) => {
-        const res = await openApiFor(`op test(): ${body};`);
-        strictEqual(res.paths["/"].get.responses["200"].schema, undefined);
-      },
-    );
-  });
-
-  it("property in body with only metadata properties should still be included", async () => {
-    const res = await openApiFor(`op read(): {
-        headers: {
-          @header header1: string;
-          @header header2: string;
-        };
-        name: string;
-      };`);
-    expect(res.paths["/"].get.responses["200"].schema).toEqual({
-      type: "object",
-      properties: {
-        headers: { type: "object" },
-        name: { type: "string" },
-      },
-      required: ["headers", "name"],
-    });
-  });
-
-  it("property in body with only metadata properties and @bodyIgnore should not be included", async () => {
-    const res = await openApiFor(`op read(): {
-        @bodyIgnore headers: {
-          @header header1: string;
-          @header header2: string;
-        };
-        name: string;
-    };`);
-    expect(res.paths["/"].get.responses["200"].schema).toEqual({
-      type: "object",
-      properties: {
-        name: { type: "string" },
-      },
-      required: ["name"],
-    });
-  });
-
-  describe("binary responses", () => {
-    it("bytes responses should produce application/json with byte schema", async () => {
-      const res = await openApiFor(`
-        @get op read(): bytes;
-      `);
-      const operation = res.paths["/"].get;
-      deepStrictEqual(operation.produces, ["application/octet-stream"]);
-      strictEqual(operation.responses["200"].schema.type, "file");
-    });
-
-    it("@body body: bytes responses should produce application/json with byte schema", async () => {
-      const res = await openApiFor(`
-        @get op read(): {@body body: bytes};
-      `);
-
-      const operation = res.paths["/"].get;
-      deepStrictEqual(operation.produces, ["application/octet-stream"]);
-      strictEqual(operation.responses["200"].schema.type, "file");
-    });
-
-    it("@header contentType should override content type and set type to file", async () => {
-      const res = await openApiFor(`
-        @get op read(): {@header contentType: "image/png", @body body: bytes};
-      `);
-
-      const operation = res.paths["/"].get;
-      deepStrictEqual(operation.produces, ["image/png"]);
-      strictEqual(operation.responses["200"].schema.type, "file");
-    });
+    const operation = res.paths["/"].get;
+    deepStrictEqual(operation.produces, ["image/png"]);
+    strictEqual(operation.responses["200"].schema.type, "file");
   });
 });

--- a/packages/typespec-autorest/test/sorting.test.ts
+++ b/packages/typespec-autorest/test/sorting.test.ts
@@ -1,142 +1,140 @@
 import { deepStrictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { sortOpenAPIDocument } from "../src/openapi.js";
 import { openApiFor } from "./test-host.js";
 
-describe("typespec-autorest: OpenAPI output should be determinstic", () => {
-  const headerDefinitions = `
-  model A_Header { @header a : string };
-  model B_Header { @header b : string };
-  model C_Header { @header c : string };
+const headerDefinitions = `
+model A_Header { @header a : string };
+model B_Header { @header b : string };
+model C_Header { @header c : string };
 `;
 
-  it("sorts root", () => {
-    const sorted = sortOpenAPIDocument({
-      info: {} as any,
-      paths: {},
-      produces: [],
-      swagger: "2.0",
-      "x-ms-paths": {},
-      consumes: [],
-    });
-
-    deepStrictEqual(Object.keys(sorted), [
-      "swagger",
-      "info",
-      "produces",
-      "consumes",
-      "paths",
-      "x-ms-paths",
-    ]);
+it("sorts root", () => {
+  const sorted = sortOpenAPIDocument({
+    info: {} as any,
+    paths: {},
+    produces: [],
+    swagger: "2.0",
+    "x-ms-paths": {},
+    consumes: [],
   });
 
-  it("sorts paths", () => {
-    const sorted = sortOpenAPIDocument({
-      swagger: "2.0",
-      info: {} as any,
-      paths: {
-        "/{things}/three": {},
-        "/foo": {},
-        "/{things}": {},
-        "/foo/{things}": {},
+  deepStrictEqual(Object.keys(sorted), [
+    "swagger",
+    "info",
+    "produces",
+    "consumes",
+    "paths",
+    "x-ms-paths",
+  ]);
+});
+
+it("sorts paths", () => {
+  const sorted = sortOpenAPIDocument({
+    swagger: "2.0",
+    info: {} as any,
+    paths: {
+      "/{things}/three": {},
+      "/foo": {},
+      "/{things}": {},
+      "/foo/{things}": {},
+    },
+  });
+
+  deepStrictEqual(Object.keys(sorted.paths), [
+    "/{things}",
+    "/{things}/three",
+    "/foo",
+    "/foo/{things}",
+  ]);
+});
+
+it("sorts path verbs", () => {
+  const sorted = sortOpenAPIDocument({
+    swagger: "2.0",
+    info: {} as any,
+    paths: {
+      "/": {
+        delete: {} as any,
+        put: {} as any,
+        parameters: {} as any,
+        post: {} as any,
+        head: {} as any,
+        options: {} as any,
+        get: {} as any,
+        patch: {} as any,
       },
-    });
-
-    deepStrictEqual(Object.keys(sorted.paths), [
-      "/{things}",
-      "/{things}/three",
-      "/foo",
-      "/foo/{things}",
-    ]);
+    },
   });
 
-  it("sorts path verbs", () => {
-    const sorted = sortOpenAPIDocument({
-      swagger: "2.0",
-      info: {} as any,
-      paths: {
-        "/": {
-          delete: {} as any,
-          put: {} as any,
-          parameters: {} as any,
-          post: {} as any,
-          head: {} as any,
-          options: {} as any,
-          get: {} as any,
-          patch: {} as any,
-        },
-      },
-    });
+  deepStrictEqual(Object.keys(sorted.paths["/"]), [
+    "parameters",
+    "get",
+    "put",
+    "post",
+    "patch",
+    "delete",
+    "options",
+    "head",
+  ]);
+});
 
-    deepStrictEqual(Object.keys(sorted.paths["/"]), [
-      "parameters",
-      "get",
-      "put",
-      "post",
-      "patch",
-      "delete",
-      "options",
-      "head",
-    ]);
+it("sorts x-ms-paths with query-only paths", () => {
+  const sorted = sortOpenAPIDocument({
+    swagger: "2.0",
+    info: {} as any,
+    paths: {},
+    "x-ms-paths": {
+      "?b=1": {},
+      "?a=1": {},
+      "?c=1": {},
+    },
   });
 
-  it("sorts x-ms-paths with query-only paths", () => {
-    const sorted = sortOpenAPIDocument({
-      swagger: "2.0",
-      info: {} as any,
-      paths: {},
-      "x-ms-paths": {
-        "?b=1": {},
-        "?a=1": {},
-        "?c=1": {},
-      },
-    });
+  deepStrictEqual(Object.keys(sorted["x-ms-paths"]!), ["?a=1", "?b=1", "?c=1"]);
+});
 
-    deepStrictEqual(Object.keys(sorted["x-ms-paths"]!), ["?a=1", "?b=1", "?c=1"]);
+it("sorts x-ms-paths with mixed path and query-only entries", () => {
+  const sorted = sortOpenAPIDocument({
+    swagger: "2.0",
+    info: {} as any,
+    paths: {},
+    "x-ms-paths": {
+      "/b?_overload=op1": {},
+      "?b=1": {},
+      "/a?_overload=op2": {},
+      "?a=1": {},
+    },
   });
 
-  it("sorts x-ms-paths with mixed path and query-only entries", () => {
-    const sorted = sortOpenAPIDocument({
-      swagger: "2.0",
-      info: {} as any,
-      paths: {},
-      "x-ms-paths": {
-        "/b?_overload=op1": {},
-        "?b=1": {},
-        "/a?_overload=op2": {},
-        "?a=1": {},
-      },
-    });
+  deepStrictEqual(Object.keys(sorted["x-ms-paths"]!), [
+    "?a=1",
+    "?b=1",
+    "/a?_overload=op2",
+    "/b?_overload=op1",
+  ]);
+});
 
-    deepStrictEqual(Object.keys(sorted["x-ms-paths"]!), [
-      "?a=1",
-      "?b=1",
-      "/a?_overload=op2",
-      "/b?_overload=op1",
-    ]);
-  });
+it("header already in lexical order", async () => {
+  const res = await openApiFor(
+    `
+    ${headerDefinitions}
+    model Headers { ...A_Header, ...B_Header, ...C_Header };
 
-  it("header already in lexical order", async () => {
-    const res = await openApiFor(
-      `
-      ${headerDefinitions}
-      model Headers { ...A_Header, ...B_Header, ...C_Header };
+    op read(): {@statusCode _: 200, content: string, headers: Headers};
+    `,
+  );
+  deepStrictEqual(Object.keys(res.paths["/"].get.responses["200"].headers), ["a", "b", "c"]);
+});
 
-      op read(): {@statusCode _: 200, content: string, headers: Headers};
-      `,
-    );
-    deepStrictEqual(Object.keys(res.paths["/"].get.responses["200"].headers), ["a", "b", "c"]);
-  });
+it("header not in lexical order", async () => {
+  const res = await openApiFor(
+    `
+    ${headerDefinitions}
+    model Headers { ...C_Header, ...A_Header, ...B_Header };
 
-  it("header not in lexical order", async () => {
-    const res = await openApiFor(
-      `
-      ${headerDefinitions}
-      model Headers { ...C_Header, ...A_Header, ...B_Header };
-
-      op read(): {@statusCode _: 200, content: string, headers: Headers};
-      `,
-    );
-    deepStrictEqual(Object.keys(res.paths["/"].get.responses["200"].headers), ["a", "b", "c"]);
-  });
+    op read(): {@statusCode _: 200, content: string, headers: Headers};
+    `,
+  );
+  deepStrictEqual(Object.keys(res.paths["/"].get.responses["200"].headers), ["a", "b", "c"]);
 });

--- a/packages/typespec-autorest/test/versioning.test.ts
+++ b/packages/typespec-autorest/test/versioning.test.ts
@@ -1,192 +1,190 @@
 import { expectDiagnostics } from "@typespec/compiler/testing";
 import { deepStrictEqual, strictEqual } from "assert";
-import { describe, expect, it } from "vitest";
+import { expect, it } from "vitest";
 import { OpenAPI2Document } from "../src/openapi2-document.js";
 import { diagnoseOpenApiFor, openApiFor } from "./test-host.js";
 
-describe("typespec-autorest: versioning", () => {
-  it("if version enum is referenced only include current member and mark it with modelAsString: true", async () => {
-    const { v1, v2 } = (await openApiFor(
-      `
-      @service
-      @versioned(Versions)
-      @server(
-        "https://example.com/{apiVersion}",
-        "Doc",
+it("if version enum is referenced only include current member and mark it with modelAsString: true", async () => {
+  const { v1, v2 } = (await openApiFor(
+    `
+    @service
+    @versioned(Versions)
+    @server(
+      "https://example.com/{apiVersion}",
+      "Doc",
+      {
+        @path apiVersion: Versions,
+      }
+    )
+    namespace MyService {
+      enum Versions {
+        v1,
+        v2,
+      }
+    }
+  `,
+    ["v1", "v2"],
+  )) as { v1: OpenAPI2Document; v2: OpenAPI2Document };
+  expect(v1["x-ms-parameterized-host"]?.parameters?.[0]).toEqual({
+    enum: ["v1"],
+    in: "path",
+    name: "apiVersion",
+    required: true,
+    type: "string",
+    "x-ms-enum": {
+      modelAsString: true,
+      name: "Versions",
+      values: [
         {
-          @path apiVersion: Versions,
-        }
-      )
-      namespace MyService {
-        enum Versions {
-          v1,
-          v2,
-        }
+          name: "v1",
+          value: "v1",
+        },
+      ],
+    },
+  });
+  expect(v2["x-ms-parameterized-host"]?.parameters?.[0]).toEqual({
+    enum: ["v2"],
+    in: "path",
+    name: "apiVersion",
+    required: true,
+    type: "string",
+    "x-ms-enum": {
+      modelAsString: true,
+      name: "Versions",
+      values: [
+        {
+          name: "v2",
+          value: "v2",
+        },
+      ],
+    },
+  });
+});
+
+it("works with models", async () => {
+  const { v1, v2, v3 } = await openApiFor(
+    `
+    @versioned(Versions)
+    @service(#{title: "My Service"})
+    namespace MyService {
+      enum Versions {
+        @useDependency(MyLibrary.Versions.A)
+        v1,
+        @useDependency(MyLibrary.Versions.B)
+        v2,
+        @useDependency(MyLibrary.Versions.C)
+        v3
       }
-    `,
-      ["v1", "v2"],
-    )) as { v1: OpenAPI2Document; v2: OpenAPI2Document };
-    expect(v1["x-ms-parameterized-host"]?.parameters?.[0]).toEqual({
-      enum: ["v1"],
-      in: "path",
-      name: "apiVersion",
-      required: true,
-      type: "string",
-      "x-ms-enum": {
-        modelAsString: true,
-        name: "Versions",
-        values: [
-          {
-            name: "v1",
-            value: "v1",
-          },
-        ],
-      },
-    });
-    expect(v2["x-ms-parameterized-host"]?.parameters?.[0]).toEqual({
-      enum: ["v2"],
-      in: "path",
-      name: "apiVersion",
-      required: true,
-      type: "string",
-      "x-ms-enum": {
-        modelAsString: true,
-        name: "Versions",
-        values: [
-          {
-            name: "v2",
-            value: "v2",
-          },
-        ],
-      },
-    });
+
+      model Test {
+        prop1: string;
+        @added(Versions.v2) prop2: string;
+        @removed(Versions.v2) prop3: string;
+        @renamedFrom(Versions.v3, "prop4") prop4new: string;
+        @madeOptional(Versions.v3) prop5?: string;
+      }
+
+      @route("/read1")
+      op read1(): Test;
+      op read2(): MyLibrary.Foo;
+    }
+
+    @versioned(Versions)
+    namespace MyLibrary {
+      enum Versions {A, B, C}
+
+      model Foo {
+        prop1: string;
+        @added(Versions.B) prop2: string;
+        @added(Versions.C) prop3: string;
+      }
+    }
+  `,
+    ["v1", "v2", "v3"],
+  );
+  strictEqual(v1.info.version, "v1");
+  deepStrictEqual(v1.definitions.Test, {
+    type: "object",
+    properties: {
+      prop1: { type: "string" },
+      prop3: { type: "string" },
+      prop4: { type: "string" },
+      prop5: { type: "string" },
+    },
+    required: ["prop1", "prop3", "prop4", "prop5"],
   });
 
-  it("works with models", async () => {
-    const { v1, v2, v3 } = await openApiFor(
-      `
-      @versioned(Versions)
-      @service(#{title: "My Service"})
-      namespace MyService {
-        enum Versions {
-          @useDependency(MyLibrary.Versions.A)
-          v1,
-          @useDependency(MyLibrary.Versions.B)
-          v2,
-          @useDependency(MyLibrary.Versions.C)
-          v3
-        }
-
-        model Test {
-          prop1: string;
-          @added(Versions.v2) prop2: string;
-          @removed(Versions.v2) prop3: string;
-          @renamedFrom(Versions.v3, "prop4") prop4new: string;
-          @madeOptional(Versions.v3) prop5?: string;
-        }
-
-        @route("/read1")
-        op read1(): Test;
-        op read2(): MyLibrary.Foo;
-      }
-
-      @versioned(Versions)
-      namespace MyLibrary {
-        enum Versions {A, B, C}
-
-        model Foo {
-          prop1: string;
-          @added(Versions.B) prop2: string;
-          @added(Versions.C) prop3: string;
-        }
-      }
-    `,
-      ["v1", "v2", "v3"],
-    );
-    strictEqual(v1.info.version, "v1");
-    deepStrictEqual(v1.definitions.Test, {
-      type: "object",
-      properties: {
-        prop1: { type: "string" },
-        prop3: { type: "string" },
-        prop4: { type: "string" },
-        prop5: { type: "string" },
-      },
-      required: ["prop1", "prop3", "prop4", "prop5"],
-    });
-
-    deepStrictEqual(v1.definitions["MyLibrary.Foo"], {
-      type: "object",
-      properties: {
-        prop1: { type: "string" },
-      },
-      required: ["prop1"],
-    });
-
-    strictEqual(v2.info.version, "v2");
-    deepStrictEqual(v2.definitions.Test, {
-      type: "object",
-      properties: {
-        prop1: { type: "string" },
-        prop2: { type: "string" },
-        prop4: { type: "string" },
-        prop5: { type: "string" },
-      },
-      required: ["prop1", "prop2", "prop4", "prop5"],
-    });
-    deepStrictEqual(v2.definitions["MyLibrary.Foo"], {
-      type: "object",
-      properties: {
-        prop1: { type: "string" },
-        prop2: { type: "string" },
-      },
-      required: ["prop1", "prop2"],
-    });
-
-    strictEqual(v3.info.version, "v3");
-    deepStrictEqual(v3.definitions.Test, {
-      type: "object",
-      properties: {
-        prop1: { type: "string" },
-        prop2: { type: "string" },
-        prop5: { type: "string" },
-        prop4new: { type: "string" },
-      },
-      required: ["prop1", "prop2", "prop4new"],
-    });
-    deepStrictEqual(v3.definitions["MyLibrary.Foo"], {
-      type: "object",
-      properties: {
-        prop1: { type: "string" },
-        prop2: { type: "string" },
-        prop3: { type: "string" },
-      },
-      required: ["prop1", "prop2", "prop3"],
-    });
+  deepStrictEqual(v1.definitions["MyLibrary.Foo"], {
+    type: "object",
+    properties: {
+      prop1: { type: "string" },
+    },
+    required: ["prop1"],
   });
 
-  it("emit diagnostics when version option is used an doesn't match the versions of the service", async () => {
-    const diagnostics = await diagnoseOpenApiFor(
-      `
+  strictEqual(v2.info.version, "v2");
+  deepStrictEqual(v2.definitions.Test, {
+    type: "object",
+    properties: {
+      prop1: { type: "string" },
+      prop2: { type: "string" },
+      prop4: { type: "string" },
+      prop5: { type: "string" },
+    },
+    required: ["prop1", "prop2", "prop4", "prop5"],
+  });
+  deepStrictEqual(v2.definitions["MyLibrary.Foo"], {
+    type: "object",
+    properties: {
+      prop1: { type: "string" },
+      prop2: { type: "string" },
+    },
+    required: ["prop1", "prop2"],
+  });
+
+  strictEqual(v3.info.version, "v3");
+  deepStrictEqual(v3.definitions.Test, {
+    type: "object",
+    properties: {
+      prop1: { type: "string" },
+      prop2: { type: "string" },
+      prop5: { type: "string" },
+      prop4new: { type: "string" },
+    },
+    required: ["prop1", "prop2", "prop4new"],
+  });
+  deepStrictEqual(v3.definitions["MyLibrary.Foo"], {
+    type: "object",
+    properties: {
+      prop1: { type: "string" },
+      prop2: { type: "string" },
+      prop3: { type: "string" },
+    },
+    required: ["prop1", "prop2", "prop3"],
+  });
+});
+
+it("emit diagnostics when version option is used an doesn't match the versions of the service", async () => {
+  const diagnostics = await diagnoseOpenApiFor(
+    `
 @versioned(Versions)
 @service
 namespace DemoService;
 
 enum Versions {
-  v1,
-  v2,
+v1,
+v2,
 }
 
 model A {}
-    `,
-      { version: "v3" },
-    );
-    expectDiagnostics(diagnostics, [
-      {
-        code: "@azure-tools/typespec-autorest/no-matching-version-found",
-        message:
-          "The emitter did not emit any files because the specified version option does not match any versions of the service.",
-      },
-    ]);
-  });
+  `,
+    { version: "v3" },
+  );
+  expectDiagnostics(diagnostics, [
+    {
+      code: "@azure-tools/typespec-autorest/no-matching-version-found",
+      message:
+        "The emitter did not emit any files because the specified version option does not match any versions of the service.",
+    },
+  ]);
 });

--- a/packages/typespec-azure-core/test/helpers/union-enums.test.ts
+++ b/packages/typespec-azure-core/test/helpers/union-enums.test.ts
@@ -8,132 +8,130 @@ import { describe, it } from "vitest";
 import { UnionEnumVariant } from "../../src/helpers/union-enums.js";
 import { getUnionAsEnum } from "../../src/index.js";
 
-describe("azure-core: helpers: getUnionAsEnum", () => {
-  async function testUnionAsEnum(code: string) {
-    const runner = await createTestRunner();
-    const { target } = await runner.compile(code);
+async function testUnionAsEnum(code: string) {
+  const runner = await createTestRunner();
+  const { target } = await runner.compile(code);
 
-    strictEqual(target.kind, "Union");
+  strictEqual(target.kind, "Union");
 
-    return getUnionAsEnum(target);
-  }
-  async function testValidUnionAsEnum(code: string) {
-    const [e, diagnostics] = await testUnionAsEnum(code);
-    expectDiagnosticEmpty(diagnostics);
-    ok(e);
-    return e;
-  }
+  return getUnionAsEnum(target);
+}
+async function testValidUnionAsEnum(code: string) {
+  const [e, diagnostics] = await testUnionAsEnum(code);
+  expectDiagnosticEmpty(diagnostics);
+  ok(e);
+  return e;
+}
 
-  function getMemberValues(members: Map<string | symbol, UnionEnumVariant<any>>) {
-    return [...members.values()].map((x) => x.value);
-  }
+function getMemberValues(members: Map<string | symbol, UnionEnumVariant<any>>) {
+  return [...members.values()].map((x) => x.value);
+}
 
-  it("resolve a string enum if all variants are string literals", async () => {
-    const res = await testValidUnionAsEnum(`@test("target") union Test {"one" , "two"}`);
-    deepStrictEqual(getMemberValues(res.members), ["one", "two"]);
-    deepStrictEqual(getMemberValues(res.flattenedMembers), ["one", "two"]);
-    strictEqual(res.open, false);
+it("resolve a string enum if all variants are string literals", async () => {
+  const res = await testValidUnionAsEnum(`@test("target") union Test {"one" , "two"}`);
+  deepStrictEqual(getMemberValues(res.members), ["one", "two"]);
+  deepStrictEqual(getMemberValues(res.flattenedMembers), ["one", "two"]);
+  strictEqual(res.open, false);
+});
+
+it("resolve a number enum if all variants are numeric literals", async () => {
+  const res = await testValidUnionAsEnum(`@test("target") union Test {0, 1, 2}`);
+  deepStrictEqual(getMemberValues(res.members), [0, 1, 2]);
+  deepStrictEqual(getMemberValues(res.flattenedMembers), [0, 1, 2]);
+  strictEqual(res.open, false);
+});
+
+it("resolve a open string enum if include string scalar", async () => {
+  const res = await testValidUnionAsEnum(`@test("target") union Test {"one" , "two", string}`);
+  deepStrictEqual(getMemberValues(res.members), ["one", "two"]);
+  deepStrictEqual(getMemberValues(res.flattenedMembers), ["one", "two"]);
+  strictEqual(res.open, true);
+});
+
+it("resolve a open string enum if sub union include string scalar", async () => {
+  const res = await testValidUnionAsEnum(`
+    @test("target") 
+    union Test {"one" , "two", Other }
+    union Other { "three", string }
+  `);
+  strictEqual(res.open, true);
+});
+
+it("resolve as nullabe if include null", async () => {
+  const res = await testValidUnionAsEnum(` @test("target") union Test {"one" , "two", null }`);
+  strictEqual(res.nullable, true);
+});
+
+it("resolve as nullabe if sub union include null", async () => {
+  const res = await testValidUnionAsEnum(`
+    @test("target") 
+    union Test {"one" , "two", Other }
+    union Other { "three", null} 
+  `);
+  strictEqual(res.nullable, true);
+});
+
+it("resolve a open number enum if include int32 scalar", async () => {
+  const res = await testValidUnionAsEnum(`@test("target") union Test {0, 1, 2, int32}`);
+  deepStrictEqual(getMemberValues(res.members), [0, 1, 2]);
+  deepStrictEqual(getMemberValues(res.flattenedMembers), [0, 1, 2]);
+  strictEqual(res.open, true);
+});
+
+it("flattendMembers include all members from included unions", async () => {
+  const res = await testValidUnionAsEnum(
+    `
+    @test("target")  union Test { UpDown, "left", "right"} 
+    union UpDown { "up", "down" }
+    `,
+  );
+  deepStrictEqual(getMemberValues(res.members), ["left", "right"]);
+  deepStrictEqual(getMemberValues(res.flattenedMembers), ["up", "down", "left", "right"]);
+});
+
+it("flattendMembers include all members from included enums", async () => {
+  const res = await testValidUnionAsEnum(
+    `
+    @test("target")  union Test { UpDown, "left", "right"} 
+    enum UpDown { up, down }
+    `,
+  );
+  deepStrictEqual(getMemberValues(res.members), ["left", "right"]);
+  deepStrictEqual(getMemberValues(res.flattenedMembers), ["up", "down", "left", "right"]);
+});
+
+it("returns undefined with diagnostic if contains different types", async () => {
+  const [res, diagnostics] = await testUnionAsEnum(`@test("target")  union Test { "one", 2}`);
+  strictEqual(res, undefined);
+  expectDiagnostics(diagnostics, {
+    code: "@azure-tools/typespec-azure-core/union-enums-multiple-kind",
+    message: "Couldn't resolve the kind of the union as it has multiple types: string, number",
   });
+});
 
-  it("resolve a number enum if all variants are numeric literals", async () => {
-    const res = await testValidUnionAsEnum(`@test("target") union Test {0, 1, 2}`);
-    deepStrictEqual(getMemberValues(res.members), [0, 1, 2]);
-    deepStrictEqual(getMemberValues(res.flattenedMembers), [0, 1, 2]);
-    strictEqual(res.open, false);
+it("returns undefined with diagnostic if contains non enum types", async () => {
+  const [res, diagnostics] = await testUnionAsEnum(
+    `
+    @test("target")  union Test { Mod, "one"} 
+    model Mod {}
+    `,
+  );
+  strictEqual(res, undefined);
+  expectDiagnostics(diagnostics, {
+    code: "@azure-tools/typespec-azure-core/union-enums-invalid-kind",
+    message: "Kind Model prevents this union from being resolved as an enum.",
   });
+});
 
-  it("resolve a open string enum if include string scalar", async () => {
-    const res = await testValidUnionAsEnum(`@test("target") union Test {"one" , "two", string}`);
-    deepStrictEqual(getMemberValues(res.members), ["one", "two"]);
-    deepStrictEqual(getMemberValues(res.flattenedMembers), ["one", "two"]);
-    strictEqual(res.open, true);
-  });
-
-  it("resolve a open string enum if sub union include string scalar", async () => {
-    const res = await testValidUnionAsEnum(`
-      @test("target") 
-      union Test {"one" , "two", Other }
-      union Other { "three", string }
-    `);
-    strictEqual(res.open, true);
-  });
-
-  it("resolve as nullabe if include null", async () => {
-    const res = await testValidUnionAsEnum(` @test("target") union Test {"one" , "two", null }`);
-    strictEqual(res.nullable, true);
-  });
-
-  it("resolve as nullabe if sub union include null", async () => {
-    const res = await testValidUnionAsEnum(`
-      @test("target") 
-      union Test {"one" , "two", Other }
-      union Other { "three", null} 
-    `);
-    strictEqual(res.nullable, true);
-  });
-
-  it("resolve a open number enum if include int32 scalar", async () => {
-    const res = await testValidUnionAsEnum(`@test("target") union Test {0, 1, 2, int32}`);
-    deepStrictEqual(getMemberValues(res.members), [0, 1, 2]);
-    deepStrictEqual(getMemberValues(res.flattenedMembers), [0, 1, 2]);
-    strictEqual(res.open, true);
-  });
-
-  it("flattendMembers include all members from included unions", async () => {
-    const res = await testValidUnionAsEnum(
-      `
-      @test("target")  union Test { UpDown, "left", "right"} 
-      union UpDown { "up", "down" }
-      `,
-    );
-    deepStrictEqual(getMemberValues(res.members), ["left", "right"]);
-    deepStrictEqual(getMemberValues(res.flattenedMembers), ["up", "down", "left", "right"]);
-  });
-
-  it("flattendMembers include all members from included enums", async () => {
-    const res = await testValidUnionAsEnum(
-      `
-      @test("target")  union Test { UpDown, "left", "right"} 
-      enum UpDown { up, down }
-      `,
-    );
-    deepStrictEqual(getMemberValues(res.members), ["left", "right"]);
-    deepStrictEqual(getMemberValues(res.flattenedMembers), ["up", "down", "left", "right"]);
-  });
-
-  it("returns undefined with diagnostic if contains different types", async () => {
-    const [res, diagnostics] = await testUnionAsEnum(`@test("target")  union Test { "one", 2}`);
-    strictEqual(res, undefined);
-    expectDiagnostics(diagnostics, {
-      code: "@azure-tools/typespec-azure-core/union-enums-multiple-kind",
-      message: "Couldn't resolve the kind of the union as it has multiple types: string, number",
-    });
-  });
-
-  it("returns undefined with diagnostic if contains non enum types", async () => {
-    const [res, diagnostics] = await testUnionAsEnum(
-      `
-      @test("target")  union Test { Mod, "one"} 
-      model Mod {}
-      `,
-    );
-    strictEqual(res, undefined);
-    expectDiagnostics(diagnostics, {
-      code: "@azure-tools/typespec-azure-core/union-enums-invalid-kind",
-      message: "Kind Model prevents this union from being resolved as an enum.",
-    });
-  });
-
-  it("returns undefined with diagnostic if union reference itself", async () => {
-    const [res, diagnostics] = await testUnionAsEnum(
-      `
-      @test("target") union Test { Test, "one"} 
-      `,
-    );
-    strictEqual(res, undefined);
-    expectDiagnostics(diagnostics, {
-      code: "@azure-tools/typespec-azure-core/union-enums-circular",
-      message: "Union is referencing itself and cannot be resolved as an enum.",
-    });
+it("returns undefined with diagnostic if union reference itself", async () => {
+  const [res, diagnostics] = await testUnionAsEnum(
+    `
+    @test("target") union Test { Test, "one"} 
+    `,
+  );
+  strictEqual(res, undefined);
+  expectDiagnostics(diagnostics, {
+    code: "@azure-tools/typespec-azure-core/union-enums-circular",
+    message: "Union is referencing itself and cannot be resolved as an enum.",
   });
 });

--- a/packages/typespec-azure-core/test/helpers/union-enums.test.ts
+++ b/packages/typespec-azure-core/test/helpers/union-enums.test.ts
@@ -4,7 +4,7 @@ import {
   expectDiagnostics,
 } from "@typespec/compiler/testing";
 import { deepStrictEqual, ok, strictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { UnionEnumVariant } from "../../src/helpers/union-enums.js";
 import { getUnionAsEnum } from "../../src/index.js";
 

--- a/packages/typespec-azure-core/test/operations.test.ts
+++ b/packages/typespec-azure-core/test/operations.test.ts
@@ -13,153 +13,201 @@ import { type LroMetadata, getLroMetadata } from "../src/lro-helpers.js";
 import { getNamespaceName } from "../src/rules/utils.js";
 import { type SimpleHttpOperation, getOperations, getSimplifiedOperations } from "./test-host.js";
 
-describe("typespec-azure-core: operation templates", () => {
-  it("gathers metadata about ResourceCreateOrUpdate operation template", async () => {
-    const [operations, diagnostics] = await getOperations(
-      `
-      @resource("test")
-      model TestModel {
-        @key
-        name: string;
+it("gathers metadata about ResourceCreateOrUpdate operation template", async () => {
+  const [operations, diagnostics] = await getOperations(
+    `
+    @resource("test")
+    model TestModel {
+      @key
+      name: string;
 
-        data: string;
-      };
+      data: string;
+    };
 
-      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-      @test op resourceUpsert is StandardResourceOperations.ResourceCreateOrUpdate<TestModel>;
-      `,
-    );
+    #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    @test op resourceUpsert is StandardResourceOperations.ResourceCreateOrUpdate<TestModel>;
+    `,
+  );
 
-    ok(operations.length === 1);
-    strictEqual(operations[0].path, "/test/{name}");
-    strictEqual(operations[0].verb, "patch");
+  ok(operations.length === 1);
+  strictEqual(operations[0].path, "/test/{name}");
+  strictEqual(operations[0].verb, "patch");
 
-    const contentTypeParam = operations[0].parameters.parameters.find(
-      (p) => p.name === "Content-Type",
-    );
-    ok(contentTypeParam, "No Content-Type header was found.");
-    strictEqual(contentTypeParam!.type, "header");
-    strictEqual(contentTypeParam!.param.type.kind, "String");
-    strictEqual(
-      (contentTypeParam!.param.type as StringLiteral).value,
-      "application/merge-patch+json",
-    );
+  const contentTypeParam = operations[0].parameters.parameters.find(
+    (p) => p.name === "Content-Type",
+  );
+  ok(contentTypeParam, "No Content-Type header was found.");
+  strictEqual(contentTypeParam!.type, "header");
+  strictEqual(contentTypeParam!.param.type.kind, "String");
+  strictEqual(
+    (contentTypeParam!.param.type as StringLiteral).value,
+    "application/merge-patch+json",
+  );
 
-    expectDiagnosticEmpty(diagnostics);
-  });
+  expectDiagnosticEmpty(diagnostics);
+});
 
-  it("properly annotates long-running operations with a status monitor", async () => {
-    const [operations, diagnostics, runner] = await getOperations(
-      `
-      @resource("test")
-      model TestModel {
-        @key
-        name: string;
-      };
+it("properly annotates long-running operations with a status monitor", async () => {
+  const [operations, diagnostics, runner] = await getOperations(
+    `
+    @resource("test")
+    model TestModel {
+      @key
+      name: string;
+    };
 
-      @test op create is StandardResourceOperations.LongRunningResourceCreateWithServiceProvidedName<TestModel>;
-      @test op createReplace is StandardResourceOperations.LongRunningResourceCreateOrReplace<TestModel>;
-      @test op delete is Azure.Core.LongRunningResourceDelete<TestModel>;
+    @test op create is StandardResourceOperations.LongRunningResourceCreateWithServiceProvidedName<TestModel>;
+    @test op createReplace is StandardResourceOperations.LongRunningResourceCreateOrReplace<TestModel>;
+    @test op delete is Azure.Core.LongRunningResourceDelete<TestModel>;
 
-      #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
-      @TypeSpec.Http.route("basic")
+    #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
+    @TypeSpec.Http.route("basic")
 @test op basicOp is Azure.Core.Foundations.LongRunningOperation<{}>;
-      `,
+    `,
+  );
+
+  function hasLocationHeader(operation: HttpOperation, statusCode: number = 201): void {
+    const response = operation.responses.find((r) => r.statusCodes === statusCode);
+    ok(response);
+    const locationHeader = response.responses[0].headers?.["Location"];
+    ok(locationHeader, `No location header: ${operation.operation.name}`);
+    ok(
+      isFinalLocation(runner.program, locationHeader),
+      `@finalLocation not found: ${operation.operation.name}`,
     );
+  }
 
-    function hasLocationHeader(operation: HttpOperation, statusCode: number = 201): void {
-      const response = operation.responses.find((r) => r.statusCodes === statusCode);
-      ok(response);
-      const locationHeader = response.responses[0].headers?.["Location"];
-      ok(locationHeader, `No location header: ${operation.operation.name}`);
-      ok(
-        isFinalLocation(runner.program, locationHeader),
-        `@finalLocation not found: ${operation.operation.name}`,
-      );
+  function hasOperationLocationHeader(operation: HttpOperation, statusCode: number = 201): void {
+    const response = operation.responses.find((r) => r.statusCodes === statusCode);
+    ok(response);
+    const operationLocationHeader = response.responses[0].headers?.["Operation-Location"];
+    ok(operationLocationHeader, `No Operation-Location header: ${operation.operation.name}`);
+    ok(
+      isPollingLocation(runner.program, operationLocationHeader),
+      `@pollingLocation not found: ${operation.operation.name}`,
+    );
+  }
+
+  expectDiagnosticEmpty(diagnostics);
+
+  strictEqual(operations.length, 4);
+  const createOp = operations[0];
+  strictEqual(createOp.operation.name, "create");
+  hasLocationHeader(createOp, 202);
+
+  const createReplaceOp = operations[1];
+  strictEqual(createReplaceOp.operation.name, "createReplace");
+  hasOperationLocationHeader(createReplaceOp);
+
+  // NOTE: CreateOrUpdate does not return an LRO status!
+
+  const deleteOp = operations[2];
+  strictEqual(deleteOp.operation.name, "delete");
+  hasOperationLocationHeader(deleteOp, 202);
+
+  const basicOp = operations[3];
+  strictEqual(basicOp.operation.name, "basicOp");
+  hasOperationLocationHeader(basicOp, 202);
+});
+
+it("allows derived class to derive resource metadata from base class", async () => {
+  const [_, diagnostics] = await getOperations(`
+    @resource("foo")
+    model BaseWithKey {
+      @key
+      name: string;
     }
 
-    function hasOperationLocationHeader(operation: HttpOperation, statusCode: number = 201): void {
-      const response = operation.responses.find((r) => r.statusCodes === statusCode);
-      ok(response);
-      const operationLocationHeader = response.responses[0].headers?.["Operation-Location"];
-      ok(operationLocationHeader, `No Operation-Location header: ${operation.operation.name}`);
-      ok(
-        isPollingLocation(runner.program, operationLocationHeader),
-        `@pollingLocation not found: ${operation.operation.name}`,
-      );
+    model Derived extends BaseWithKey {
+      extra: string;
     }
 
-    expectDiagnosticEmpty(diagnostics);
+    op read is Azure.Core.StandardResourceOperations.ResourceRead<Derived>;
+  `);
+  expectDiagnosticEmpty(diagnostics);
+});
 
-    strictEqual(operations.length, 4);
-    const createOp = operations[0];
-    strictEqual(createOp.operation.name, "create");
-    hasLocationHeader(createOp, 202);
+it("emits diagnostic when invalid resource type is given", async () => {
+  const [_, diagnostics] = await getOperations(`
+    model NoKeyModel {
+      name: string;
+    }
 
-    const createReplaceOp = operations[1];
-    strictEqual(createReplaceOp.operation.name, "createReplace");
-    hasOperationLocationHeader(createReplaceOp);
+    model NoSegmentModel {
+      @key
+      name: string;
+    }
 
-    // NOTE: CreateOrUpdate does not return an LRO status!
+    op read is Azure.Core.ResourceRead<NoKeyModel>;
+    #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    op create is StandardResourceOperations.ResourceCreateOrUpdate<NoSegmentModel>;
+  `);
 
-    const deleteOp = operations[2];
-    strictEqual(deleteOp.operation.name, "delete");
-    hasOperationLocationHeader(deleteOp, 202);
+  expectDiagnostics(diagnostics, [
+    {
+      code: "@azure-tools/typespec-azure-core/invalid-resource-type",
+      message:
+        "Model type 'Azure.MyService.NoKeyModel' is not a valid resource type.  It must contain a property decorated with '@key'.",
+    },
+    {
+      code: "@azure-tools/typespec-azure-core/invalid-resource-type",
+      message:
+        "Model type 'Azure.MyService.NoSegmentModel' is not a valid resource type.  It must be decorated with the '@resource' decorator.",
+    },
+  ]);
+});
 
-    const basicOp = operations[3];
-    strictEqual(basicOp.operation.name, "basicOp");
-    hasOperationLocationHeader(basicOp, 202);
-  });
+function wrapResourceCode(code: string): string {
+  return `
+  model TestModel {
+    @key
+    @segment("test")
+    name: string;
+    value: int32;
+  }
 
-  it("allows derived class to derive resource metadata from base class", async () => {
-    const [_, diagnostics] = await getOperations(`
-      @resource("foo")
-      model BaseWithKey {
-        @key
-        name: string;
-      }
+  model CustomRequestHeaders {
+    @header
+    "x-ms-foobar": string;
+  }
 
-      model Derived extends BaseWithKey {
-        extra: string;
-      }
+  model CustomQueryParameters {
+    @query
+    nameHint: string;
+  }
 
-      op read is Azure.Core.StandardResourceOperations.ResourceRead<Derived>;
-    `);
-    expectDiagnosticEmpty(diagnostics);
-  });
+  model CustomParameters { ...CustomRequestHeaders; ...CustomQueryParameters; }
 
-  it("emits diagnostic when invalid resource type is given", async () => {
-    const [_, diagnostics] = await getOperations(`
-      model NoKeyModel {
-        name: string;
-      }
+  model CustomResponseProperties {
+    @header
+    "x-ms-response-id": int32;
+  }
 
-      model NoSegmentModel {
-        @key
-        name: string;
-      }
+  alias Customizations = Azure.Core.Traits.RequestHeadersTrait<CustomRequestHeaders> & Azure.Core.Traits.QueryParametersTrait<CustomQueryParameters> & Azure.Core.Traits.ResponseHeadersTrait<CustomResponseProperties>;
 
-      op read is Azure.Core.ResourceRead<NoKeyModel>;
-      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-      op create is StandardResourceOperations.ResourceCreateOrUpdate<NoSegmentModel>;
-    `);
+  ${code}
+  `;
+}
 
-    expectDiagnostics(diagnostics, [
-      {
-        code: "@azure-tools/typespec-azure-core/invalid-resource-type",
-        message:
-          "Model type 'Azure.MyService.NoKeyModel' is not a valid resource type.  It must contain a property decorated with '@key'.",
-      },
-      {
-        code: "@azure-tools/typespec-azure-core/invalid-resource-type",
-        message:
-          "Model type 'Azure.MyService.NoSegmentModel' is not a valid resource type.  It must be decorated with the '@resource' decorator.",
-      },
-    ]);
-  });
+async function compileResourceOperations(code: string): Promise<SimpleHttpOperation[]> {
+  const [operations, diagnostics] = await getSimplifiedOperations(wrapResourceCode(code));
 
-  function wrapResourceCode(code: string): string {
-    return `
+  expectDiagnosticEmpty(diagnostics);
+  return operations;
+}
+
+async function compileResourceOperation(code: string): Promise<SimpleHttpOperation> {
+  const operations = await compileResourceOperations(code);
+  strictEqual(operations.length, 1);
+  return operations[0];
+}
+
+async function compileLroOperation(
+  code: string,
+  operationName?: string,
+): Promise<[HttpOperation, LroMetadata | undefined, TesterInstance]> {
+  let [operations, diagnostics, runner] = await getOperations(
+    `
     model TestModel {
       @key
       @segment("test")
@@ -187,360 +235,486 @@ describe("typespec-azure-core: operation templates", () => {
     alias Customizations = Azure.Core.Traits.RequestHeadersTrait<CustomRequestHeaders> & Azure.Core.Traits.QueryParametersTrait<CustomQueryParameters> & Azure.Core.Traits.ResponseHeadersTrait<CustomResponseProperties>;
 
     ${code}
-    `;
+    `,
+  );
+
+  expectDiagnosticEmpty(diagnostics);
+
+  if (operationName !== undefined) {
+    operations = operations.filter((o) => o.operation.name === operationName);
   }
 
-  async function compileResourceOperations(code: string): Promise<SimpleHttpOperation[]> {
-    const [operations, diagnostics] = await getSimplifiedOperations(wrapResourceCode(code));
+  strictEqual(operations.length, 1);
+  const lro = getLroMetadata(runner.program, operations[0].operation);
+  expectDiagnosticEmpty(runner.program.diagnostics);
 
-    expectDiagnosticEmpty(diagnostics);
-    return operations;
-  }
+  return [operations[0], lro, runner];
+}
 
-  async function compileResourceOperation(code: string): Promise<SimpleHttpOperation> {
-    const operations = await compileResourceOperations(code);
-    strictEqual(operations.length, 1);
-    return operations[0];
-  }
+const expectedParams = [
+  {
+    name: "api-version",
+    type: "query",
+  },
+  {
+    name: "x-ms-foobar",
+    type: "header",
+  },
+  {
+    name: "nameHint",
+    type: "query",
+  },
+];
 
-  async function compileLroOperation(
-    code: string,
-    operationName?: string,
-  ): Promise<[HttpOperation, LroMetadata | undefined, TesterInstance]> {
-    let [operations, diagnostics, runner] = await getOperations(
-      `
-      model TestModel {
-        @key
-        @segment("test")
-        name: string;
-        value: int32;
-      }
+const expectedParamsWithName = [...expectedParams];
+expectedParamsWithName.splice(1, 0, {
+  name: "name",
+  type: "path",
+});
 
-      model CustomRequestHeaders {
-        @header
-        "x-ms-foobar": string;
-      }
+it("ResourceRead", async () => {
+  const operation = await compileResourceOperation(
+    `@test op read is Azure.Core.ResourceRead<TestModel, Customizations>;`,
+  );
 
-      model CustomQueryParameters {
-        @query
-        nameHint: string;
-      }
+  deepStrictEqual(operation, {
+    name: "read",
+    verb: "get",
+    path: "/test/{name}",
+    params: {
+      body: undefined,
+      params: expectedParamsWithName,
+    },
+    responseProperties: ["name", "value", "x-ms-response-id"],
+  });
+});
 
-      model CustomParameters { ...CustomRequestHeaders; ...CustomQueryParameters; }
-
-      model CustomResponseProperties {
-        @header
-        "x-ms-response-id": int32;
-      }
-
-      alias Customizations = Azure.Core.Traits.RequestHeadersTrait<CustomRequestHeaders> & Azure.Core.Traits.QueryParametersTrait<CustomQueryParameters> & Azure.Core.Traits.ResponseHeadersTrait<CustomResponseProperties>;
-
-      ${code}
-      `,
-    );
-
-    expectDiagnosticEmpty(diagnostics);
-
-    if (operationName !== undefined) {
-      operations = operations.filter((o) => o.operation.name === operationName);
+it("emits warning if you overload a standard operation with a different verb", async () => {
+  const [_, diagnostics] = await getOperations(`
+    @resource("widgets")
+    model Widget {
+      @key
+      @visibility(Lifecycle.Read)
+      name: string;
     }
 
-    strictEqual(operations.length, 1);
-    const lro = getLroMetadata(runner.program, operations[0].operation);
-    expectDiagnosticEmpty(runner.program.diagnostics);
-
-    return [operations[0], lro, runner];
-  }
-
-  const expectedParams = [
+    @test @delete op read is Azure.Core.ResourceRead<Widget>;
+  `);
+  expectDiagnostics(diagnostics, [
     {
-      name: "api-version",
-      type: "query",
+      code: "@azure-tools/typespec-azure-core/verb-conflict",
+      severity: "warning",
+      message: "Operation template 'ResourceRead' requires HTTP verb 'GET' but found 'DELETE'.",
     },
-    {
-      name: "x-ms-foobar",
-      type: "header",
-    },
-    {
-      name: "nameHint",
-      type: "query",
-    },
-  ];
+  ]);
+});
 
-  const expectedParamsWithName = [...expectedParams];
-  expectedParamsWithName.splice(1, 0, {
-    name: "name",
-    type: "path",
+it("ResourceList", async () => {
+  const operation = await compileResourceOperation(
+    `@test op list is Azure.Core.ResourceList<TestModel, Customizations>;`,
+  );
+
+  deepStrictEqual(operation, {
+    name: "list",
+    verb: "get",
+    path: "/test",
+    params: {
+      body: undefined,
+      params: expectedParams,
+    },
+    responseProperties: ["value", "nextLink", "x-ms-response-id"],
+  });
+});
+
+it("NonPagedResourceList", async () => {
+  const operation = await compileResourceOperation(
+    `
+    #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
+    @test op list is Azure.Core.Foundations.NonPagedResourceList<TestModel, Customizations>;
+    `,
+  );
+
+  deepStrictEqual(operation, {
+    name: "list",
+    verb: "get",
+    path: "/test",
+    params: {
+      body: undefined,
+      params: expectedParams,
+    },
+    responseProperties: ["body", "x-ms-response-id"],
+  });
+});
+
+it("ResourceCreateWithServiceProvidedName", async () => {
+  const operation = await compileResourceOperation(
+    `@test op create is StandardResourceOperations.ResourceCreateWithServiceProvidedName<TestModel, Customizations>;`,
+  );
+
+  deepStrictEqual(operation, {
+    name: "create",
+    verb: "post",
+    path: "/test",
+    params: {
+      body: "resource",
+      params: expectedParams,
+    },
+    responseProperties: ["statusCode", "location", "x-ms-response-id"],
+  });
+});
+
+it("ResourceCreateOrUpdate", async () => {
+  const operation = await compileResourceOperation(
+    `#suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    @test op createOrUpdate is StandardResourceOperations.ResourceCreateOrUpdate<TestModel, Customizations>;`,
+  );
+
+  const params = [...expectedParamsWithName];
+  params.splice(2, 0, {
+    name: "Content-Type",
+    type: "header",
   });
 
-  it("ResourceRead", async () => {
+  deepStrictEqual(operation, {
+    name: "createOrUpdate",
+    verb: "patch",
+    path: "/test/{name}",
+    params: {
+      body: "resource",
+      params,
+    },
+    responseProperties: ["statusCode", "name", "value", "x-ms-response-id"],
+  });
+});
+
+it("ResourceUpdate", async () => {
+  const operation = await compileResourceOperation(
+    `#suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    @test op update is StandardResourceOperations.ResourceUpdate<TestModel, Customizations>;`,
+  );
+
+  const params = [...expectedParamsWithName];
+  params.splice(2, 0, {
+    name: "Content-Type",
+    type: "header",
+  });
+
+  deepStrictEqual(operation, {
+    name: "update",
+    verb: "patch",
+    path: "/test/{name}",
+    params: {
+      body: "resource",
+      params,
+    },
+    responseProperties: ["statusCode", "name", "value", "x-ms-response-id"],
+  });
+});
+
+it("ResourceCreateOrReplace", async () => {
+  const operation = await compileResourceOperation(
+    `@test op createOrReplace is StandardResourceOperations.ResourceCreateOrReplace<TestModel, Customizations>;`,
+  );
+
+  deepStrictEqual(operation, {
+    name: "createOrReplace",
+    verb: "put",
+    path: "/test/{name}",
+    params: {
+      body: "resource",
+      params: expectedParamsWithName,
+    },
+    responseProperties: ["statusCode", "name", "value", "x-ms-response-id"],
+  });
+});
+
+it("ResourceDelete", async () => {
+  const operation = await compileResourceOperation(
+    `@test op delete is Azure.Core.ResourceDelete<TestModel, Customizations>;`,
+  );
+
+  deepStrictEqual(operation, {
+    name: "delete",
+    verb: "delete",
+    path: "/test/{name}",
+    params: {
+      body: undefined,
+      params: expectedParamsWithName,
+    },
+    responseProperties: ["statusCode", "x-ms-response-id"],
+  });
+});
+
+it("LongRunningResourceCreateWithServiceProvidedName", async () => {
+  const operation = await compileResourceOperation(
+    `@test op create is StandardResourceOperations.LongRunningResourceCreateWithServiceProvidedName<TestModel, Customizations>;`,
+  );
+
+  deepStrictEqual(operation, {
+    name: "create",
+    verb: "post",
+    path: "/test",
+    params: {
+      body: "resource",
+      params: expectedParams,
+    },
+    responseProperties: ["statusCode", "location", "x-ms-response-id"],
+  });
+});
+
+it("LongRunningResourceCreateOrUpdate", async () => {
+  const operation = await compileResourceOperation(
+    `#suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    @test op createOrUpdate is StandardResourceOperations.LongRunningResourceCreateOrUpdate<TestModel, Customizations>;`,
+  );
+
+  const params = [...expectedParamsWithName];
+  params.splice(2, 0, {
+    name: "Content-Type",
+    type: "header",
+  });
+
+  deepStrictEqual(operation, {
+    name: "createOrUpdate",
+    verb: "patch",
+    path: "/test/{name}",
+    params: {
+      body: "resource",
+      params,
+    },
+    responseProperties: ["statusCode", "name", "value", "x-ms-response-id", "operationLocation"],
+  });
+});
+
+it("LongRunningResourceCreateOrReplace", async () => {
+  const operation = await compileResourceOperation(
+    `@test op createOrReplace is StandardResourceOperations.LongRunningResourceCreateOrReplace<TestModel, Customizations>;`,
+  );
+
+  deepStrictEqual(operation, {
+    name: "createOrReplace",
+    verb: "put",
+    path: "/test/{name}",
+    params: {
+      body: "resource",
+      params: expectedParamsWithName,
+    },
+    responseProperties: ["statusCode", "name", "value", "x-ms-response-id", "operationLocation"],
+  });
+});
+
+it("LongRunningResourceUpdate", async () => {
+  const operation = await compileResourceOperation(
+    `#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
+     #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+     @test op update is Azure.Core.Foundations.LongRunningResourceUpdate<TestModel, Customizations>;`,
+  );
+
+  const params = [...expectedParamsWithName];
+  params.splice(2, 0, {
+    name: "Content-Type",
+    type: "header",
+  });
+
+  deepStrictEqual(operation, {
+    name: "update",
+    verb: "patch",
+    path: "/test/{name}",
+    params: {
+      body: "resource",
+      params,
+    },
+    responseProperties: ["statusCode", "name", "value", "x-ms-response-id", "operationLocation"],
+  });
+});
+
+it("LongRunningResourceDelete", async () => {
+  const operation = await compileResourceOperation(
+    `@test op delete is Azure.Core.LongRunningResourceDelete<TestModel, Customizations>;`,
+  );
+
+  deepStrictEqual(operation, {
+    name: "delete",
+    verb: "delete",
+    path: "/test/{name}",
+    params: {
+      body: undefined,
+      params: expectedParamsWithName,
+    },
+    responseProperties: [
+      "statusCode",
+      "id",
+      "status",
+      "error",
+      "result",
+      "operationLocation",
+      "x-ms-response-id",
+    ],
+  });
+});
+
+it("ResourceAction", async () => {
+  const operation = await compileResourceOperation(
+    `
+    // Reuse CustomParameters and CustomResponseProperties in the "normal" TParams and TResponse fields
+    model OpParams {
+      value: string;
+      ...CustomParameters;
+    };
+
+    model OpResponse is CustomResponseProperties {
+      message: string;
+    }
+
+    @test op customAction is Azure.Core.ResourceAction<TestModel, OpParams, OpResponse>;
+    `,
+  );
+
+  deepStrictEqual(operation, {
+    name: "customAction",
+    verb: "post",
+    path: "/test/{name}:customAction",
+    params: {
+      body: ["value"],
+      params: expectedParamsWithName,
+    },
+    responseProperties: ["x-ms-response-id", "message"],
+  });
+});
+
+it("ResourceAction customizations", async () => {
+  const [operations, _] = await getOperations(
+    `
+    @TypeSpec.Rest.resource("things")
+    model Thing {
+      @key
+      id: string
+    }
+
+    @TypeSpec.Rest.actionSeparator("/")
+    @test op action2 is Azure.Core.ResourceAction<Thing, {}, {}>;
+    `,
+  );
+  strictEqual(operations[0].path, "/things/{id}/action2");
+});
+
+it("ResourceCollectionAction", async () => {
+  const operation = await compileResourceOperation(
+    `
+      // Reuse CustomParameters and CustomResponseProperties in the "normal" TParams and TResponse fields
+      model OpParams {
+        value: string;
+        ...CustomParameters;
+      };
+
+      model OpResponse is CustomResponseProperties {
+        message: string;
+      }
+
+      @test op customAction is Azure.Core.ResourceCollectionAction<TestModel, OpParams, OpResponse>;`,
+  );
+
+  deepStrictEqual(operation, {
+    name: "customAction",
+    verb: "post",
+    path: "/test:customAction",
+    params: {
+      body: ["value"],
+      params: expectedParams,
+    },
+    responseProperties: ["x-ms-response-id", "message"],
+  });
+});
+
+it("ResourceCollectionAction customizations", async () => {
+  const [operations, _] = await getOperations(
+    `
+    @TypeSpec.Rest.resource("things")
+    model Thing {
+      @key
+      id: string
+    }
+    
+    @TypeSpec.Rest.actionSeparator("/")
+    @test op customAction is Azure.Core.ResourceCollectionAction<Thing, {}, {}>;
+    `,
+  );
+  strictEqual(operations[0].path, "/things/customAction");
+});
+
+describe("RpcOperation", () => {
+  it("allows override of TraitContext", async () => {
     const operation = await compileResourceOperation(
-      `@test op read is Azure.Core.ResourceRead<TestModel, Customizations>;`,
+      `@test @route("/test") op rpcOp is Azure.Core.RpcOperation<{}, TestModel, Customizations, Azure.Core.Foundations.ErrorResponse, Azure.Core.Traits.TraitContext.Read>;`,
     );
 
     deepStrictEqual(operation, {
-      name: "read",
+      name: "rpcOp",
       verb: "get",
-      path: "/test/{name}",
+      path: "/test",
       params: {
         body: undefined,
-        params: expectedParamsWithName,
+        params: expectedParams,
       },
       responseProperties: ["name", "value", "x-ms-response-id"],
     });
   });
 
-  it("emits warning if you overload a standard operation with a different verb", async () => {
-    const [_, diagnostics] = await getOperations(`
-      @resource("widgets")
-      model Widget {
-        @key
-        @visibility(Lifecycle.Read)
-        name: string;
+  it("works with default TraitContext.Undefined", async () => {
+    const operation = await compileResourceOperation(
+      `@test @route("/test") op rpcOp is Azure.Core.RpcOperation<{}, TestModel>;`,
+    );
+
+    deepStrictEqual(operation, {
+      name: "rpcOp",
+      verb: "get",
+      path: "/test",
+      params: {
+        body: undefined,
+        params: [
+          {
+            name: "api-version",
+            type: "query",
+          },
+        ],
+      },
+      responseProperties: ["name", "value"],
+    });
+  });
+});
+
+describe("LongRunningRpcOperation", () => {
+  it("allows override of TraitContext", async () => {
+    const operations = await compileResourceOperations(
+      `
+      @route("/lrRpcOp/{operationId}")
+      @get op getStatus(@path operationId: string): PollingStatus;
+
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
       }
 
-      @test @delete op read is Azure.Core.ResourceRead<Widget>;
-    `);
-    expectDiagnostics(diagnostics, [
-      {
-        code: "@azure-tools/typespec-azure-core/verb-conflict",
-        severity: "warning",
-        message: "Operation template 'ResourceRead' requires HTTP verb 'GET' but found 'DELETE'.",
-      },
-    ]);
-  });
-
-  it("ResourceList", async () => {
-    const operation = await compileResourceOperation(
-      `@test op list is Azure.Core.ResourceList<TestModel, Customizations>;`,
+      model StatusError { message: string; }
+      @test @pollingOperation(getStatus) @route("/lrRpcOp") op lrRpcOp is Azure.Core.LongRunningRpcOperation<{}, TestModel, PollingStatus, StatusError, Customizations, Azure.Core.Foundations.ErrorResponse, Azure.Core.Traits.TraitContext.Read>;
+    `,
     );
 
-    deepStrictEqual(operation, {
-      name: "list",
-      verb: "get",
-      path: "/test",
-      params: {
-        body: undefined,
-        params: expectedParams,
-      },
-      responseProperties: ["value", "nextLink", "x-ms-response-id"],
-    });
-  });
+    const statusOp = operations[0];
+    const lroOp = operations[1];
 
-  it("NonPagedResourceList", async () => {
-    const operation = await compileResourceOperation(
-      `
-      #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
-      @test op list is Azure.Core.Foundations.NonPagedResourceList<TestModel, Customizations>;
-      `,
-    );
-
-    deepStrictEqual(operation, {
-      name: "list",
-      verb: "get",
-      path: "/test",
-      params: {
-        body: undefined,
-        params: expectedParams,
-      },
-      responseProperties: ["body", "x-ms-response-id"],
-    });
-  });
-
-  it("ResourceCreateWithServiceProvidedName", async () => {
-    const operation = await compileResourceOperation(
-      `@test op create is StandardResourceOperations.ResourceCreateWithServiceProvidedName<TestModel, Customizations>;`,
-    );
-
-    deepStrictEqual(operation, {
-      name: "create",
+    deepStrictEqual(lroOp, {
+      name: "lrRpcOp",
       verb: "post",
-      path: "/test",
-      params: {
-        body: "resource",
-        params: expectedParams,
-      },
-      responseProperties: ["statusCode", "location", "x-ms-response-id"],
-    });
-  });
-
-  it("ResourceCreateOrUpdate", async () => {
-    const operation = await compileResourceOperation(
-      `#suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-      @test op createOrUpdate is StandardResourceOperations.ResourceCreateOrUpdate<TestModel, Customizations>;`,
-    );
-
-    const params = [...expectedParamsWithName];
-    params.splice(2, 0, {
-      name: "Content-Type",
-      type: "header",
-    });
-
-    deepStrictEqual(operation, {
-      name: "createOrUpdate",
-      verb: "patch",
-      path: "/test/{name}",
-      params: {
-        body: "resource",
-        params,
-      },
-      responseProperties: ["statusCode", "name", "value", "x-ms-response-id"],
-    });
-  });
-
-  it("ResourceUpdate", async () => {
-    const operation = await compileResourceOperation(
-      `#suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-      @test op update is StandardResourceOperations.ResourceUpdate<TestModel, Customizations>;`,
-    );
-
-    const params = [...expectedParamsWithName];
-    params.splice(2, 0, {
-      name: "Content-Type",
-      type: "header",
-    });
-
-    deepStrictEqual(operation, {
-      name: "update",
-      verb: "patch",
-      path: "/test/{name}",
-      params: {
-        body: "resource",
-        params,
-      },
-      responseProperties: ["statusCode", "name", "value", "x-ms-response-id"],
-    });
-  });
-
-  it("ResourceCreateOrReplace", async () => {
-    const operation = await compileResourceOperation(
-      `@test op createOrReplace is StandardResourceOperations.ResourceCreateOrReplace<TestModel, Customizations>;`,
-    );
-
-    deepStrictEqual(operation, {
-      name: "createOrReplace",
-      verb: "put",
-      path: "/test/{name}",
-      params: {
-        body: "resource",
-        params: expectedParamsWithName,
-      },
-      responseProperties: ["statusCode", "name", "value", "x-ms-response-id"],
-    });
-  });
-
-  it("ResourceDelete", async () => {
-    const operation = await compileResourceOperation(
-      `@test op delete is Azure.Core.ResourceDelete<TestModel, Customizations>;`,
-    );
-
-    deepStrictEqual(operation, {
-      name: "delete",
-      verb: "delete",
-      path: "/test/{name}",
+      path: "/lrRpcOp",
       params: {
         body: undefined,
-        params: expectedParamsWithName,
-      },
-      responseProperties: ["statusCode", "x-ms-response-id"],
-    });
-  });
-
-  it("LongRunningResourceCreateWithServiceProvidedName", async () => {
-    const operation = await compileResourceOperation(
-      `@test op create is StandardResourceOperations.LongRunningResourceCreateWithServiceProvidedName<TestModel, Customizations>;`,
-    );
-
-    deepStrictEqual(operation, {
-      name: "create",
-      verb: "post",
-      path: "/test",
-      params: {
-        body: "resource",
-        params: expectedParams,
-      },
-      responseProperties: ["statusCode", "location", "x-ms-response-id"],
-    });
-  });
-
-  it("LongRunningResourceCreateOrUpdate", async () => {
-    const operation = await compileResourceOperation(
-      `#suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-      @test op createOrUpdate is StandardResourceOperations.LongRunningResourceCreateOrUpdate<TestModel, Customizations>;`,
-    );
-
-    const params = [...expectedParamsWithName];
-    params.splice(2, 0, {
-      name: "Content-Type",
-      type: "header",
-    });
-
-    deepStrictEqual(operation, {
-      name: "createOrUpdate",
-      verb: "patch",
-      path: "/test/{name}",
-      params: {
-        body: "resource",
-        params,
-      },
-      responseProperties: ["statusCode", "name", "value", "x-ms-response-id", "operationLocation"],
-    });
-  });
-
-  it("LongRunningResourceCreateOrReplace", async () => {
-    const operation = await compileResourceOperation(
-      `@test op createOrReplace is StandardResourceOperations.LongRunningResourceCreateOrReplace<TestModel, Customizations>;`,
-    );
-
-    deepStrictEqual(operation, {
-      name: "createOrReplace",
-      verb: "put",
-      path: "/test/{name}",
-      params: {
-        body: "resource",
-        params: expectedParamsWithName,
-      },
-      responseProperties: ["statusCode", "name", "value", "x-ms-response-id", "operationLocation"],
-    });
-  });
-
-  it("LongRunningResourceUpdate", async () => {
-    const operation = await compileResourceOperation(
-      `#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
-       #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-       @test op update is Azure.Core.Foundations.LongRunningResourceUpdate<TestModel, Customizations>;`,
-    );
-
-    const params = [...expectedParamsWithName];
-    params.splice(2, 0, {
-      name: "Content-Type",
-      type: "header",
-    });
-
-    deepStrictEqual(operation, {
-      name: "update",
-      verb: "patch",
-      path: "/test/{name}",
-      params: {
-        body: "resource",
-        params,
-      },
-      responseProperties: ["statusCode", "name", "value", "x-ms-response-id", "operationLocation"],
-    });
-  });
-
-  it("LongRunningResourceDelete", async () => {
-    const operation = await compileResourceOperation(
-      `@test op delete is Azure.Core.LongRunningResourceDelete<TestModel, Customizations>;`,
-    );
-
-    deepStrictEqual(operation, {
-      name: "delete",
-      verb: "delete",
-      path: "/test/{name}",
-      params: {
-        body: undefined,
-        params: expectedParamsWithName,
+        params: [
+          { type: "query", name: "api-version" },
+          { type: "header", name: "x-ms-foobar" },
+          { type: "query", name: "nameHint" },
+        ],
       },
       responseProperties: [
         "statusCode",
@@ -552,10 +726,460 @@ describe("typespec-azure-core: operation templates", () => {
         "x-ms-response-id",
       ],
     });
+
+    deepStrictEqual(statusOp, {
+      name: "getStatus",
+      verb: "get",
+      path: "/lrRpcOp/{operationId}",
+      params: {
+        body: undefined,
+        params: [
+          {
+            name: "operationId",
+            type: "path",
+          },
+        ],
+      },
+      responseProperties: ["location", "statusValue"],
+    });
   });
 
-  it("ResourceAction", async () => {
-    const operation = await compileResourceOperation(
+  it("works with default TraitContext.Undefined", async () => {
+    const operations = await compileResourceOperations(
+      `
+      @route("/lrRpcOp/{operationId}")
+      @get op getStatus(@path operationId: string): PollingStatus;
+
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+
+      model StatusError { message: string; }
+      @test @pollingOperation(getStatus) @route("/lrRpcOp") op lrRpcOp is Azure.Core.LongRunningRpcOperation<{}, TestModel, PollingStatus, StatusError>;
+    `,
+    );
+
+    const statusOp = operations[0];
+    const lroOp = operations[1];
+
+    deepStrictEqual(lroOp, {
+      name: "lrRpcOp",
+      verb: "post",
+      path: "/lrRpcOp",
+      params: {
+        body: undefined,
+        params: [{ type: "query", name: "api-version" }],
+      },
+      responseProperties: ["statusCode", "id", "status", "error", "result", "operationLocation"],
+    });
+
+    deepStrictEqual(statusOp, {
+      name: "getStatus",
+      verb: "get",
+      path: "/lrRpcOp/{operationId}",
+      params: {
+        body: undefined,
+        params: [
+          {
+            name: "operationId",
+            type: "path",
+          },
+        ],
+      },
+      responseProperties: ["location", "statusValue"],
+    });
+  });
+});
+
+describe("LongRunningOperation", () => {
+  it("Gets Lro for standard Async CreateOrUpdate", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `#suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+      @test op createOrUpdate is StandardResourceOperations.LongRunningResourceCreateOrUpdate<TestModel, Customizations>;`,
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "OperationStatus");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "OperationStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
+
+    deepStrictEqual(metadata.finalStateVia, "operation-location");
+    deepStrictEqual(metadata.logicalResult.name, "TestModel");
+    deepStrictEqual(metadata.envelopeResult.name, "OperationStatus");
+    deepStrictEqual(metadata.logicalPath, "result");
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "OperationStatus");
+    deepStrictEqual(metadata.finalResultPath, "result");
+  });
+
+  it("Gets Lro for standard Async CreateOrUpdate with polling reference", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      op poll is StandardResourceOperations.GetResourceOperationStatus<TestModel>;
+
+      @Azure.Core.pollingOperation(poll)
+      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+      @test op createOrUpdate is StandardResourceOperations.LongRunningResourceCreateOrUpdate<TestModel, Customizations>;`,
+      "createOrUpdate",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "ResourceOperationStatus");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "ResourceOperationStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
+
+    deepStrictEqual(metadata.finalStateVia, "operation-location");
+    deepStrictEqual(metadata.logicalResult.name, "TestModel");
+    deepStrictEqual(metadata.envelopeResult.name, "ResourceOperationStatus");
+    deepStrictEqual(metadata.logicalPath, "result");
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "ResourceOperationStatus");
+    deepStrictEqual(metadata.finalResultPath, "result");
+  });
+
+  it("Gets Lro for standard Async CreateOrReplace", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `@test op createOrReplace is StandardResourceOperations.LongRunningResourceCreateOrReplace<TestModel, Customizations>;`,
+    );
+
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "OperationStatus");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "OperationStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, undefined);
+
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    deepStrictEqual(metadata.logicalResult.name, "TestModel");
+    deepStrictEqual(metadata.envelopeResult.name, "OperationStatus");
+    // For createOrReplace, since the resource is returned in the 200 or 201 envelope, the status monitor will not return a results field
+    deepStrictEqual(metadata.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "TestModel");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+  });
+
+  it("Gets Lro for standard Async CreateOrReplace with polling reference", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      op poll is StandardResourceOperations.GetResourceOperationStatus<TestModel>;
+
+      @Azure.Core.pollingOperation(poll)
+      @test op createOrReplace is StandardResourceOperations.LongRunningResourceCreateOrReplace<TestModel, Customizations>;`,
+      "createOrReplace",
+    );
+
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "ResourceOperationStatus");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "ResourceOperationStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
+
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    deepStrictEqual(metadata.logicalResult.name, "TestModel");
+    deepStrictEqual(metadata.envelopeResult.name, "ResourceOperationStatus");
+    deepStrictEqual(metadata.logicalPath, "result");
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "ResourceOperationStatus");
+    deepStrictEqual(metadata.finalResultPath, "result");
+  });
+
+  it("Gets Lro for non-resource PUT with polling reference", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+model Job {
+@path
+@key
+@visibility(Lifecycle.Read)
+id: uuid;
+
+name: string;
+}
+
+model StartJobRequest {
+name: string;
+
+instructions: string[];
+}
+
+model JobStatus is Azure.Core.Foundations.OperationStatus<Job>;
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Non-resource operation"
+@route("/jobs/{id}")
+op getJobStatus is Foundations.GetOperationStatus<
+Rest.Resource.KeysOf<Job>,
+Job
+>;
+
+alias JobLroResponse = {
+@header("Operation-Location") operationLocation: url;
+...Azure.Core.Foundations.OperationStatus<Job>;
+};
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Non-resource operation"
+@pollingOperation(getJobStatus)
+@route("/startJob/")
+@put
+op startJobAsync(
+...Azure.Core.Foundations.ApiVersionParameter,
+
+@body _: StartJobRequest,
+): (CreatedResponse & JobLroResponse) | (OkResponse &
+JobLroResponse) | Azure.Core.Foundations.ErrorResponse;
+`,
+      "startJobAsync",
+    );
+
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "OperationStatus");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "OperationStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
+
+    deepStrictEqual(metadata.finalStateVia, "operation-location");
+    deepStrictEqual(metadata.logicalResult.name, "Job");
+    deepStrictEqual(metadata.envelopeResult.name, "OperationStatus");
+    deepStrictEqual(metadata.logicalPath, "result");
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "Job");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "OperationStatus");
+    deepStrictEqual(metadata.finalResultPath, "result");
+  });
+
+  it("Gets Lro for custom PUT with polling reference", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      @resource("jobs")
+model Job {
+@path
+@key
+@visibility(Lifecycle.Read)
+name: string;
+
+instructions: string[];
+}
+
+model StartJobRequest {
+name: string;
+
+instructions: string[];
+}
+
+model JobStatus is Azure.Core.Foundations.OperationStatus;
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Non-resource operation"
+@route("/jobs/status/{name}")
+op getJobStatus is Foundations.GetOperationStatus<
+Rest.Resource.KeysOf<Job>,
+Job
+>;
+
+op read is StandardResourceOperations.ResourceRead<Job>;
+
+alias JobLroResponse = {
+@header("Operation-Location") operationLocation: string;
+...Azure.Core.Foundations.OperationStatus<Job>;
+};
+
+#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "test"
+@finalOperation(read)
+@pollingOperation(getJobStatus)
+@createsOrReplacesResource(Job)
+@route("/jobs/{name}")
+@put
+op createJob(
+...Azure.Core.Foundations.ApiVersionParameter,
+@path name: string,
+@bodyRoot body: Job,
+): (CreatedResponse & JobLroResponse) | (OkResponse &
+JobLroResponse) | Azure.Core.Foundations.ErrorResponse;
+`,
+      "createJob",
+    );
+
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "OperationStatus");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "OperationStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
+
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    deepStrictEqual(metadata.logicalResult.name, "Job");
+    deepStrictEqual(metadata.envelopeResult.name, "OperationStatus");
+    deepStrictEqual(metadata.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "Job");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "Job");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+  });
+
+  it("Gets Lro for standard Async Delete", async () => {
+    const [_, metadata, runner] = await compileLroOperation(
+      `@test op delete is Azure.Core.LongRunningResourceDelete<TestModel, Customizations>;`,
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "OperationStatus");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "OperationStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, undefined);
+
+    deepStrictEqual(metadata.finalStateVia, "operation-location");
+    deepStrictEqual(metadata.logicalResult.name, "OperationStatus");
+    deepStrictEqual(
+      getNamespaceName(runner.program, metadata.logicalResult.namespace),
+      "Azure.Core.Foundations",
+    );
+    deepStrictEqual(metadata.envelopeResult.name, "OperationStatus");
+    deepStrictEqual(metadata.logicalPath, undefined);
+
+    deepStrictEqual(metadata.finalResult, "void");
+    deepStrictEqual(metadata.finalEnvelopeResult, "void");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep.kind, "noPollingResult");
+  });
+
+  it("Gets Lro for standard Async Delete with polling reference", async () => {
+    const [_, metadata, runner] = await compileLroOperation(
+      `
+      op poll is StandardResourceOperations.GetResourceOperationStatus<TestModel, never>;
+
+      @Azure.Core.pollingOperation(poll)
+      @test op delete is Azure.Core.LongRunningResourceDelete<TestModel, Customizations>;`,
+      "delete",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "ResourceOperationStatus");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "ResourceOperationStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, undefined);
+
+    deepStrictEqual(metadata.finalStateVia, "operation-location");
+    deepStrictEqual(metadata.logicalResult.name, "ResourceOperationStatus");
+    deepStrictEqual(
+      getNamespaceName(runner.program, metadata.logicalResult.namespace),
+      "Azure.Core",
+    );
+    deepStrictEqual(metadata.envelopeResult.name, "ResourceOperationStatus");
+    deepStrictEqual(metadata.logicalPath, undefined);
+
+    deepStrictEqual(metadata.finalResult, "void");
+    deepStrictEqual(metadata.finalEnvelopeResult, "void");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep.kind, "noPollingResult");
+  });
+
+  it("Gets Lro for standard Async Update", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
+       #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+       @test op update is Azure.Core.Foundations.LongRunningResourceUpdate<TestModel, Customizations>;`,
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "OperationStatus");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "OperationStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
+
+    deepStrictEqual(metadata.finalStateVia, "operation-location");
+    deepStrictEqual(metadata.logicalResult.name, "TestModel");
+    deepStrictEqual(metadata.envelopeResult.name, "OperationStatus");
+    deepStrictEqual(metadata.logicalPath, "result");
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "OperationStatus");
+    deepStrictEqual(metadata.finalResultPath, "result");
+  });
+
+  it("Gets Lro for standard Async Update with polling reference", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+       op poll is StandardResourceOperations.GetResourceOperationStatus<TestModel>;
+
+      
+       #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
+       @Azure.Core.pollingOperation(poll)
+       #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+       @test op update is Azure.Core.Foundations.LongRunningResourceUpdate<TestModel, Customizations>;`,
+      "update",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "ResourceOperationStatus");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "ResourceOperationStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
+
+    deepStrictEqual(metadata.finalStateVia, "operation-location");
+    deepStrictEqual(metadata.logicalResult.name, "TestModel");
+    deepStrictEqual(metadata.envelopeResult.name, "ResourceOperationStatus");
+    deepStrictEqual(metadata.logicalPath, "result");
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "ResourceOperationStatus");
+    deepStrictEqual(metadata.finalResultPath, "result");
+  });
+
+  it("Gets Lro for standard Async ResourceAction", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `// Reuse CustomParameters and CustomResponseProperties in the "normal" TParams and TResponse fields
+      model OpParams {
+        value: string;
+        ...CustomParameters;
+      };
+
+      model OpResponse is CustomResponseProperties {
+        message: string;
+      }
+
+      @test op doAction is Azure.Core.LongRunningResourceAction<TestModel, OpParams, OpResponse>;`,
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "OperationStatus");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "OperationStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
+
+    deepStrictEqual(metadata.finalStateVia, "operation-location");
+    deepStrictEqual(metadata.logicalResult.name, "OpResponse");
+    deepStrictEqual(metadata.envelopeResult.name, "OperationStatus");
+    deepStrictEqual(metadata.logicalPath, "result");
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "OpResponse");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "OperationStatus");
+    deepStrictEqual(metadata.finalResultPath, "result");
+  });
+
+  it("Gets Lro for standard Async ResourceAction with polling reference", async () => {
+    const [_, metadata] = await compileLroOperation(
       `
       // Reuse CustomParameters and CustomResponseProperties in the "normal" TParams and TResponse fields
       model OpParams {
@@ -566,2753 +1190,2127 @@ describe("typespec-azure-core: operation templates", () => {
       model OpResponse is CustomResponseProperties {
         message: string;
       }
+      op poll is StandardResourceOperations.GetResourceOperationStatus<TestModel>;
 
-      @test op customAction is Azure.Core.ResourceAction<TestModel, OpParams, OpResponse>;
-      `,
+      @Azure.Core.pollingOperation(poll)
+      @test op doAction is Azure.Core.LongRunningResourceAction<TestModel, OpParams, OpResponse>;`,
+      "doAction",
     );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "ResourceOperationStatus");
 
-    deepStrictEqual(operation, {
-      name: "customAction",
-      verb: "post",
-      path: "/test/{name}:customAction",
-      params: {
-        body: ["value"],
-        params: expectedParamsWithName,
-      },
-      responseProperties: ["x-ms-response-id", "message"],
-    });
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "ResourceOperationStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
+
+    deepStrictEqual(metadata.finalStateVia, "operation-location");
+    deepStrictEqual(metadata.logicalResult.name, "TestModel");
+    deepStrictEqual(metadata.envelopeResult.name, "ResourceOperationStatus");
+    deepStrictEqual(metadata.logicalPath, "result");
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "ResourceOperationStatus");
+    deepStrictEqual(metadata.finalResultPath, "result");
   });
 
-  it("ResourceAction customizations", async () => {
-    const [operations, _] = await getOperations(
+  it("Gets Lro for standard Async RpcOperation with polling reference", async () => {
+    const [_, metadata] = await compileLroOperation(
       `
-      @TypeSpec.Rest.resource("things")
-      model Thing {
-        @key
-        id: string
+      @route("/lrRpcOp/{operationId}")
+      @get op getStatus(@path operationId: string): PollingStatus;
+
+      model PollingStatus {
+        @header location?: ResourceLocation<TestModel>;
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+        @Azure.Core.lroResult
+        result?: TestModel;
       }
 
-      @TypeSpec.Rest.actionSeparator("/")
-      @test op action2 is Azure.Core.ResourceAction<Thing, {}, {}>;
-      `,
+      model StatusError { message: string; }
+      @test @pollingOperation(getStatus) @route("/lrRpcOp") op lrRpcOp is Azure.Core.LongRunningRpcOperation<{}, TestModel, PollingStatus, StatusError, Customizations, Azure.Core.Foundations.ErrorResponse, Azure.Core.Traits.TraitContext.Read>;`,
+      "lrRpcOp",
     );
-    strictEqual(operations[0].path, "/things/{id}/action2");
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "PollingStatus");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
+
+    deepStrictEqual(metadata.finalStateVia, "operation-location");
+    deepStrictEqual(metadata.logicalResult.name, "TestModel");
+    deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata.logicalPath, "result");
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "PollingStatus");
+    deepStrictEqual(metadata.finalResultPath, "result");
   });
 
-  it("ResourceCollectionAction", async () => {
-    const operation = await compileResourceOperation(
+  it("Gets Lro for polling and final reference", async () => {
+    const [_, metadata] = await compileLroOperation(
       `
-        // Reuse CustomParameters and CustomResponseProperties in the "normal" TParams and TResponse fields
-        model OpParams {
-          value: string;
-          ...CustomParameters;
-        };
-
-        model OpResponse is CustomResponseProperties {
-          message: string;
-        }
-  
-        @test op customAction is Azure.Core.ResourceCollectionAction<TestModel, OpParams, OpResponse>;`,
-    );
-
-    deepStrictEqual(operation, {
-      name: "customAction",
-      verb: "post",
-      path: "/test:customAction",
-      params: {
-        body: ["value"],
-        params: expectedParams,
-      },
-      responseProperties: ["x-ms-response-id", "message"],
-    });
-  });
-
-  it("ResourceCollectionAction customizations", async () => {
-    const [operations, _] = await getOperations(
-      `
-      @TypeSpec.Rest.resource("things")
-      model Thing {
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+      model SimpleWidget {
         @key
-        id: string
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+        value: string;
+      }
+      @route("/simpleWidgets/{id}")
+      @get op getWidget(@path id: string): SimpleWidget;
+      @finalOperation(getWidget, {id: ResponseProperty<"id">})
+      @pollingOperation(getStatus, {id: ResponseProperty<"id">; operationId: ResponseProperty<"operationId">})
+      @route("/simpleWidgets/{id}")
+      @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operationId: string};
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      `,
+      "createWidget",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationReference");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "PollingStatus");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, undefined);
+
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+  });
+
+  it("Gets Lro for polling operation with custom lro template and operation reference", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model TLongRunningStatusLocation<TStatusResult extends TypeSpec.Reflection.Model> {
+        @pollingLocation
+        @TypeSpec.Http.header("Operation-Location")
+        operationLocation: ResourceLocation<TStatusResult>;
+      }
+
+      @post
+      op TLongRunningRpcOperation<
+        TParams,
+        TResponse extends TypeSpec.Reflection.Model
+      > is Azure.Core.Foundations.Operation<
+        TParams & RepeatabilityRequestHeaders,
+        (Foundations.AcceptedResponse<TLongRunningStatusLocation<TResponse>> &
+          Foundations.RetryAfterHeader &
+          RepeatabilityResponseHeaders),
+        RepeatabilityRequestHeaders & RepeatabilityResponseHeaders,
+        Azure.Core.Foundations.ErrorResponse
+      >;
+
+      enum JobStatus {
+        Running: "running",
+        Succeeded: "succeeded",
+        Failed: "failed",
+        Canceled: "canceled",
+      }  
+
+      alias Request = {
+        patients: string[];
+      };
+
+      model JobResults {
+        success: string;
+        error?: Azure.Core.Foundations.Error;
+      }
+
+      @resource("foo/jobs")
+      model JobResult {
+        @key
+        @format("uuid")
+        jobId: string;
+          
+        @lroStatus
+        status: JobStatus;
+
+        @lroResult
+        results?: JobResults;
+        errors?: Azure.Core.Foundations.Error[];          
+      }
+
+      interface Foo {
+        @route("/foo/jobs")
+        createJob is TLongRunningRpcOperation<{...Request}, JobResult>;
+      }
+      `,
+      "createJob",
+    );
+    ok(metadata);
+
+    deepStrictEqual(metadata.finalStep?.kind, "pollingSuccessProperty");
+    deepStrictEqual((metadata.finalStep?.target as any).name, "results");
+    deepStrictEqual((metadata.finalStep?.target as any).type.name, "JobResults");
+
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "JobResult");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "JobResult");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "results");
+
+    deepStrictEqual(metadata.finalStateVia, "operation-location");
+    deepStrictEqual(metadata.logicalResult.name, "JobResults");
+    deepStrictEqual(metadata.envelopeResult.name, "JobResult");
+    deepStrictEqual(metadata.logicalPath, "results");
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "JobResults");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "JobResult");
+    deepStrictEqual(metadata.finalResultPath, "results");
+  });
+
+  it("Gets Lro for non-standard polling in custom createOrReplace operations with finalLocation", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
       }
       
-      @TypeSpec.Rest.actionSeparator("/")
-      @test op customAction is Azure.Core.ResourceCollectionAction<Thing, {}, {}>;
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+      
+        value: string;
+      }
+      
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      
+      @pollingOperation(getStatus)
+      @route("/simpleWidgets/{id}")
+      @put op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
+        {
+          @statusCode statusCode: 201;
+          @header id: string,
+          @header("operation-id") operate: string,
+          @finalLocation @header("Location") location: ResourceLocation<SimpleWidget>,
+          @pollingLocation @header("Operation-Location") opLink: string,
+          @lroResult @bodyRoot body?: SimpleWidget
+        };      
       `,
+      "createWidget",
     );
-    strictEqual(operations[0].path, "/things/customAction");
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
+
+    deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
+
+    deepStrictEqual(metadata.finalStep?.kind, "finalOperationLink");
+    deepStrictEqual(metadata.finalStep?.target?.kind, "link");
+    deepStrictEqual((metadata.finalStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.finalStep?.target as any).property.name, "location");
+
+    deepStrictEqual(metadata.finalStateVia, "location");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
   });
 
-  describe("RpcOperation", () => {
-    it("allows override of TraitContext", async () => {
-      const operation = await compileResourceOperation(
-        `@test @route("/test") op rpcOp is Azure.Core.RpcOperation<{}, TestModel, Customizations, Azure.Core.Foundations.ErrorResponse, Azure.Core.Traits.TraitContext.Read>;`,
-      );
-
-      deepStrictEqual(operation, {
-        name: "rpcOp",
-        verb: "get",
-        path: "/test",
-        params: {
-          body: undefined,
-          params: expectedParams,
-        },
-        responseProperties: ["name", "value", "x-ms-response-id"],
-      });
-    });
-
-    it("works with default TraitContext.Undefined", async () => {
-      const operation = await compileResourceOperation(
-        `@test @route("/test") op rpcOp is Azure.Core.RpcOperation<{}, TestModel>;`,
-      );
-
-      deepStrictEqual(operation, {
-        name: "rpcOp",
-        verb: "get",
-        path: "/test",
-        params: {
-          body: undefined,
-          params: [
-            {
-              name: "api-version",
-              type: "query",
-            },
-          ],
-        },
-        responseProperties: ["name", "value"],
-      });
-    });
-  });
-
-  describe("LongRunningRpcOperation", () => {
-    it("allows override of TraitContext", async () => {
-      const operations = await compileResourceOperations(
-        `
-        @route("/lrRpcOp/{operationId}")
-        @get op getStatus(@path operationId: string): PollingStatus;
-  
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-  
-        model StatusError { message: string; }
-        @test @pollingOperation(getStatus) @route("/lrRpcOp") op lrRpcOp is Azure.Core.LongRunningRpcOperation<{}, TestModel, PollingStatus, StatusError, Customizations, Azure.Core.Foundations.ErrorResponse, Azure.Core.Traits.TraitContext.Read>;
-      `,
-      );
-
-      const statusOp = operations[0];
-      const lroOp = operations[1];
-
-      deepStrictEqual(lroOp, {
-        name: "lrRpcOp",
-        verb: "post",
-        path: "/lrRpcOp",
-        params: {
-          body: undefined,
-          params: [
-            { type: "query", name: "api-version" },
-            { type: "header", name: "x-ms-foobar" },
-            { type: "query", name: "nameHint" },
-          ],
-        },
-        responseProperties: [
-          "statusCode",
-          "id",
-          "status",
-          "error",
-          "result",
-          "operationLocation",
-          "x-ms-response-id",
-        ],
-      });
-
-      deepStrictEqual(statusOp, {
-        name: "getStatus",
-        verb: "get",
-        path: "/lrRpcOp/{operationId}",
-        params: {
-          body: undefined,
-          params: [
-            {
-              name: "operationId",
-              type: "path",
-            },
-          ],
-        },
-        responseProperties: ["location", "statusValue"],
-      });
-    });
-
-    it("works with default TraitContext.Undefined", async () => {
-      const operations = await compileResourceOperations(
-        `
-        @route("/lrRpcOp/{operationId}")
-        @get op getStatus(@path operationId: string): PollingStatus;
-  
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-  
-        model StatusError { message: string; }
-        @test @pollingOperation(getStatus) @route("/lrRpcOp") op lrRpcOp is Azure.Core.LongRunningRpcOperation<{}, TestModel, PollingStatus, StatusError>;
-      `,
-      );
-
-      const statusOp = operations[0];
-      const lroOp = operations[1];
-
-      deepStrictEqual(lroOp, {
-        name: "lrRpcOp",
-        verb: "post",
-        path: "/lrRpcOp",
-        params: {
-          body: undefined,
-          params: [{ type: "query", name: "api-version" }],
-        },
-        responseProperties: ["statusCode", "id", "status", "error", "result", "operationLocation"],
-      });
-
-      deepStrictEqual(statusOp, {
-        name: "getStatus",
-        verb: "get",
-        path: "/lrRpcOp/{operationId}",
-        params: {
-          body: undefined,
-          params: [
-            {
-              name: "operationId",
-              type: "path",
-            },
-          ],
-        },
-        responseProperties: ["location", "statusValue"],
-      });
-    });
-  });
-
-  describe("LongRunningOperation", () => {
-    it("Gets Lro for standard Async CreateOrUpdate", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `#suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-        @test op createOrUpdate is StandardResourceOperations.LongRunningResourceCreateOrUpdate<TestModel, Customizations>;`,
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "OperationStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "OperationStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
-
-      deepStrictEqual(metadata.finalStateVia, "operation-location");
-      deepStrictEqual(metadata.logicalResult.name, "TestModel");
-      deepStrictEqual(metadata.envelopeResult.name, "OperationStatus");
-      deepStrictEqual(metadata.logicalPath, "result");
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "OperationStatus");
-      deepStrictEqual(metadata.finalResultPath, "result");
-    });
-
-    it("Gets Lro for standard Async CreateOrUpdate with polling reference", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        op poll is StandardResourceOperations.GetResourceOperationStatus<TestModel>;
-  
-        @Azure.Core.pollingOperation(poll)
-        #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-        @test op createOrUpdate is StandardResourceOperations.LongRunningResourceCreateOrUpdate<TestModel, Customizations>;`,
-        "createOrUpdate",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "ResourceOperationStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "ResourceOperationStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
-
-      deepStrictEqual(metadata.finalStateVia, "operation-location");
-      deepStrictEqual(metadata.logicalResult.name, "TestModel");
-      deepStrictEqual(metadata.envelopeResult.name, "ResourceOperationStatus");
-      deepStrictEqual(metadata.logicalPath, "result");
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "ResourceOperationStatus");
-      deepStrictEqual(metadata.finalResultPath, "result");
-    });
-
-    it("Gets Lro for standard Async CreateOrReplace", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `@test op createOrReplace is StandardResourceOperations.LongRunningResourceCreateOrReplace<TestModel, Customizations>;`,
-      );
-
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "OperationStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "OperationStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, undefined);
-
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      deepStrictEqual(metadata.logicalResult.name, "TestModel");
-      deepStrictEqual(metadata.envelopeResult.name, "OperationStatus");
-      // For createOrReplace, since the resource is returned in the 200 or 201 envelope, the status monitor will not return a results field
-      deepStrictEqual(metadata.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "TestModel");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for standard Async CreateOrReplace with polling reference", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        op poll is StandardResourceOperations.GetResourceOperationStatus<TestModel>;
-  
-        @Azure.Core.pollingOperation(poll)
-        @test op createOrReplace is StandardResourceOperations.LongRunningResourceCreateOrReplace<TestModel, Customizations>;`,
-        "createOrReplace",
-      );
-
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "ResourceOperationStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "ResourceOperationStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
-
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      deepStrictEqual(metadata.logicalResult.name, "TestModel");
-      deepStrictEqual(metadata.envelopeResult.name, "ResourceOperationStatus");
-      deepStrictEqual(metadata.logicalPath, "result");
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "ResourceOperationStatus");
-      deepStrictEqual(metadata.finalResultPath, "result");
-    });
-
-    it("Gets Lro for non-resource PUT with polling reference", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-model Job {
-  @path
-  @key
-  @visibility(Lifecycle.Read)
-  id: uuid;
-
-  name: string;
-}
-
-model StartJobRequest {
-  name: string;
-
-  instructions: string[];
-}
-
-model JobStatus is Azure.Core.Foundations.OperationStatus<Job>;
-
-#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Non-resource operation"
-@route("/jobs/{id}")
-op getJobStatus is Foundations.GetOperationStatus<
-  Rest.Resource.KeysOf<Job>,
-  Job
->;
-
-alias JobLroResponse = {
-  @header("Operation-Location") operationLocation: url;
-  ...Azure.Core.Foundations.OperationStatus<Job>;
-};
-
-#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Non-resource operation"
-@pollingOperation(getJobStatus)
-@route("/startJob/")
-@put
-op startJobAsync(
-  ...Azure.Core.Foundations.ApiVersionParameter,
-
-  @body _: StartJobRequest,
-): (CreatedResponse & JobLroResponse) | (OkResponse &
-  JobLroResponse) | Azure.Core.Foundations.ErrorResponse;
-`,
-        "startJobAsync",
-      );
-
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "OperationStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "OperationStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
-
-      deepStrictEqual(metadata.finalStateVia, "operation-location");
-      deepStrictEqual(metadata.logicalResult.name, "Job");
-      deepStrictEqual(metadata.envelopeResult.name, "OperationStatus");
-      deepStrictEqual(metadata.logicalPath, "result");
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "Job");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "OperationStatus");
-      deepStrictEqual(metadata.finalResultPath, "result");
-    });
-
-    it("Gets Lro for custom PUT with polling reference", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        @resource("jobs")
-model Job {
-  @path
-  @key
-  @visibility(Lifecycle.Read)
-  name: string;
-
-  instructions: string[];
-}
-
-model StartJobRequest {
-  name: string;
-
-  instructions: string[];
-}
-
-model JobStatus is Azure.Core.Foundations.OperationStatus;
-
-#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "Non-resource operation"
-@route("/jobs/status/{name}")
-op getJobStatus is Foundations.GetOperationStatus<
-  Rest.Resource.KeysOf<Job>,
-  Job
->;
-
-op read is StandardResourceOperations.ResourceRead<Job>;
-
-alias JobLroResponse = {
-  @header("Operation-Location") operationLocation: string;
-  ...Azure.Core.Foundations.OperationStatus<Job>;
-};
-
-#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "test"
-@finalOperation(read)
-@pollingOperation(getJobStatus)
-@createsOrReplacesResource(Job)
-@route("/jobs/{name}")
-@put
-op createJob(
-  ...Azure.Core.Foundations.ApiVersionParameter,
-  @path name: string,
-  @bodyRoot body: Job,
-): (CreatedResponse & JobLroResponse) | (OkResponse &
-  JobLroResponse) | Azure.Core.Foundations.ErrorResponse;
-`,
-        "createJob",
-      );
-
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "OperationStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "OperationStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
-
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      deepStrictEqual(metadata.logicalResult.name, "Job");
-      deepStrictEqual(metadata.envelopeResult.name, "OperationStatus");
-      deepStrictEqual(metadata.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "Job");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "Job");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for standard Async Delete", async () => {
-      const [_, metadata, runner] = await compileLroOperation(
-        `@test op delete is Azure.Core.LongRunningResourceDelete<TestModel, Customizations>;`,
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "OperationStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "OperationStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, undefined);
-
-      deepStrictEqual(metadata.finalStateVia, "operation-location");
-      deepStrictEqual(metadata.logicalResult.name, "OperationStatus");
-      deepStrictEqual(
-        getNamespaceName(runner.program, metadata.logicalResult.namespace),
-        "Azure.Core.Foundations",
-      );
-      deepStrictEqual(metadata.envelopeResult.name, "OperationStatus");
-      deepStrictEqual(metadata.logicalPath, undefined);
-
-      deepStrictEqual(metadata.finalResult, "void");
-      deepStrictEqual(metadata.finalEnvelopeResult, "void");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep.kind, "noPollingResult");
-    });
-
-    it("Gets Lro for standard Async Delete with polling reference", async () => {
-      const [_, metadata, runner] = await compileLroOperation(
-        `
-        op poll is StandardResourceOperations.GetResourceOperationStatus<TestModel, never>;
-  
-        @Azure.Core.pollingOperation(poll)
-        @test op delete is Azure.Core.LongRunningResourceDelete<TestModel, Customizations>;`,
-        "delete",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "ResourceOperationStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "ResourceOperationStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, undefined);
-
-      deepStrictEqual(metadata.finalStateVia, "operation-location");
-      deepStrictEqual(metadata.logicalResult.name, "ResourceOperationStatus");
-      deepStrictEqual(
-        getNamespaceName(runner.program, metadata.logicalResult.namespace),
-        "Azure.Core",
-      );
-      deepStrictEqual(metadata.envelopeResult.name, "ResourceOperationStatus");
-      deepStrictEqual(metadata.logicalPath, undefined);
-
-      deepStrictEqual(metadata.finalResult, "void");
-      deepStrictEqual(metadata.finalEnvelopeResult, "void");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep.kind, "noPollingResult");
-    });
-
-    it("Gets Lro for standard Async Update", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `#suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
-         #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-         @test op update is Azure.Core.Foundations.LongRunningResourceUpdate<TestModel, Customizations>;`,
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "OperationStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "OperationStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
-
-      deepStrictEqual(metadata.finalStateVia, "operation-location");
-      deepStrictEqual(metadata.logicalResult.name, "TestModel");
-      deepStrictEqual(metadata.envelopeResult.name, "OperationStatus");
-      deepStrictEqual(metadata.logicalPath, "result");
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "OperationStatus");
-      deepStrictEqual(metadata.finalResultPath, "result");
-    });
-
-    it("Gets Lro for standard Async Update with polling reference", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-         op poll is StandardResourceOperations.GetResourceOperationStatus<TestModel>;
-  
-        
-         #suppress "@azure-tools/typespec-azure-core/use-standard-operations" "This is a test."
-         @Azure.Core.pollingOperation(poll)
-         #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-         @test op update is Azure.Core.Foundations.LongRunningResourceUpdate<TestModel, Customizations>;`,
-        "update",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "ResourceOperationStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "ResourceOperationStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
-
-      deepStrictEqual(metadata.finalStateVia, "operation-location");
-      deepStrictEqual(metadata.logicalResult.name, "TestModel");
-      deepStrictEqual(metadata.envelopeResult.name, "ResourceOperationStatus");
-      deepStrictEqual(metadata.logicalPath, "result");
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "ResourceOperationStatus");
-      deepStrictEqual(metadata.finalResultPath, "result");
-    });
-
-    it("Gets Lro for standard Async ResourceAction", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `// Reuse CustomParameters and CustomResponseProperties in the "normal" TParams and TResponse fields
-        model OpParams {
-          value: string;
-          ...CustomParameters;
-        };
-  
-        model OpResponse is CustomResponseProperties {
-          message: string;
-        }
-  
-        @test op doAction is Azure.Core.LongRunningResourceAction<TestModel, OpParams, OpResponse>;`,
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "OperationStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "OperationStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
-
-      deepStrictEqual(metadata.finalStateVia, "operation-location");
-      deepStrictEqual(metadata.logicalResult.name, "OpResponse");
-      deepStrictEqual(metadata.envelopeResult.name, "OperationStatus");
-      deepStrictEqual(metadata.logicalPath, "result");
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "OpResponse");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "OperationStatus");
-      deepStrictEqual(metadata.finalResultPath, "result");
-    });
-
-    it("Gets Lro for standard Async ResourceAction with polling reference", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        // Reuse CustomParameters and CustomResponseProperties in the "normal" TParams and TResponse fields
-        model OpParams {
-          value: string;
-          ...CustomParameters;
-        };
-  
-        model OpResponse is CustomResponseProperties {
-          message: string;
-        }
-        op poll is StandardResourceOperations.GetResourceOperationStatus<TestModel>;
-  
-        @Azure.Core.pollingOperation(poll)
-        @test op doAction is Azure.Core.LongRunningResourceAction<TestModel, OpParams, OpResponse>;`,
-        "doAction",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "ResourceOperationStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "ResourceOperationStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
-
-      deepStrictEqual(metadata.finalStateVia, "operation-location");
-      deepStrictEqual(metadata.logicalResult.name, "TestModel");
-      deepStrictEqual(metadata.envelopeResult.name, "ResourceOperationStatus");
-      deepStrictEqual(metadata.logicalPath, "result");
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "ResourceOperationStatus");
-      deepStrictEqual(metadata.finalResultPath, "result");
-    });
-
-    it("Gets Lro for standard Async RpcOperation with polling reference", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        @route("/lrRpcOp/{operationId}")
-        @get op getStatus(@path operationId: string): PollingStatus;
-  
-        model PollingStatus {
-          @header location?: ResourceLocation<TestModel>;
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-          @Azure.Core.lroResult
-          result?: TestModel;
-        }
-  
-        model StatusError { message: string; }
-        @test @pollingOperation(getStatus) @route("/lrRpcOp") op lrRpcOp is Azure.Core.LongRunningRpcOperation<{}, TestModel, PollingStatus, StatusError, Customizations, Azure.Core.Foundations.ErrorResponse, Azure.Core.Traits.TraitContext.Read>;`,
-        "lrRpcOp",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "PollingStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
-
-      deepStrictEqual(metadata.finalStateVia, "operation-location");
-      deepStrictEqual(metadata.logicalResult.name, "TestModel");
-      deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata.logicalPath, "result");
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "TestModel");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "PollingStatus");
-      deepStrictEqual(metadata.finalResultPath, "result");
-    });
-
-    it("Gets Lro for polling and final reference", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-          value: string;
-        }
-        @route("/simpleWidgets/{id}")
-        @get op getWidget(@path id: string): SimpleWidget;
-        @finalOperation(getWidget, {id: ResponseProperty<"id">})
-        @pollingOperation(getStatus, {id: ResponseProperty<"id">; operationId: ResponseProperty<"operationId">})
-        @route("/simpleWidgets/{id}")
-        @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operationId: string};
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        `,
-        "createWidget",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationReference");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "PollingStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, undefined);
-
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for polling operation with custom lro template and operation reference", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model TLongRunningStatusLocation<TStatusResult extends TypeSpec.Reflection.Model> {
-          @pollingLocation
-          @TypeSpec.Http.header("Operation-Location")
-          operationLocation: ResourceLocation<TStatusResult>;
-        }
-  
-        @post
-        op TLongRunningRpcOperation<
-          TParams,
-          TResponse extends TypeSpec.Reflection.Model
-        > is Azure.Core.Foundations.Operation<
-          TParams & RepeatabilityRequestHeaders,
-          (Foundations.AcceptedResponse<TLongRunningStatusLocation<TResponse>> &
-            Foundations.RetryAfterHeader &
-            RepeatabilityResponseHeaders),
-          RepeatabilityRequestHeaders & RepeatabilityResponseHeaders,
-          Azure.Core.Foundations.ErrorResponse
-        >;
-  
-        enum JobStatus {
-          Running: "running",
-          Succeeded: "succeeded",
-          Failed: "failed",
-          Canceled: "canceled",
-        }  
-
-        alias Request = {
-          patients: string[];
-        };
-  
-        model JobResults {
-          success: string;
-          error?: Azure.Core.Foundations.Error;
-        }
-
-        @resource("foo/jobs")
-        model JobResult {
-          @key
-          @format("uuid")
-          jobId: string;
-            
-          @lroStatus
-          status: JobStatus;
-
-          @lroResult
-          results?: JobResults;
-          errors?: Azure.Core.Foundations.Error[];          
-        }
-  
-        interface Foo {
-          @route("/foo/jobs")
-          createJob is TLongRunningRpcOperation<{...Request}, JobResult>;
-        }
-        `,
-        "createJob",
-      );
-      ok(metadata);
-
-      deepStrictEqual(metadata.finalStep?.kind, "pollingSuccessProperty");
-      deepStrictEqual((metadata.finalStep?.target as any).name, "results");
-      deepStrictEqual((metadata.finalStep?.target as any).type.name, "JobResults");
-
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationLink");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "JobResult");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "JobResult");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "results");
-
-      deepStrictEqual(metadata.finalStateVia, "operation-location");
-      deepStrictEqual(metadata.logicalResult.name, "JobResults");
-      deepStrictEqual(metadata.envelopeResult.name, "JobResult");
-      deepStrictEqual(metadata.logicalPath, "results");
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "JobResults");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "JobResult");
-      deepStrictEqual(metadata.finalResultPath, "results");
-    });
-
-    it("Gets Lro for non-standard polling in custom createOrReplace operations with finalLocation", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-        
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-        
-          value: string;
-        }
-        
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        
-        @pollingOperation(getStatus)
-        @route("/simpleWidgets/{id}")
-        @put op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
-          {
-            @statusCode statusCode: 201;
-            @header id: string,
-            @header("operation-id") operate: string,
-            @finalLocation @header("Location") location: ResourceLocation<SimpleWidget>,
-            @pollingLocation @header("Operation-Location") opLink: string,
-            @lroResult @bodyRoot body?: SimpleWidget
-          };      
-        `,
-        "createWidget",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
-
-      deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
-
-      deepStrictEqual(metadata.finalStep?.kind, "finalOperationLink");
-      deepStrictEqual(metadata.finalStep?.target?.kind, "link");
-      deepStrictEqual((metadata.finalStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.finalStep?.target as any).property.name, "location");
-
-      deepStrictEqual(metadata.finalStateVia, "location");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for arm-style azure-async + location operation polling in createOrReplace operations", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-          provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
-          value: string;
-        }
-        
-        @route("/simpleWidgets/{id}")
-        @put op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
-          {
-            @statusCode statusCode: 201;
-            @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("Azure-AsyncOperation") opLink: string,
-            @finalLocation(SimpleWidget)
-            @header location: string;
-            @bodyRoot body?: SimpleWidget
-          };      
-        `,
-        "createWidget",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
-
-      deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
-
-      deepStrictEqual(metadata.finalStep?.kind, "finalOperationLink");
-      deepStrictEqual(metadata.finalStep?.target?.kind, "link");
-      deepStrictEqual((metadata.finalStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.finalStep?.target as any).property.name, "location");
-
-      deepStrictEqual(metadata.finalStateVia, "location");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for arm-style azure-async operation polling in createOrReplace operations", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-          provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
-          value: string;
-        }
-        
-        @route("/simpleWidgets/{id}")
-        @createsOrReplacesResource(SimpleWidget)
-        @put op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
-          {
-            @statusCode statusCode: 201;
-            @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("Azure-AsyncOperation") opLink: string,
-            @bodyRoot body?: SimpleWidget
-          };      
-        `,
-        "createWidget",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
-
-      deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
-
-      deepStrictEqual(metadata.finalStep, undefined);
-
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for arm-style location polling in createOrReplace operations", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-          provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
-          value: string;
-        }
-        
-        @route("/simpleWidgets/{id}")
-        @createsOrUpdatesResource(SimpleWidget)
-        @put op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
-          {
-            @statusCode statusCode: 201;
-            @pollingLocation(StatusMonitorPollingOptions<SimpleWidget>) @header("location") opLink: string,
-            @bodyRoot body?: SimpleWidget
-          };      
-        `,
-        "createWidget",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
-
-      deepStrictEqual(metadata.pollingInfo?.responseModel.name, "SimpleWidget");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "provisioningState");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
-      deepStrictEqual(metadata.finalStep, undefined);
-
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.envelopeResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for arm-style azure-async + location operation polling in update operations", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-          provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
-          value: string;
-        }
-        
-        #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-        @route("/simpleWidgets/{id}")
-        #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-        @patch(#{implicitOptionality: true}) op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
-          {
-            @statusCode statusCode: 201;
-            @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("Azure-AsyncOperation") opLink: string,
-            @finalLocation(SimpleWidget)
-            @header location: string;
-            @bodyRoot body?: SimpleWidget
-          };      
-        `,
-        "createWidget",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
-
-      deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
-
-      deepStrictEqual(metadata.finalStep?.kind, "finalOperationLink");
-      deepStrictEqual(metadata.finalStep?.target?.kind, "link");
-      deepStrictEqual((metadata.finalStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.finalStep?.target as any).property.name, "location");
-
-      deepStrictEqual(metadata.finalStateVia, "location");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for arm-style azure-async operation polling in update operations", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+  it("Gets Lro for arm-style azure-async + location operation polling in createOrReplace operations", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+        provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
+        value: string;
+      }
+      
+      @route("/simpleWidgets/{id}")
+      @put op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
+        {
+          @statusCode statusCode: 201;
+          @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("Azure-AsyncOperation") opLink: string,
           @finalLocation(SimpleWidget)
           @header location: string;
-        }
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-          provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
-          value: string;
-        }
-        
-        #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-        @route("/simpleWidgets/{id}")
-        #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-        @patch(#{implicitOptionality: true}) op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
-          {
-            @statusCode statusCode: 201;
-            @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("Azure-AsyncOperation") opLink: string,
-            @bodyRoot body?: SimpleWidget
-          };      
-        `,
-        "createWidget",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
-
-      deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
-
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep.kind, "finalOperationLink");
-      deepStrictEqual((metadata.finalStep.responseModel as Model).name, "SimpleWidget");
-      deepStrictEqual(metadata.finalStep.target?.property.name, "location");
-
-      deepStrictEqual(metadata.finalStateVia, "location");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for arm-style location polling in update operations", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-          provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
-          value: string;
-        }
-        
-        #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-        @route("/simpleWidgets/{id}")
-        #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-        @patch(#{implicitOptionality: true}) op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
-          {
-            @statusCode statusCode: 201;
-            @finalLocation(SimpleWidget) @pollingLocation(StatusMonitorPollingOptions<SimpleWidget>) @header("location") opLink: string,
-            @bodyRoot body?: SimpleWidget
-          };      
-        `,
-        "createWidget",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
-
-      deepStrictEqual(metadata.pollingInfo?.responseModel.name, "SimpleWidget");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "provisioningState");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep.kind, "finalOperationLink");
-      deepStrictEqual((metadata.finalStep.responseModel as Model).name, "SimpleWidget");
-      deepStrictEqual(metadata.finalStep?.target?.kind, "link");
-      deepStrictEqual((metadata.finalStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.finalStep?.target as any).property.name, "opLink");
-
-      deepStrictEqual(metadata.finalStateVia, "location");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.envelopeResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for arm-style azure-async + location operation polling in action operations", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-          provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
-          value: string;
-        }
-        
-        @route("/simpleWidgets/{id}")
-        @post op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
-          {
-            @statusCode statusCode: 202;
-            @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("Azure-AsyncOperation") opLink: string,
-            @finalLocation(SimpleWidget)
-            @header location: string;
-            @bodyRoot body?: SimpleWidget
-          };      
-        `,
-        "createWidget",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
-
-      deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
-
-      deepStrictEqual(metadata.finalStep?.kind, "finalOperationLink");
-      deepStrictEqual(metadata.finalStep?.target?.kind, "link");
-      deepStrictEqual((metadata.finalStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.finalStep?.target as any).property.name, "location");
-
-      deepStrictEqual(metadata.finalStateVia, "location");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for arm-style azure-async operation polling in action operations", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-          provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
-          value: string;
-        }
-        
-        @route("/simpleWidgets/{id}")
-        @post op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
-          {
-            @statusCode statusCode: 202;
-            @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("Azure-AsyncOperation") opLink: string,
-            @bodyRoot body?: SimpleWidget
-          };      
-        `,
-        "createWidget",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
-
-      deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
-
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep?.kind, "noPollingResult");
-
-      deepStrictEqual(metadata.finalStateVia, "azure-async-operation");
-      deepStrictEqual(metadata.logicalResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual(metadata.finalResult, "void");
-      deepStrictEqual(metadata.finalEnvelopeResult, "void");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for arm-style location polling in action operations", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-          provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
-          value: string;
-        }
-        
-        @route("/simpleWidgets/{id}")
-        @post op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
-          {
-            @statusCode statusCode: 202;
-            @finalLocation(SimpleWidget) @pollingLocation(StatusMonitorPollingOptions<SimpleWidget>) @header("location") opLink: string,
-            @bodyRoot body?: SimpleWidget
-          };      
-        `,
-        "createWidget",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
-
-      deepStrictEqual(metadata.pollingInfo?.responseModel.name, "SimpleWidget");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "provisioningState");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep?.kind, "finalOperationLink");
-      deepStrictEqual(metadata.finalStep?.target?.kind, "link");
-      deepStrictEqual((metadata.finalStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.finalStep?.target as any).property.name, "opLink");
-
-      deepStrictEqual(metadata.finalStateVia, "location");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.envelopeResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for arm-style azure-async operation polling in delete operations", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-        
-        @route("/simpleWidgets/{id}")
-        @delete op deleteWidget(@path id: string) : {
-            @statusCode statusCode: 201;
-            @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("Azure-AsyncOperation") opLink: string,
-          };      
-        `,
-        "deleteWidget",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
-
-      deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
-
-      //ok(metadata.finalStep);
-      //deepStrictEqual(metadata.finalStep?.kind, "noPollingResult");
-
-      deepStrictEqual(metadata.finalStateVia, "azure-async-operation");
-      deepStrictEqual(metadata.logicalResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual(metadata.finalResult, "void");
-      deepStrictEqual(metadata.finalEnvelopeResult, "void");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for arm-style location polling in delete operations", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-        
-        @route("/simpleWidgets/{id}")
-        @delete op deleteWidget(@path id: string) : {
-            @statusCode statusCode: 201;
-            @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("location") opLink: string,
-          };      
-        `,
-        "deleteWidget",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
-      deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
-
-      deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
-      //ok(metadata.finalStep);
-      //deepStrictEqual(metadata.finalStep?.kind, "noPollingResult");
-
-      deepStrictEqual(metadata.finalStateVia, "location");
-      deepStrictEqual(metadata.logicalResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual(metadata.finalResult, "void");
-      deepStrictEqual(metadata.finalEnvelopeResult, "void");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-    });
-
-    it("Gets Lro for non-standard polling in custom createOrReplace operations without finalLocation", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-        
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-        
-          value: string;
-        }
-        
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        
-        @pollingOperation(getStatus)
-        @route("/simpleWidgets/{id}")
-        @createsOrReplacesResource(SimpleWidget)
-        @put op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
-          {
-            @statusCode statusCode: 201;
-            @header id: string,
-            @header("operation-id") operate: string,
-            @pollingLocation @header("Operation-Location") opLink: string,
-            @lroResult @bodyRoot body?: SimpleWidget
-          };      
-        `,
-        "createWidget",
-      );
-
-      ok(metadata);
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata?.finalResultPath, undefined);
-
-      ok(metadata.statusMonitorStep);
-      deepStrictEqual(metadata.statusMonitorStep.target.kind, "link");
-      deepStrictEqual((metadata.statusMonitorStep.target as any)?.location, "ResponseHeader");
-      deepStrictEqual((metadata.statusMonitorStep.target as any)?.property.name, "opLink");
-
-      ok(metadata.pollingInfo);
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
-    });
-
-    it("Gets Lro for non-standard polling in custom put operations without finalLocation", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-        
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-        
-          value: string;
-        }
-        
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        
-        @pollingOperation(getStatus)
-        @route("/simpleWidgets/{id}")
-        @createsOrReplacesResource(SimpleWidget)
-        @put op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
-          {
-            @statusCode statusCode: 201;
-            @header id: string,
-            @header("operation-id") operate: string,
-            @pollingLocation @header("Operation-Location") opLink: string,
-            @lroResult @bodyRoot body?: SimpleWidget
-          };      
-        `,
-        "createWidget",
-      );
-
-      ok(metadata);
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata?.finalResultPath, undefined);
-
-      ok(metadata.statusMonitorStep);
-      deepStrictEqual(metadata.statusMonitorStep.target.kind, "link");
-      deepStrictEqual((metadata.statusMonitorStep.target as any)?.location, "ResponseHeader");
-      deepStrictEqual((metadata.statusMonitorStep.target as any)?.property.name, "opLink");
-
-      ok(metadata.pollingInfo);
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
-    });
-
-    it("Gets Lro for non-standard polling in post operations", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-          result?: SimpleWidget;
-        }
-        
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-        
-          value: string;
-        }
-        
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get
-        op getStatus(@path id: string, @path operationId: string): PollingStatus & {@header correlationId: string;};
-        
-        @pollingOperation(getStatus, {operationId: ResponseProperty<"operate">})
-        @route("/simpleWidgets/{id}")
-        @post
-        op mungeWidget(@path id: string, body: SimpleWidget): SimpleWidget | {
-          @statusCode statusCode: 201;
-          @header id: string;
-          @header("operation-id") operate: string;
-          @pollingLocation @header("Operation-Location") opLink: string;
-          @lroResult @bodyRoot body?: SimpleWidget;
-        };
-        `,
-        "mungeWidget",
-      );
-
-      ok(metadata);
-      deepStrictEqual(metadata.finalStateVia, "custom-operation-reference");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata?.logicalPath, "result");
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "PollingStatus");
-      deepStrictEqual(metadata?.finalResultPath, "result");
-
-      ok(metadata.statusMonitorStep);
-      deepStrictEqual(metadata.statusMonitorStep.target.kind, "reference");
-
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep.kind, "pollingSuccessProperty");
-      deepStrictEqual(metadata.finalStep.target?.kind, "ModelProperty");
-
-      ok(metadata.pollingInfo);
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
-    });
-
-    it("Gets Lro for non-standard polling with void return type", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        using Azure.Core.Traits;
-        
-        alias ServiceTraits = SupportsClientRequestId &
-        NoConditionalRequests &
-        NoRepeatableRequests;
-      
-        alias ServiceOperations = Azure.Core.ResourceOperations<ServiceTraits>;
-
-        @lroStatus
-        enum OperationStatus {
-          NotStarted,
-          Running,
-          Succeeded,
-          Failed,
-          Canceled,
-        }
-        
-        enum ImportType {
-          Devices,
-          Modules,
-          All,
-        }
-        
-        @resource("management/operations")
-        model DeviceOperation {
-          @key
-          @visibility(Lifecycle.Read)
-          operationId: string;
-          error?: Azure.Core.Foundations.Error;
-        }
-        
-        @resource("updates/operations")
-        model UpdateOperation {
-          @key
-          @visibility(Lifecycle.Read)
-          operationId: string;
-          status: OperationStatus;
-          resourceLocation?: string;
-          error?: Azure.Core.Foundations.Error;
-        }
-        
-        model IfNoneMatchParameter {
-          @TypeSpec.Http.header("If-None-Match")
-          ifNoneMatch?: string;
-        }
-        
-        op getOperationStatus is ServiceOperations.ResourceRead<
-          UpdateOperation,
-          TraitOverride<RequestHeadersTrait<
-            {
-              ...IfNoneMatchParameter;
-            },
-            TraitContext.Read
-          >>
-        >;
-        
-        @pollingOperation(getOperationStatus)
-        @route("management/devices:import")
-        @post
-        op importDevices is Azure.Core.Foundations.Operation<
-          {
-            @body
-            importType: ImportType;
-          },
-          {
-            @statusCode _: 202;
-        
-            @pollingLocation
-            @header("Operation-Location")
-            operationLocation?: ResourceLocation<DeviceOperation>;
-          }
-        >;`,
-        "importDevices",
-      );
-
-      ok(metadata);
-      deepStrictEqual(metadata.finalStateVia, "operation-location");
-      deepStrictEqual(metadata.logicalResult.name, "UpdateOperation");
-      deepStrictEqual(metadata?.envelopeResult.name, "UpdateOperation");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      deepStrictEqual(metadata.finalResult, "void");
-      deepStrictEqual(metadata?.finalEnvelopeResult, "void");
-      deepStrictEqual(metadata?.logicalPath, undefined);
-
-      ok(metadata.statusMonitorStep);
-      deepStrictEqual(metadata.statusMonitorStep.target.kind, "link");
-
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep.kind, "noPollingResult");
-
-      ok(metadata.pollingInfo);
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "UpdateOperation");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "status");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
-    });
-
-    it("Gets Lro for status monitor with scalar result type", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-          @Azure.Core.lroResult
-          result?: string;
-        }
-        @route("/scalarResult/operations/{operationId}")
-        @get op getScalarStatus(@path operationId: string): PollingStatus;
-        @pollingOperation(getScalarStatus, {operationId: ResponseProperty<"operationId">})
-        @route("/scalarResult")
-        @post @test op startScalarOp(@body body: {}): {
-          @statusCode _: 202;
-          @header("operation-id") operationId: string;
-        };
-        `,
-        "startScalarOp",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationReference");
-      deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "PollingStatus");
-
-      deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
-
-      deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata.logicalPath, "result");
-
-      // The final result should be a Scalar type (string), not "void"
-      ok(metadata.finalResult !== "void");
-      ok(metadata.finalResult !== undefined);
-      strictEqual((metadata.finalResult as Scalar).kind, "Scalar");
-      strictEqual((metadata.finalResult as Scalar).name, "string");
-
-      deepStrictEqual((metadata.finalEnvelopeResult as Model).name, "PollingStatus");
-      deepStrictEqual(metadata.finalResultPath, "result");
-
-      // logicalResult should be the polling response model when the actual result is a scalar
-      strictEqual(metadata.logicalResult.name, "PollingStatus");
-
-      // finalStep should be pollingSuccessProperty with scalar responseModel
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep.kind, "pollingSuccessProperty");
-      if (metadata.finalStep.kind === "pollingSuccessProperty") {
-        strictEqual(metadata.finalStep.responseModel.kind, "Scalar");
-        strictEqual((metadata.finalStep.responseModel as Scalar).name, "string");
-      }
-    });
-
-    it("ignores bad lro operation links with Operation-Location", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;
-  
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-  
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-  
-          value: string;
-        }
-  
-        @route("/simpleWidgets/{id}")
-        @get op getWidget(@path id: string): SimpleWidget;
-  
-        @finalOperation(getWidget)
-        @pollingOperation(getStatus, {id: ResponseProperty<"id">})
-        @route("/simpleWidgets/{id}")
-        #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-        @patch(#{implicitOptionality: true}) op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operate: string, @header("Operation-Location")opLink: string};
-  
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        `,
-        "createWidget",
-      );
-
-      ok(metadata);
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep.kind, "finalOperationReference");
-      deepStrictEqual(metadata.finalStep.target?.kind, "reference");
-      deepStrictEqual(metadata.finalStep.target?.operation.name, "getWidget");
-      ok(metadata.statusMonitorStep);
-      deepStrictEqual(metadata.statusMonitorStep.target.kind, "link");
-      ok(metadata.pollingInfo);
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
-    });
-
-    it("ignores bad lro operation links with @pollingLocation", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-          value: string;
-        }
-        @route("/simpleWidgets/{id}")
-        @get op getWidget(@path id: string): SimpleWidget;
-        @finalOperation(getWidget)
-        @pollingOperation(getStatus, {id: ResponseProperty<"id">})
-        @route("/simpleWidgets/{id}")
-        @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operate: string, @Azure.Core.pollingLocation opLink: string};
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        `,
-        "createWidget",
-      );
-
-      ok(metadata);
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep.kind, "finalOperationReference");
-      deepStrictEqual(metadata.finalStep.target?.kind, "reference");
-      deepStrictEqual(metadata.finalStep.target?.operation.name, "getWidget");
-      ok(metadata.statusMonitorStep);
-      deepStrictEqual(metadata.statusMonitorStep.target.kind, "link");
-      ok(metadata.pollingInfo);
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
-    });
-
-    it("throws with bad lro operation links and no polling header", async () => {
-      const [_, diagnostics] = await getOperations(
-        `
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-          value: string;
-        }
-        @route("/simpleWidgets/{id}")
-        @get op getWidget(@path id: string): SimpleWidget;
-        @finalOperation(getWidget)
-        @pollingOperation(getStatus, {id: ResponseProperty<"id">})
-        @route("/simpleWidgets/{id}")
-        @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operate: string};
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        `,
-      );
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "@azure-tools/typespec-azure-core/polling-operation-no-ref-or-link",
-          message:
-            "An operation decorated with '@pollingOperation' must either return a response with an 'Operation-Location' header that will contain a runtime link to the polling operation, or specify parameters and return type properties to map into the polling operation parameters.  A map into polling operation parameters can be created using the '@pollingOperationParameter' decorator",
-        },
-      ]);
-    });
-
-    it("handles custom lro with polling and final links", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Failed" | "Canceled" | "Running" | "NotStarted";
-        }
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-          value: string;
-        }
-        @route("/simpleWidgets/{id}")
-        @get op getWidget(@path id: string): SimpleWidget;
-        @finalOperation(getWidget)
-        @pollingOperation(getStatus, {id: ResponseProperty<"id">; operationId: ResponseProperty<"operation">})
-        @route("/simpleWidgets/{id}")
-        @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operation: string};
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        `,
-        "createWidget",
-      );
-
-      ok(metadata);
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep.kind, "finalOperationReference");
-      deepStrictEqual(metadata.finalStep.target?.kind, "reference");
-      deepStrictEqual(metadata.finalStep.target?.operation.name, "getWidget");
-      ok(metadata.statusMonitorStep);
-      deepStrictEqual(metadata.statusMonitorStep.target.kind, "reference");
-      deepStrictEqual(metadata.statusMonitorStep.target.operation.name, "getStatus");
-      ok(metadata.pollingInfo);
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
-    });
-
-    it("handles custom lro with polling using polling parameter decorators by name", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;
-  
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-  
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-  
-          value: string;
-        }
-  
-        @route("/simpleWidgets/{id}")
-        @get op getWidget(@path id: string): SimpleWidget;
-  
-        @finalOperation(getWidget)
-        @pollingOperation(getStatus)
-        @route("/simpleWidgets/{id}")
-        @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @pollingOperationParameter @header id: string, @pollingOperationParameter("operationId") @header("operation-id") operation: string};
-  
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        `,
-        "createWidget",
-      );
-
-      ok(metadata);
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep.kind, "finalOperationReference");
-      deepStrictEqual(metadata.finalStep.target?.kind, "reference");
-      deepStrictEqual(metadata.finalStep.target?.operation.name, "getWidget");
-      ok(metadata.statusMonitorStep);
-      deepStrictEqual(metadata.statusMonitorStep.target.kind, "reference");
-      deepStrictEqual(metadata.statusMonitorStep.target.operation.name, "getStatus");
-      ok(metadata.pollingInfo);
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
-    });
-
-    it("handles custom lro with polling using polling parameter decorators by reference", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;
-  
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-        }
-  
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-  
-          value: string;
-        }
-  
-        @route("/simpleWidgets/{id}")
-        @get op getWidget(@path id: string): SimpleWidget;
-  
-        @finalOperation(getWidget)
-        @pollingOperation(getStatus)
-        @route("/simpleWidgets/{id}")
-        @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @pollingOperationParameter(getStatus::parameters.id) @header id: string, @pollingOperationParameter(getStatus::parameters.operationId) @header("operation-id") operation: string};
-  
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        `,
-        "createWidget",
-      );
-
-      ok(metadata);
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep.kind, "finalOperationReference");
-      deepStrictEqual(metadata.finalStep.target?.kind, "reference");
-      deepStrictEqual(metadata.finalStep.target?.operation.name, "getWidget");
-      ok(metadata.statusMonitorStep);
-      deepStrictEqual(metadata.statusMonitorStep.target.kind, "reference");
-      deepStrictEqual(metadata.statusMonitorStep.target.operation.name, "getStatus");
-      ok(metadata.pollingInfo);
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
-    });
-
-    it("handles custom lro status values", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;  
-          statusValue: CustomStatus;
-        }
-        
-        @Azure.Core.lroStatus
-        enum CustomStatus {
-          @Azure.Core.lroSucceeded
-          Successful: "Successful";
-          @Azure.Core.lroCanceled
-          Cancelled: "Cancelled";
-          @Azure.Core.lroFailed
-          Faulted: "Faulted";
-          Normal: "Running";
-        }
-  
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-  
-          value: string;
-        }
-  
-        @route("/simpleWidgets/{id}")
-        @get op getWidget(@path id: string): SimpleWidget;
-  
-        @finalOperation(getWidget)
-        @pollingOperation(getStatus, {id: ResponseProperty<"id">; operationId: ResponseProperty<"operation">})
-        @route("/simpleWidgets/{id}")
-        @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operation: string};
-  
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        `,
-        "createWidget",
-      );
-
-      ok(metadata);
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep.kind, "finalOperationReference");
-      deepStrictEqual(metadata.finalStep.target?.kind, "reference");
-      deepStrictEqual(metadata.finalStep.target?.operation.name, "getWidget");
-      ok(metadata.statusMonitorStep);
-      deepStrictEqual(metadata.statusMonitorStep.target.kind, "reference");
-      deepStrictEqual(metadata.statusMonitorStep.target.operation.name, "getStatus");
-      ok(metadata.pollingInfo);
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Cancelled"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Faulted"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Successful"]);
-    });
-
-    it("throws for missing success value", async () => {
-      const [_, diagnostics] = await getOperations(
-        `
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;
-          status: "Successful" | "Canceled" | "Failed";
-        }
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-          value: string;
-        }
-        @route("/simpleWidgets/{id}")
-        @get op getWidget(@path id: string): SimpleWidget;
-        @finalOperation(getWidget)
-        @pollingOperation(getStatus, {id: ResponseProperty<"id">; operationId: ResponseProperty<"operation">})
-        @route("/simpleWidgets/{id}")
-        @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operation: string};
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        `,
-      );
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "@azure-tools/typespec-azure-core/polling-operation-no-status-monitor",
-          message:
-            "The operation linked in  @pollingOperation must return a valid status monitor.  The status monitor model must contain a 'status' property, or a property decorated with  '@lroStatus'.  The status field must be of Enum or Union type and contain terminal status values for success and failure.",
-        },
-      ]);
-    });
-
-    it("handles custom lro with non-standard status and error fields", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;
-  
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-  
-          @Azure.Core.lroResult
-          yeah: SimpleWidget;
-  
-          @Azure.Core.lroErrorResult
-          nay: Azure.Core.Foundations.Error;
-        }
-        
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-  
-          value: string;
-        }
-  
-        @route("/simpleWidgets/{id}")
-        @get op getWidget(@path id: string): SimpleWidget;
-  
-        @finalOperation(getWidget)
-        @pollingOperation(getStatus, {id: ResponseProperty<"id">; operationId: ResponseProperty<"operation">})
-        @route("/simpleWidgets/{id}")
-        @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operation: string};
-  
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        `,
-        "createWidget",
-      );
-      ok(metadata);
-      deepStrictEqual(metadata.finalStateVia, "original-uri");
-      deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
-      deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
-      deepStrictEqual(metadata.logicalPath, undefined);
-
-      deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
-      deepStrictEqual(metadata.finalResultPath, undefined);
-
-      ok(metadata.finalStep);
-      deepStrictEqual(metadata.finalStep.kind, "finalOperationReference");
-      deepStrictEqual(metadata.finalStep.target?.kind, "reference");
-      deepStrictEqual(metadata.finalStep.target?.operation.name, "getWidget");
-      ok(metadata.statusMonitorStep);
-      deepStrictEqual(metadata.statusMonitorStep.target.kind, "reference");
-      deepStrictEqual(metadata.statusMonitorStep.target.operation.name, "getStatus");
-      ok(metadata.pollingInfo);
-      deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
-      deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
-      ok(metadata.pollingInfo.resultProperty);
-      deepStrictEqual(metadata.pollingInfo.resultProperty.name, "yeah");
-      ok(metadata.pollingInfo.errorProperty);
-      deepStrictEqual(metadata.pollingInfo.errorProperty.name, "nay");
-    });
-
-    it("emits diagnostics for multiple lro result fields", async () => {
-      const [_ops, diagnostics, _runner] = await getOperations(
-        `
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;
-  
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-  
-          @Azure.Core.lroResult
-          yeah: SimpleWidget;
-  
-          @Azure.Core.lroResult
-          notSoYeah: SimpleWidget;
-  
-          @Azure.Core.lroErrorResult
-          nay: Azure.Core.Foundations.Error;
-  
-          @Azure.Core.lroErrorResult
-          alsoNay: Azure.Core.Foundations.Error;
-        }
-        
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-  
-          value: string;
-        }
-  
-        @route("/simpleWidgets/{id}")
-        @get op getWidget(@path id: string): SimpleWidget;
-  
-        @finalOperation(getWidget)
-        @pollingOperation(getStatus, {id: ResponseProperty<"id">; operationId: ResponseProperty<"operation">})
-        @route("/simpleWidgets/{id}")
-        @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operation: string};
-  
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        `,
-      );
-      ok(diagnostics.length > 1);
-      expectDiagnostics(diagnostics, [
-        {
-          code: `@azure-tools/typespec-azure-core/lro-status-monitor-invalid-result-property`,
-          message: `StatusMonitor has more than one result property marked with '@lroResult'.  Ensure that only one property in the model is marked with this decorator.`,
-        },
-        {
-          code: `@azure-tools/typespec-azure-core/lro-status-monitor-invalid-result-property`,
-          message: `StatusMonitor has more than one error property marked with '@lroErrorResult'.  Ensure that only one property in the model is marked with this decorator.`,
-        },
-      ]);
-    });
-
-    it("emits diagnostic for invalid @lroResult property type (enum)", async () => {
-      const [_ops, diagnostics, _runner] = await getOperations(
-        `
-        enum MyStatus {
-          Active,
-          Inactive,
-        }
-
-        model PollingStatus {
-          @header location?: ResourceLocation<PollingStatus>;
-
-          @Azure.Core.lroStatus
-          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-
-          @Azure.Core.lroResult
-          result?: MyStatus;
-        }
-
-        model SimpleWidget {
-          @key
-          @segment("simpleWidgets")
-          @visibility(Lifecycle.Read)
-          @path
-          id: string;
-
-          value: string;
-        }
-
-        @route("/simpleWidgets/{id}")
-        @get op getWidget(@path id: string): SimpleWidget;
-
-        @finalOperation(getWidget)
-        @pollingOperation(getStatus, {id: ResponseProperty<"id">; operationId: ResponseProperty<"operation">})
-        @route("/simpleWidgets/{id}")
-        @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operation: string};
-
-        @route("/simpleWidgets/{id}/operations/{operationId}")
-        @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
-        `,
-      );
-      expectDiagnostics(diagnostics, [
-        {
-          code: `@azure-tools/typespec-azure-core/lro-status-monitor-invalid-result-property-type`,
-          message:
-            /Property 'result' used as the final result of a long-running operation has an invalid type '.*MyStatus'. The property type must be a Model, Scalar, or 'unknown'./,
-        },
-      ]);
-    });
-
-    it("Gets Lro undefined for sync operation", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `// Reuse CustomParameters and CustomResponseProperties in the "normal" TParams and TResponse fields
-        model OpParams {
-          value: string;
-          ...CustomParameters;
-        };
-  
-        model OpResponse is CustomResponseProperties {
-          message: string;
-        }
-         @test op update is Azure.Core.ResourceAction<TestModel, OpParams, OpResponse>;`,
-      );
-      deepStrictEqual(metadata, undefined);
-    });
-
-    it("Gets Lro undefined for sync operation with status field", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `// Reuse CustomParameters and CustomResponseProperties in the "normal" TParams and TResponse fields
-        model OpParams {
-          value: string;
-          ...CustomParameters;
-        };
-  
-        model OpResponse is CustomResponseProperties {
-          message: string;
-          status: "Succeeded" | "Failed" | "Canceled";
-        }
-         @test op update is Azure.Core.ResourceAction<TestModel, OpParams, OpResponse>;`,
-      );
-      deepStrictEqual(metadata, undefined);
-    });
-
-    it("Gets Lro undefined for sync operation with provisioningState field", async () => {
-      const [_, metadata] = await compileLroOperation(
-        `// Reuse CustomParameters and CustomResponseProperties in the "normal" TParams and TResponse fields
-        model OpParams {
-          value: string;
-          ...CustomParameters;
-        };
-  
-        model OpResponse is CustomResponseProperties {
-          message: string;
-          provisioningState: "Succeeded" | "Failed" | "Canceled";
-        }
-         @test op update is Azure.Core.ResourceAction<TestModel, OpParams, OpResponse>;`,
-      );
-      deepStrictEqual(metadata, undefined);
-    });
-
-    it("signatures with customizable responses do not accept unions for TResponse", async () => {
-      const [_, diagnostics] = await getOperations(`
-        model Foo {}
-        model Bar {}
-        @resource("widgets") model Widget { @key name: string; }
-        op customAction is Azure.Core.StandardResourceOperations.ResourceAction<Widget, {}, Foo | Bar>;
-        op customCollectionAction is Azure.Core.StandardResourceOperations.ResourceCollectionAction<Widget, {}, Foo | Bar>;
-        op rpcAction is Azure.Core.RpcOperation<{}, Foo | Bar>;
-  
-        op poll is StandardResourceOperations.GetResourceOperationStatus<Widget>;
-  
-        @Azure.Core.pollingOperation(poll)
-        op lroCustomAction is Azure.Core.StandardResourceOperations.LongRunningResourceAction<Widget, {}, Bar | Foo>;
-        @Azure.Core.pollingOperation(poll)
-        op lroCustomCollectionAction is Azure.Core.StandardResourceOperations.LongRunningResourceCollectionAction<Widget, {}, Bar | Foo>;
-        @Azure.Core.pollingOperation(poll)
-        op lroRpcAction is Azure.Core.LongRunningRpcOperation<{}, Bar | Foo, {}>;
-      `);
-
-      expectDiagnostics(diagnostics, [
-        {
-          code: "invalid-argument",
-        },
-        {
-          code: "invalid-argument",
-        },
-        {
-          code: "invalid-argument",
-        },
-        {
-          code: "invalid-argument",
-        },
-        {
-          code: "invalid-argument",
-        },
-        {
-          code: "invalid-argument",
-        },
-      ]);
-    });
-
-    describe("original-uri with no GET operation", () => {
-      async function compileLroWithDiagnostics(
-        code: string,
-        operationName?: string,
-      ): Promise<[HttpOperation, LroMetadata | undefined, TesterInstance]> {
-        let [operations, , runner] = await getOperations(
-          `
-          model TestModel {
-            @key
-            @segment("test")
-            name: string;
-            value: int32;
-          }
-
-          ${code}
-          `,
-        );
-
-        if (operationName !== undefined) {
-          operations = operations.filter((o) => o.operation.name === operationName);
-        }
-
-        strictEqual(operations.length, 1);
-        const lro = getLroMetadata(runner.program, operations[0].operation);
-        return [operations[0], lro, runner];
-      }
-
-      it("emits no-operation-at-original-uri for PUT with original-uri and no GET", async () => {
-        const [_, metadata, runner] = await compileLroWithDiagnostics(
-          `
-          model PollingStatus {
-            @Azure.Core.lroStatus
-            statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-          }
-
-          @route("/widgets/{id}/operations/{operationId}")
-          @get
-          op getStatus(@path id: string, @path operationId: string): PollingStatus;
-
-          @pollingOperation(getStatus, {operationId: ResponseProperty<"opId">})
-          @useFinalStateVia("original-uri")
-          @route("/widgets/{id}")
-          @put
-          op createWidget(@path id: string, @body body: TestModel): TestModel | {
-            @statusCode statusCode: 201;
-            @header opId: string;
-            @pollingLocation @header("Operation-Location") opLink: string;
-          };
-          `,
-          "createWidget",
-        );
-
-        ok(metadata);
-        expectDiagnostics(runner.program.diagnostics, [
-          {
-            code: "@azure-tools/typespec-azure-core/no-operation-at-original-uri",
-          },
-        ]);
-      });
-
-      it("emits no-operation-at-original-uri for PATCH with original-uri and no GET", async () => {
-        const [_, metadata, runner] = await compileLroWithDiagnostics(
-          `
-          model PollingStatus {
-            @Azure.Core.lroStatus
-            statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-          }
-
-          @route("/widgets/{id}/operations/{operationId}")
-          @get
-          op getStatus(@path id: string, @path operationId: string): PollingStatus;
-
-          @pollingOperation(getStatus, {operationId: ResponseProperty<"opId">})
-          @useFinalStateVia("original-uri")
-          @route("/widgets/{id}")
-          @patch
-          op updateWidget(@path id: string, @body body: TestModel): {
-            @statusCode statusCode: 200;
-            @header opId: string;
-            @pollingLocation @header("Operation-Location") opLink: string;
-            @bodyRoot body: TestModel;
-          } | {
-            @statusCode statusCode: 201;
-            @header opId: string;
-            @pollingLocation @header("Operation-Location") opLink: string;
-            @bodyRoot body: TestModel;
-          };
-          `,
-          "updateWidget",
-        );
-
-        ok(metadata);
-        expectDiagnostics(runner.program.diagnostics, [
-          {
-            code: "@azure-tools/typespec-azure-core/no-operation-at-original-uri",
-          },
-        ]);
-      });
-
-      it("emits no-operation-at-original-uri for POST with original-uri and no GET", async () => {
-        const [_, metadata, runner] = await compileLroWithDiagnostics(
-          `
-          model PollingStatus {
-            @Azure.Core.lroStatus
-            statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-          }
-
-          @route("/widgets/{id}/operations/{operationId}")
-          @get
-          op getStatus(@path id: string, @path operationId: string): PollingStatus;
-
-          @pollingOperation(getStatus, {operationId: ResponseProperty<"opId">})
-          @useFinalStateVia("original-uri")
-          @route("/widgets/{id}")
-          @post
-          op processWidget(@path id: string, @body body: TestModel): {
-            @statusCode statusCode: 202;
-            @header opId: string;
-            @pollingLocation @header("Operation-Location") opLink: string;
-          };
-          `,
-          "processWidget",
-        );
-
-        ok(metadata);
-        expectDiagnostics(runner.program.diagnostics, [
-          {
-            code: "@azure-tools/typespec-azure-core/no-operation-at-original-uri",
-          },
-        ]);
-      });
-
-      it("returns void finalResult for PUT with original-uri and no GET when diagnostic is suppressed", async () => {
-        const [_, metadata] = await compileLroWithDiagnostics(
-          `
-          model PollingStatus {
-            @Azure.Core.lroStatus
-            statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-          }
-
-          @route("/widgets/{id}/operations/{operationId}")
-          @get
-          op getStatus(@path id: string, @path operationId: string): PollingStatus;
-
-          @pollingOperation(getStatus, {operationId: ResponseProperty<"opId">})
-          #suppress "@azure-tools/typespec-azure-core/no-operation-at-original-uri" "No GET at original URI"
-          @useFinalStateVia("original-uri")
-          @route("/widgets/{id}")
-          @put
-          op createWidget(@path id: string, @body body: TestModel): TestModel | {
-            @statusCode statusCode: 201;
-            @header opId: string;
-            @pollingLocation @header("Operation-Location") opLink: string;
-          };
-          `,
-          "createWidget",
-        );
-
-        ok(metadata);
-        deepStrictEqual(metadata.finalStateVia, "original-uri");
-        deepStrictEqual(metadata.finalResult, "void");
-        deepStrictEqual(metadata.finalEnvelopeResult, "void");
-      });
-
-      it("returns void finalResult for PATCH with original-uri and no GET when diagnostic is suppressed", async () => {
-        const [_, metadata] = await compileLroWithDiagnostics(
-          `
-          model PollingStatus {
-            @Azure.Core.lroStatus
-            statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-          }
-
-          @route("/widgets/{id}/operations/{operationId}")
-          @get
-          op getStatus(@path id: string, @path operationId: string): PollingStatus;
-
-          @pollingOperation(getStatus, {operationId: ResponseProperty<"opId">})
-          #suppress "@azure-tools/typespec-azure-core/no-operation-at-original-uri" "No GET at original URI"
-          @useFinalStateVia("original-uri")
-          @route("/widgets/{id}")
-          @patch
-          op updateWidget(@path id: string, @body body: TestModel): {
-            @statusCode statusCode: 200;
-            @header opId: string;
-            @pollingLocation @header("Operation-Location") opLink: string;
-            @bodyRoot body: TestModel;
-          } | {
-            @statusCode statusCode: 201;
-            @header opId: string;
-            @pollingLocation @header("Operation-Location") opLink: string;
-            @bodyRoot body: TestModel;
-          };
-          `,
-          "updateWidget",
-        );
-
-        ok(metadata);
-        deepStrictEqual(metadata.finalStateVia, "original-uri");
-        deepStrictEqual(metadata.finalResult, "void");
-        deepStrictEqual(metadata.finalEnvelopeResult, "void");
-      });
-
-      it("returns void finalResult for POST with original-uri and no GET when diagnostic is suppressed", async () => {
-        const [_, metadata] = await compileLroWithDiagnostics(
-          `
-          model PollingStatus {
-            @Azure.Core.lroStatus
-            statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-          }
-
-          @route("/widgets/{id}/operations/{operationId}")
-          @get
-          op getStatus(@path id: string, @path operationId: string): PollingStatus;
-
-          @pollingOperation(getStatus, {operationId: ResponseProperty<"opId">})
-          #suppress "@azure-tools/typespec-azure-core/no-operation-at-original-uri" "No GET at original URI"
-          @useFinalStateVia("original-uri")
-          @route("/widgets/{id}")
-          @post
-          op processWidget(@path id: string, @body body: TestModel): {
-            @statusCode statusCode: 202;
-            @header opId: string;
-            @pollingLocation @header("Operation-Location") opLink: string;
-          };
-          `,
-          "processWidget",
-        );
-
-        ok(metadata);
-        deepStrictEqual(metadata.finalStateVia, "original-uri");
-        deepStrictEqual(metadata.finalResult, "void");
-        deepStrictEqual(metadata.finalEnvelopeResult, "void");
-      });
-
-      it("does not emit no-operation-at-original-uri when GET exists at same path", async () => {
-        const [_, metadata, runner] = await compileLroWithDiagnostics(
-          `
-          model PollingStatus {
-            @Azure.Core.lroStatus
-            statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
-          }
-
-          @route("/widgets/{id}/operations/{operationId}")
-          @get
-          op getStatus(@path id: string, @path operationId: string): PollingStatus;
-
-          @route("/widgets/{id}")
-          @get
-          op getWidget(@path id: string): TestModel;
-
-          @pollingOperation(getStatus, {operationId: ResponseProperty<"opId">})
-          @useFinalStateVia("original-uri")
-          @route("/widgets/{id}")
-          @put
-          op createWidget(@path id: string, @body body: TestModel): TestModel | {
-            @statusCode statusCode: 201;
-            @header opId: string;
-            @pollingLocation @header("Operation-Location") opLink: string;
-          };
-          `,
-          "createWidget",
-        );
-
-        ok(metadata);
-        deepStrictEqual(metadata.finalStateVia, "original-uri");
-        expectDiagnosticEmpty(
-          runner.program.diagnostics.filter(
-            (d) => d.code === "@azure-tools/typespec-azure-core/no-operation-at-original-uri",
-          ),
-        );
-      });
-    });
-  });
-
-  // Regression test for https://github.com/Azure/typespec-azure/issues/332
-  it("doesn't crash when passing non model to ServiceTraits", async () => {
-    const [_, diagnostics] = await getOperations(`
-      alias Operations = Azure.Core.ResourceOperations<abc>;
-    `);
-    expectDiagnostics(
-      diagnostics.filter((x) => x.severity === "error"),
-      [
-        {
-          code: "invalid-ref",
-          message: "Unknown identifier abc",
-        },
-        {
-          code: "invalid-argument",
-        },
-      ],
+          @bodyRoot body?: SimpleWidget
+        };      
+      `,
+      "createWidget",
     );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
+
+    deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
+
+    deepStrictEqual(metadata.finalStep?.kind, "finalOperationLink");
+    deepStrictEqual(metadata.finalStep?.target?.kind, "link");
+    deepStrictEqual((metadata.finalStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.finalStep?.target as any).property.name, "location");
+
+    deepStrictEqual(metadata.finalStateVia, "location");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
   });
+
+  it("Gets Lro for arm-style azure-async operation polling in createOrReplace operations", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+        provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
+        value: string;
+      }
+      
+      @route("/simpleWidgets/{id}")
+      @createsOrReplacesResource(SimpleWidget)
+      @put op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
+        {
+          @statusCode statusCode: 201;
+          @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("Azure-AsyncOperation") opLink: string,
+          @bodyRoot body?: SimpleWidget
+        };      
+      `,
+      "createWidget",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
+
+    deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
+
+    deepStrictEqual(metadata.finalStep, undefined);
+
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+  });
+
+  it("Gets Lro for arm-style location polling in createOrReplace operations", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+        provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
+        value: string;
+      }
+      
+      @route("/simpleWidgets/{id}")
+      @createsOrUpdatesResource(SimpleWidget)
+      @put op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
+        {
+          @statusCode statusCode: 201;
+          @pollingLocation(StatusMonitorPollingOptions<SimpleWidget>) @header("location") opLink: string,
+          @bodyRoot body?: SimpleWidget
+        };      
+      `,
+      "createWidget",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
+
+    deepStrictEqual(metadata.pollingInfo?.responseModel.name, "SimpleWidget");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "provisioningState");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
+    deepStrictEqual(metadata.finalStep, undefined);
+
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.envelopeResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+  });
+
+  it("Gets Lro for arm-style azure-async + location operation polling in update operations", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+        provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
+        value: string;
+      }
+      
+      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+      @route("/simpleWidgets/{id}")
+      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+      @patch(#{implicitOptionality: true}) op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
+        {
+          @statusCode statusCode: 201;
+          @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("Azure-AsyncOperation") opLink: string,
+          @finalLocation(SimpleWidget)
+          @header location: string;
+          @bodyRoot body?: SimpleWidget
+        };      
+      `,
+      "createWidget",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
+
+    deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
+
+    deepStrictEqual(metadata.finalStep?.kind, "finalOperationLink");
+    deepStrictEqual(metadata.finalStep?.target?.kind, "link");
+    deepStrictEqual((metadata.finalStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.finalStep?.target as any).property.name, "location");
+
+    deepStrictEqual(metadata.finalStateVia, "location");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+  });
+
+  it("Gets Lro for arm-style azure-async operation polling in update operations", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+        @finalLocation(SimpleWidget)
+        @header location: string;
+      }
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+        provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
+        value: string;
+      }
+      
+      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+      @route("/simpleWidgets/{id}")
+      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+      @patch(#{implicitOptionality: true}) op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
+        {
+          @statusCode statusCode: 201;
+          @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("Azure-AsyncOperation") opLink: string,
+          @bodyRoot body?: SimpleWidget
+        };      
+      `,
+      "createWidget",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
+
+    deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
+
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep.kind, "finalOperationLink");
+    deepStrictEqual((metadata.finalStep.responseModel as Model).name, "SimpleWidget");
+    deepStrictEqual(metadata.finalStep.target?.property.name, "location");
+
+    deepStrictEqual(metadata.finalStateVia, "location");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+  });
+
+  it("Gets Lro for arm-style location polling in update operations", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+        provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
+        value: string;
+      }
+      
+      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+      @route("/simpleWidgets/{id}")
+      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+      @patch(#{implicitOptionality: true}) op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
+        {
+          @statusCode statusCode: 201;
+          @finalLocation(SimpleWidget) @pollingLocation(StatusMonitorPollingOptions<SimpleWidget>) @header("location") opLink: string,
+          @bodyRoot body?: SimpleWidget
+        };      
+      `,
+      "createWidget",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
+
+    deepStrictEqual(metadata.pollingInfo?.responseModel.name, "SimpleWidget");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "provisioningState");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep.kind, "finalOperationLink");
+    deepStrictEqual((metadata.finalStep.responseModel as Model).name, "SimpleWidget");
+    deepStrictEqual(metadata.finalStep?.target?.kind, "link");
+    deepStrictEqual((metadata.finalStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.finalStep?.target as any).property.name, "opLink");
+
+    deepStrictEqual(metadata.finalStateVia, "location");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.envelopeResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+  });
+
+  it("Gets Lro for arm-style azure-async + location operation polling in action operations", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+        provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
+        value: string;
+      }
+      
+      @route("/simpleWidgets/{id}")
+      @post op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
+        {
+          @statusCode statusCode: 202;
+          @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("Azure-AsyncOperation") opLink: string,
+          @finalLocation(SimpleWidget)
+          @header location: string;
+          @bodyRoot body?: SimpleWidget
+        };      
+      `,
+      "createWidget",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
+
+    deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
+
+    deepStrictEqual(metadata.finalStep?.kind, "finalOperationLink");
+    deepStrictEqual(metadata.finalStep?.target?.kind, "link");
+    deepStrictEqual((metadata.finalStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.finalStep?.target as any).property.name, "location");
+
+    deepStrictEqual(metadata.finalStateVia, "location");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+  });
+
+  it("Gets Lro for arm-style azure-async operation polling in action operations", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+        provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
+        value: string;
+      }
+      
+      @route("/simpleWidgets/{id}")
+      @post op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
+        {
+          @statusCode statusCode: 202;
+          @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("Azure-AsyncOperation") opLink: string,
+          @bodyRoot body?: SimpleWidget
+        };      
+      `,
+      "createWidget",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
+
+    deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
+
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep?.kind, "noPollingResult");
+
+    deepStrictEqual(metadata.finalStateVia, "azure-async-operation");
+    deepStrictEqual(metadata.logicalResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual(metadata.finalResult, "void");
+    deepStrictEqual(metadata.finalEnvelopeResult, "void");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+  });
+
+  it("Gets Lro for arm-style location polling in action operations", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+        provisioningState: "Succeeded" | "Failed" | "Canceled" | "Running";
+        value: string;
+      }
+      
+      @route("/simpleWidgets/{id}")
+      @post op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
+        {
+          @statusCode statusCode: 202;
+          @finalLocation(SimpleWidget) @pollingLocation(StatusMonitorPollingOptions<SimpleWidget>) @header("location") opLink: string,
+          @bodyRoot body?: SimpleWidget
+        };      
+      `,
+      "createWidget",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
+
+    deepStrictEqual(metadata.pollingInfo?.responseModel.name, "SimpleWidget");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "provisioningState");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep?.kind, "finalOperationLink");
+    deepStrictEqual(metadata.finalStep?.target?.kind, "link");
+    deepStrictEqual((metadata.finalStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.finalStep?.target as any).property.name, "opLink");
+
+    deepStrictEqual(metadata.finalStateVia, "location");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.envelopeResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+  });
+
+  it("Gets Lro for arm-style azure-async operation polling in delete operations", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+      
+      @route("/simpleWidgets/{id}")
+      @delete op deleteWidget(@path id: string) : {
+          @statusCode statusCode: 201;
+          @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("Azure-AsyncOperation") opLink: string,
+        };      
+      `,
+      "deleteWidget",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
+
+    deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
+
+    //ok(metadata.finalStep);
+    //deepStrictEqual(metadata.finalStep?.kind, "noPollingResult");
+
+    deepStrictEqual(metadata.finalStateVia, "azure-async-operation");
+    deepStrictEqual(metadata.logicalResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual(metadata.finalResult, "void");
+    deepStrictEqual(metadata.finalEnvelopeResult, "void");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+  });
+
+  it("Gets Lro for arm-style location polling in delete operations", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+      
+      @route("/simpleWidgets/{id}")
+      @delete op deleteWidget(@path id: string) : {
+          @statusCode statusCode: 201;
+          @pollingLocation(StatusMonitorPollingOptions<PollingStatus>) @header("location") opLink: string,
+        };      
+      `,
+      "deleteWidget",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.target.kind, "link");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).location, "ResponseHeader");
+    deepStrictEqual((metadata.statusMonitorStep?.target as any).property.name, "opLink");
+
+    deepStrictEqual(metadata.pollingInfo?.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus?.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo?.terminationStatus.succeededState, ["Succeeded"]);
+    //ok(metadata.finalStep);
+    //deepStrictEqual(metadata.finalStep?.kind, "noPollingResult");
+
+    deepStrictEqual(metadata.finalStateVia, "location");
+    deepStrictEqual(metadata.logicalResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual(metadata.finalResult, "void");
+    deepStrictEqual(metadata.finalEnvelopeResult, "void");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+  });
+
+  it("Gets Lro for non-standard polling in custom createOrReplace operations without finalLocation", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+      
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+      
+        value: string;
+      }
+      
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      
+      @pollingOperation(getStatus)
+      @route("/simpleWidgets/{id}")
+      @createsOrReplacesResource(SimpleWidget)
+      @put op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
+        {
+          @statusCode statusCode: 201;
+          @header id: string,
+          @header("operation-id") operate: string,
+          @pollingLocation @header("Operation-Location") opLink: string,
+          @lroResult @bodyRoot body?: SimpleWidget
+        };      
+      `,
+      "createWidget",
+    );
+
+    ok(metadata);
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata?.finalResultPath, undefined);
+
+    ok(metadata.statusMonitorStep);
+    deepStrictEqual(metadata.statusMonitorStep.target.kind, "link");
+    deepStrictEqual((metadata.statusMonitorStep.target as any)?.location, "ResponseHeader");
+    deepStrictEqual((metadata.statusMonitorStep.target as any)?.property.name, "opLink");
+
+    ok(metadata.pollingInfo);
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
+  });
+
+  it("Gets Lro for non-standard polling in custom put operations without finalLocation", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+      
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+      
+        value: string;
+      }
+      
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      
+      @pollingOperation(getStatus)
+      @route("/simpleWidgets/{id}")
+      @createsOrReplacesResource(SimpleWidget)
+      @put op createWidget(@path id: string, body: SimpleWidget) : SimpleWidget | 
+        {
+          @statusCode statusCode: 201;
+          @header id: string,
+          @header("operation-id") operate: string,
+          @pollingLocation @header("Operation-Location") opLink: string,
+          @lroResult @bodyRoot body?: SimpleWidget
+        };      
+      `,
+      "createWidget",
+    );
+
+    ok(metadata);
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata?.finalResultPath, undefined);
+
+    ok(metadata.statusMonitorStep);
+    deepStrictEqual(metadata.statusMonitorStep.target.kind, "link");
+    deepStrictEqual((metadata.statusMonitorStep.target as any)?.location, "ResponseHeader");
+    deepStrictEqual((metadata.statusMonitorStep.target as any)?.property.name, "opLink");
+
+    ok(metadata.pollingInfo);
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
+  });
+
+  it("Gets Lro for non-standard polling in post operations", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+        result?: SimpleWidget;
+      }
+      
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+      
+        value: string;
+      }
+      
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get
+      op getStatus(@path id: string, @path operationId: string): PollingStatus & {@header correlationId: string;};
+      
+      @pollingOperation(getStatus, {operationId: ResponseProperty<"operate">})
+      @route("/simpleWidgets/{id}")
+      @post
+      op mungeWidget(@path id: string, body: SimpleWidget): SimpleWidget | {
+        @statusCode statusCode: 201;
+        @header id: string;
+        @header("operation-id") operate: string;
+        @pollingLocation @header("Operation-Location") opLink: string;
+        @lroResult @bodyRoot body?: SimpleWidget;
+      };
+      `,
+      "mungeWidget",
+    );
+
+    ok(metadata);
+    deepStrictEqual(metadata.finalStateVia, "custom-operation-reference");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata?.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata?.logicalPath, "result");
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "PollingStatus");
+    deepStrictEqual(metadata?.finalResultPath, "result");
+
+    ok(metadata.statusMonitorStep);
+    deepStrictEqual(metadata.statusMonitorStep.target.kind, "reference");
+
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep.kind, "pollingSuccessProperty");
+    deepStrictEqual(metadata.finalStep.target?.kind, "ModelProperty");
+
+    ok(metadata.pollingInfo);
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
+  });
+
+  it("Gets Lro for non-standard polling with void return type", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      using Azure.Core.Traits;
+      
+      alias ServiceTraits = SupportsClientRequestId &
+      NoConditionalRequests &
+      NoRepeatableRequests;
+    
+      alias ServiceOperations = Azure.Core.ResourceOperations<ServiceTraits>;
+
+      @lroStatus
+      enum OperationStatus {
+        NotStarted,
+        Running,
+        Succeeded,
+        Failed,
+        Canceled,
+      }
+      
+      enum ImportType {
+        Devices,
+        Modules,
+        All,
+      }
+      
+      @resource("management/operations")
+      model DeviceOperation {
+        @key
+        @visibility(Lifecycle.Read)
+        operationId: string;
+        error?: Azure.Core.Foundations.Error;
+      }
+      
+      @resource("updates/operations")
+      model UpdateOperation {
+        @key
+        @visibility(Lifecycle.Read)
+        operationId: string;
+        status: OperationStatus;
+        resourceLocation?: string;
+        error?: Azure.Core.Foundations.Error;
+      }
+      
+      model IfNoneMatchParameter {
+        @TypeSpec.Http.header("If-None-Match")
+        ifNoneMatch?: string;
+      }
+      
+      op getOperationStatus is ServiceOperations.ResourceRead<
+        UpdateOperation,
+        TraitOverride<RequestHeadersTrait<
+          {
+            ...IfNoneMatchParameter;
+          },
+          TraitContext.Read
+        >>
+      >;
+      
+      @pollingOperation(getOperationStatus)
+      @route("management/devices:import")
+      @post
+      op importDevices is Azure.Core.Foundations.Operation<
+        {
+          @body
+          importType: ImportType;
+        },
+        {
+          @statusCode _: 202;
+      
+          @pollingLocation
+          @header("Operation-Location")
+          operationLocation?: ResourceLocation<DeviceOperation>;
+        }
+      >;`,
+      "importDevices",
+    );
+
+    ok(metadata);
+    deepStrictEqual(metadata.finalStateVia, "operation-location");
+    deepStrictEqual(metadata.logicalResult.name, "UpdateOperation");
+    deepStrictEqual(metadata?.envelopeResult.name, "UpdateOperation");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    deepStrictEqual(metadata.finalResult, "void");
+    deepStrictEqual(metadata?.finalEnvelopeResult, "void");
+    deepStrictEqual(metadata?.logicalPath, undefined);
+
+    ok(metadata.statusMonitorStep);
+    deepStrictEqual(metadata.statusMonitorStep.target.kind, "link");
+
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep.kind, "noPollingResult");
+
+    ok(metadata.pollingInfo);
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "UpdateOperation");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "status");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
+  });
+
+  it("Gets Lro for status monitor with scalar result type", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+        @Azure.Core.lroResult
+        result?: string;
+      }
+      @route("/scalarResult/operations/{operationId}")
+      @get op getScalarStatus(@path operationId: string): PollingStatus;
+      @pollingOperation(getScalarStatus, {operationId: ResponseProperty<"operationId">})
+      @route("/scalarResult")
+      @post @test op startScalarOp(@body body: {}): {
+        @statusCode _: 202;
+        @header("operation-id") operationId: string;
+      };
+      `,
+      "startScalarOp",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.statusMonitorStep?.kind, "nextOperationReference");
+    deepStrictEqual(metadata.statusMonitorStep?.responseModel.name, "PollingStatus");
+
+    deepStrictEqual(metadata.pollingInfo.kind, "pollingOperationStep");
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo.resultProperty?.name, "result");
+
+    deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata.logicalPath, "result");
+
+    // The final result should be a Scalar type (string), not "void"
+    ok(metadata.finalResult !== "void");
+    ok(metadata.finalResult !== undefined);
+    strictEqual((metadata.finalResult as Scalar).kind, "Scalar");
+    strictEqual((metadata.finalResult as Scalar).name, "string");
+
+    deepStrictEqual((metadata.finalEnvelopeResult as Model).name, "PollingStatus");
+    deepStrictEqual(metadata.finalResultPath, "result");
+
+    // logicalResult should be the polling response model when the actual result is a scalar
+    strictEqual(metadata.logicalResult.name, "PollingStatus");
+
+    // finalStep should be pollingSuccessProperty with scalar responseModel
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep.kind, "pollingSuccessProperty");
+    if (metadata.finalStep.kind === "pollingSuccessProperty") {
+      strictEqual(metadata.finalStep.responseModel.kind, "Scalar");
+      strictEqual((metadata.finalStep.responseModel as Scalar).name, "string");
+    }
+  });
+
+  it("ignores bad lro operation links with Operation-Location", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;
+
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+
+        value: string;
+      }
+
+      @route("/simpleWidgets/{id}")
+      @get op getWidget(@path id: string): SimpleWidget;
+
+      @finalOperation(getWidget)
+      @pollingOperation(getStatus, {id: ResponseProperty<"id">})
+      @route("/simpleWidgets/{id}")
+      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+      @patch(#{implicitOptionality: true}) op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operate: string, @header("Operation-Location")opLink: string};
+
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      `,
+      "createWidget",
+    );
+
+    ok(metadata);
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep.kind, "finalOperationReference");
+    deepStrictEqual(metadata.finalStep.target?.kind, "reference");
+    deepStrictEqual(metadata.finalStep.target?.operation.name, "getWidget");
+    ok(metadata.statusMonitorStep);
+    deepStrictEqual(metadata.statusMonitorStep.target.kind, "link");
+    ok(metadata.pollingInfo);
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
+  });
+
+  it("ignores bad lro operation links with @pollingLocation", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+        value: string;
+      }
+      @route("/simpleWidgets/{id}")
+      @get op getWidget(@path id: string): SimpleWidget;
+      @finalOperation(getWidget)
+      @pollingOperation(getStatus, {id: ResponseProperty<"id">})
+      @route("/simpleWidgets/{id}")
+      @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operate: string, @Azure.Core.pollingLocation opLink: string};
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      `,
+      "createWidget",
+    );
+
+    ok(metadata);
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep.kind, "finalOperationReference");
+    deepStrictEqual(metadata.finalStep.target?.kind, "reference");
+    deepStrictEqual(metadata.finalStep.target?.operation.name, "getWidget");
+    ok(metadata.statusMonitorStep);
+    deepStrictEqual(metadata.statusMonitorStep.target.kind, "link");
+    ok(metadata.pollingInfo);
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
+  });
+
+  it("throws with bad lro operation links and no polling header", async () => {
+    const [_, diagnostics] = await getOperations(
+      `
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+        value: string;
+      }
+      @route("/simpleWidgets/{id}")
+      @get op getWidget(@path id: string): SimpleWidget;
+      @finalOperation(getWidget)
+      @pollingOperation(getStatus, {id: ResponseProperty<"id">})
+      @route("/simpleWidgets/{id}")
+      @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operate: string};
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      `,
+    );
+
+    expectDiagnostics(diagnostics, [
+      {
+        code: "@azure-tools/typespec-azure-core/polling-operation-no-ref-or-link",
+        message:
+          "An operation decorated with '@pollingOperation' must either return a response with an 'Operation-Location' header that will contain a runtime link to the polling operation, or specify parameters and return type properties to map into the polling operation parameters.  A map into polling operation parameters can be created using the '@pollingOperationParameter' decorator",
+      },
+    ]);
+  });
+
+  it("handles custom lro with polling and final links", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Failed" | "Canceled" | "Running" | "NotStarted";
+      }
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+        value: string;
+      }
+      @route("/simpleWidgets/{id}")
+      @get op getWidget(@path id: string): SimpleWidget;
+      @finalOperation(getWidget)
+      @pollingOperation(getStatus, {id: ResponseProperty<"id">; operationId: ResponseProperty<"operation">})
+      @route("/simpleWidgets/{id}")
+      @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operation: string};
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      `,
+      "createWidget",
+    );
+
+    ok(metadata);
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep.kind, "finalOperationReference");
+    deepStrictEqual(metadata.finalStep.target?.kind, "reference");
+    deepStrictEqual(metadata.finalStep.target?.operation.name, "getWidget");
+    ok(metadata.statusMonitorStep);
+    deepStrictEqual(metadata.statusMonitorStep.target.kind, "reference");
+    deepStrictEqual(metadata.statusMonitorStep.target.operation.name, "getStatus");
+    ok(metadata.pollingInfo);
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
+  });
+
+  it("handles custom lro with polling using polling parameter decorators by name", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;
+
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+
+        value: string;
+      }
+
+      @route("/simpleWidgets/{id}")
+      @get op getWidget(@path id: string): SimpleWidget;
+
+      @finalOperation(getWidget)
+      @pollingOperation(getStatus)
+      @route("/simpleWidgets/{id}")
+      @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @pollingOperationParameter @header id: string, @pollingOperationParameter("operationId") @header("operation-id") operation: string};
+
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      `,
+      "createWidget",
+    );
+
+    ok(metadata);
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep.kind, "finalOperationReference");
+    deepStrictEqual(metadata.finalStep.target?.kind, "reference");
+    deepStrictEqual(metadata.finalStep.target?.operation.name, "getWidget");
+    ok(metadata.statusMonitorStep);
+    deepStrictEqual(metadata.statusMonitorStep.target.kind, "reference");
+    deepStrictEqual(metadata.statusMonitorStep.target.operation.name, "getStatus");
+    ok(metadata.pollingInfo);
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
+  });
+
+  it("handles custom lro with polling using polling parameter decorators by reference", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;
+
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+      }
+
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+
+        value: string;
+      }
+
+      @route("/simpleWidgets/{id}")
+      @get op getWidget(@path id: string): SimpleWidget;
+
+      @finalOperation(getWidget)
+      @pollingOperation(getStatus)
+      @route("/simpleWidgets/{id}")
+      @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @pollingOperationParameter(getStatus::parameters.id) @header id: string, @pollingOperationParameter(getStatus::parameters.operationId) @header("operation-id") operation: string};
+
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      `,
+      "createWidget",
+    );
+
+    ok(metadata);
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep.kind, "finalOperationReference");
+    deepStrictEqual(metadata.finalStep.target?.kind, "reference");
+    deepStrictEqual(metadata.finalStep.target?.operation.name, "getWidget");
+    ok(metadata.statusMonitorStep);
+    deepStrictEqual(metadata.statusMonitorStep.target.kind, "reference");
+    deepStrictEqual(metadata.statusMonitorStep.target.operation.name, "getStatus");
+    ok(metadata.pollingInfo);
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
+  });
+
+  it("handles custom lro status values", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;  
+        statusValue: CustomStatus;
+      }
+      
+      @Azure.Core.lroStatus
+      enum CustomStatus {
+        @Azure.Core.lroSucceeded
+        Successful: "Successful";
+        @Azure.Core.lroCanceled
+        Cancelled: "Cancelled";
+        @Azure.Core.lroFailed
+        Faulted: "Faulted";
+        Normal: "Running";
+      }
+
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+
+        value: string;
+      }
+
+      @route("/simpleWidgets/{id}")
+      @get op getWidget(@path id: string): SimpleWidget;
+
+      @finalOperation(getWidget)
+      @pollingOperation(getStatus, {id: ResponseProperty<"id">; operationId: ResponseProperty<"operation">})
+      @route("/simpleWidgets/{id}")
+      @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operation: string};
+
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      `,
+      "createWidget",
+    );
+
+    ok(metadata);
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep.kind, "finalOperationReference");
+    deepStrictEqual(metadata.finalStep.target?.kind, "reference");
+    deepStrictEqual(metadata.finalStep.target?.operation.name, "getWidget");
+    ok(metadata.statusMonitorStep);
+    deepStrictEqual(metadata.statusMonitorStep.target.kind, "reference");
+    deepStrictEqual(metadata.statusMonitorStep.target.operation.name, "getStatus");
+    ok(metadata.pollingInfo);
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Cancelled"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Faulted"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Successful"]);
+  });
+
+  it("throws for missing success value", async () => {
+    const [_, diagnostics] = await getOperations(
+      `
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;
+        status: "Successful" | "Canceled" | "Failed";
+      }
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+        value: string;
+      }
+      @route("/simpleWidgets/{id}")
+      @get op getWidget(@path id: string): SimpleWidget;
+      @finalOperation(getWidget)
+      @pollingOperation(getStatus, {id: ResponseProperty<"id">; operationId: ResponseProperty<"operation">})
+      @route("/simpleWidgets/{id}")
+      @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operation: string};
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      `,
+    );
+
+    expectDiagnostics(diagnostics, [
+      {
+        code: "@azure-tools/typespec-azure-core/polling-operation-no-status-monitor",
+        message:
+          "The operation linked in  @pollingOperation must return a valid status monitor.  The status monitor model must contain a 'status' property, or a property decorated with  '@lroStatus'.  The status field must be of Enum or Union type and contain terminal status values for success and failure.",
+      },
+    ]);
+  });
+
+  it("handles custom lro with non-standard status and error fields", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;
+
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+
+        @Azure.Core.lroResult
+        yeah: SimpleWidget;
+
+        @Azure.Core.lroErrorResult
+        nay: Azure.Core.Foundations.Error;
+      }
+      
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+
+        value: string;
+      }
+
+      @route("/simpleWidgets/{id}")
+      @get op getWidget(@path id: string): SimpleWidget;
+
+      @finalOperation(getWidget)
+      @pollingOperation(getStatus, {id: ResponseProperty<"id">; operationId: ResponseProperty<"operation">})
+      @route("/simpleWidgets/{id}")
+      @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operation: string};
+
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      `,
+      "createWidget",
+    );
+    ok(metadata);
+    deepStrictEqual(metadata.finalStateVia, "original-uri");
+    deepStrictEqual(metadata.logicalResult.name, "SimpleWidget");
+    deepStrictEqual(metadata.envelopeResult.name, "PollingStatus");
+    deepStrictEqual(metadata.logicalPath, undefined);
+
+    deepStrictEqual((metadata.finalResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual((metadata.finalEnvelopeResult as Model)?.name, "SimpleWidget");
+    deepStrictEqual(metadata.finalResultPath, undefined);
+
+    ok(metadata.finalStep);
+    deepStrictEqual(metadata.finalStep.kind, "finalOperationReference");
+    deepStrictEqual(metadata.finalStep.target?.kind, "reference");
+    deepStrictEqual(metadata.finalStep.target?.operation.name, "getWidget");
+    ok(metadata.statusMonitorStep);
+    deepStrictEqual(metadata.statusMonitorStep.target.kind, "reference");
+    deepStrictEqual(metadata.statusMonitorStep.target.operation.name, "getStatus");
+    ok(metadata.pollingInfo);
+    deepStrictEqual(metadata.pollingInfo.responseModel.name, "PollingStatus");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.kind, "model-property");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.property.name, "statusValue");
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.canceledState, ["Canceled"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.failedState, ["Failed"]);
+    deepStrictEqual(metadata.pollingInfo.terminationStatus.succeededState, ["Succeeded"]);
+    ok(metadata.pollingInfo.resultProperty);
+    deepStrictEqual(metadata.pollingInfo.resultProperty.name, "yeah");
+    ok(metadata.pollingInfo.errorProperty);
+    deepStrictEqual(metadata.pollingInfo.errorProperty.name, "nay");
+  });
+
+  it("emits diagnostics for multiple lro result fields", async () => {
+    const [_ops, diagnostics, _runner] = await getOperations(
+      `
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;
+
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+
+        @Azure.Core.lroResult
+        yeah: SimpleWidget;
+
+        @Azure.Core.lroResult
+        notSoYeah: SimpleWidget;
+
+        @Azure.Core.lroErrorResult
+        nay: Azure.Core.Foundations.Error;
+
+        @Azure.Core.lroErrorResult
+        alsoNay: Azure.Core.Foundations.Error;
+      }
+      
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+
+        value: string;
+      }
+
+      @route("/simpleWidgets/{id}")
+      @get op getWidget(@path id: string): SimpleWidget;
+
+      @finalOperation(getWidget)
+      @pollingOperation(getStatus, {id: ResponseProperty<"id">; operationId: ResponseProperty<"operation">})
+      @route("/simpleWidgets/{id}")
+      @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operation: string};
+
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      `,
+    );
+    ok(diagnostics.length > 1);
+    expectDiagnostics(diagnostics, [
+      {
+        code: `@azure-tools/typespec-azure-core/lro-status-monitor-invalid-result-property`,
+        message: `StatusMonitor has more than one result property marked with '@lroResult'.  Ensure that only one property in the model is marked with this decorator.`,
+      },
+      {
+        code: `@azure-tools/typespec-azure-core/lro-status-monitor-invalid-result-property`,
+        message: `StatusMonitor has more than one error property marked with '@lroErrorResult'.  Ensure that only one property in the model is marked with this decorator.`,
+      },
+    ]);
+  });
+
+  it("emits diagnostic for invalid @lroResult property type (enum)", async () => {
+    const [_ops, diagnostics, _runner] = await getOperations(
+      `
+      enum MyStatus {
+        Active,
+        Inactive,
+      }
+
+      model PollingStatus {
+        @header location?: ResourceLocation<PollingStatus>;
+
+        @Azure.Core.lroStatus
+        statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+
+        @Azure.Core.lroResult
+        result?: MyStatus;
+      }
+
+      model SimpleWidget {
+        @key
+        @segment("simpleWidgets")
+        @visibility(Lifecycle.Read)
+        @path
+        id: string;
+
+        value: string;
+      }
+
+      @route("/simpleWidgets/{id}")
+      @get op getWidget(@path id: string): SimpleWidget;
+
+      @finalOperation(getWidget)
+      @pollingOperation(getStatus, {id: ResponseProperty<"id">; operationId: ResponseProperty<"operation">})
+      @route("/simpleWidgets/{id}")
+      @put op createWidget(@path id: string, body: SimpleWidget) : {@statusCode _: 202; @header id: string, @header("operation-id") operation: string};
+
+      @route("/simpleWidgets/{id}/operations/{operationId}")
+      @get op getStatus(@path id: string, @path operationId: string): PollingStatus;
+      `,
+    );
+    expectDiagnostics(diagnostics, [
+      {
+        code: `@azure-tools/typespec-azure-core/lro-status-monitor-invalid-result-property-type`,
+        message:
+          /Property 'result' used as the final result of a long-running operation has an invalid type '.*MyStatus'. The property type must be a Model, Scalar, or 'unknown'./,
+      },
+    ]);
+  });
+
+  it("Gets Lro undefined for sync operation", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `// Reuse CustomParameters and CustomResponseProperties in the "normal" TParams and TResponse fields
+      model OpParams {
+        value: string;
+        ...CustomParameters;
+      };
+
+      model OpResponse is CustomResponseProperties {
+        message: string;
+      }
+       @test op update is Azure.Core.ResourceAction<TestModel, OpParams, OpResponse>;`,
+    );
+    deepStrictEqual(metadata, undefined);
+  });
+
+  it("Gets Lro undefined for sync operation with status field", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `// Reuse CustomParameters and CustomResponseProperties in the "normal" TParams and TResponse fields
+      model OpParams {
+        value: string;
+        ...CustomParameters;
+      };
+
+      model OpResponse is CustomResponseProperties {
+        message: string;
+        status: "Succeeded" | "Failed" | "Canceled";
+      }
+       @test op update is Azure.Core.ResourceAction<TestModel, OpParams, OpResponse>;`,
+    );
+    deepStrictEqual(metadata, undefined);
+  });
+
+  it("Gets Lro undefined for sync operation with provisioningState field", async () => {
+    const [_, metadata] = await compileLroOperation(
+      `// Reuse CustomParameters and CustomResponseProperties in the "normal" TParams and TResponse fields
+      model OpParams {
+        value: string;
+        ...CustomParameters;
+      };
+
+      model OpResponse is CustomResponseProperties {
+        message: string;
+        provisioningState: "Succeeded" | "Failed" | "Canceled";
+      }
+       @test op update is Azure.Core.ResourceAction<TestModel, OpParams, OpResponse>;`,
+    );
+    deepStrictEqual(metadata, undefined);
+  });
+
+  it("signatures with customizable responses do not accept unions for TResponse", async () => {
+    const [_, diagnostics] = await getOperations(`
+      model Foo {}
+      model Bar {}
+      @resource("widgets") model Widget { @key name: string; }
+      op customAction is Azure.Core.StandardResourceOperations.ResourceAction<Widget, {}, Foo | Bar>;
+      op customCollectionAction is Azure.Core.StandardResourceOperations.ResourceCollectionAction<Widget, {}, Foo | Bar>;
+      op rpcAction is Azure.Core.RpcOperation<{}, Foo | Bar>;
+
+      op poll is StandardResourceOperations.GetResourceOperationStatus<Widget>;
+
+      @Azure.Core.pollingOperation(poll)
+      op lroCustomAction is Azure.Core.StandardResourceOperations.LongRunningResourceAction<Widget, {}, Bar | Foo>;
+      @Azure.Core.pollingOperation(poll)
+      op lroCustomCollectionAction is Azure.Core.StandardResourceOperations.LongRunningResourceCollectionAction<Widget, {}, Bar | Foo>;
+      @Azure.Core.pollingOperation(poll)
+      op lroRpcAction is Azure.Core.LongRunningRpcOperation<{}, Bar | Foo, {}>;
+    `);
+
+    expectDiagnostics(diagnostics, [
+      {
+        code: "invalid-argument",
+      },
+      {
+        code: "invalid-argument",
+      },
+      {
+        code: "invalid-argument",
+      },
+      {
+        code: "invalid-argument",
+      },
+      {
+        code: "invalid-argument",
+      },
+      {
+        code: "invalid-argument",
+      },
+    ]);
+  });
+
+  describe("original-uri with no GET operation", () => {
+    async function compileLroWithDiagnostics(
+      code: string,
+      operationName?: string,
+    ): Promise<[HttpOperation, LroMetadata | undefined, TesterInstance]> {
+      let [operations, , runner] = await getOperations(
+        `
+        model TestModel {
+          @key
+          @segment("test")
+          name: string;
+          value: int32;
+        }
+
+        ${code}
+        `,
+      );
+
+      if (operationName !== undefined) {
+        operations = operations.filter((o) => o.operation.name === operationName);
+      }
+
+      strictEqual(operations.length, 1);
+      const lro = getLroMetadata(runner.program, operations[0].operation);
+      return [operations[0], lro, runner];
+    }
+
+    it("emits no-operation-at-original-uri for PUT with original-uri and no GET", async () => {
+      const [_, metadata, runner] = await compileLroWithDiagnostics(
+        `
+        model PollingStatus {
+          @Azure.Core.lroStatus
+          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+        }
+
+        @route("/widgets/{id}/operations/{operationId}")
+        @get
+        op getStatus(@path id: string, @path operationId: string): PollingStatus;
+
+        @pollingOperation(getStatus, {operationId: ResponseProperty<"opId">})
+        @useFinalStateVia("original-uri")
+        @route("/widgets/{id}")
+        @put
+        op createWidget(@path id: string, @body body: TestModel): TestModel | {
+          @statusCode statusCode: 201;
+          @header opId: string;
+          @pollingLocation @header("Operation-Location") opLink: string;
+        };
+        `,
+        "createWidget",
+      );
+
+      ok(metadata);
+      expectDiagnostics(runner.program.diagnostics, [
+        {
+          code: "@azure-tools/typespec-azure-core/no-operation-at-original-uri",
+        },
+      ]);
+    });
+
+    it("emits no-operation-at-original-uri for PATCH with original-uri and no GET", async () => {
+      const [_, metadata, runner] = await compileLroWithDiagnostics(
+        `
+        model PollingStatus {
+          @Azure.Core.lroStatus
+          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+        }
+
+        @route("/widgets/{id}/operations/{operationId}")
+        @get
+        op getStatus(@path id: string, @path operationId: string): PollingStatus;
+
+        @pollingOperation(getStatus, {operationId: ResponseProperty<"opId">})
+        @useFinalStateVia("original-uri")
+        @route("/widgets/{id}")
+        @patch
+        op updateWidget(@path id: string, @body body: TestModel): {
+          @statusCode statusCode: 200;
+          @header opId: string;
+          @pollingLocation @header("Operation-Location") opLink: string;
+          @bodyRoot body: TestModel;
+        } | {
+          @statusCode statusCode: 201;
+          @header opId: string;
+          @pollingLocation @header("Operation-Location") opLink: string;
+          @bodyRoot body: TestModel;
+        };
+        `,
+        "updateWidget",
+      );
+
+      ok(metadata);
+      expectDiagnostics(runner.program.diagnostics, [
+        {
+          code: "@azure-tools/typespec-azure-core/no-operation-at-original-uri",
+        },
+      ]);
+    });
+
+    it("emits no-operation-at-original-uri for POST with original-uri and no GET", async () => {
+      const [_, metadata, runner] = await compileLroWithDiagnostics(
+        `
+        model PollingStatus {
+          @Azure.Core.lroStatus
+          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+        }
+
+        @route("/widgets/{id}/operations/{operationId}")
+        @get
+        op getStatus(@path id: string, @path operationId: string): PollingStatus;
+
+        @pollingOperation(getStatus, {operationId: ResponseProperty<"opId">})
+        @useFinalStateVia("original-uri")
+        @route("/widgets/{id}")
+        @post
+        op processWidget(@path id: string, @body body: TestModel): {
+          @statusCode statusCode: 202;
+          @header opId: string;
+          @pollingLocation @header("Operation-Location") opLink: string;
+        };
+        `,
+        "processWidget",
+      );
+
+      ok(metadata);
+      expectDiagnostics(runner.program.diagnostics, [
+        {
+          code: "@azure-tools/typespec-azure-core/no-operation-at-original-uri",
+        },
+      ]);
+    });
+
+    it("returns void finalResult for PUT with original-uri and no GET when diagnostic is suppressed", async () => {
+      const [_, metadata] = await compileLroWithDiagnostics(
+        `
+        model PollingStatus {
+          @Azure.Core.lroStatus
+          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+        }
+
+        @route("/widgets/{id}/operations/{operationId}")
+        @get
+        op getStatus(@path id: string, @path operationId: string): PollingStatus;
+
+        @pollingOperation(getStatus, {operationId: ResponseProperty<"opId">})
+        #suppress "@azure-tools/typespec-azure-core/no-operation-at-original-uri" "No GET at original URI"
+        @useFinalStateVia("original-uri")
+        @route("/widgets/{id}")
+        @put
+        op createWidget(@path id: string, @body body: TestModel): TestModel | {
+          @statusCode statusCode: 201;
+          @header opId: string;
+          @pollingLocation @header("Operation-Location") opLink: string;
+        };
+        `,
+        "createWidget",
+      );
+
+      ok(metadata);
+      deepStrictEqual(metadata.finalStateVia, "original-uri");
+      deepStrictEqual(metadata.finalResult, "void");
+      deepStrictEqual(metadata.finalEnvelopeResult, "void");
+    });
+
+    it("returns void finalResult for PATCH with original-uri and no GET when diagnostic is suppressed", async () => {
+      const [_, metadata] = await compileLroWithDiagnostics(
+        `
+        model PollingStatus {
+          @Azure.Core.lroStatus
+          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+        }
+
+        @route("/widgets/{id}/operations/{operationId}")
+        @get
+        op getStatus(@path id: string, @path operationId: string): PollingStatus;
+
+        @pollingOperation(getStatus, {operationId: ResponseProperty<"opId">})
+        #suppress "@azure-tools/typespec-azure-core/no-operation-at-original-uri" "No GET at original URI"
+        @useFinalStateVia("original-uri")
+        @route("/widgets/{id}")
+        @patch
+        op updateWidget(@path id: string, @body body: TestModel): {
+          @statusCode statusCode: 200;
+          @header opId: string;
+          @pollingLocation @header("Operation-Location") opLink: string;
+          @bodyRoot body: TestModel;
+        } | {
+          @statusCode statusCode: 201;
+          @header opId: string;
+          @pollingLocation @header("Operation-Location") opLink: string;
+          @bodyRoot body: TestModel;
+        };
+        `,
+        "updateWidget",
+      );
+
+      ok(metadata);
+      deepStrictEqual(metadata.finalStateVia, "original-uri");
+      deepStrictEqual(metadata.finalResult, "void");
+      deepStrictEqual(metadata.finalEnvelopeResult, "void");
+    });
+
+    it("returns void finalResult for POST with original-uri and no GET when diagnostic is suppressed", async () => {
+      const [_, metadata] = await compileLroWithDiagnostics(
+        `
+        model PollingStatus {
+          @Azure.Core.lroStatus
+          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+        }
+
+        @route("/widgets/{id}/operations/{operationId}")
+        @get
+        op getStatus(@path id: string, @path operationId: string): PollingStatus;
+
+        @pollingOperation(getStatus, {operationId: ResponseProperty<"opId">})
+        #suppress "@azure-tools/typespec-azure-core/no-operation-at-original-uri" "No GET at original URI"
+        @useFinalStateVia("original-uri")
+        @route("/widgets/{id}")
+        @post
+        op processWidget(@path id: string, @body body: TestModel): {
+          @statusCode statusCode: 202;
+          @header opId: string;
+          @pollingLocation @header("Operation-Location") opLink: string;
+        };
+        `,
+        "processWidget",
+      );
+
+      ok(metadata);
+      deepStrictEqual(metadata.finalStateVia, "original-uri");
+      deepStrictEqual(metadata.finalResult, "void");
+      deepStrictEqual(metadata.finalEnvelopeResult, "void");
+    });
+
+    it("does not emit no-operation-at-original-uri when GET exists at same path", async () => {
+      const [_, metadata, runner] = await compileLroWithDiagnostics(
+        `
+        model PollingStatus {
+          @Azure.Core.lroStatus
+          statusValue: "Succeeded" | "Canceled" | "Failed" | "Running";
+        }
+
+        @route("/widgets/{id}/operations/{operationId}")
+        @get
+        op getStatus(@path id: string, @path operationId: string): PollingStatus;
+
+        @route("/widgets/{id}")
+        @get
+        op getWidget(@path id: string): TestModel;
+
+        @pollingOperation(getStatus, {operationId: ResponseProperty<"opId">})
+        @useFinalStateVia("original-uri")
+        @route("/widgets/{id}")
+        @put
+        op createWidget(@path id: string, @body body: TestModel): TestModel | {
+          @statusCode statusCode: 201;
+          @header opId: string;
+          @pollingLocation @header("Operation-Location") opLink: string;
+        };
+        `,
+        "createWidget",
+      );
+
+      ok(metadata);
+      deepStrictEqual(metadata.finalStateVia, "original-uri");
+      expectDiagnosticEmpty(
+        runner.program.diagnostics.filter(
+          (d) => d.code === "@azure-tools/typespec-azure-core/no-operation-at-original-uri",
+        ),
+      );
+    });
+  });
+});
+
+// Regression test for https://github.com/Azure/typespec-azure/issues/332
+it("doesn't crash when passing non model to ServiceTraits", async () => {
+  const [_, diagnostics] = await getOperations(`
+    alias Operations = Azure.Core.ResourceOperations<abc>;
+  `);
+  expectDiagnostics(
+    diagnostics.filter((x) => x.severity === "error"),
+    [
+      {
+        code: "invalid-ref",
+        message: "Unknown identifier abc",
+      },
+      {
+        code: "invalid-argument",
+      },
+    ],
+  );
 });

--- a/packages/typespec-azure-core/test/rules/bad-record-type.test.ts
+++ b/packages/typespec-azure-core/test/rules/bad-record-type.test.ts
@@ -3,98 +3,96 @@ import { LinterRuleTester, createLinterRuleTester } from "@typespec/compiler/tes
 import { beforeEach, describe, it } from "vitest";
 import { badRecordTypeRule } from "../../src/rules/bad-record-type.js";
 
-describe("typespec-azure-core: Record type rules", () => {
-  let tester: LinterRuleTester;
+let tester: LinterRuleTester;
 
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    tester = createLinterRuleTester(runner, badRecordTypeRule, "@azure-tools/typespec-azure-core");
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  tester = createLinterRuleTester(runner, badRecordTypeRule, "@azure-tools/typespec-azure-core");
+});
+
+describe("model is Record<T>", () => {
+  it("valid for string with no properties", async () => {
+    await tester.expect(`model Foo is Record<string>;`).toBeValid();
   });
 
-  describe("model is Record<T>", () => {
-    it("valid for string with no properties", async () => {
-      await tester.expect(`model Foo is Record<string>;`).toBeValid();
+  it("emit warning if unknown", async () => {
+    await tester.expect(`model Foo is Record<unknown>;`).toEmitDiagnostics({
+      code: "@azure-tools/typespec-azure-core/bad-record-type",
+      message: `Foo should not use 'is Record<unknown>'. Use 'is Record<string>' instead.`,
     });
+  });
 
-    it("emit warning if unknown", async () => {
-      await tester.expect(`model Foo is Record<unknown>;`).toEmitDiagnostics({
+  it("emit warning if string but has properties", async () => {
+    await tester
+      .expect(
+        `
+        model Foo is Record<string> {
+            name: string;
+        }
+      `,
+      )
+      .toEmitDiagnostics({
         code: "@azure-tools/typespec-azure-core/bad-record-type",
-        message: `Foo should not use 'is Record<unknown>'. Use 'is Record<string>' instead.`,
+        message: `Foo that uses 'is Record<string>' should not have properties.`,
       });
-    });
+  });
+});
 
-    it("emit warning if string but has properties", async () => {
-      await tester
-        .expect(
-          `
-          model Foo is Record<string> {
-              name: string;
-          }
-        `,
-        )
-        .toEmitDiagnostics({
-          code: "@azure-tools/typespec-azure-core/bad-record-type",
-          message: `Foo that uses 'is Record<string>' should not have properties.`,
-        });
-    });
+describe("models extends Record<T>", () => {
+  it("valid for string with no properties", async () => {
+    await tester.expect(`model Foo extends Record<string> {}`).toBeValid();
   });
 
-  describe("models extends Record<T>", () => {
-    it("valid for string with no properties", async () => {
-      await tester.expect(`model Foo extends Record<string> {}`).toBeValid();
-    });
-
-    it("emit warning if unknown with long inheritance chain", async () => {
-      await tester
-        .expect(
-          `
-        model Foo extends Record<unknown> {};
-        model Bar extends Foo {};
-        model Baz extends Bar {};
-        `,
-        )
-        .toEmitDiagnostics({
-          code: "@azure-tools/typespec-azure-core/bad-record-type",
-          message: `Foo should not use 'extends Record<unknown>'. Use 'extends Record<string>' instead.`,
-        });
-    });
-
-    it("emit warning if string but has properties", async () => {
-      await tester
-        .expect(
-          `model Foo extends Record<string> {
-        name: string;
-      }`,
-        )
-        .toEmitDiagnostics({
-          code: "@azure-tools/typespec-azure-core/bad-record-type",
-          message: `Foo that uses 'extends Record<string>' should not have properties.`,
-        });
-    });
+  it("emit warning if unknown with long inheritance chain", async () => {
+    await tester
+      .expect(
+        `
+      model Foo extends Record<unknown> {};
+      model Bar extends Foo {};
+      model Baz extends Bar {};
+      `,
+      )
+      .toEmitDiagnostics({
+        code: "@azure-tools/typespec-azure-core/bad-record-type",
+        message: `Foo should not use 'extends Record<unknown>'. Use 'extends Record<string>' instead.`,
+      });
   });
 
-  describe("models properties of type Record<T>", () => {
-    it("valid for string", async () => {
-      await tester
-        .expect(
-          `model Foo {
-        props: Record<string>;
-      }`,
-        )
-        .toBeValid();
-    });
+  it("emit warning if string but has properties", async () => {
+    await tester
+      .expect(
+        `model Foo extends Record<string> {
+      name: string;
+    }`,
+      )
+      .toEmitDiagnostics({
+        code: "@azure-tools/typespec-azure-core/bad-record-type",
+        message: `Foo that uses 'extends Record<string>' should not have properties.`,
+      });
+  });
+});
 
-    it("emit warning if unknown", async () => {
-      await tester
-        .expect(
-          `model Foo {
-        props: Record<unknown>;
-      }`,
-        )
-        .toEmitDiagnostics({
-          code: "@azure-tools/typespec-azure-core/bad-record-type",
-          message: `Foo.props should not use ': Record<unknown>'. Use ': Record<string>' instead.`,
-        });
-    });
+describe("models properties of type Record<T>", () => {
+  it("valid for string", async () => {
+    await tester
+      .expect(
+        `model Foo {
+      props: Record<string>;
+    }`,
+      )
+      .toBeValid();
+  });
+
+  it("emit warning if unknown", async () => {
+    await tester
+      .expect(
+        `model Foo {
+      props: Record<unknown>;
+    }`,
+      )
+      .toEmitDiagnostics({
+        code: "@azure-tools/typespec-azure-core/bad-record-type",
+        message: `Foo.props should not use ': Record<unknown>'. Use ': Record<string>' instead.`,
+      });
   });
 });

--- a/packages/typespec-azure-core/test/rules/byos.test.ts
+++ b/packages/typespec-azure-core/test/rules/byos.test.ts
@@ -1,43 +1,41 @@
 import { Tester } from "#test/test-host.js";
 import { LinterRuleTester, createLinterRuleTester } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, it } from "vitest";
 import { byosRule } from "../../src/rules/byos.js";
 
-describe("typespec-azure-core: byos rule", () => {
-  let tester: LinterRuleTester;
+let tester: LinterRuleTester;
 
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    tester = createLinterRuleTester(runner, byosRule, "@azure-tools/typespec-azure-core");
-  });
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  tester = createLinterRuleTester(runner, byosRule, "@azure-tools/typespec-azure-core");
+});
 
-  it("emit warning if content type is application/octet-stream ", async () => {
-    await tester
-      .expect(`op uploadFile(data: bytes, @header contentType: "application/octet-stream"): void;`)
-      .toEmitDiagnostics({
-        code: "@azure-tools/typespec-azure-core/byos",
-      });
-  });
+it("emit warning if content type is application/octet-stream ", async () => {
+  await tester
+    .expect(`op uploadFile(data: bytes, @header contentType: "application/octet-stream"): void;`)
+    .toEmitDiagnostics({
+      code: "@azure-tools/typespec-azure-core/byos",
+    });
+});
 
-  it("emit warning if content type is multipart/form-data (explicit)", async () => {
-    await tester
-      .expect(
-        `op uploadFile(@multipartBody data: {data: HttpPart<bytes>}, @header contentType: "multipart/form-data"): void;`,
-      )
-      .toEmitDiagnostics({
-        code: "@azure-tools/typespec-azure-core/byos",
-      });
-  });
+it("emit warning if content type is multipart/form-data (explicit)", async () => {
+  await tester
+    .expect(
+      `op uploadFile(@multipartBody data: {data: HttpPart<bytes>}, @header contentType: "multipart/form-data"): void;`,
+    )
+    .toEmitDiagnostics({
+      code: "@azure-tools/typespec-azure-core/byos",
+    });
+});
 
-  it("is ok if requesting json data", async () => {
-    await tester
-      .expect(`op sendJsonBase64(data: bytes, @header contentType: "application/json"): void;`)
-      .toBeValid();
-  });
+it("is ok if requesting json data", async () => {
+  await tester
+    .expect(`op sendJsonBase64(data: bytes, @header contentType: "application/json"): void;`)
+    .toBeValid();
+});
 
-  it("is ok if returning binary data", async () => {
-    await tester
-      .expect(`op download(): {data: bytes, @header contentType: "application/octet-stream"};`)
-      .toBeValid();
-  });
+it("is ok if returning binary data", async () => {
+  await tester
+    .expect(`op download(): {data: bytes, @header contentType: "application/octet-stream"};`)
+    .toBeValid();
 });

--- a/packages/typespec-azure-core/test/rules/casing-style.test.ts
+++ b/packages/typespec-azure-core/test/rules/casing-style.test.ts
@@ -9,134 +9,132 @@ import {
   isPascalCaseWithAcceptedAcronyms,
 } from "../../src/rules/utils.js";
 
-describe("typespec-azure-core: casing rule", () => {
-  let tester: LinterRuleTester;
+let tester: LinterRuleTester;
 
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    tester = createLinterRuleTester(runner, casingRule, "@azure-tools/typespec-azure-core");
-  });
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  tester = createLinterRuleTester(runner, casingRule, "@azure-tools/typespec-azure-core");
+});
 
-  describe("utils", () => {
-    it("isPascalCaseNoAcronyms works as expected", () => {
-      ["", "A", "PascalCase", "PascalCase123", "SignalR", "VmResource", "Rp"].forEach((name) =>
-        assert.ok(isPascalCaseNoAcronyms(name), `${name} should be PascalCase`),
-      );
-      ["a", "foo", "fooBar", "foo_bar", "foo-bar", "VMResource", "RP"].forEach((name) => {
-        assert.ok(!isPascalCaseNoAcronyms(name), `${name} should not be PascalCase`);
-      });
+describe("utils", () => {
+  it("isPascalCaseNoAcronyms works as expected", () => {
+    ["", "A", "PascalCase", "PascalCase123", "SignalR", "VmResource", "Rp"].forEach((name) =>
+      assert.ok(isPascalCaseNoAcronyms(name), `${name} should be PascalCase`),
+    );
+    ["a", "foo", "fooBar", "foo_bar", "foo-bar", "VMResource", "RP"].forEach((name) => {
+      assert.ok(!isPascalCaseNoAcronyms(name), `${name} should not be PascalCase`);
     });
-    it("isPascalCaseWithAcceptedAcronyms works as expected", () => {
-      const acceptedTestAcronyms = ["AI"];
-      ["", "A", "PascalCase", "PascalCase123", "OpenAI", "OpenAIAgent", "AI", "AIPolicy"].forEach(
-        (name) =>
-          assert.ok(
-            isPascalCaseWithAcceptedAcronyms(name, acceptedTestAcronyms),
-            `${name} should be PascalCase`,
-          ),
-      );
-      ["a", "foo", "fooBar", "VMResource", "RP", "OpenAIAGent", "OpenAIAgentVM"].forEach((name) => {
+  });
+  it("isPascalCaseWithAcceptedAcronyms works as expected", () => {
+    const acceptedTestAcronyms = ["AI"];
+    ["", "A", "PascalCase", "PascalCase123", "OpenAI", "OpenAIAgent", "AI", "AIPolicy"].forEach(
+      (name) =>
         assert.ok(
-          !isPascalCaseWithAcceptedAcronyms(name, acceptedTestAcronyms),
-          `${name} should not be PascalCase`,
-        );
-      });
-    });
-
-    it("isCamelCaseNoAcronyms works as expected", () => {
-      ["", "a", "foo", "fooBar", "office365", "signalR", "aRp", "$aRp", "_aRp"].forEach((name) =>
-        assert.ok(isCamelCaseNoAcronyms(name), `${name} should be camelCase`),
-      );
-      ["Foo", "123", "foo.bar", "foo-bar", "foo_bar", "aRP", "$aRP", "_ARp"].forEach((name) =>
-        assert.ok(!isCamelCaseNoAcronyms(name), `${name} should not be camelCase`),
+          isPascalCaseWithAcceptedAcronyms(name, acceptedTestAcronyms),
+          `${name} should be PascalCase`,
+        ),
+    );
+    ["a", "foo", "fooBar", "VMResource", "RP", "OpenAIAGent", "OpenAIAgentVM"].forEach((name) => {
+      assert.ok(
+        !isPascalCaseWithAcceptedAcronyms(name, acceptedTestAcronyms),
+        `${name} should not be PascalCase`,
       );
     });
   });
 
-  describe("model name must be PascalCase", () => {
-    it("is valid", async () => {
-      await tester.expect(`model FooProperties {}`).toBeValid();
-    });
-    it("is valid for accepted acronyms", async () => {
-      await tester.expect(`model ScaleSetVM {}`).toBeValid();
-    });
+  it("isCamelCaseNoAcronyms works as expected", () => {
+    ["", "a", "foo", "fooBar", "office365", "signalR", "aRp", "$aRp", "_aRp"].forEach((name) =>
+      assert.ok(isCamelCaseNoAcronyms(name), `${name} should be camelCase`),
+    );
+    ["Foo", "123", "foo.bar", "foo-bar", "foo_bar", "aRP", "$aRP", "_ARp"].forEach((name) =>
+      assert.ok(!isCamelCaseNoAcronyms(name), `${name} should not be camelCase`),
+    );
+  });
+});
 
-    it("emit warnings if not PascalCase", async () => {
-      await tester.expect(`model fooProperties {}`).toEmitDiagnostics({
-        code: "@azure-tools/typespec-azure-core/casing-style",
-        message: `The names of Model types must use PascalCase`,
-      });
-    });
+describe("model name must be PascalCase", () => {
+  it("is valid", async () => {
+    await tester.expect(`model FooProperties {}`).toBeValid();
+  });
+  it("is valid for accepted acronyms", async () => {
+    await tester.expect(`model ScaleSetVM {}`).toBeValid();
   });
 
-  describe("namespace name must be PascalCase", () => {
-    it("is valid", async () => {
-      await tester.expect(`namespace Models {}`).toBeValid();
-    });
-
-    it("is valid if contains .", async () => {
-      await tester.expect(`namespace Microsoft.FooBar {}`).toBeValid();
-    });
-
-    it("emit warnings if not PascalCase", async () => {
-      await tester.expect(`namespace models {}`).toEmitDiagnostics({
-        code: "@azure-tools/typespec-azure-core/casing-style",
-        message: `The names of Namespace types must use PascalCase`,
-      });
+  it("emit warnings if not PascalCase", async () => {
+    await tester.expect(`model fooProperties {}`).toEmitDiagnostics({
+      code: "@azure-tools/typespec-azure-core/casing-style",
+      message: `The names of Model types must use PascalCase`,
     });
   });
+});
 
-  describe("interface name must be PascalCase", () => {
-    it("is valid", async () => {
-      await tester.expect(`interface StoreFront {}`).toBeValid();
-    });
-
-    it("emit warnings if not PascalCase", async () => {
-      await tester.expect(`interface storeFront {}`).toEmitDiagnostics({
-        code: "@azure-tools/typespec-azure-core/casing-style",
-        message: `The names of Interface types must use PascalCase`,
-      });
-    });
+describe("namespace name must be PascalCase", () => {
+  it("is valid", async () => {
+    await tester.expect(`namespace Models {}`).toBeValid();
   });
 
-  describe("operation name must be camelCase", () => {
-    it("is valid", async () => {
-      await tester.expect(`op myOperation(): void;`).toBeValid();
-    });
-
-    it("emit warnings if not camelCase", async () => {
-      await tester.expect(`op MyOperation(): void;`).toEmitDiagnostics({
-        code: "@azure-tools/typespec-azure-core/casing-style",
-        message: `The names of Operation types must use camelCase`,
-      });
-    });
+  it("is valid if contains .", async () => {
+    await tester.expect(`namespace Microsoft.FooBar {}`).toBeValid();
   });
 
-  describe("operation template must be PascalCase", () => {
-    it("is valid", async () => {
-      await tester.expect(`op MyOperation<T>(): T; op myOp is MyOperation<string>;`).toBeValid();
-    });
-
-    it("emit warnings if not PascalCase", async () => {
-      await tester
-        .expect(`op myOperation<T>(): T; op myOp is myOperation<string>;`)
-        .toEmitDiagnostics({
-          code: "@azure-tools/typespec-azure-core/casing-style",
-          message: `The names of Operation Template types must use PascalCase`,
-        });
+  it("emit warnings if not PascalCase", async () => {
+    await tester.expect(`namespace models {}`).toEmitDiagnostics({
+      code: "@azure-tools/typespec-azure-core/casing-style",
+      message: `The names of Namespace types must use PascalCase`,
     });
   });
+});
 
-  describe("model property name must be camelCase", () => {
-    it("is valid", async () => {
-      await tester.expect(`model User {firstName: string, age: int32}`).toBeValid();
+describe("interface name must be PascalCase", () => {
+  it("is valid", async () => {
+    await tester.expect(`interface StoreFront {}`).toBeValid();
+  });
+
+  it("emit warnings if not PascalCase", async () => {
+    await tester.expect(`interface storeFront {}`).toEmitDiagnostics({
+      code: "@azure-tools/typespec-azure-core/casing-style",
+      message: `The names of Interface types must use PascalCase`,
     });
+  });
+});
 
-    it("emit warnings if not camelCase", async () => {
-      await tester.expect(`model User {FirstName: string}`).toEmitDiagnostics({
+describe("operation name must be camelCase", () => {
+  it("is valid", async () => {
+    await tester.expect(`op myOperation(): void;`).toBeValid();
+  });
+
+  it("emit warnings if not camelCase", async () => {
+    await tester.expect(`op MyOperation(): void;`).toEmitDiagnostics({
+      code: "@azure-tools/typespec-azure-core/casing-style",
+      message: `The names of Operation types must use camelCase`,
+    });
+  });
+});
+
+describe("operation template must be PascalCase", () => {
+  it("is valid", async () => {
+    await tester.expect(`op MyOperation<T>(): T; op myOp is MyOperation<string>;`).toBeValid();
+  });
+
+  it("emit warnings if not PascalCase", async () => {
+    await tester
+      .expect(`op myOperation<T>(): T; op myOp is myOperation<string>;`)
+      .toEmitDiagnostics({
         code: "@azure-tools/typespec-azure-core/casing-style",
-        message: `The names of Property types must use camelCase`,
+        message: `The names of Operation Template types must use PascalCase`,
       });
+  });
+});
+
+describe("model property name must be camelCase", () => {
+  it("is valid", async () => {
+    await tester.expect(`model User {firstName: string, age: int32}`).toBeValid();
+  });
+
+  it("emit warnings if not camelCase", async () => {
+    await tester.expect(`model User {FirstName: string}`).toEmitDiagnostics({
+      code: "@azure-tools/typespec-azure-core/casing-style",
+      message: `The names of Property types must use camelCase`,
     });
   });
 });

--- a/packages/typespec-azure-core/test/rules/known-encoding.test.ts
+++ b/packages/typespec-azure-core/test/rules/known-encoding.test.ts
@@ -1,51 +1,49 @@
 import { Tester } from "#test/test-host.js";
 import { LinterRuleTester, createLinterRuleTester } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, it } from "vitest";
 import { knownEncodingRule } from "../../src/rules/known-encoding.js";
 
-describe("typespec-azure-core: known-encoding rule", () => {
-  let tester: LinterRuleTester;
+let tester: LinterRuleTester;
 
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    tester = createLinterRuleTester(runner, knownEncodingRule, "@azure-tools/typespec-azure-core");
-  });
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  tester = createLinterRuleTester(runner, knownEncodingRule, "@azure-tools/typespec-azure-core");
+});
 
-  it("emit warning if using an unknown encoding on a scalar", async () => {
-    await tester
-      .expect(`@encode("custom-rfc") scalar myDateTime extends utcDateTime;`)
-      .toEmitDiagnostics({
-        code: "@azure-tools/typespec-azure-core/known-encoding",
-      });
-  });
+it("emit warning if using an unknown encoding on a scalar", async () => {
+  await tester
+    .expect(`@encode("custom-rfc") scalar myDateTime extends utcDateTime;`)
+    .toEmitDiagnostics({
+      code: "@azure-tools/typespec-azure-core/known-encoding",
+    });
+});
 
-  it("emit warning if using an unknown encoding on model property", async () => {
-    await tester
-      .expect(
-        `
-        model Foo {
-          @encode("custom-rfc") myDateTime:  utcDateTime;
-        }
-        `,
-      )
-      .toEmitDiagnostics({
-        code: "@azure-tools/typespec-azure-core/known-encoding",
-      });
-  });
+it("emit warning if using an unknown encoding on model property", async () => {
+  await tester
+    .expect(
+      `
+      model Foo {
+        @encode("custom-rfc") myDateTime:  utcDateTime;
+      }
+      `,
+    )
+    .toEmitDiagnostics({
+      code: "@azure-tools/typespec-azure-core/known-encoding",
+    });
+});
 
-  it("is ok if using known encoding on scalar", async () => {
-    await tester.expect(`@encode("rfc3339") scalar myDateTime extends utcDateTime;`).toBeValid();
-  });
+it("is ok if using known encoding on scalar", async () => {
+  await tester.expect(`@encode("rfc3339") scalar myDateTime extends utcDateTime;`).toBeValid();
+});
 
-  it("is ok if using known encoding on model property", async () => {
-    await tester
-      .expect(
-        `
-        model Foo {
-          @encode("rfc3339") myDateTime:  utcDateTime;
-        }
-        `,
-      )
-      .toBeValid();
-  });
+it("is ok if using known encoding on model property", async () => {
+  await tester
+    .expect(
+      `
+      model Foo {
+        @encode("rfc3339") myDateTime:  utcDateTime;
+      }
+      `,
+    )
+    .toBeValid();
 });

--- a/packages/typespec-azure-core/test/rules/no-closed-literal-union.test.ts
+++ b/packages/typespec-azure-core/test/rules/no-closed-literal-union.test.ts
@@ -1,40 +1,38 @@
 import { Tester } from "#test/test-host.js";
 import { LinterRuleTester, createLinterRuleTester } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, it } from "vitest";
 import { noClosedLiteralUnionRule } from "../../src/rules/no-closed-literal-union.js";
 
-describe("typespec-azure-core: no-closed-literal-union rule", () => {
-  let tester: LinterRuleTester;
+let tester: LinterRuleTester;
 
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    tester = createLinterRuleTester(
-      runner,
-      noClosedLiteralUnionRule,
-      "@azure-tools/typespec-azure-core",
-    );
-  });
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  tester = createLinterRuleTester(
+    runner,
+    noClosedLiteralUnionRule,
+    "@azure-tools/typespec-azure-core",
+  );
+});
 
-  it("emits a warning diagnostic if union only contains literals", async () => {
-    await tester.expect(`union PetKind { "cat", "dog" }`).toEmitDiagnostics([
-      {
-        code: "@azure-tools/typespec-azure-core/no-closed-literal-union",
-      },
-    ]);
-  });
-  it("emits a warning diagnostic if union expression only contains literals", async () => {
-    await tester.expect(`model Pet { kind: "cat" | "dog" }`).toEmitDiagnostics([
-      {
-        code: "@azure-tools/typespec-azure-core/no-closed-literal-union",
-      },
-    ]);
-  });
+it("emits a warning diagnostic if union only contains literals", async () => {
+  await tester.expect(`union PetKind { "cat", "dog" }`).toEmitDiagnostics([
+    {
+      code: "@azure-tools/typespec-azure-core/no-closed-literal-union",
+    },
+  ]);
+});
+it("emits a warning diagnostic if union expression only contains literals", async () => {
+  await tester.expect(`model Pet { kind: "cat" | "dog" }`).toEmitDiagnostics([
+    {
+      code: "@azure-tools/typespec-azure-core/no-closed-literal-union",
+    },
+  ]);
+});
 
-  it("pass if the union contains the base scalar", async () => {
-    await tester.expect(`union PetKind { "cat", "dog", string }`).toBeValid();
-  });
+it("pass if the union contains the base scalar", async () => {
+  await tester.expect(`union PetKind { "cat", "dog", string }`).toBeValid();
+});
 
-  it("pass if the union expression contains the base scalar", async () => {
-    await tester.expect(`model Pet { kind: "cat" | "dog" | string }`).toBeValid();
-  });
+it("pass if the union expression contains the base scalar", async () => {
+  await tester.expect(`model Pet { kind: "cat" | "dog" | string }`).toBeValid();
 });

--- a/packages/typespec-azure-core/test/rules/no-explicit-routes-resource-ops.test.ts
+++ b/packages/typespec-azure-core/test/rules/no-explicit-routes-resource-ops.test.ts
@@ -1,44 +1,42 @@
 import { Tester } from "#test/test-host.js";
 import { LinterRuleTester, createLinterRuleTester } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, it } from "vitest";
 import { noExplicitRoutesResourceOps } from "../../src/rules/no-explicit-routes-resource-ops.js";
 
-describe("typespec-azure-core: no explicit routes on resource operations", () => {
-  let tester: LinterRuleTester;
+let tester: LinterRuleTester;
 
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    tester = createLinterRuleTester(
-      runner,
-      noExplicitRoutesResourceOps,
-      "@azure-tools/typespec-azure-core",
-    );
-  });
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  tester = createLinterRuleTester(
+    runner,
+    noExplicitRoutesResourceOps,
+    "@azure-tools/typespec-azure-core",
+  );
+});
 
-  it("emit a warning if @route is used on a resource operation", async () => {
-    await tester
-      .expect(
-        `
-        @resource("widgets") model Widget { @key name: string; }
+it("emit a warning if @route is used on a resource operation", async () => {
+  await tester
+    .expect(
+      `
+      @resource("widgets") model Widget { @key name: string; }
 
-        @route("/api/widgets/{name}")
-        op readWidget is Azure.Core.StandardResourceOperations.ResourceRead<Widget>;
+      @route("/api/widgets/{name}")
+      op readWidget is Azure.Core.StandardResourceOperations.ResourceRead<Widget>;
 
-        @route("/api/widgets")
-        op listWidgets is Azure.Core.StandardResourceOperations.ResourceList<Widget>;
-        `,
-      )
-      .toEmitDiagnostics([
-        {
-          code: "@azure-tools/typespec-azure-core/no-explicit-routes-resource-ops",
-          severity: "warning",
-          message: `The @route decorator should not be used on standard resource operation signatures. If you are trying to add a route prefix to an operation use the @route decorator on an interface or namespace instead.`,
-        },
-        {
-          code: "@azure-tools/typespec-azure-core/no-explicit-routes-resource-ops",
-          severity: "warning",
-          message: `The @route decorator should not be used on standard resource operation signatures. If you are trying to add a route prefix to an operation use the @route decorator on an interface or namespace instead.`,
-        },
-      ]);
-  });
+      @route("/api/widgets")
+      op listWidgets is Azure.Core.StandardResourceOperations.ResourceList<Widget>;
+      `,
+    )
+    .toEmitDiagnostics([
+      {
+        code: "@azure-tools/typespec-azure-core/no-explicit-routes-resource-ops",
+        severity: "warning",
+        message: `The @route decorator should not be used on standard resource operation signatures. If you are trying to add a route prefix to an operation use the @route decorator on an interface or namespace instead.`,
+      },
+      {
+        code: "@azure-tools/typespec-azure-core/no-explicit-routes-resource-ops",
+        severity: "warning",
+        message: `The @route decorator should not be used on standard resource operation signatures. If you are trying to add a route prefix to an operation use the @route decorator on an interface or namespace instead.`,
+      },
+    ]);
 });

--- a/packages/typespec-azure-core/test/rules/no-nullable.test.ts
+++ b/packages/typespec-azure-core/test/rules/no-nullable.test.ts
@@ -1,20 +1,18 @@
 import { Tester } from "#test/test-host.js";
 import { LinterRuleTester, createLinterRuleTester } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, it } from "vitest";
 import { noNullableRule } from "../../src/rules/no-nullable.js";
 
-describe("typespec-azure-core: no-nullable rule", () => {
-  let tester: LinterRuleTester;
+let tester: LinterRuleTester;
 
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    tester = createLinterRuleTester(runner, noNullableRule, "@azure-tools/typespec-azure-core");
-  });
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  tester = createLinterRuleTester(runner, noNullableRule, "@azure-tools/typespec-azure-core");
+});
 
-  it("emit warning if using nullable property", async () => {
-    await tester.expect(`model Bar { prop: string | null }`).toEmitDiagnostics({
-      code: "@azure-tools/typespec-azure-core/no-nullable",
-      severity: "warning",
-    });
+it("emit warning if using nullable property", async () => {
+  await tester.expect(`model Bar { prop: string | null }`).toEmitDiagnostics({
+    code: "@azure-tools/typespec-azure-core/no-nullable",
+    severity: "warning",
   });
 });

--- a/packages/typespec-azure-core/test/rules/no-offsetdatetime.test.ts
+++ b/packages/typespec-azure-core/test/rules/no-offsetdatetime.test.ts
@@ -1,44 +1,42 @@
 import { Tester } from "#test/test-host.js";
 import { LinterRuleTester, createLinterRuleTester } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, it } from "vitest";
 import { noOffsetDateTimeRule } from "../../src/rules/no-offsetdatetime.js";
 
-describe("typespec-azure-core: no-offsetdatetime rule", () => {
-  let tester: LinterRuleTester;
+let tester: LinterRuleTester;
 
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    tester = createLinterRuleTester(
-      runner,
-      noOffsetDateTimeRule,
-      "@azure-tools/typespec-azure-core",
-    );
-  });
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  tester = createLinterRuleTester(
+    runner,
+    noOffsetDateTimeRule,
+    "@azure-tools/typespec-azure-core",
+  );
+});
 
-  it("emit warning if offsetDateTime used as property type", async () => {
-    await tester.expect(`model Bar { prop: offsetDateTime }`).toEmitDiagnostics({
-      code: "@azure-tools/typespec-azure-core/no-offsetdatetime",
-      severity: "warning",
-    });
+it("emit warning if offsetDateTime used as property type", async () => {
+  await tester.expect(`model Bar { prop: offsetDateTime }`).toEmitDiagnostics({
+    code: "@azure-tools/typespec-azure-core/no-offsetdatetime",
+    severity: "warning",
   });
+});
 
-  it("emit warning if offsetDateTime used as operation return type", async () => {
-    await tester.expect(`op test(): offsetDateTime;`).toEmitDiagnostics({
-      code: "@azure-tools/typespec-azure-core/no-offsetdatetime",
-      severity: "warning",
-    });
+it("emit warning if offsetDateTime used as operation return type", async () => {
+  await tester.expect(`op test(): offsetDateTime;`).toEmitDiagnostics({
+    code: "@azure-tools/typespec-azure-core/no-offsetdatetime",
+    severity: "warning",
   });
+});
 
-  it("emit warning if offsetDateTime used as union variant", async () => {
-    await tester.expect(`union U {a: offsetDateTime}`).toEmitDiagnostics({
-      code: "@azure-tools/typespec-azure-core/no-offsetdatetime",
-      severity: "warning",
-    });
+it("emit warning if offsetDateTime used as union variant", async () => {
+  await tester.expect(`union U {a: offsetDateTime}`).toEmitDiagnostics({
+    code: "@azure-tools/typespec-azure-core/no-offsetdatetime",
+    severity: "warning",
   });
-  it("emit warning if offsetDateTime used as scalar extends", async () => {
-    await tester.expect(`scalar Foo extends offsetDateTime;`).toEmitDiagnostics({
-      code: "@azure-tools/typespec-azure-core/no-offsetdatetime",
-      severity: "warning",
-    });
+});
+it("emit warning if offsetDateTime used as scalar extends", async () => {
+  await tester.expect(`scalar Foo extends offsetDateTime;`).toEmitDiagnostics({
+    code: "@azure-tools/typespec-azure-core/no-offsetdatetime",
+    severity: "warning",
   });
 });

--- a/packages/typespec-azure-core/test/rules/no-offsetdatetime.test.ts
+++ b/packages/typespec-azure-core/test/rules/no-offsetdatetime.test.ts
@@ -7,11 +7,7 @@ let tester: LinterRuleTester;
 
 beforeEach(async () => {
   const runner = await Tester.createInstance();
-  tester = createLinterRuleTester(
-    runner,
-    noOffsetDateTimeRule,
-    "@azure-tools/typespec-azure-core",
-  );
+  tester = createLinterRuleTester(runner, noOffsetDateTimeRule, "@azure-tools/typespec-azure-core");
 });
 
 it("emit warning if offsetDateTime used as property type", async () => {

--- a/packages/typespec-azure-core/test/rules/no-route-parameter-name-mismatch.test.ts
+++ b/packages/typespec-azure-core/test/rules/no-route-parameter-name-mismatch.test.ts
@@ -1,250 +1,248 @@
 import { Tester } from "#test/test-host.js";
 import { LinterRuleTester, createLinterRuleTester } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, it } from "vitest";
 import { noRouteParameterNameMismatchRule } from "../../src/rules/no-route-parameter-name-mismatch.js";
 
-describe("typespec-azure-core: no-route-parameter-name-mismatch", () => {
-  let tester: LinterRuleTester;
+let tester: LinterRuleTester;
 
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    tester = createLinterRuleTester(
-      runner,
-      noRouteParameterNameMismatchRule,
-      "@azure-tools/typespec-azure-core",
-    );
-  });
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  tester = createLinterRuleTester(
+    runner,
+    noRouteParameterNameMismatchRule,
+    "@azure-tools/typespec-azure-core",
+  );
+});
 
-  it("emit a warning if two operations have the same path but different parameter names", async () => {
-    await tester
-      .expect(
-        `
-        @service namespace TestService;
+it("emit a warning if two operations have the same path but different parameter names", async () => {
+  await tester
+    .expect(
+      `
+      @service namespace TestService;
 
-        @route("/providers/Microsoft.Contoso/foos/{fooName}/bars/{barName}")
-        op getBar(@path fooName: string, @path barName: string): void;
+      @route("/providers/Microsoft.Contoso/foos/{fooName}/bars/{barName}")
+      op getBar(@path fooName: string, @path barName: string): void;
 
-        @route("/providers/Microsoft.Contoso/foos/{name}/bars/{barId}")
-        op updateBar(@path name: string, @path barId: string): void;
-        `,
-      )
-      .toEmitDiagnostics([
-        {
-          code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
-          severity: "warning",
-          message: `Operation "TestService.updateBar" path "/providers/Microsoft.Contoso/foos/{name}/bars/{barId}" has inconsistent parameter name "name" which should be "fooName" to match operation "TestService.getBar" with path "/providers/Microsoft.Contoso/foos/{fooName}/bars/{barName}"`,
-        },
-        {
-          code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
-          severity: "warning",
-          message: `Operation "TestService.updateBar" path "/providers/Microsoft.Contoso/foos/{name}/bars/{barId}" has inconsistent parameter name "barId" which should be "barName" to match operation "TestService.getBar" with path "/providers/Microsoft.Contoso/foos/{fooName}/bars/{barName}"`,
-        },
-      ]);
-  });
+      @route("/providers/Microsoft.Contoso/foos/{name}/bars/{barId}")
+      op updateBar(@path name: string, @path barId: string): void;
+      `,
+    )
+    .toEmitDiagnostics([
+      {
+        code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
+        severity: "warning",
+        message: `Operation "TestService.updateBar" path "/providers/Microsoft.Contoso/foos/{name}/bars/{barId}" has inconsistent parameter name "name" which should be "fooName" to match operation "TestService.getBar" with path "/providers/Microsoft.Contoso/foos/{fooName}/bars/{barName}"`,
+      },
+      {
+        code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
+        severity: "warning",
+        message: `Operation "TestService.updateBar" path "/providers/Microsoft.Contoso/foos/{name}/bars/{barId}" has inconsistent parameter name "barId" which should be "barName" to match operation "TestService.getBar" with path "/providers/Microsoft.Contoso/foos/{fooName}/bars/{barName}"`,
+      },
+    ]);
+});
 
-  it("emit warnings for multiple mismatched parameters", async () => {
-    await tester
-      .expect(
-        `
-        @service namespace TestService;
+it("emit warnings for multiple mismatched parameters", async () => {
+  await tester
+    .expect(
+      `
+      @service namespace TestService;
 
-        @route("/providers/Microsoft.Contoso/foos/{fooName}/bars/{name}")
-        op getBar(@path fooName: string, @path name: string): void;
+      @route("/providers/Microsoft.Contoso/foos/{fooName}/bars/{name}")
+      op getBar(@path fooName: string, @path name: string): void;
 
-        @route("/providers/Microsoft.Contoso/foos/{name}/bars/{barName}")
-        op updateBar(@path name: string, @path barName: string): void;
-        `,
-      )
-      .toEmitDiagnostics([
-        {
-          code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
-          severity: "warning",
-          message: `Operation "TestService.updateBar" path "/providers/Microsoft.Contoso/foos/{name}/bars/{barName}" has inconsistent parameter name "name" which should be "fooName" to match operation "TestService.getBar" with path "/providers/Microsoft.Contoso/foos/{fooName}/bars/{name}"`,
-        },
-        {
-          code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
-          severity: "warning",
-          message: `Operation "TestService.updateBar" path "/providers/Microsoft.Contoso/foos/{name}/bars/{barName}" has inconsistent parameter name "barName" which should be "name" to match operation "TestService.getBar" with path "/providers/Microsoft.Contoso/foos/{fooName}/bars/{name}"`,
-        },
-      ]);
-  });
+      @route("/providers/Microsoft.Contoso/foos/{name}/bars/{barName}")
+      op updateBar(@path name: string, @path barName: string): void;
+      `,
+    )
+    .toEmitDiagnostics([
+      {
+        code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
+        severity: "warning",
+        message: `Operation "TestService.updateBar" path "/providers/Microsoft.Contoso/foos/{name}/bars/{barName}" has inconsistent parameter name "name" which should be "fooName" to match operation "TestService.getBar" with path "/providers/Microsoft.Contoso/foos/{fooName}/bars/{name}"`,
+      },
+      {
+        code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
+        severity: "warning",
+        message: `Operation "TestService.updateBar" path "/providers/Microsoft.Contoso/foos/{name}/bars/{barName}" has inconsistent parameter name "barName" which should be "name" to match operation "TestService.getBar" with path "/providers/Microsoft.Contoso/foos/{fooName}/bars/{name}"`,
+      },
+    ]);
+});
 
-  it("does not emit a warning when parameter names are consistent", async () => {
-    await tester
-      .expect(
-        `
-        @service namespace TestService;
+it("does not emit a warning when parameter names are consistent", async () => {
+  await tester
+    .expect(
+      `
+      @service namespace TestService;
 
-        @route("/providers/Microsoft.Contoso/foos/{fooName}/bars/{barName}")
-        op getBar(@path fooName: string, @path barName: string): void;
+      @route("/providers/Microsoft.Contoso/foos/{fooName}/bars/{barName}")
+      op getBar(@path fooName: string, @path barName: string): void;
 
-        @put
-        @route("/providers/Microsoft.Contoso/foos/{fooName}/bars/{barName}")
-        op updateBar(@path fooName: string, @path barName: string): void;
-        `,
-      )
-      .toBeValid();
-  });
+      @put
+      @route("/providers/Microsoft.Contoso/foos/{fooName}/bars/{barName}")
+      op updateBar(@path fooName: string, @path barName: string): void;
+      `,
+    )
+    .toBeValid();
+});
 
-  it("does not emit a warning for different paths", async () => {
-    await tester
-      .expect(
-        `
-        @service namespace TestService;
+it("does not emit a warning for different paths", async () => {
+  await tester
+    .expect(
+      `
+      @service namespace TestService;
 
-        @route("/providers/Microsoft.Contoso/foos/{fooName}")
-        op getFoo(@path fooName: string): void;
+      @route("/providers/Microsoft.Contoso/foos/{fooName}")
+      op getFoo(@path fooName: string): void;
 
-        @route("/providers/Microsoft.Contoso/bars/{barName}")
-        op getBar(@path barName: string): void;
-        `,
-      )
-      .toBeValid();
-  });
+      @route("/providers/Microsoft.Contoso/bars/{barName}")
+      op getBar(@path barName: string): void;
+      `,
+    )
+    .toBeValid();
+});
 
-  it("emit warnings when both allowReserved and non-allowReserved params are mismatched", async () => {
-    await tester
-      .expect(
-        `
-        @service namespace TestService;
+it("emit warnings when both allowReserved and non-allowReserved params are mismatched", async () => {
+  await tester
+    .expect(
+      `
+      @service namespace TestService;
 
-        @route("/{+scope}/providers/Microsoft.Contoso/foos/{fooName}")
-        op getFoo(@path scope: string, @path fooName: string): void;
+      @route("/{+scope}/providers/Microsoft.Contoso/foos/{fooName}")
+      op getFoo(@path scope: string, @path fooName: string): void;
 
-        @route("/{+resourceUri}/providers/Microsoft.Contoso/foos/{name}")
-        op updateFoo(@path resourceUri: string, @path name: string): void;
-        `,
-      )
-      .toEmitDiagnostics([
-        {
-          code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
-          severity: "warning",
-          message: `Operation "TestService.updateFoo" path "/{resourceUri}/providers/Microsoft.Contoso/foos/{name}" has inconsistent parameter name "resourceUri" which should be "scope" to match operation "TestService.getFoo" with path "/{scope}/providers/Microsoft.Contoso/foos/{fooName}"`,
-        },
-        {
-          code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
-          severity: "warning",
-          message: `Operation "TestService.updateFoo" path "/{resourceUri}/providers/Microsoft.Contoso/foos/{name}" has inconsistent parameter name "name" which should be "fooName" to match operation "TestService.getFoo" with path "/{scope}/providers/Microsoft.Contoso/foos/{fooName}"`,
-        },
-      ]);
-  });
+      @route("/{+resourceUri}/providers/Microsoft.Contoso/foos/{name}")
+      op updateFoo(@path resourceUri: string, @path name: string): void;
+      `,
+    )
+    .toEmitDiagnostics([
+      {
+        code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
+        severity: "warning",
+        message: `Operation "TestService.updateFoo" path "/{resourceUri}/providers/Microsoft.Contoso/foos/{name}" has inconsistent parameter name "resourceUri" which should be "scope" to match operation "TestService.getFoo" with path "/{scope}/providers/Microsoft.Contoso/foos/{fooName}"`,
+      },
+      {
+        code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
+        severity: "warning",
+        message: `Operation "TestService.updateFoo" path "/{resourceUri}/providers/Microsoft.Contoso/foos/{name}" has inconsistent parameter name "name" which should be "fooName" to match operation "TestService.getFoo" with path "/{scope}/providers/Microsoft.Contoso/foos/{fooName}"`,
+      },
+    ]);
+});
 
-  it("emit a warning when both allowReserved path parameters have different names", async () => {
-    await tester
-      .expect(
-        `
-        @service namespace TestService;
+it("emit a warning when both allowReserved path parameters have different names", async () => {
+  await tester
+    .expect(
+      `
+      @service namespace TestService;
 
-        @route("/{+resourceUri}/providers/Microsoft.Contoso/foos/{fooName}")
-        op getFoo(@path resourceUri: string, @path fooName: string): void;
+      @route("/{+resourceUri}/providers/Microsoft.Contoso/foos/{fooName}")
+      op getFoo(@path resourceUri: string, @path fooName: string): void;
 
-        @put
-        @route("/{+scope}/providers/Microsoft.Contoso/foos/{fooName}")
-        op updateFoo(@path scope: string, @path fooName: string): void;
-        `,
-      )
-      .toEmitDiagnostics([
-        {
-          code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
-          severity: "warning",
-          message: `Operation "TestService.updateFoo" path "/{scope}/providers/Microsoft.Contoso/foos/{fooName}" has inconsistent parameter name "scope" which should be "resourceUri" to match operation "TestService.getFoo" with path "/{resourceUri}/providers/Microsoft.Contoso/foos/{fooName}"`,
-        },
-      ]);
-  });
+      @put
+      @route("/{+scope}/providers/Microsoft.Contoso/foos/{fooName}")
+      op updateFoo(@path scope: string, @path fooName: string): void;
+      `,
+    )
+    .toEmitDiagnostics([
+      {
+        code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
+        severity: "warning",
+        message: `Operation "TestService.updateFoo" path "/{scope}/providers/Microsoft.Contoso/foos/{fooName}" has inconsistent parameter name "scope" which should be "resourceUri" to match operation "TestService.getFoo" with path "/{resourceUri}/providers/Microsoft.Contoso/foos/{fooName}"`,
+      },
+    ]);
+});
 
-  it("does not emit a warning when allowReserved differs between matching path parameters", async () => {
-    await tester
-      .expect(
-        `
-        @service namespace TestService;
+it("does not emit a warning when allowReserved differs between matching path parameters", async () => {
+  await tester
+    .expect(
+      `
+      @service namespace TestService;
 
-        @route("/{+scope}/providers/Microsoft.Contoso/foos/{fooName}")
-        op getFoo(@path scope: string, @path fooName: string): void;
+      @route("/{+scope}/providers/Microsoft.Contoso/foos/{fooName}")
+      op getFoo(@path scope: string, @path fooName: string): void;
 
-        @put
-        @route("/{scope}/providers/Microsoft.Contoso/foos/{name}")
-        op updateFoo(@path scope: string, @path name: string): void;
-        `,
-      )
-      .toBeValid();
-  });
+      @put
+      @route("/{scope}/providers/Microsoft.Contoso/foos/{name}")
+      op updateFoo(@path scope: string, @path name: string): void;
+      `,
+    )
+    .toBeValid();
+});
 
-  it("does not emit a warning when allowReserved operations have consistent names", async () => {
-    await tester
-      .expect(
-        `
-        @service namespace TestService;
+it("does not emit a warning when allowReserved operations have consistent names", async () => {
+  await tester
+    .expect(
+      `
+      @service namespace TestService;
 
-        @route("/{+scope}/providers/Microsoft.Contoso/foos/{fooName}")
-        op getFoo(@path scope: string, @path fooName: string): void;
+      @route("/{+scope}/providers/Microsoft.Contoso/foos/{fooName}")
+      op getFoo(@path scope: string, @path fooName: string): void;
 
-        @put
-        @route("/{+scope}/providers/Microsoft.Contoso/foos/{fooName}")
-        op updateFoo(@path scope: string, @path fooName: string): void;
-        `,
-      )
-      .toBeValid();
-  });
+      @put
+      @route("/{+scope}/providers/Microsoft.Contoso/foos/{fooName}")
+      op updateFoo(@path scope: string, @path fooName: string): void;
+      `,
+    )
+    .toBeValid();
+});
 
-  it("does not emit a warning for paths with no static segments", async () => {
-    await tester
-      .expect(
-        `
-        @service namespace TestService;
+it("does not emit a warning for paths with no static segments", async () => {
+  await tester
+    .expect(
+      `
+      @service namespace TestService;
 
-        @route("/{scope}")
-        op getByScope(@path scope: string): void;
+      @route("/{scope}")
+      op getByScope(@path scope: string): void;
 
-        @route("/{resourceUri}")
-        op getByResourceUri(@path resourceUri: string): void;
-        `,
-      )
-      .toBeValid();
-  });
+      @route("/{resourceUri}")
+      op getByResourceUri(@path resourceUri: string): void;
+      `,
+    )
+    .toBeValid();
+});
 
-  it("does not emit a warning for paths with consecutive path variables", async () => {
-    await tester
-      .expect(
-        `
-        @service namespace TestService;
+it("does not emit a warning for paths with consecutive path variables", async () => {
+  await tester
+    .expect(
+      `
+      @service namespace TestService;
 
-        @route("/providers/Microsoft.Contoso/{foo}/{bar}")
-        op getBar(@path foo: string, @path bar: string): void;
+      @route("/providers/Microsoft.Contoso/{foo}/{bar}")
+      op getBar(@path foo: string, @path bar: string): void;
 
-        @route("/providers/Microsoft.Contoso/{name}/{id}")
-        op updateBar(@path name: string, @path id: string): void;
-        `,
-      )
-      .toBeValid();
-  });
+      @route("/providers/Microsoft.Contoso/{name}/{id}")
+      op updateBar(@path name: string, @path id: string): void;
+      `,
+    )
+    .toBeValid();
+});
 
-  it("emit warnings when third operation also mismatches", async () => {
-    await tester
-      .expect(
-        `
-        @service namespace TestService;
+it("emit warnings when third operation also mismatches", async () => {
+  await tester
+    .expect(
+      `
+      @service namespace TestService;
 
-        @route("/subscriptions/{subscriptionId}/providers/Microsoft.Foo/widgets/{widgetName}")
-        op getWidget(@path subscriptionId: string, @path widgetName: string): void;
+      @route("/subscriptions/{subscriptionId}/providers/Microsoft.Foo/widgets/{widgetName}")
+      op getWidget(@path subscriptionId: string, @path widgetName: string): void;
 
-        @route("/subscriptions/{subscriptionId}/providers/Microsoft.Foo/widgets/{name}")
-        op updateWidget(@path subscriptionId: string, @path name: string): void;
+      @route("/subscriptions/{subscriptionId}/providers/Microsoft.Foo/widgets/{name}")
+      op updateWidget(@path subscriptionId: string, @path name: string): void;
 
-        @route("/subscriptions/{subscription}/providers/Microsoft.Foo/widgets/{widgetName}")
-        op deleteWidget(@path subscription: string, @path widgetName: string): void;
-        `,
-      )
-      .toEmitDiagnostics([
-        {
-          code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
-          severity: "warning",
-          message: `Operation "TestService.updateWidget" path "/subscriptions/{subscriptionId}/providers/Microsoft.Foo/widgets/{name}" has inconsistent parameter name "name" which should be "widgetName" to match operation "TestService.getWidget" with path "/subscriptions/{subscriptionId}/providers/Microsoft.Foo/widgets/{widgetName}"`,
-        },
-        {
-          code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
-          severity: "warning",
-          message: `Operation "TestService.deleteWidget" path "/subscriptions/{subscription}/providers/Microsoft.Foo/widgets/{widgetName}" has inconsistent parameter name "subscription" which should be "subscriptionId" to match operation "TestService.getWidget" with path "/subscriptions/{subscriptionId}/providers/Microsoft.Foo/widgets/{widgetName}"`,
-        },
-      ]);
-  });
+      @route("/subscriptions/{subscription}/providers/Microsoft.Foo/widgets/{widgetName}")
+      op deleteWidget(@path subscription: string, @path widgetName: string): void;
+      `,
+    )
+    .toEmitDiagnostics([
+      {
+        code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
+        severity: "warning",
+        message: `Operation "TestService.updateWidget" path "/subscriptions/{subscriptionId}/providers/Microsoft.Foo/widgets/{name}" has inconsistent parameter name "name" which should be "widgetName" to match operation "TestService.getWidget" with path "/subscriptions/{subscriptionId}/providers/Microsoft.Foo/widgets/{widgetName}"`,
+      },
+      {
+        code: "@azure-tools/typespec-azure-core/no-route-parameter-name-mismatch",
+        severity: "warning",
+        message: `Operation "TestService.deleteWidget" path "/subscriptions/{subscription}/providers/Microsoft.Foo/widgets/{widgetName}" has inconsistent parameter name "subscription" which should be "subscriptionId" to match operation "TestService.getWidget" with path "/subscriptions/{subscriptionId}/providers/Microsoft.Foo/widgets/{widgetName}"`,
+      },
+    ]);
 });

--- a/packages/typespec-azure-core/test/rules/prevent-rest-library.test.ts
+++ b/packages/typespec-azure-core/test/rules/prevent-rest-library.test.ts
@@ -1,44 +1,42 @@
 import { Tester } from "#test/test-host.js";
 import { LinterRuleTester, createLinterRuleTester } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, it } from "vitest";
 import { preventRestLibraryInterfaces } from "../../src/rules/prevent-rest-library.js";
 
-describe("typespec-azure-core: no-rest-library-interfaces rule", () => {
-  let tester: LinterRuleTester;
+let tester: LinterRuleTester;
 
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    tester = createLinterRuleTester(
-      runner,
-      preventRestLibraryInterfaces,
-      "@azure-tools/typespec-azure-core",
-    );
-  });
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  tester = createLinterRuleTester(
+    runner,
+    preventRestLibraryInterfaces,
+    "@azure-tools/typespec-azure-core",
+  );
+});
 
-  it("emits an error diagnostic for interfaces that extend one from TypeSpec.Rest.Resource", async () => {
-    await tester
-      .expect(
-        `
-      @resource("widgets")
-      model Widget { @key name: string; }
+it("emits an error diagnostic for interfaces that extend one from TypeSpec.Rest.Resource", async () => {
+  await tester
+    .expect(
+      `
+    @resource("widgets")
+    model Widget { @key name: string; }
 
-      interface MyResourceOperations<TResource extends TypeSpec.Reflection.Model> {
-        read is ResourceRead<TResource>;
-      }
+    interface MyResourceOperations<TResource extends TypeSpec.Reflection.Model> {
+      read is ResourceRead<TResource>;
+    }
 
-      @TypeSpec.Http.route("bad")
-      interface Widgets extends TypeSpec.Rest.Resource.ResourceOperations<Widget, Foundations.ErrorResponse> {};
+    @TypeSpec.Http.route("bad")
+    interface Widgets extends TypeSpec.Rest.Resource.ResourceOperations<Widget, Foundations.ErrorResponse> {};
 
-      @TypeSpec.Http.route("good")
-      interface WidgetsAlt extends MyResourceOperations<Widget> {};
+    @TypeSpec.Http.route("good")
+    interface WidgetsAlt extends MyResourceOperations<Widget> {};
 `,
-      )
-      .toEmitDiagnostics([
-        {
-          code: "@azure-tools/typespec-azure-core/no-rest-library-interfaces",
-          message:
-            "Resource interfaces from the TypeSpec.Rest.Resource library are incompatible with Azure.Core.",
-        },
-      ]);
-  });
+    )
+    .toEmitDiagnostics([
+      {
+        code: "@azure-tools/typespec-azure-core/no-rest-library-interfaces",
+        message:
+          "Resource interfaces from the TypeSpec.Rest.Resource library are incompatible with Azure.Core.",
+      },
+    ]);
 });

--- a/packages/typespec-azure-core/test/rules/request-body-array.test.ts
+++ b/packages/typespec-azure-core/test/rules/request-body-array.test.ts
@@ -3,25 +3,23 @@ import { LinterRuleTester, createLinterRuleTester } from "@typespec/compiler/tes
 import { beforeEach, describe, it } from "vitest";
 import { bodyArrayRule } from "../../src/rules/request-body-array.js";
 
-describe("typespec-azure-core: Request body raw array rule", () => {
-  let tester: LinterRuleTester;
+let tester: LinterRuleTester;
 
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    tester = createLinterRuleTester(runner, bodyArrayRule, "@azure-tools/typespec-azure-core");
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  tester = createLinterRuleTester(runner, bodyArrayRule, "@azure-tools/typespec-azure-core");
+});
+
+describe("operation request body should not be raw array type", () => {
+  it("emits warning if request body is raw array", async () => {
+    await tester.expect(`op foo( @body body: string[]): string;`).toEmitDiagnostics({
+      code: "@azure-tools/typespec-azure-core/request-body-problem",
+      message:
+        "Request body should not be of raw array type. Consider creating a container model that can add properties over time to avoid introducing breaking changes.",
+    });
   });
 
-  describe("operation request body should not be raw array type", () => {
-    it("emits warning if request body is raw array", async () => {
-      await tester.expect(`op foo( @body body: string[]): string;`).toEmitDiagnostics({
-        code: "@azure-tools/typespec-azure-core/request-body-problem",
-        message:
-          "Request body should not be of raw array type. Consider creating a container model that can add properties over time to avoid introducing breaking changes.",
-      });
-    });
-
-    it("does not emit warning if response body is raw array", async () => {
-      await tester.expect(`op foo( @body body: string): string[];`).toBeValid();
-    });
+  it("does not emit warning if response body is raw array", async () => {
+    await tester.expect(`op foo( @body body: string): string[];`).toBeValid();
   });
 });

--- a/packages/typespec-azure-core/test/rules/spread-discriminated-model.test.ts
+++ b/packages/typespec-azure-core/test/rules/spread-discriminated-model.test.ts
@@ -1,70 +1,68 @@
 import {
-  createLinterRuleTester,
-  extractCursor,
-  LinterRuleTester,
+createLinterRuleTester,
+extractCursor,
+LinterRuleTester,
 } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, it } from "vitest";
 import { spreadDiscriminatedModelRule } from "../../src/rules/spread-discriminated-model.js";
 import { Tester } from "../test-host.js";
 
-describe("typespec-azure-core: spread-discriminated-model rule", () => {
-  let tester: LinterRuleTester;
+let tester: LinterRuleTester;
 
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    tester = createLinterRuleTester(
-      runner,
-      spreadDiscriminatedModelRule,
-      "@azure-tools/typespec-azure-core",
-    );
-  });
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  tester = createLinterRuleTester(
+    runner,
+    spreadDiscriminatedModelRule,
+    "@azure-tools/typespec-azure-core",
+  );
+});
 
-  it("emit warning when spreading a model with a discriminator", async () => {
-    const { source } = extractCursor(`
-    @discriminator("kind")
-    model Pet { kind: string; }
-    
-    model Cat { ┆...Pet; }
-    `);
-    await tester.expect(source).toEmitDiagnostics({
-      code: "@azure-tools/typespec-azure-core/spread-discriminated-model",
-      message:
-        "Model 'Pet' is being spread but has a discriminator. The relation between those 2 models will be lost and defeat the purpose of `@discriminator` Consider using `extends` instead.",
-    });
+it("emit warning when spreading a model with a discriminator", async () => {
+  const { source } = extractCursor(`
+  @discriminator("kind")
+  model Pet { kind: string; }
+  
+  model Cat { ┆...Pet; }
+  `);
+  await tester.expect(source).toEmitDiagnostics({
+    code: "@azure-tools/typespec-azure-core/spread-discriminated-model",
+    message:
+      "Model 'Pet' is being spread but has a discriminator. The relation between those 2 models will be lost and defeat the purpose of `@discriminator` Consider using `extends` instead.",
   });
+});
 
-  it("good when using inheritance with a discriminator", async () => {
-    await tester
-      .expect(
-        `
-        @discriminator("kind") model Pet { kind: string }
-        model Cat extends Pet { kind: "cat" }
-        model Dog extends Pet { kind: "dog" }`,
-      )
-      .toBeValid();
-  });
+it("good when using inheritance with a discriminator", async () => {
+  await tester
+    .expect(
+      `
+      @discriminator("kind") model Pet { kind: string }
+      model Cat extends Pet { kind: "cat" }
+      model Dog extends Pet { kind: "dog" }`,
+    )
+    .toBeValid();
+});
 
-  it("ok when using model is", async () => {
-    await tester
-      .expect(
-        `
-        @discriminator("kind")
-        model Pet { kind: string; }
-        model Dog is Pet {}`,
-      )
-      .toBeValid();
-  });
+it("ok when using model is", async () => {
+  await tester
+    .expect(
+      `
+      @discriminator("kind")
+      model Pet { kind: string; }
+      model Dog is Pet {}`,
+    )
+    .toBeValid();
+});
 
-  it("ignore when property are not merged into a model statement", async () => {
-    await tester
-      .expect(
-        `
-        @discriminator("kind")
-        model Pet { kind: string; }
-        model Bar {
-          pet: Pet & { name: string; };
-        }`,
-      )
-      .toBeValid();
-  });
+it("ignore when property are not merged into a model statement", async () => {
+  await tester
+    .expect(
+      `
+      @discriminator("kind")
+      model Pet { kind: string; }
+      model Bar {
+        pet: Pet & { name: string; };
+      }`,
+    )
+    .toBeValid();
 });

--- a/packages/typespec-azure-core/test/rules/spread-discriminated-model.test.ts
+++ b/packages/typespec-azure-core/test/rules/spread-discriminated-model.test.ts
@@ -1,7 +1,7 @@
 import {
-createLinterRuleTester,
-extractCursor,
-LinterRuleTester,
+  createLinterRuleTester,
+  extractCursor,
+  LinterRuleTester,
 } from "@typespec/compiler/testing";
 import { beforeEach, it } from "vitest";
 import { spreadDiscriminatedModelRule } from "../../src/rules/spread-discriminated-model.js";

--- a/packages/typespec-azure-core/test/rules/use-standard-names.test.ts
+++ b/packages/typespec-azure-core/test/rules/use-standard-names.test.ts
@@ -68,8 +68,7 @@ it("emits a diagnostic for operations that don't follow naming standards", async
       {
         code: "@azure-tools/typespec-azure-core/use-standard-names",
         severity: "warning",
-        message:
-          "PUT operations that return 200 should start with 'replace' or 'createOrReplace'",
+        message: "PUT operations that return 200 should start with 'replace' or 'createOrReplace'",
       },
       {
         code: "@azure-tools/typespec-azure-core/use-standard-names",

--- a/packages/typespec-azure-core/test/rules/use-standard-names.test.ts
+++ b/packages/typespec-azure-core/test/rules/use-standard-names.test.ts
@@ -1,95 +1,19 @@
 import { Tester } from "#test/test-host.js";
 import { LinterRuleTester, createLinterRuleTester } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, it } from "vitest";
 import { useStandardNames } from "../../src/rules/use-standard-names.js";
 
-describe("typespec-azure-core: use-standard-names rule", () => {
-  let tester: LinterRuleTester;
+let tester: LinterRuleTester;
 
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    tester = createLinterRuleTester(runner, useStandardNames, "@azure-tools/typespec-azure-core");
-  });
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  tester = createLinterRuleTester(runner, useStandardNames, "@azure-tools/typespec-azure-core");
+});
 
-  it("emits a diagnostic for operations that don't follow naming standards", async () => {
-    await tester
-      .expect(
-        `
-        model Foo {};
-
-        model FooPage {
-          @nextLink
-          next: string,
-          @pageItems
-          value: Foo[];
-        }
-        
-        model FooResponse<T, C> {
-          @statusCode
-          _: C;
-          @body body: T;
-        }
-        
-        @route("1")
-        @get op returnFoo(): Foo;
-        
-        @route("2")
-        @list
-        @get op getFoos(): FooPage;
-        
-        @route("3")
-        @put op makeFoo(@body body: Foo): FooResponse<Foo, 201>;
-        
-        @route("4")
-        @put op wholeNewFoo(@body body: Foo): FooResponse<Foo, 200>;
-        
-        @route("5")
-        #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-        @patch(#{implicitOptionality: true}) op changeFoo(@body body: Foo): FooResponse<Foo, 201>;
-        
-        @route("6")
-        @delete op removeFoo(): void;        `,
-      )
-      .toEmitDiagnostics([
-        {
-          code: "@azure-tools/typespec-azure-core/use-standard-names",
-          severity: "warning",
-          message: "GET operations that return single objects should start with 'get'",
-        },
-        {
-          code: "@azure-tools/typespec-azure-core/use-standard-names",
-          severity: "warning",
-          message: "GET operations that return lists should start with 'list'",
-        },
-        {
-          code: "@azure-tools/typespec-azure-core/use-standard-names",
-          severity: "warning",
-          message: "PUT operations that return 201 should start with 'create' or 'createOrReplace'",
-        },
-        {
-          code: "@azure-tools/typespec-azure-core/use-standard-names",
-          severity: "warning",
-          message:
-            "PUT operations that return 200 should start with 'replace' or 'createOrReplace'",
-        },
-        {
-          code: "@azure-tools/typespec-azure-core/use-standard-names",
-          severity: "warning",
-          message:
-            "PATCH operations that return 201 should start with 'create', 'update', or 'createOrUpdate'",
-        },
-        {
-          code: "@azure-tools/typespec-azure-core/use-standard-names",
-          severity: "warning",
-          message: "DELETE operations should start with 'delete'",
-        },
-      ]);
-  });
-
-  it("is valid for operations that follow naming standards", async () => {
-    await tester
-      .expect(
-        `
+it("emits a diagnostic for operations that don't follow naming standards", async () => {
+  await tester
+    .expect(
+      `
       model Foo {};
 
       model FooPage {
@@ -106,42 +30,116 @@ describe("typespec-azure-core: use-standard-names rule", () => {
       }
       
       @route("1")
-      @get op getFoo(): Foo;
+      @get op returnFoo(): Foo;
       
       @route("2")
       @list
-      @get op listFoos(): FooPage;
+      @get op getFoos(): FooPage;
       
       @route("3")
-      @put op createOrReplaceFoo(@body body: Foo): FooResponse<Foo, 201>;
-
+      @put op makeFoo(@body body: Foo): FooResponse<Foo, 201>;
+      
       @route("4")
-      @put op createFoo(@body body: Foo): FooResponse<Foo, 201>;
-
+      @put op wholeNewFoo(@body body: Foo): FooResponse<Foo, 200>;
+      
       @route("5")
-      @put op replaceFoo(@body body: Foo): FooResponse<Foo, 200>;
-      
       #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+      @patch(#{implicitOptionality: true}) op changeFoo(@body body: Foo): FooResponse<Foo, 201>;
+      
       @route("6")
-      #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
-      @patch(#{implicitOptionality: true}) op createOrUpdateFoo(@body body: Foo): FooResponse<Foo, 201>;
-      
-      @route("7")
-      @delete op deleteFoo(): void;        `,
-      )
-      .toBeValid();
-  });
+      @delete op removeFoo(): void;        `,
+    )
+    .toEmitDiagnostics([
+      {
+        code: "@azure-tools/typespec-azure-core/use-standard-names",
+        severity: "warning",
+        message: "GET operations that return single objects should start with 'get'",
+      },
+      {
+        code: "@azure-tools/typespec-azure-core/use-standard-names",
+        severity: "warning",
+        message: "GET operations that return lists should start with 'list'",
+      },
+      {
+        code: "@azure-tools/typespec-azure-core/use-standard-names",
+        severity: "warning",
+        message: "PUT operations that return 201 should start with 'create' or 'createOrReplace'",
+      },
+      {
+        code: "@azure-tools/typespec-azure-core/use-standard-names",
+        severity: "warning",
+        message:
+          "PUT operations that return 200 should start with 'replace' or 'createOrReplace'",
+      },
+      {
+        code: "@azure-tools/typespec-azure-core/use-standard-names",
+        severity: "warning",
+        message:
+          "PATCH operations that return 201 should start with 'create', 'update', or 'createOrUpdate'",
+      },
+      {
+        code: "@azure-tools/typespec-azure-core/use-standard-names",
+        severity: "warning",
+        message: "DELETE operations should start with 'delete'",
+      },
+    ]);
+});
 
-  it("does not emit diagnostic for operation templates", async () => {
-    await tester
-      .expect(
-        `
-        op MyOperation<T>(): T;
-        
-        @route("1")
-        @get op getString is MyOperation<string>;
-      `,
-      )
-      .toBeValid();
-  });
+it("is valid for operations that follow naming standards", async () => {
+  await tester
+    .expect(
+      `
+    model Foo {};
+
+    model FooPage {
+      @nextLink
+      next: string,
+      @pageItems
+      value: Foo[];
+    }
+    
+    model FooResponse<T, C> {
+      @statusCode
+      _: C;
+      @body body: T;
+    }
+    
+    @route("1")
+    @get op getFoo(): Foo;
+    
+    @route("2")
+    @list
+    @get op listFoos(): FooPage;
+    
+    @route("3")
+    @put op createOrReplaceFoo(@body body: Foo): FooResponse<Foo, 201>;
+
+    @route("4")
+    @put op createFoo(@body body: Foo): FooResponse<Foo, 201>;
+
+    @route("5")
+    @put op replaceFoo(@body body: Foo): FooResponse<Foo, 200>;
+    
+    #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    @route("6")
+    #suppress "@typespec/http/deprecated-implicit-optionality" "For test"
+    @patch(#{implicitOptionality: true}) op createOrUpdateFoo(@body body: Foo): FooResponse<Foo, 201>;
+    
+    @route("7")
+    @delete op deleteFoo(): void;        `,
+    )
+    .toBeValid();
+});
+
+it("does not emit diagnostic for operation templates", async () => {
+  await tester
+    .expect(
+      `
+      op MyOperation<T>(): T;
+      
+      @route("1")
+      @get op getString is MyOperation<string>;
+    `,
+    )
+    .toBeValid();
 });

--- a/packages/typespec-azure-core/test/rules/use-standard-operations.test.ts
+++ b/packages/typespec-azure-core/test/rules/use-standard-operations.test.ts
@@ -1,78 +1,76 @@
 import { Tester } from "#test/test-host.js";
 import { LinterRuleTester, createLinterRuleTester } from "@typespec/compiler/testing";
-import { beforeEach, describe, it } from "vitest";
+import { beforeEach, it } from "vitest";
 import { useStandardOperations } from "../../src/rules/use-standard-operations.js";
 
-describe("typespec-azure-core: use-standard-operations rule", () => {
-  let tester: LinterRuleTester;
+let tester: LinterRuleTester;
 
-  beforeEach(async () => {
-    const runner = await Tester.createInstance();
-    tester = createLinterRuleTester(
-      runner,
-      useStandardOperations,
-      "@azure-tools/typespec-azure-core",
-    );
-  });
+beforeEach(async () => {
+  const runner = await Tester.createInstance();
+  tester = createLinterRuleTester(
+    runner,
+    useStandardOperations,
+    "@azure-tools/typespec-azure-core",
+  );
+});
 
-  it("emits a diagnostic for operations not defined from a standard signature", async () => {
-    await tester
-      .expect(
-        `
-      @route("bad")
-      op badOp(): string;
+it("emits a diagnostic for operations not defined from a standard signature", async () => {
+  await tester
+    .expect(
+      `
+    @route("bad")
+    op badOp(): string;
 
-      // Skipped because it's a templated operation
-      op BadBaseOp<TParams>(...TParams): string;
+    // Skipped because it's a templated operation
+    op BadBaseOp<TParams>(...TParams): string;
 
-      @route("badder")
-      op anotherBadOp is BadBaseOp<{}>;
+    @route("badder")
+    op anotherBadOp is BadBaseOp<{}>;
 
-      op GoodBaseOp<TResource extends TypeSpec.Reflection.Model> is Azure.Core.StandardResourceOperations.ResourceRead<TResource>;
+    op GoodBaseOp<TResource extends TypeSpec.Reflection.Model> is Azure.Core.StandardResourceOperations.ResourceRead<TResource>;
 
-      @resource("widgets")
-      model Widget {
-        @key
-        name: string;
-      }
+    @resource("widgets")
+    model Widget {
+      @key
+      name: string;
+    }
 
-      @route("good")
-      op goodOp is GoodBaseOp<Widget>;
+    @route("good")
+    op goodOp is GoodBaseOp<Widget>;
 `,
-      )
-      .toEmitDiagnostics([
-        {
-          code: "@azure-tools/typespec-azure-core/use-standard-operations",
-          message:
-            "Operation 'badOp' should be defined using a signature from the Azure.Core namespace.",
-        },
-        {
-          code: "@azure-tools/typespec-azure-core/use-standard-operations",
-          message:
-            "Operation 'anotherBadOp' should be defined using a signature from the Azure.Core namespace.",
-        },
-      ]);
-  });
+    )
+    .toEmitDiagnostics([
+      {
+        code: "@azure-tools/typespec-azure-core/use-standard-operations",
+        message:
+          "Operation 'badOp' should be defined using a signature from the Azure.Core namespace.",
+      },
+      {
+        code: "@azure-tools/typespec-azure-core/use-standard-operations",
+        message:
+          "Operation 'anotherBadOp' should be defined using a signature from the Azure.Core namespace.",
+      },
+    ]);
+});
 
-  it("emits a diagnostic for operations defined from a low-level Foundations signature", async () => {
-    await tester
-      .expect(
-        `
-      @resource("widgets")
-      model Widget { @key name: string; }
+it("emits a diagnostic for operations defined from a low-level Foundations signature", async () => {
+  await tester
+    .expect(
+      `
+    @resource("widgets")
+    model Widget { @key name: string; }
 
-      op CustomResourceOp<TResource extends TypeSpec.Reflection.Model> is Azure.Core.Foundations.ResourceOperation<TResource, {}, TResource>;
-      op usingCustomOp is CustomResourceOp<Widget>;
+    op CustomResourceOp<TResource extends TypeSpec.Reflection.Model> is Azure.Core.Foundations.ResourceOperation<TResource, {}, TResource>;
+    op usingCustomOp is CustomResourceOp<Widget>;
 `,
-      )
-      .toEmitDiagnostics([
-        // NOTE: This is *desired behavior* because any new operation defined from a
-        // low-level signature likely will not be following the Azure REST API Guidelines.
-        {
-          code: "@azure-tools/typespec-azure-core/use-standard-operations",
-          message:
-            "Operation 'usingCustomOp' should be defined using a signature from the Azure.Core namespace.",
-        },
-      ]);
-  });
+    )
+    .toEmitDiagnostics([
+      // NOTE: This is *desired behavior* because any new operation defined from a
+      // low-level signature likely will not be following the Azure REST API Guidelines.
+      {
+        code: "@azure-tools/typespec-azure-core/use-standard-operations",
+        message:
+          "Operation 'usingCustomOp' should be defined using a signature from the Azure.Core namespace.",
+      },
+    ]);
 });

--- a/packages/typespec-client-generator-core/test/package/license.test.ts
+++ b/packages/typespec-client-generator-core/test/package/license.test.ts
@@ -1,117 +1,115 @@
 import { strictEqual } from "assert";
-import { describe, it } from "vitest";
+import { it } from "vitest";
 import { licenseMap } from "../../src/license.js";
 import { createSdkContextForTester, SimpleTester } from "../tester.js";
 
-describe("typespec-client-generator-core: license", () => {
-  it("none license", async () => {
-    const { program } = await SimpleTester.compile(`
+it("none license", async () => {
+  const { program } = await SimpleTester.compile(`
       @service
       namespace MyService {
       }
     `);
 
-    const context = await createSdkContextForTester(program);
-    const licenseInfo = context.sdkPackage.licenseInfo;
-    strictEqual(licenseInfo, undefined);
+  const context = await createSdkContextForTester(program);
+  const licenseInfo = context.sdkPackage.licenseInfo;
+  strictEqual(licenseInfo, undefined);
+});
+
+it("mit license without company name", async () => {
+  const { program } = await SimpleTester.compile(`
+      @service
+      namespace MyService {
+      }
+    `);
+
+  const context = await createSdkContextForTester(program, {
+    license: { name: "MIT License" },
   });
+  const licenseInfo = context.sdkPackage.licenseInfo;
+  strictEqual(licenseInfo?.name, licenseMap["MIT License"].name);
+  strictEqual(licenseInfo?.company, "");
+  strictEqual(licenseInfo?.link, licenseMap["MIT License"].link);
+  strictEqual(licenseInfo?.header, licenseMap["MIT License"].header.replace("<company>", ""));
+  strictEqual(
+    licenseInfo?.description,
+    licenseMap["MIT License"].description.replace("<company>", ""),
+  );
+});
 
-  it("mit license without company name", async () => {
-    const { program } = await SimpleTester.compile(`
+it("mit license with company name", async () => {
+  const { program } = await SimpleTester.compile(`
       @service
       namespace MyService {
       }
     `);
 
-    const context = await createSdkContextForTester(program, {
-      license: { name: "MIT License" },
-    });
-    const licenseInfo = context.sdkPackage.licenseInfo;
-    strictEqual(licenseInfo?.name, licenseMap["MIT License"].name);
-    strictEqual(licenseInfo?.company, "");
-    strictEqual(licenseInfo?.link, licenseMap["MIT License"].link);
-    strictEqual(licenseInfo?.header, licenseMap["MIT License"].header.replace("<company>", ""));
-    strictEqual(
-      licenseInfo?.description,
-      licenseMap["MIT License"].description.replace("<company>", ""),
-    );
+  const context = await createSdkContextForTester(program, {
+    license: { name: "MIT License", company: "Microsoft Cooperation" },
   });
+  const licenseInfo = context.sdkPackage.licenseInfo;
+  strictEqual(licenseInfo?.name, licenseMap["MIT License"].name);
+  strictEqual(licenseInfo?.company, "Microsoft Cooperation");
+  strictEqual(licenseInfo?.link, licenseMap["MIT License"].link);
+  strictEqual(
+    licenseInfo?.header,
+    licenseMap["MIT License"].header.replace("<company>", "Microsoft Cooperation"),
+  );
+  strictEqual(
+    licenseInfo?.description,
+    licenseMap["MIT License"].description.replace("<company>", "Microsoft Cooperation"),
+  );
+  strictEqual(licenseInfo?.description.startsWith("Copyright (c) Microsoft Cooperation"), true);
+});
 
-  it("mit license with company name", async () => {
-    const { program } = await SimpleTester.compile(`
+it("mit license with some customization", async () => {
+  const { program } = await SimpleTester.compile(`
       @service
       namespace MyService {
       }
     `);
 
-    const context = await createSdkContextForTester(program, {
-      license: { name: "MIT License", company: "Microsoft Cooperation" },
-    });
-    const licenseInfo = context.sdkPackage.licenseInfo;
-    strictEqual(licenseInfo?.name, licenseMap["MIT License"].name);
-    strictEqual(licenseInfo?.company, "Microsoft Cooperation");
-    strictEqual(licenseInfo?.link, licenseMap["MIT License"].link);
-    strictEqual(
-      licenseInfo?.header,
-      licenseMap["MIT License"].header.replace("<company>", "Microsoft Cooperation"),
-    );
-    strictEqual(
-      licenseInfo?.description,
-      licenseMap["MIT License"].description.replace("<company>", "Microsoft Cooperation"),
-    );
-    strictEqual(licenseInfo?.description.startsWith("Copyright (c) Microsoft Cooperation"), true);
-  });
-
-  it("mit license with some customization", async () => {
-    const { program } = await SimpleTester.compile(`
-      @service
-      namespace MyService {
-      }
-    `);
-
-    const context = await createSdkContextForTester(program, {
-      license: {
-        name: "MIT License",
-        header: `Copyright (c) Microsoft Corporation. All rights reserved.\n
+  const context = await createSdkContextForTester(program, {
+    license: {
+      name: "MIT License",
+      header: `Copyright (c) Microsoft Corporation. All rights reserved.\n
 Licensed under the MIT License. See LICENSE in the project root for license information.`,
-      },
-    });
-    const licenseInfo = context.sdkPackage.licenseInfo;
-    strictEqual(licenseInfo?.name, licenseMap["MIT License"].name);
-    strictEqual(licenseInfo?.company, "");
-    strictEqual(licenseInfo?.link, licenseMap["MIT License"].link);
-    strictEqual(
-      licenseInfo?.header,
-      `Copyright (c) Microsoft Corporation. All rights reserved.\n
-Licensed under the MIT License. See LICENSE in the project root for license information.`,
-    );
-    strictEqual(
-      licenseInfo?.description,
-      licenseMap["MIT License"].description.replace("<company>", ""),
-    );
+    },
   });
+  const licenseInfo = context.sdkPackage.licenseInfo;
+  strictEqual(licenseInfo?.name, licenseMap["MIT License"].name);
+  strictEqual(licenseInfo?.company, "");
+  strictEqual(licenseInfo?.link, licenseMap["MIT License"].link);
+  strictEqual(
+    licenseInfo?.header,
+    `Copyright (c) Microsoft Corporation. All rights reserved.\n
+Licensed under the MIT License. See LICENSE in the project root for license information.`,
+  );
+  strictEqual(
+    licenseInfo?.description,
+    licenseMap["MIT License"].description.replace("<company>", ""),
+  );
+});
 
-  it("fully customize license", async () => {
-    const { program } = await SimpleTester.compile(`
+it("fully customize license", async () => {
+  const { program } = await SimpleTester.compile(`
       @service
       namespace MyService {
       }
     `);
 
-    const context = await createSdkContextForTester(program, {
-      license: {
-        name: "Test License",
-        company: "Microsoft Cooperation",
-        link: "https://example.com",
-        header: "Copyright Microsoft Cooperation",
-        description: "Copyright Microsoft Cooperation",
-      },
-    });
-    const licenseInfo = context.sdkPackage.licenseInfo;
-    strictEqual(licenseInfo?.name, "Test License");
-    strictEqual(licenseInfo?.company, "Microsoft Cooperation");
-    strictEqual(licenseInfo?.link, "https://example.com");
-    strictEqual(licenseInfo?.header, "Copyright Microsoft Cooperation");
-    strictEqual(licenseInfo?.description, "Copyright Microsoft Cooperation");
+  const context = await createSdkContextForTester(program, {
+    license: {
+      name: "Test License",
+      company: "Microsoft Cooperation",
+      link: "https://example.com",
+      header: "Copyright Microsoft Cooperation",
+      description: "Copyright Microsoft Cooperation",
+    },
   });
+  const licenseInfo = context.sdkPackage.licenseInfo;
+  strictEqual(licenseInfo?.name, "Test License");
+  strictEqual(licenseInfo?.company, "Microsoft Cooperation");
+  strictEqual(licenseInfo?.link, "https://example.com");
+  strictEqual(licenseInfo?.header, "Copyright Microsoft Cooperation");
+  strictEqual(licenseInfo?.description, "Copyright Microsoft Cooperation");
 });


### PR DESCRIPTION
## Summary

Cleanup old pattern where we had a top level describe
- Doing this in order to prevent agents and people from generating new test following this pattern

> Use ignore whitespace mode for review

## Changes

36 files across 3 packages:
- `typespec-autorest` (19 files)
- `typespec-azure-core` (16 files)  
- `typespec-client-generator-core` (1 file)

### What was done:
- **Simple files** (only `it()` calls): Removed wrapper, dedented body, cleaned vitest imports
- **Files with `beforeEach`/shared vars**: Moved setup to file scope (vitest supports file-level `beforeEach`)
- **Files with nested describes**: Promoted inner describes to top level
- **Multi-describe file** (`openapi-output.test.ts`): Stripped `"typespec-autorest: "` prefix from describe names

## Testing

All tests pass across all affected packages:
- `typespec-autorest`: 478 tests ✅
- `typespec-azure-core`: 329 tests ✅
- `typespec-client-generator-core`: 1327 tests ✅