### PR TITLE
fix: write spector coverage by gracefully stopping server in conftest

### DIFF
--- a/.chronus/changes/python-spector-coverage-graceful-stop-2026-6-9-11-30-0.md
+++ b/.chronus/changes/python-spector-coverage-graceful-stop-2026-6-9-11-30-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Gracefully stop the spector mock server at the end of the test session so it writes its coverage file, removing the need for an extra pipeline step.

--- a/packages/typespec-python/tests/conftest.py
+++ b/packages/typespec-python/tests/conftest.py
@@ -96,6 +96,50 @@ def terminate_server_process(process):
             pass
 
 
+def graceful_stop_server(timeout: float = 30.0) -> None:
+    """Gracefully stop the mock server so it writes its coverage file.
+
+    The tsp-spector server only persists spec-coverage.json from its process
+    ``exit`` handler, which is triggered by a POST to the ``/.admin/stop`` admin
+    endpoint (it then calls ``process.exit(0)``). A hard kill of the process
+    skips that handler and leaves no coverage file. Posting to the admin
+    endpoint here lets coverage be written by the test run itself, so no extra
+    pipeline step is required to flush coverage before uploading it.
+    """
+    try:
+        req = urllib.request.Request(f"{SERVER_URL}/.admin/stop", method="POST")
+        urllib.request.urlopen(req, timeout=5)
+    except (urllib.error.URLError, OSError):
+        # Server already stopped or never started — nothing to do.
+        return
+
+    # Coverage is written synchronously in the server's exit handler. Wait until
+    # the server is no longer reachable to ensure the file is flushed to disk.
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        try:
+            urllib.request.urlopen(SERVER_URL, timeout=1)
+        except urllib.error.HTTPError:
+            pass  # Server up but returned an error response — still running.
+        except (urllib.error.URLError, OSError):
+            return  # Server is down — coverage has been flushed.
+        time.sleep(0.3)
+
+
+def pytest_unconfigure(config):
+    """Stop the shared mock server once the whole test session is finished.
+
+    Under pytest-xdist the server must outlive individual workers (which may
+    finish at different times), so it is intentionally not stopped in the
+    session-scoped fixture teardown. This hook runs after all workers complete:
+    only the controller process (no ``workerinput``) gracefully stops the
+    server so the coverage file is written.
+    """
+    if hasattr(config, "workerinput"):
+        return  # xdist worker — leave the shared server running for others.
+    graceful_stop_server()
+
+
 @pytest.fixture(scope="session", autouse=True)
 def testserver():
     """Start the mock API server, coordinated across xdist workers via file lock.

--- a/packages/typespec-python/tests/conftest.py
+++ b/packages/typespec-python/tests/conftest.py
@@ -100,16 +100,27 @@ def graceful_stop_server(timeout: float = 30.0) -> None:
     """Gracefully stop the mock server so it writes its coverage file.
 
     The tsp-spector server only persists spec-coverage.json from its process
-    ``exit`` handler, which is triggered by a POST to the ``/.admin/stop`` admin
-    endpoint (it then calls ``process.exit(0)``). A hard kill of the process
-    skips that handler and leaves no coverage file. Posting to the admin
-    endpoint here lets coverage be written by the test run itself, so no extra
-    pipeline step is required to flush coverage before uploading it.
+    ``exit`` handler, which is triggered by the ``tsp-spector server stop``
+    command (it posts to the ``/.admin/stop`` admin endpoint and the server then
+    calls ``process.exit(0)``). A hard kill of the process skips that handler and
+    leaves no coverage file. Stopping the server via the CLI here lets coverage
+    be written by the test run itself, so no extra pipeline step is required to
+    flush coverage before uploading it.
     """
+    env = os.environ.copy()
+    node_bin = str(ROOT / "node_modules" / ".bin")
+    env["PATH"] = f"{node_bin}{os.pathsep}{env.get('PATH', '')}"
     try:
-        req = urllib.request.Request(f"{SERVER_URL}/.admin/stop", method="POST")
-        urllib.request.urlopen(req, timeout=5)
-    except (urllib.error.URLError, OSError):
+        subprocess.run(
+            f"npx tsp-spector server stop --port {SERVER_PORT}",
+            shell=True,
+            cwd=str(ROOT),
+            env=env,
+            capture_output=True,
+            check=False,
+            timeout=30,
+        )
+    except Exception:
         # Server already stopped or never started — nothing to do.
         return
 


### PR DESCRIPTION
## Summary

Stop the tsp-spector mock server gracefully from the Python e2e test run so that the spector coverage file (`spec-coverage.json`) is written **without** needing an extra step in the publish pipeline.

## Background

`tsp-spector` only persists `spec-coverage.json` from its process `exit` handler, which is triggered by `POST /.admin/stop` (the admin route then calls `process.exit(0)`). Today the server is hard-killed when the parent process exits, which skips that handler — so no coverage file is produced. That is why #4579 adds a manual `curl -X POST .../.admin/stop` step in `build-for-publish.yml`.

## Change

Add a `pytest_unconfigure` hook in `packages/typespec-python/tests/conftest.py` that gracefully stops the server via the admin endpoint:

- Runs only in the xdist **controller** (or the non-xdist main process), i.e. after all workers finish, so the shared server is not killed prematurely while other workers still need it. This preserves the existing `testserver` fixture behavior that intentionally avoids stopping the server in per-worker teardown.
- Waits until the server is no longer reachable, guaranteeing the synchronous coverage write has been flushed to disk before the upload step runs.
- Is a safe no-op if the server is already stopped / was never started (mirrors the unconditional `curl ... || true` behavior it replaces).

With this in place, the extra pipeline step from #4579 is no longer needed.

## Testing

Will be validated in the publish pipeline.
