### PR TITLE
[python] Stop syncing conftest.py to preserve graceful spector server shutdown

### DIFF
--- a/.chronus/changes/python-sync-exclude-conftest-2026-6-10-11-30-0.md
+++ b/.chronus/changes/python-sync-exclude-conftest-2026-6-10-11-30-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Stop syncing `tests/conftest.py` from http-client-python so the local conftest with graceful spector server shutdown is preserved.

--- a/packages/typespec-python/eng/scripts/sync.ts
+++ b/packages/typespec-python/eng/scripts/sync.ts
@@ -99,11 +99,6 @@ const INCLUDES: readonly string[] = [
   "tests/data/",
   "tests/mock_api/",
   "tests/requirements/",
-
-  // Shared test driver/helper file. Treated as the upstream source of truth
-  // (DATA_FOLDER, server-launch logic, etc.) and kept aligned with
-  // http-client-python.
-  "tests/conftest.py",
 ];
 
 /**

--- a/packages/typespec-python/tests/mock_api/azure/asynctests/test_azure_client_generator_core_exact_name_async.py
+++ b/packages/typespec-python/tests/mock_api/azure/asynctests/test_azure_client_generator_core_exact_name_async.py
@@ -8,6 +8,7 @@ import pytest_asyncio
 from specs.azure.clientgenerator.core.exactname.aio import ExactNameClient
 from specs.azure.clientgenerator.core.exactname.model.models import My_model
 from specs.azure.clientgenerator.core.exactname.property.models import ScopedModel
+from specs.azure.clientgenerator.core.exactname.enumvalue.models import AgentEndpointProtocol, EndpointConfig
 
 
 @pytest_asyncio.fixture
@@ -41,3 +42,36 @@ def test_property_name_preserved():
     # exact("_my_name") scoped to python should preserve the property name exactly,
     # including the leading underscore, instead of being stripped or having its case changed.
     assert "_my_name" in ScopedModel.__annotations__
+
+
+@pytest.mark.asyncio
+async def test_enum_value(client: ExactNameClient):
+    body = EndpointConfig(protocol=AgentEndpointProtocol.A2A)
+    response = await client.enum_value.send(body=body)
+    assert response.protocol == "a2a"
+
+
+def test_enum_value_member_name_preserved():
+    # exact("A2A") should preserve the enum member name as-is, so Python should NOT
+    # convert it to "A_2_A". The wire value stays "a2a".
+    assert AgentEndpointProtocol.A2A.name == "A2A"
+    assert AgentEndpointProtocol.A2A.value == "a2a"
+
+
+@pytest.mark.asyncio
+async def test_operation(client: ExactNameClient):
+    await client.operation.myOp()
+
+
+def test_operation_method_name_preserved():
+    # exact("myOp") should preserve the operation method name as-is, so Python should NOT
+    # convert it to "my_op".
+    from specs.azure.clientgenerator.core.exactname.operation.aio.operations import OperationOperations
+
+    assert hasattr(OperationOperations, "myOp")
+    assert not hasattr(OperationOperations, "my_op")
+
+
+@pytest.mark.asyncio
+async def test_parameter(client: ExactNameClient):
+    await client.parameter.send(myParam="hello")

--- a/packages/typespec-python/tests/mock_api/azure/test_azure_client_generator_core_exact_name.py
+++ b/packages/typespec-python/tests/mock_api/azure/test_azure_client_generator_core_exact_name.py
@@ -7,6 +7,7 @@ import pytest
 from specs.azure.clientgenerator.core.exactname import ExactNameClient
 from specs.azure.clientgenerator.core.exactname.model.models import My_model
 from specs.azure.clientgenerator.core.exactname.property.models import ScopedModel
+from specs.azure.clientgenerator.core.exactname.enumvalue.models import AgentEndpointProtocol, EndpointConfig
 
 
 @pytest.fixture
@@ -38,3 +39,33 @@ def test_property_name_preserved():
     # exact("_my_name") scoped to python should preserve the property name exactly,
     # including the leading underscore, instead of being stripped or having its case changed.
     assert "_my_name" in ScopedModel.__annotations__
+
+
+def test_enum_value(client: ExactNameClient):
+    body = EndpointConfig(protocol=AgentEndpointProtocol.A2A)
+    response = client.enum_value.send(body=body)
+    assert response.protocol == "a2a"
+
+
+def test_enum_value_member_name_preserved():
+    # exact("A2A") should preserve the enum member name as-is, so Python should NOT
+    # convert it to "A_2_A". The wire value stays "a2a".
+    assert AgentEndpointProtocol.A2A.name == "A2A"
+    assert AgentEndpointProtocol.A2A.value == "a2a"
+
+
+def test_operation(client: ExactNameClient):
+    client.operation.myOp()
+
+
+def test_operation_method_name_preserved():
+    # exact("myOp") should preserve the operation method name as-is, so Python should NOT
+    # convert it to "my_op".
+    from specs.azure.clientgenerator.core.exactname.operation.operations import OperationOperations
+
+    assert hasattr(OperationOperations, "myOp")
+    assert not hasattr(OperationOperations, "my_op")
+
+
+def test_parameter(client: ExactNameClient):
+    client.parameter.send(myParam="hello")


### PR DESCRIPTION
## Summary

Removes `tests/conftest.py` from the list of files synced from `http-client-python` in [packages/typespec-python/eng/scripts/sync.ts](packages/typespec-python/eng/scripts/sync.ts). This preserves the local `conftest.py` that gracefully stops the spector mock server at the end of the test session so it writes its coverage file, avoiding it being overwritten by the upstream copy on each sync.

## Changes

- `packages/typespec-python/eng/scripts/sync.ts`: drop `tests/conftest.py` from the `INCLUDES` sync list.
- `tests/mock_api/azure/test_azure_client_generator_core_exact_name.py` and async counterpart: regenerated mock api tests.
- Added chronus changelog entry.
