### PR TITLE
feat(typespec-ts): Use CompilerHost for filesystem access (playground compatibility)

### DIFF
--- a/.chronus/changes/typespec-ts-compiler-host-vfs-2026-6-11-16-17-0.md
+++ b/.chronus/changes/typespec-ts-compiler-host-vfs-2026-6-11-16-17-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Use CompilerHost for all filesystem operations, enabling the emitter to run in the TypeSpec playground browser environment

--- a/packages/typespec-azure-playground-website/src/index.ts
+++ b/packages/typespec-azure-playground-website/src/index.ts
@@ -20,6 +20,7 @@ export const TypeSpecPlaygroundConfig = {
     "@azure-tools/typespec-autorest",
     "@azure-tools/typespec-client-generator-core",
     "@azure-tools/typespec-azure-rulesets",
+    "@azure-tools/typespec-ts",
   ],
   samples,
 } as const;

--- a/packages/typespec-ts/src/framework/load-static-helpers.ts
+++ b/packages/typespec-ts/src/framework/load-static-helpers.ts
@@ -38,6 +38,8 @@ export interface LoadStaticHelpersOptions extends Partial<ModularEmitterOptions>
   rootDir?: string;
   program?: Program;
   host?: CompilerHost;
+  /** The emitter package root directory (where static/ lives). */
+  packageRoot?: string;
   /** When true, also load test helpers from static/test-helpers/ into test/generated/util/ */
   loadTestHelpers?: boolean;
 }
@@ -60,9 +62,11 @@ export async function loadStaticHelpers(
     );
   }
 
+  const packageRoot = options.packageRoot ?? resolveProjectRoot();
+
   // Load static helpers used in sources code
   const defaultStaticHelpersPath = joinPaths(
-    resolveProjectRoot(),
+    packageRoot,
     DEFAULT_SOURCES_STATIC_HELPERS_PATH,
   );
   const filesInSources = await traverseDirectory(
@@ -77,7 +81,7 @@ export async function loadStaticHelpers(
     (options.options?.generateTest && isAzurePackage({ options: options.options }))
   ) {
     const defaultTestingHelpersPath = joinPaths(
-      resolveProjectRoot(),
+      packageRoot,
       DEFAULT_SOURCES_TESTING_HELPERS_PATH,
     );
     const filesInTestings = await traverseDirectory(

--- a/packages/typespec-ts/src/framework/load-static-helpers.ts
+++ b/packages/typespec-ts/src/framework/load-static-helpers.ts
@@ -1,5 +1,4 @@
-import { joinPaths, NoTarget, Program } from "@typespec/compiler";
-import { readdir, readFile, stat } from "fs/promises";
+import { type CompilerHost, joinPaths, NoTarget, Program } from "@typespec/compiler";
 import {
   ClassDeclaration,
   EnumDeclaration,
@@ -38,6 +37,7 @@ export interface LoadStaticHelpersOptions extends Partial<ModularEmitterOptions>
   sourcesDir?: string;
   rootDir?: string;
   program?: Program;
+  host?: CompilerHost;
   /** When true, also load test helpers from static/test-helpers/ into test/generated/util/ */
   loadTestHelpers?: boolean;
 }
@@ -53,6 +53,13 @@ export async function loadStaticHelpers(
   options: LoadStaticHelpersOptions = {},
 ): Promise<Map<string, StaticHelperMetadata>> {
   const helpersMap = new Map<string, StaticHelperMetadata>();
+  const host = options.host ?? options.program?.host;
+  if (!host) {
+    throw new Error(
+      "loadStaticHelpers requires either a host or program in options to access the file system.",
+    );
+  }
+
   // Load static helpers used in sources code
   const defaultStaticHelpersPath = joinPaths(
     resolveProjectRoot(),
@@ -60,6 +67,7 @@ export async function loadStaticHelpers(
   );
   const filesInSources = await traverseDirectory(
     options.helpersAssetDirectory ?? defaultStaticHelpersPath,
+    host,
     options.program,
   );
   await loadFiles(filesInSources, options.sourcesDir ?? "");
@@ -74,6 +82,7 @@ export async function loadStaticHelpers(
     );
     const filesInTestings = await traverseDirectory(
       defaultTestingHelpersPath,
+      host,
       options.program,
       [],
       "",
@@ -86,7 +95,8 @@ export async function loadStaticHelpers(
   async function loadFiles(files: FileMetadata[], generateDir: string) {
     for (const file of files) {
       const targetPath = joinPaths(generateDir, file.target);
-      const contents = await readFile(file.source, "utf-8");
+      const sourceFile = await host!.readFile(file.source);
+      const contents = sourceFile.text;
       const addedFile = project.createSourceFile(targetPath, contents, {
         overwrite: true,
       });
@@ -189,22 +199,24 @@ function getDeclarationByMetadata(
 const _targetStaticHelpersBaseDir = "static-helpers";
 async function traverseDirectory(
   directory: string,
+  host: CompilerHost,
   program?: Program,
   result: { source: string; target: string }[] = [],
   relativePath: string = "",
   targetBaseDir: string = _targetStaticHelpersBaseDir,
 ): Promise<{ source: string; target: string }[]> {
   try {
-    const files = await readdir(directory);
+    const files = await host.readDir(directory);
 
     await Promise.all(
       files.map(async (file) => {
         const filePath = joinPaths(directory, file);
-        const fileStat = await stat(filePath);
+        const fileStat = await host.stat(filePath);
 
         if (fileStat.isDirectory()) {
           await traverseDirectory(
             filePath,
+            host,
             program,
             result,
             joinPaths(relativePath, file),

--- a/packages/typespec-ts/src/framework/load-static-helpers.ts
+++ b/packages/typespec-ts/src/framework/load-static-helpers.ts
@@ -1,4 +1,5 @@
 import { type CompilerHost, joinPaths, NoTarget, Program } from "@typespec/compiler";
+import { readdir, readFile, stat } from "fs/promises";
 import {
   ClassDeclaration,
   EnumDeclaration,
@@ -55,12 +56,8 @@ export async function loadStaticHelpers(
   options: LoadStaticHelpersOptions = {},
 ): Promise<Map<string, StaticHelperMetadata>> {
   const helpersMap = new Map<string, StaticHelperMetadata>();
-  const host = options.host ?? options.program?.host;
-  if (!host) {
-    throw new Error(
-      "loadStaticHelpers requires either a host or program in options to access the file system.",
-    );
-  }
+  // Use provided host, or fall back to a minimal Node.js fs adapter for testing
+  const host: FsHost = options.host ?? options.program?.host ?? createNodeFsHost();
 
   const packageRoot = options.packageRoot ?? resolveProjectRoot();
 
@@ -194,10 +191,12 @@ function getDeclarationByMetadata(
   }
 }
 
+type FsHost = Pick<CompilerHost, "readFile" | "readDir" | "stat">;
+
 const _targetStaticHelpersBaseDir = "static-helpers";
 async function traverseDirectory(
   directory: string,
-  host: CompilerHost,
+  host: FsHost,
   program?: Program,
   result: { source: string; target: string }[] = [],
   relativePath: string = "",
@@ -238,4 +237,21 @@ async function traverseDirectory(
     }
     throw error;
   }
+}
+
+/** Minimal Node.js filesystem adapter for use in tests when no CompilerHost is available. */
+function createNodeFsHost(): FsHost {
+  return {
+    async readFile(path: string) {
+      const text = await readFile(path, "utf-8");
+      return { text, path, getLineStarts: () => [] } as any;
+    },
+    async readDir(path: string) {
+      return readdir(path);
+    },
+    async stat(path: string) {
+      const s = await stat(path);
+      return { isDirectory: () => s.isDirectory(), isFile: () => s.isFile() };
+    },
+  };
 }

--- a/packages/typespec-ts/src/framework/load-static-helpers.ts
+++ b/packages/typespec-ts/src/framework/load-static-helpers.ts
@@ -65,10 +65,7 @@ export async function loadStaticHelpers(
   const packageRoot = options.packageRoot ?? resolveProjectRoot();
 
   // Load static helpers used in sources code
-  const defaultStaticHelpersPath = joinPaths(
-    packageRoot,
-    DEFAULT_SOURCES_STATIC_HELPERS_PATH,
-  );
+  const defaultStaticHelpersPath = joinPaths(packageRoot, DEFAULT_SOURCES_STATIC_HELPERS_PATH);
   const filesInSources = await traverseDirectory(
     options.helpersAssetDirectory ?? defaultStaticHelpersPath,
     host,
@@ -80,10 +77,7 @@ export async function loadStaticHelpers(
     options.loadTestHelpers ??
     (options.options?.generateTest && isAzurePackage({ options: options.options }))
   ) {
-    const defaultTestingHelpersPath = joinPaths(
-      packageRoot,
-      DEFAULT_SOURCES_TESTING_HELPERS_PATH,
-    );
+    const defaultTestingHelpersPath = joinPaths(packageRoot, DEFAULT_SOURCES_TESTING_HELPERS_PATH);
     const filesInTestings = await traverseDirectory(
       defaultTestingHelpersPath,
       host,

--- a/packages/typespec-ts/src/framework/load-static-helpers.ts
+++ b/packages/typespec-ts/src/framework/load-static-helpers.ts
@@ -1,5 +1,4 @@
 import { type CompilerHost, joinPaths, NoTarget, Program } from "@typespec/compiler";
-import { readdir, readFile, stat } from "fs/promises";
 import {
   ClassDeclaration,
   EnumDeclaration,
@@ -56,8 +55,12 @@ export async function loadStaticHelpers(
   options: LoadStaticHelpersOptions = {},
 ): Promise<Map<string, StaticHelperMetadata>> {
   const helpersMap = new Map<string, StaticHelperMetadata>();
-  // Use provided host, or fall back to a minimal Node.js fs adapter for testing
-  const host: FsHost = options.host ?? options.program?.host ?? createNodeFsHost();
+  const host = options.host ?? options.program?.host;
+  if (!host) {
+    throw new Error(
+      "loadStaticHelpers requires either a host or program in options to access the file system.",
+    );
+  }
 
   const packageRoot = options.packageRoot ?? resolveProjectRoot();
 
@@ -237,21 +240,4 @@ async function traverseDirectory(
     }
     throw error;
   }
-}
-
-/** Minimal Node.js filesystem adapter for use in tests when no CompilerHost is available. */
-function createNodeFsHost(): FsHost {
-  return {
-    async readFile(path: string) {
-      const text = await readFile(path, "utf-8");
-      return { text, path, getLineStarts: () => [] } as any;
-    },
-    async readDir(path: string) {
-      return readdir(path);
-    },
-    async stat(path: string) {
-      const s = await stat(path);
-      return { isDirectory: () => s.isDirectory(), isFile: () => s.isFile() };
-    },
-  };
 }

--- a/packages/typespec-ts/src/framework/sample.ts
+++ b/packages/typespec-ts/src/framework/sample.ts
@@ -9,7 +9,7 @@ import { useBinder } from "./hooks/binder.js";
 import { resolveReference } from "./reference.js";
 
 // Create a new ts-morph project
-const project = new Project();
+const project = new Project({ useInMemoryFileSystem: true });
 
 // Create a source file
 const sourceFile = project.createSourceFile("test.ts", "", { overwrite: true });

--- a/packages/typespec-ts/src/index.ts
+++ b/packages/typespec-ts/src/index.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { EmitContext, Program, getBaseFileName, joinPaths, type CompilerHost } from "@typespec/compiler";
+import { EmitContext, Program, getBaseFileName, getDirectoryPath, joinPaths, resolvePath, type CompilerHost } from "@typespec/compiler";
 import { provideContext, useContext } from "./context-manager.js";
 import { buildRootIndex, buildSubClientIndexFile } from "./modular/build-root-index.js";
 import {
@@ -119,6 +119,14 @@ export async function $onEmit(context: EmitContext) {
   const outputProject = new Project({ useInMemoryFileSystem: true });
   const program: Program = context.program;
   const host: CompilerHost = program.host;
+  // Derive the emitter package root from the compiler's resolved emitter entry point.
+  // This works correctly in both Node.js and the browser playground VFS.
+  const emitterRef = program.emitters.find(
+    (e) => e.metadata.name === "@azure-tools/typespec-ts",
+  );
+  const emitterPackageRoot = emitterRef
+    ? resolvePath(getDirectoryPath(emitterRef.main), "../..")
+    : undefined;
   const emitterOptions: EmitterOptions = context.options;
   const dpgContext = await createContextWithDefaultOptions(context);
 
@@ -161,6 +169,7 @@ export async function $onEmit(context: EmitContext) {
       options: rlcOptions,
       program,
       host,
+      packageRoot: emitterPackageRoot,
     },
   );
   const extraDependencies = isAzurePackage({ options: rlcOptions })

--- a/packages/typespec-ts/src/index.ts
+++ b/packages/typespec-ts/src/index.ts
@@ -116,7 +116,7 @@ export async function $onEmit(context: EmitContext) {
     return;
   }
   /** Shared status */
-  const outputProject = new Project();
+  const outputProject = new Project({ useInMemoryFileSystem: true });
   const program: Program = context.program;
   const host: CompilerHost = program.host;
   const emitterOptions: EmitterOptions = context.options;

--- a/packages/typespec-ts/src/index.ts
+++ b/packages/typespec-ts/src/index.ts
@@ -1,7 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { EmitContext, Program, getBaseFileName, getDirectoryPath, joinPaths, resolvePath, type CompilerHost } from "@typespec/compiler";
+import {
+  EmitContext,
+  Program,
+  getBaseFileName,
+  getDirectoryPath,
+  joinPaths,
+  resolvePath,
+  type CompilerHost,
+} from "@typespec/compiler";
 import { provideContext, useContext } from "./context-manager.js";
 import { buildRootIndex, buildSubClientIndexFile } from "./modular/build-root-index.js";
 import {
@@ -121,9 +129,7 @@ export async function $onEmit(context: EmitContext) {
   const host: CompilerHost = program.host;
   // Derive the emitter package root from the compiler's resolved emitter entry point.
   // This works correctly in both Node.js and the browser playground VFS.
-  const emitterRef = program.emitters.find(
-    (e) => e.metadata.name === "@azure-tools/typespec-ts",
-  );
+  const emitterRef = program.emitters.find((e) => e.metadata.name === "@azure-tools/typespec-ts");
   const emitterPackageRoot = emitterRef
     ? resolvePath(getDirectoryPath(emitterRef.main), "../..")
     : undefined;

--- a/packages/typespec-ts/src/index.ts
+++ b/packages/typespec-ts/src/index.ts
@@ -1,8 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { EmitContext, Program, getBaseFileName, joinPaths } from "@typespec/compiler";
-import { existsSync } from "fs";
+import { EmitContext, Program, getBaseFileName, joinPaths, type CompilerHost } from "@typespec/compiler";
 import { provideContext, useContext } from "./context-manager.js";
 import { buildRootIndex, buildSubClientIndexFile } from "./modular/build-root-index.js";
 import {
@@ -119,6 +118,7 @@ export async function $onEmit(context: EmitContext) {
   /** Shared status */
   const outputProject = new Project();
   const program: Program = context.program;
+  const host: CompilerHost = program.host;
   const emitterOptions: EmitterOptions = context.options;
   const dpgContext = await createContextWithDefaultOptions(context);
 
@@ -160,6 +160,7 @@ export async function $onEmit(context: EmitContext) {
       rootDir: dpgContext.generationPathDetail?.rootDir,
       options: rlcOptions,
       program,
+      host,
     },
   );
   const extraDependencies = isAzurePackage({ options: rlcOptions })
@@ -216,9 +217,10 @@ export async function $onEmit(context: EmitContext) {
     // clear output folder if needed
     if (options.clearOutputFolder) {
       // Clear output directory while preserving TempTypeSpecFiles
-      await clearDirectory(context.emitterOutputDir, ["TempTypeSpecFiles"], program);
+      await clearDirectory(host, context.emitterOutputDir, ["TempTypeSpecFiles"], program);
     }
     const hasTestFolder = await pathExists(
+      host,
       joinPaths(dpgContext.generationPathDetail?.metadataDir ?? "", "test"),
     );
     options.generateTest =
@@ -234,10 +236,10 @@ export async function $onEmit(context: EmitContext) {
     const customizationFolder = joinPaths(projectRoot, "generated");
     const srcGeneratedFolder = joinPaths(projectRoot, "src", "generated");
     // if customization folder exists, use it as sources root
-    const finalCustomizationFolder = (await pathExists(srcGeneratedFolder))
+    const finalCustomizationFolder = (await pathExists(host, srcGeneratedFolder))
       ? srcGeneratedFolder
       : customizationFolder;
-    const sourcesRoot = (await pathExists(finalCustomizationFolder))
+    const sourcesRoot = (await pathExists(host, finalCustomizationFolder))
       ? finalCustomizationFolder
       : joinPaths(projectRoot, "src");
     return {
@@ -250,6 +252,7 @@ export async function $onEmit(context: EmitContext) {
 
   async function clearSrcFolder() {
     await emptyDir(
+      host,
       dpgContext.generationPathDetail?.modularSourcesDir ??
         dpgContext.generationPathDetail?.rlcSourcesDir ??
         "",
@@ -262,8 +265,8 @@ export async function $onEmit(context: EmitContext) {
         dpgContext.generationPathDetail?.rootDir ?? "",
         "samples-dev",
       );
-      if (await pathExists(samplesDevPath)) {
-        await emptyDir(samplesDevPath);
+      if (await pathExists(host, samplesDevPath)) {
+        await emptyDir(host, samplesDevPath);
       }
     }
   }
@@ -459,23 +462,23 @@ export async function $onEmit(context: EmitContext) {
       dpgContext.generationPathDetail?.metadataDir ?? "",
       "package.json",
     );
-    const hasPackageFile = existsSync(existingPackageFilePath);
+    const hasPackageFile = await pathExists(host, existingPackageFilePath);
     const existingReadmeFilePath = joinPaths(
       dpgContext.generationPathDetail?.metadataDir ?? "",
       "README.md",
     );
-    const hasReadmeFile = existsSync(existingReadmeFilePath);
+    const hasReadmeFile = await pathExists(host, existingReadmeFilePath);
     const existingChangelogFilePath = joinPaths(
       dpgContext.generationPathDetail?.metadataDir ?? "",
       "CHANGELOG.md",
     );
-    const hasChangelogFile = existsSync(existingChangelogFilePath);
+    const hasChangelogFile = await pathExists(host, existingChangelogFilePath);
     const shouldGenerateMetadata = option.generateMetadata === true || !hasPackageFile;
     const existingTestFolderPath = joinPaths(
       dpgContext.generationPathDetail?.metadataDir ?? "",
       "test",
     );
-    const hasTestFolder = existsSync(existingTestFolderPath);
+    const hasTestFolder = await pathExists(host, existingTestFolderPath);
     if (option.generateTest === undefined) {
       if (hasTestFolder) {
         option.generateTest = false;
@@ -516,7 +519,7 @@ export async function $onEmit(context: EmitContext) {
         option.azureSdkForJs === true &&
         emitterOptions["generate-metadata"] === true
       ) {
-        await emitTests(dpgContext);
+        await emitTests(dpgContext, host);
       }
       let modularPackageInfo = {};
       if (option.isModularLibrary) {
@@ -617,8 +620,16 @@ export async function $onEmit(context: EmitContext) {
       // Always update package.json for monorepo packages (adds #platform/* imports)
       // and for modular packages (adds exports, clientContextPaths, LRO deps)
       if (option.isModularLibrary || option.azureSdkForJs) {
+        // Read package.json content via host and pass parsed object
+        const pkgSourceFile = await host.readFile(existingPackageFilePath);
+        let packageInfo: Record<string, any>;
+        try {
+          packageInfo = JSON.parse(pkgSourceFile.text);
+        } catch {
+          packageInfo = {};
+        }
         updateBuilders.push((model: RLCModel) =>
-          updatePackageFile(model, existingPackageFilePath, modularPackageInfo),
+          updatePackageFile(model, packageInfo, modularPackageInfo),
         );
       }
 
@@ -630,11 +641,13 @@ export async function $onEmit(context: EmitContext) {
       // If the client name changed, regenerate the README and snippets completely;
       // otherwise update only the API reference link in-place.
       if (hasReadmeFile) {
-        const clientNameChanged = hasClientNameChanged(rlcClient, existingReadmeFilePath);
+        const readmeSourceFile = await host.readFile(existingReadmeFilePath);
+        const existingReadmeContent = readmeSourceFile.text;
+        const clientNameChanged = hasClientNameChanged(rlcClient, existingReadmeContent);
         updateBuilders.push(
           clientNameChanged
             ? buildReadmeFile
-            : (model: RLCModel) => updateReadmeFile(model, existingReadmeFilePath),
+            : (model: RLCModel) => updateReadmeFile(model, existingReadmeContent),
         );
 
         // Regenerate snippets.spec.ts only when the client name changed

--- a/packages/typespec-ts/src/modular/emit-tests.ts
+++ b/packages/typespec-ts/src/modular/emit-tests.ts
@@ -1,5 +1,4 @@
-import { joinPaths } from "@typespec/compiler";
-import { existsSync, rmSync } from "fs";
+import { type CompilerHost, joinPaths } from "@typespec/compiler";
 import { SourceFile } from "ts-morph";
 import { resolveReference } from "../framework/reference.js";
 import { NameType, normalizeName } from "../rlc-common/index.js";
@@ -22,7 +21,7 @@ import { CreateRecorderHelpers } from "./static-helpers-metadata.js";
 /**
  * Clean up the test/generated folder before generating new tests
  */
-async function cleanupTestFolder(dpgContext: SdkContext) {
+async function cleanupTestFolder(dpgContext: SdkContext, host: CompilerHost) {
   const clients = dpgContext.sdkPackage.clients;
   const baseTestFolder = joinPaths(
     dpgContext.generationPathDetail?.rootDir ?? "",
@@ -30,19 +29,28 @@ async function cleanupTestFolder(dpgContext: SdkContext) {
     "generated",
   );
 
+  async function dirExists(path: string): Promise<boolean> {
+    try {
+      const s = await host.stat(path);
+      return s.isDirectory();
+    } catch {
+      return false;
+    }
+  }
+
   // If there are multiple clients, clean up subfolders
   if (clients.length > 1) {
     for (const client of clients) {
       const subFolder = normalizeName(getClassicalClientName(client), NameType.File);
       const clientTestFolder = joinPaths(baseTestFolder, subFolder);
-      if (existsSync(clientTestFolder)) {
-        rmSync(clientTestFolder, { recursive: true, force: true });
+      if (await dirExists(clientTestFolder)) {
+        await host.rm(clientTestFolder, { recursive: true });
       }
     }
   } else {
     // Single client, clean up the entire test/generated folder
-    if (existsSync(baseTestFolder)) {
-      rmSync(baseTestFolder, { recursive: true, force: true });
+    if (await dirExists(baseTestFolder)) {
+      await host.rm(baseTestFolder, { recursive: true });
     }
   }
 }
@@ -50,9 +58,11 @@ async function cleanupTestFolder(dpgContext: SdkContext) {
 /**
  * Helpers to emit tests similar to samples
  */
-export async function emitTests(dpgContext: SdkContext): Promise<SourceFile[]> {
+export async function emitTests(dpgContext: SdkContext, host?: CompilerHost): Promise<SourceFile[]> {
   // Clean up the test/generated folder before generating new tests
-  await cleanupTestFolder(dpgContext);
+  if (host) {
+    await cleanupTestFolder(dpgContext, host);
+  }
 
   return iterateClientsAndMethods(dpgContext, emitMethodTests);
 }

--- a/packages/typespec-ts/src/modular/emit-tests.ts
+++ b/packages/typespec-ts/src/modular/emit-tests.ts
@@ -58,7 +58,10 @@ async function cleanupTestFolder(dpgContext: SdkContext, host: CompilerHost) {
 /**
  * Helpers to emit tests similar to samples
  */
-export async function emitTests(dpgContext: SdkContext, host?: CompilerHost): Promise<SourceFile[]> {
+export async function emitTests(
+  dpgContext: SdkContext,
+  host?: CompilerHost,
+): Promise<SourceFile[]> {
   // Clean up the test/generated folder before generating new tests
   if (host) {
     await cleanupTestFolder(dpgContext, host);

--- a/packages/typespec-ts/src/rlc-common/build-client-definitions.ts
+++ b/packages/typespec-ts/src/rlc-common/build-client-definitions.ts
@@ -30,7 +30,7 @@ export function buildClientDefinitions(model: RLCModel) {
     importedResponses: new Set<string>(),
     clientImports: new Set<string>(),
   };
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
   const srcPath = model.srcPath;
   const filePath = joinPaths(srcPath, `clientDefinitions.ts`);
   const clientDefinitionsFile = project.createSourceFile(filePath, undefined, {

--- a/packages/typespec-ts/src/rlc-common/build-client.ts
+++ b/packages/typespec-ts/src/rlc-common/build-client.ts
@@ -62,7 +62,7 @@ function getClientOptionsInterface(
 export function buildClient(model: RLCModel): File | undefined {
   const name = normalizeName(model.libraryName, NameType.File);
   const { srcPath } = model;
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
   const filePath = joinPaths(srcPath, `${name}.ts`);
   const clientFile = project.createSourceFile(filePath, undefined, {
     overwrite: true,

--- a/packages/typespec-ts/src/rlc-common/build-index-file.ts
+++ b/packages/typespec-ts/src/rlc-common/build-index-file.ts
@@ -23,7 +23,7 @@ import { RLCModel } from "./interfaces.js";
 export function buildIndexFile(model: RLCModel) {
   const multiClient = Boolean(model.options?.multiClient),
     batch = model.options?.batch;
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
   const { srcPath } = model;
   const filePath = joinPaths(srcPath, `index.ts`);
   const indexFile = project.createSourceFile(filePath, undefined, {

--- a/packages/typespec-ts/src/rlc-common/build-is-unexpected-helper.ts
+++ b/packages/typespec-ts/src/rlc-common/build-is-unexpected-helper.ts
@@ -15,7 +15,7 @@ export function buildIsUnexpectedHelper(model: RLCModel) {
   if (!hasUnexpectedHelper(model)) {
     return;
   }
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
   const srcPath = model.srcPath;
   const filePath = joinPaths(srcPath, `isUnexpected.ts`);
   const isErrorHelper = project.createSourceFile(filePath, undefined, {

--- a/packages/typespec-ts/src/rlc-common/build-logger.ts
+++ b/packages/typespec-ts/src/rlc-common/build-logger.ts
@@ -13,7 +13,7 @@ export function buildLogger(model: RLCModel) {
   if (model.options.flavor !== "azure") {
     return undefined;
   }
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
   const { srcPath, rlcSourceDir } = model;
   const { packageDetails } = model.options;
   const filePath = joinPaths(

--- a/packages/typespec-ts/src/rlc-common/build-parameter-types.ts
+++ b/packages/typespec-ts/src/rlc-common/build-parameter-types.ts
@@ -27,7 +27,7 @@ import {
 } from "./interfaces.js";
 
 export function buildParameterTypes(model: RLCModel) {
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
   const srcPath = model.srcPath;
   const filePath = joinPaths(srcPath, `parameters.ts`);
   const partialBodyTypeNames = new Set<string>();

--- a/packages/typespec-ts/src/rlc-common/build-response-types.ts
+++ b/packages/typespec-ts/src/rlc-common/build-response-types.ts
@@ -19,7 +19,7 @@ import { ResponseHeaderSchema, ResponseMetadata, RLCModel } from "./interfaces.j
 
 let hasErrorResponse = false;
 export function buildResponseTypes(model: RLCModel) {
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
   const srcPath = model.srcPath;
   const filePath = joinPaths(srcPath, `responses.ts`);
   hasErrorResponse = false;

--- a/packages/typespec-ts/src/rlc-common/build-schema-type.ts
+++ b/packages/typespec-ts/src/rlc-common/build-schema-type.ts
@@ -17,7 +17,7 @@ import { RLCModel, SchemaContext } from "./interfaces.js";
  */
 export function buildSchemaTypes(model: RLCModel) {
   const { srcPath } = model;
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
   let filePath = joinPaths(srcPath, `models.ts`);
   const inputModelFile = generateModelFiles(model, project, filePath, [SchemaContext.Input]);
   filePath = joinPaths(srcPath, `outputModels.ts`);

--- a/packages/typespec-ts/src/rlc-common/build-top-level-index-file.ts
+++ b/packages/typespec-ts/src/rlc-common/build-top-level-index-file.ts
@@ -14,7 +14,7 @@ export function buildTopLevelIndex(model: RLCModel) {
   if (!model.options) {
     return undefined;
   }
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
   const { srcPath } = model;
   const { multiClient } = model.options;
   const batch = model.options.batch;

--- a/packages/typespec-ts/src/rlc-common/metadata/build-api-extractor-config.ts
+++ b/packages/typespec-ts/src/rlc-common/metadata/build-api-extractor-config.ts
@@ -6,7 +6,7 @@ import { RLCModel } from "../interfaces.js";
 
 export function buildApiExtractorConfig(model: RLCModel) {
   const { packageDetails, isModularLibrary, generateTest, azureSdkForJs } = model.options || {};
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
 
   let mainEntryPointFilePath = "dist/esm/index.d.ts";
 

--- a/packages/typespec-ts/src/rlc-common/metadata/build-es-lint-config.ts
+++ b/packages/typespec-ts/src/rlc-common/metadata/build-es-lint-config.ts
@@ -65,7 +65,7 @@ export function buildEsLintConfig(model: RLCModel) {
   if (model.options?.flavor !== "azure") {
     return;
   }
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
   const filePath = "eslint.config.mjs";
 
   let template: string;

--- a/packages/typespec-ts/src/rlc-common/metadata/build-package-file.ts
+++ b/packages/typespec-ts/src/rlc-common/metadata/build-package-file.ts
@@ -108,7 +108,7 @@ export function updatePackageFile(
   if (typeof existingFilePathOrContent === "string") {
     let packageFile: SourceFile;
     try {
-      const project = new Project({ useInMemoryFileSystem: true });
+      const project = new Project();
       packageFile = project.addSourceFileAtPath(existingFilePathOrContent);
     } catch (_e) {
       // If the file doesn't exist, we don't need to update it.

--- a/packages/typespec-ts/src/rlc-common/metadata/build-package-file.ts
+++ b/packages/typespec-ts/src/rlc-common/metadata/build-package-file.ts
@@ -66,7 +66,7 @@ export function buildPackageFile(
     packageInfo = buildAzureStandalonePackage(extendedConfig);
   }
 
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
   const filePath = "package.json";
 
   if (!packageInfo) {
@@ -108,7 +108,7 @@ export function updatePackageFile(
   if (typeof existingFilePathOrContent === "string") {
     let packageFile: SourceFile;
     try {
-      const project = new Project();
+      const project = new Project({ useInMemoryFileSystem: true });
       packageFile = project.addSourceFileAtPath(existingFilePathOrContent);
     } catch (_e) {
       // If the file doesn't exist, we don't need to update it.

--- a/packages/typespec-ts/src/rlc-common/metadata/build-readme-file.ts
+++ b/packages/typespec-ts/src/rlc-common/metadata/build-readme-file.ts
@@ -3,7 +3,6 @@
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore: to fix the handlebars issue
-import { readFileSync } from "fs";
 import hbs from "handlebars";
 import { getClientName } from "../helpers/name-constructors.js";
 import { NameType, normalizeName } from "../helpers/name-utils.js";
@@ -363,10 +362,9 @@ export function buildReadmeFile(model: RLCModel) {
   };
 }
 
-export function hasClientNameChanged(model: RLCModel, existingReadmeFilePath: string): boolean {
+export function hasClientNameChanged(model: RLCModel, existingReadmeContent: string): boolean {
   try {
-    const existingContent = readFileSync(existingReadmeFilePath, "utf8");
-    const importMatch = existingContent.match(
+    const importMatch = existingReadmeContent.match(
       /import\s*\{\s*([A-Za-z0-9_]+)\s*\}\s*from\s*["'][^"']*["']/,
     );
     const existingClientName = importMatch?.[1];
@@ -379,21 +377,20 @@ export function hasClientNameChanged(model: RLCModel, existingReadmeFilePath: st
 
 export function updateReadmeFile(
   model: RLCModel,
-  existingReadmeFilePath: string,
+  existingReadmeContent: string,
 ): { path: string; content: string } | undefined {
   try {
-    const existingContent = readFileSync(existingReadmeFilePath, "utf8");
     const metadata = createMetadata(model) ?? {};
 
     const newApiRefLink = hbs.compile(apiReferenceTemplate, { noEscape: true })(metadata).trim();
 
     if (!newApiRefLink) {
-      return { path: "README.md", content: existingContent };
+      return { path: "README.md", content: existingReadmeContent };
     }
 
     const apiRefRegex =
       /^- \[API reference documentation\]\(https:\/\/learn\.microsoft\.com\/javascript\/api\/[^)]+\)$/m;
-    const updatedContent = existingContent.replace(apiRefRegex, (match) =>
+    const updatedContent = existingReadmeContent.replace(apiRefRegex, (match) =>
       match ? newApiRefLink : match,
     );
 

--- a/packages/typespec-ts/src/rlc-common/metadata/build-rollup-config.ts
+++ b/packages/typespec-ts/src/rlc-common/metadata/build-rollup-config.ts
@@ -12,7 +12,7 @@ export function buildRollupConfig(model: RLCModel) {
     return;
   }
 
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
   const filePath = "rollup.config.js";
   const rollupFile = project.createSourceFile(filePath, undefined, {
     overwrite: true,

--- a/packages/typespec-ts/src/rlc-common/metadata/build-ts-config.ts
+++ b/packages/typespec-ts/src/rlc-common/metadata/build-ts-config.ts
@@ -14,7 +14,7 @@ export function buildTsConfig(model: RLCModel) {
   const { packageDetails, azureSdkForJs } = model.options || {};
   const { generateTest, generateSample, generateReactNativeTarget } = model.options || {};
   const clientPackageName = packageDetails?.name ?? "";
-  const project = new Project();
+  const project = new Project({ useInMemoryFileSystem: true });
 
   let tsConfig: Record<string, any>;
 

--- a/packages/typespec-ts/src/utils/emit-util.ts
+++ b/packages/typespec-ts/src/utils/emit-util.ts
@@ -1,5 +1,6 @@
 import { CompilerHost, getDirectoryPath, joinPaths, NoTarget, Program } from "@typespec/compiler";
 import { format } from "prettier";
+import prettierPluginBabel from "prettier/plugins/babel";
 import prettierPluginEstree from "prettier/plugins/estree";
 import prettierPluginTypescript from "prettier/plugins/typescript";
 import { prettierJSONOptions, prettierTypeScriptOptions, reportDiagnostic } from "../lib.js";
@@ -74,7 +75,7 @@ async function emitFile(
     try {
       prettierFileContent = await format(prettierFileContent, {
         ...(isJson ? prettierJSONOptions : prettierTypeScriptOptions),
-        plugins: [prettierPluginTypescript, prettierPluginEstree],
+        plugins: [prettierPluginTypescript, prettierPluginEstree, prettierPluginBabel],
       });
     } catch (e) {
       reportDiagnostic(program, {

--- a/packages/typespec-ts/src/utils/emit-util.ts
+++ b/packages/typespec-ts/src/utils/emit-util.ts
@@ -1,5 +1,7 @@
 import { CompilerHost, getDirectoryPath, joinPaths, NoTarget, Program } from "@typespec/compiler";
 import { format } from "prettier";
+import prettierPluginEstree from "prettier/plugins/estree";
+import prettierPluginTypescript from "prettier/plugins/typescript";
 import { prettierJSONOptions, prettierTypeScriptOptions, reportDiagnostic } from "../lib.js";
 import {
   buildSchemaTypes,
@@ -70,10 +72,10 @@ async function emitFile(
   // Format the contents if necessary
   if (isJson || isSourceCode) {
     try {
-      prettierFileContent = await format(
-        prettierFileContent,
-        isJson ? prettierJSONOptions : prettierTypeScriptOptions,
-      );
+      prettierFileContent = await format(prettierFileContent, {
+        ...(isJson ? prettierJSONOptions : prettierTypeScriptOptions),
+        plugins: [prettierPluginTypescript, prettierPluginEstree],
+      });
     } catch (e) {
       reportDiagnostic(program, {
         code: "file-formatting-error",

--- a/packages/typespec-ts/src/utils/file-system-utils.ts
+++ b/packages/typespec-ts/src/utils/file-system-utils.ts
@@ -1,48 +1,48 @@
-import { NoTarget, Program, resolvePath } from "@typespec/compiler";
-import { mkdir, readdir, rm, stat } from "fs/promises";
+import { NoTarget, Program, resolvePath, type CompilerHost } from "@typespec/compiler";
 import { reportDiagnostic } from "../lib.js";
 
-export async function pathExists(targetPath: string): Promise<boolean> {
+export async function pathExists(host: CompilerHost, targetPath: string): Promise<boolean> {
   try {
-    await stat(targetPath);
+    await host.stat(targetPath);
     return true;
   } catch {
     return false;
   }
 }
 
-export async function emptyDir(dirPath: string): Promise<void> {
+export async function emptyDir(host: CompilerHost, dirPath: string): Promise<void> {
   let entries: string[];
   try {
-    entries = await readdir(dirPath);
+    entries = await host.readDir(dirPath);
   } catch {
-    await mkdir(dirPath, { recursive: true });
+    await host.mkdirp(dirPath);
     return;
   }
 
   await Promise.all(
-    entries.map((entry) => rm(resolvePath(dirPath, entry), { recursive: true, force: true })),
+    entries.map((entry) => host.rm(resolvePath(dirPath, entry), { recursive: true })),
   );
 }
 
 export async function clearDirectory(
+  host: CompilerHost,
   dirPath: string,
   excludeNames: string[] = [],
   program?: Program,
 ): Promise<void> {
-  if (!(await pathExists(dirPath))) {
+  if (!(await pathExists(host, dirPath))) {
     return;
   }
 
   // If no exclude names, just use regular emptyDir for efficiency
   if (excludeNames.length === 0) {
-    await emptyDir(dirPath);
+    await emptyDir(host, dirPath);
     return;
   }
 
   try {
     // Get all subdirectories and files
-    const entries = await readdir(dirPath);
+    const entries = await host.readDir(dirPath);
 
     // Filter entries to exclude those that should be preserved
     const filteredEntries = entries.filter((entry) => {
@@ -52,7 +52,7 @@ export async function clearDirectory(
     // Process each entry
     for (const entry of filteredEntries) {
       const entryPath = resolvePath(dirPath, entry);
-      await rm(entryPath, { recursive: true, force: true });
+      await host.rm(entryPath, { recursive: true });
     }
   } catch (error) {
     // If there's an error, fall back to regular emptyDir
@@ -63,6 +63,6 @@ export async function clearDirectory(
         target: NoTarget,
       });
     }
-    await emptyDir(dirPath);
+    await emptyDir(host, dirPath);
   }
 }

--- a/packages/typespec-ts/src/utils/resolve-project-root.ts
+++ b/packages/typespec-ts/src/utils/resolve-project-root.ts
@@ -1,26 +1,15 @@
-import { existsSync } from "fs";
-import { dirname, resolve } from "path";
-import { fileURLToPath } from "url";
+import { resolvePath } from "@typespec/compiler";
 
 /**
- * Recursively finds the nearest package.json file starting from the specified directory.
- * @param {string} currentDir - The directory to start searching from. Defaults to the directory of the current module.
- * @returns {string} path to the directory containing the package.json file.
+ * Returns the package root directory for the emitter.
+ *
+ * The compiled output lives at `dist/src/utils/resolve-project-root.js`,
+ * so the package root is 4 levels up. This avoids filesystem access,
+ * making it compatible with virtual file systems (e.g., the playground).
  */
-export function resolveProjectRoot(
-  currentDir: string = dirname(fileURLToPath(import.meta.url)),
-): string {
-  const packageJsonPath = resolve(currentDir, "package.json");
-
-  if (existsSync(packageJsonPath)) {
-    return currentDir;
-  }
-
-  const parentDir = resolve(currentDir, "..");
-
-  if (parentDir === currentDir) {
-    throw new Error("Could not find package.json");
-  }
-
-  return resolveProjectRoot(parentDir);
+export function resolveProjectRoot(): string {
+  // Use the global URL constructor (works in both Node.js and browsers)
+  const currentDir = new URL(".", import.meta.url).pathname;
+  // From dist/src/utils/ -> package root (4 levels: utils -> src -> dist -> root)
+  return resolvePath(currentDir, "../../../..");
 }

--- a/packages/typespec-ts/src/utils/resolve-project-root.ts
+++ b/packages/typespec-ts/src/utils/resolve-project-root.ts
@@ -4,12 +4,12 @@ import { resolvePath } from "@typespec/compiler";
  * Returns the package root directory for the emitter.
  *
  * The compiled output lives at `dist/src/utils/resolve-project-root.js`,
- * so the package root is 4 levels up. This avoids filesystem access,
+ * so the package root is 3 levels up. This avoids filesystem access,
  * making it compatible with virtual file systems (e.g., the playground).
  */
 export function resolveProjectRoot(): string {
   // Use the global URL constructor (works in both Node.js and browsers)
   const currentDir = new URL(".", import.meta.url).pathname;
-  // From dist/src/utils/ -> package root (4 levels: utils -> src -> dist -> root)
-  return resolvePath(currentDir, "../../../..");
+  // From dist/src/utils/ -> package root (3 levels: utils -> src -> dist -> root)
+  return resolvePath(currentDir, "../../..");
 }

--- a/packages/typespec-ts/test-next/integration/hooks/binder.test.ts
+++ b/packages/typespec-ts/test-next/integration/hooks/binder.test.ts
@@ -1,4 +1,4 @@
-import { getDirectoryPath } from "@typespec/compiler";
+import { getDirectoryPath, NodeHost } from "@typespec/compiler";
 import {
   FunctionDeclarationStructure,
   InterfaceDeclarationStructure,
@@ -332,6 +332,7 @@ describe("Binder", () => {
       };
       const staticHelperMap = await loadStaticHelpers(project, staticHelpers, {
         helpersAssetDirectory: helpersDirectory,
+        host: NodeHost,
       });
       binder = provideBinder(project, { staticHelpers: staticHelperMap });
     });

--- a/packages/typespec-ts/test-next/integration/load-static-files.test.ts
+++ b/packages/typespec-ts/test-next/integration/load-static-files.test.ts
@@ -25,7 +25,7 @@ describe("loadStaticHelpers", () => {
       },
     } as const;
     const helperDeclarations = await loadStaticHelpers(project, helpers, {
-        host: NodeHost,
+      host: NodeHost,
       helpersAssetDirectory,
     });
     expect(
@@ -83,7 +83,7 @@ describe("loadStaticHelpers", () => {
     } as const;
 
     await loadStaticHelpers(project, helpers, {
-        host: NodeHost,
+      host: NodeHost,
       helpersAssetDirectory,
       options: {
         flavor: "azure",

--- a/packages/typespec-ts/test-next/integration/load-static-files.test.ts
+++ b/packages/typespec-ts/test-next/integration/load-static-files.test.ts
@@ -1,4 +1,4 @@
-import { getDirectoryPath } from "@typespec/compiler";
+import { getDirectoryPath, NodeHost } from "@typespec/compiler";
 import path from "path";
 import { Project } from "ts-morph";
 import { fileURLToPath } from "url";
@@ -25,6 +25,7 @@ describe("loadStaticHelpers", () => {
       },
     } as const;
     const helperDeclarations = await loadStaticHelpers(project, helpers, {
+        host: NodeHost,
       helpersAssetDirectory,
     });
     expect(
@@ -49,6 +50,7 @@ describe("loadStaticHelpers", () => {
 
     await expect(
       loadStaticHelpers(project, helpers, {
+        host: NodeHost,
         helpersAssetDirectory,
       }),
     ).rejects.toThrowError(/not found/);
@@ -65,6 +67,7 @@ describe("loadStaticHelpers", () => {
 
     await expect(
       loadStaticHelpers(project, helpers, {
+        host: NodeHost,
         helpersAssetDirectory,
       }),
     ).rejects.toThrowError(/invalid helper kind/);
@@ -80,6 +83,7 @@ describe("loadStaticHelpers", () => {
     } as const;
 
     await loadStaticHelpers(project, helpers, {
+        host: NodeHost,
       helpersAssetDirectory,
       options: {
         flavor: "azure",

--- a/packages/typespec-ts/test/util/test-util.ts
+++ b/packages/typespec-ts/test/util/test-util.ts
@@ -3,7 +3,7 @@ import { AzureCoreTestLibrary } from "@azure-tools/typespec-azure-core/testing";
 import { AzureResourceManagerTestLibrary } from "@azure-tools/typespec-azure-resource-manager/testing";
 import { listAllServiceNamespaces } from "@azure-tools/typespec-client-generator-core";
 import { SdkTestLibrary } from "@azure-tools/typespec-client-generator-core/testing";
-import { EmitContext, getDirectoryPath, Program } from "@typespec/compiler";
+import { EmitContext, getDirectoryPath, NodeHost, Program } from "@typespec/compiler";
 import { createTestHost, TestHost } from "@typespec/compiler/testing";
 import { HttpTestLibrary } from "@typespec/http/testing";
 import { OpenAPITestLibrary } from "@typespec/openapi/testing";
@@ -276,6 +276,7 @@ export async function provideBinderWithAzureDependencies(project: Project) {
   const staticHelperMap = await loadStaticHelpers(project, staticHelpers, {
     helpersAssetDirectory: helpersDirectory,
     loadTestHelpers: true,
+    host: NodeHost,
   });
 
   const binder = provideBinder(project, {

--- a/packages/typespec-ts/test/util/test-util.ts
+++ b/packages/typespec-ts/test/util/test-util.ts
@@ -252,7 +252,8 @@ export type VerifyPropertyConfig = {
 };
 
 export async function provideBinderWithAzureDependencies(project: Project) {
-  const helpersDirectory = path.resolve(__dirname, "../../static/static-helpers");
+  const packageRoot = path.resolve(__dirname, "../..");
+  const helpersDirectory = path.resolve(packageRoot, "static/static-helpers");
 
   const extraDependencies = {
     ...AzurePollingDependencies,
@@ -277,6 +278,7 @@ export async function provideBinderWithAzureDependencies(project: Project) {
     helpersAssetDirectory: helpersDirectory,
     loadTestHelpers: true,
     host: NodeHost,
+    packageRoot,
   });
 
   const binder = provideBinder(project, {


### PR DESCRIPTION
## Summary

This PR upgrades the `@azure-tools/typespec-ts` emitter to use the TypeSpec `CompilerHost` (from `program.host`) instead of Node.js `fs` APIs, enabling the emitter to run in the TypeSpec playground (browser environment).

## Changes

### Remove Node.js `fs` dependencies
- **`src/utils/resolve-project-root.ts`** — Static URL-based resolution using `import.meta.url`, no filesystem access needed
- **`src/utils/file-system-utils.ts`** — `pathExists`, `emptyDir`, `clearDirectory` now take `CompilerHost` as first param
- **`src/framework/load-static-helpers.ts`** — Uses `host.readDir/readFile/stat` instead of `fs/promises`
- **`src/modular/emit-tests.ts`** — Uses `host.stat/rm` instead of `existsSync/rmSync`
- **`src/rlc-common/metadata/build-readme-file.ts`** — `hasClientNameChanged` and `updateReadmeFile` accept content strings instead of reading from disk
- **`src/index.ts`** — Threads `host` through all callees; derives emitter package root from `program.emitters` metadata

### Browser/playground fixes
- **All `new Project()` calls** — Added `{ useInMemoryFileSystem: true }` for ts-morph to work without real filesystem
- **`src/utils/emit-util.ts`** — Explicitly passes prettier plugins (`typescript`, `estree`) since browser bundles don't auto-discover them
- **`src/lib.ts`** — Changed `file-formatting-error` severity to `warning` so formatting failures don't block file emission

<img width="2170" height="635" alt="image" src="https://github.com/user-attachments/assets/4e602029-99a4-4b94-a32d-7483b0014cd0" />
