### PR TITLE
[python] Temporarily disable encode duration test cases

### DIFF
--- a/.chronus/changes/disable-duration-tests-2026-6-12-0-0-0.md
+++ b/.chronus/changes/disable-duration-tests-2026-6-12-0-0-0.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Temporarily disable encode duration test cases until duration is fully supported

--- a/packages/typespec-python/tests/mock_api/azure/asynctests/test_encode_duration_async.py
+++ b/packages/typespec-python/tests/mock_api/azure/asynctests/test_encode_duration_async.py
@@ -1,64 +1,64 @@
-# -------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for
-# license information.
-# --------------------------------------------------------------------------
-import datetime
+# # -------------------------------------------------------------------------
+# # Copyright (c) Microsoft Corporation. All rights reserved.
+# # Licensed under the MIT License. See License.txt in the project root for
+# # license information.
+# # --------------------------------------------------------------------------
+# import datetime
 
-import pytest
-import pytest_asyncio
-from encode.duration.aio import DurationClient
-from encode.duration.models import (
-    Int32SecondsDurationProperty,
-    ISO8601DurationProperty,
-    FloatSecondsDurationProperty,
-    DefaultDurationProperty,
-    FloatSecondsDurationArrayProperty,
-)
-
-
-@pytest_asyncio.fixture
-async def client():
-    async with DurationClient() as client:
-        yield client
+# import pytest
+# import pytest_asyncio
+# from encode.duration.aio import DurationClient
+# from encode.duration.models import (
+#     Int32SecondsDurationProperty,
+#     ISO8601DurationProperty,
+#     FloatSecondsDurationProperty,
+#     DefaultDurationProperty,
+#     FloatSecondsDurationArrayProperty,
+# )
 
 
-@pytest.mark.asyncio
-async def test_query(client: DurationClient):
-    await client.query.default(input=datetime.timedelta(days=40))
-    await client.query.iso8601(input=datetime.timedelta(days=40))
-    await client.query.int32_seconds(input=36)
-    await client.query.int32_seconds_array(input=[36, 47])
-    await client.query.float_seconds(input=35.625)
-    await client.query.float64_seconds(input=35.625)
+# @pytest_asyncio.fixture
+# async def client():
+#     async with DurationClient() as client:
+#         yield client
 
 
-@pytest.mark.asyncio
-async def test_property(client: DurationClient):
-    result = await client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
-    assert result.value == datetime.timedelta(days=40)
-    result = await client.property.default(DefaultDurationProperty(value="P40D"))
-    assert result.value == datetime.timedelta(days=40)
-    result = await client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
-    assert result.value == datetime.timedelta(days=40)
-    result = await client.property.iso8601(ISO8601DurationProperty(value="P40D"))
-    assert result.value == datetime.timedelta(days=40)
-    result = await client.property.int32_seconds(Int32SecondsDurationProperty(value=36))
-    assert result.value == 36
-    result = await client.property.float_seconds(FloatSecondsDurationProperty(value=35.625))
-    assert abs(result.value - 35.625) < 0.0001
-    result = await client.property.float64_seconds(FloatSecondsDurationProperty(value=35.625))
-    assert abs(result.value - 35.625) < 0.0001
-    result = await client.property.float_seconds_array(FloatSecondsDurationArrayProperty(value=[35.625, 46.75]))
-    assert abs(result.value[0] - 35.625) < 0.0001
-    assert abs(result.value[1] - 46.75) < 0.0001
+# @pytest.mark.asyncio
+# async def test_query(client: DurationClient):
+#     await client.query.default(input=datetime.timedelta(days=40))
+#     await client.query.iso8601(input=datetime.timedelta(days=40))
+#     await client.query.int32_seconds(input=36)
+#     await client.query.int32_seconds_array(input=[36, 47])
+#     await client.query.float_seconds(input=35.625)
+#     await client.query.float64_seconds(input=35.625)
 
 
-@pytest.mark.asyncio
-async def test_header(client: DurationClient):
-    await client.header.default(duration=datetime.timedelta(days=40))
-    await client.header.iso8601(duration=datetime.timedelta(days=40))
-    await client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
-    await client.header.int32_seconds(duration=36)
-    await client.header.float_seconds(duration=35.625)
-    await client.header.float64_seconds(duration=35.625)
+# @pytest.mark.asyncio
+# async def test_property(client: DurationClient):
+#     result = await client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
+#     assert result.value == datetime.timedelta(days=40)
+#     result = await client.property.default(DefaultDurationProperty(value="P40D"))
+#     assert result.value == datetime.timedelta(days=40)
+#     result = await client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
+#     assert result.value == datetime.timedelta(days=40)
+#     result = await client.property.iso8601(ISO8601DurationProperty(value="P40D"))
+#     assert result.value == datetime.timedelta(days=40)
+#     result = await client.property.int32_seconds(Int32SecondsDurationProperty(value=36))
+#     assert result.value == 36
+#     result = await client.property.float_seconds(FloatSecondsDurationProperty(value=35.625))
+#     assert abs(result.value - 35.625) < 0.0001
+#     result = await client.property.float64_seconds(FloatSecondsDurationProperty(value=35.625))
+#     assert abs(result.value - 35.625) < 0.0001
+#     result = await client.property.float_seconds_array(FloatSecondsDurationArrayProperty(value=[35.625, 46.75]))
+#     assert abs(result.value[0] - 35.625) < 0.0001
+#     assert abs(result.value[1] - 46.75) < 0.0001
+
+
+# @pytest.mark.asyncio
+# async def test_header(client: DurationClient):
+#     await client.header.default(duration=datetime.timedelta(days=40))
+#     await client.header.iso8601(duration=datetime.timedelta(days=40))
+#     await client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
+#     await client.header.int32_seconds(duration=36)
+#     await client.header.float_seconds(duration=35.625)
+#     await client.header.float64_seconds(duration=35.625)

--- a/packages/typespec-python/tests/mock_api/azure/test_encode_duration.py
+++ b/packages/typespec-python/tests/mock_api/azure/test_encode_duration.py
@@ -1,60 +1,60 @@
-# -------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for
-# license information.
-# --------------------------------------------------------------------------
-import datetime
+# # -------------------------------------------------------------------------
+# # Copyright (c) Microsoft Corporation. All rights reserved.
+# # Licensed under the MIT License. See License.txt in the project root for
+# # license information.
+# # --------------------------------------------------------------------------
+# import datetime
 
-import pytest
-from encode.duration import DurationClient
-from encode.duration.models import (
-    Int32SecondsDurationProperty,
-    ISO8601DurationProperty,
-    FloatSecondsDurationProperty,
-    DefaultDurationProperty,
-    FloatSecondsDurationArrayProperty,
-)
-
-
-@pytest.fixture
-def client():
-    with DurationClient() as client:
-        yield client
+# import pytest
+# from encode.duration import DurationClient
+# from encode.duration.models import (
+#     Int32SecondsDurationProperty,
+#     ISO8601DurationProperty,
+#     FloatSecondsDurationProperty,
+#     DefaultDurationProperty,
+#     FloatSecondsDurationArrayProperty,
+# )
 
 
-def test_query(client: DurationClient):
-    client.query.default(input=datetime.timedelta(days=40))
-    client.query.iso8601(input=datetime.timedelta(days=40))
-    client.query.int32_seconds(input=36)
-    client.query.int32_seconds_array(input=[36, 47])
-    client.query.float_seconds(input=35.625)
-    client.query.float64_seconds(input=35.625)
+# @pytest.fixture
+# def client():
+#     with DurationClient() as client:
+#         yield client
 
 
-def test_property(client: DurationClient):
-    result = client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
-    assert result.value == datetime.timedelta(days=40)
-    result = client.property.default(DefaultDurationProperty(value="P40D"))
-    assert result.value == datetime.timedelta(days=40)
-    result = client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
-    assert result.value == datetime.timedelta(days=40)
-    result = client.property.iso8601(ISO8601DurationProperty(value="P40D"))
-    assert result.value == datetime.timedelta(days=40)
-    result = client.property.int32_seconds(Int32SecondsDurationProperty(value=36))
-    assert result.value == 36
-    result = client.property.float_seconds(FloatSecondsDurationProperty(value=35.625))
-    assert abs(result.value - 35.625) < 0.0001
-    result = client.property.float64_seconds(FloatSecondsDurationProperty(value=35.625))
-    assert abs(result.value - 35.625) < 0.0001
-    result = client.property.float_seconds_array(FloatSecondsDurationArrayProperty(value=[35.625, 46.75]))
-    assert abs(result.value[0] - 35.625) < 0.0001
-    assert abs(result.value[1] - 46.75) < 0.0001
+# def test_query(client: DurationClient):
+#     client.query.default(input=datetime.timedelta(days=40))
+#     client.query.iso8601(input=datetime.timedelta(days=40))
+#     client.query.int32_seconds(input=36)
+#     client.query.int32_seconds_array(input=[36, 47])
+#     client.query.float_seconds(input=35.625)
+#     client.query.float64_seconds(input=35.625)
 
 
-def test_header(client: DurationClient):
-    client.header.default(duration=datetime.timedelta(days=40))
-    client.header.iso8601(duration=datetime.timedelta(days=40))
-    client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
-    client.header.int32_seconds(duration=36)
-    client.header.float_seconds(duration=35.625)
-    client.header.float64_seconds(duration=35.625)
+# def test_property(client: DurationClient):
+#     result = client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
+#     assert result.value == datetime.timedelta(days=40)
+#     result = client.property.default(DefaultDurationProperty(value="P40D"))
+#     assert result.value == datetime.timedelta(days=40)
+#     result = client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
+#     assert result.value == datetime.timedelta(days=40)
+#     result = client.property.iso8601(ISO8601DurationProperty(value="P40D"))
+#     assert result.value == datetime.timedelta(days=40)
+#     result = client.property.int32_seconds(Int32SecondsDurationProperty(value=36))
+#     assert result.value == 36
+#     result = client.property.float_seconds(FloatSecondsDurationProperty(value=35.625))
+#     assert abs(result.value - 35.625) < 0.0001
+#     result = client.property.float64_seconds(FloatSecondsDurationProperty(value=35.625))
+#     assert abs(result.value - 35.625) < 0.0001
+#     result = client.property.float_seconds_array(FloatSecondsDurationArrayProperty(value=[35.625, 46.75]))
+#     assert abs(result.value[0] - 35.625) < 0.0001
+#     assert abs(result.value[1] - 46.75) < 0.0001
+
+
+# def test_header(client: DurationClient):
+#     client.header.default(duration=datetime.timedelta(days=40))
+#     client.header.iso8601(duration=datetime.timedelta(days=40))
+#     client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
+#     client.header.int32_seconds(duration=36)
+#     client.header.float_seconds(duration=35.625)
+#     client.header.float64_seconds(duration=35.625)

--- a/packages/typespec-python/tests/mock_api/unbranded/asynctests/test_encode_duration_async.py
+++ b/packages/typespec-python/tests/mock_api/unbranded/asynctests/test_encode_duration_async.py
@@ -1,64 +1,64 @@
-# -------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for
-# license information.
-# --------------------------------------------------------------------------
-import datetime
+# # -------------------------------------------------------------------------
+# # Copyright (c) Microsoft Corporation. All rights reserved.
+# # Licensed under the MIT License. See License.txt in the project root for
+# # license information.
+# # --------------------------------------------------------------------------
+# import datetime
 
-import pytest
-import pytest_asyncio
-from encode.duration.aio import DurationClient
-from encode.duration.property.models import (
-    Int32SecondsDurationProperty,
-    ISO8601DurationProperty,
-    FloatSecondsDurationProperty,
-    DefaultDurationProperty,
-    FloatSecondsDurationArrayProperty,
-)
-
-
-@pytest_asyncio.fixture
-async def client():
-    async with DurationClient() as client:
-        yield client
+# import pytest
+# import pytest_asyncio
+# from encode.duration.aio import DurationClient
+# from encode.duration.property.models import (
+#     Int32SecondsDurationProperty,
+#     ISO8601DurationProperty,
+#     FloatSecondsDurationProperty,
+#     DefaultDurationProperty,
+#     FloatSecondsDurationArrayProperty,
+# )
 
 
-@pytest.mark.asyncio
-async def test_query(client: DurationClient):
-    await client.query.default(input=datetime.timedelta(days=40))
-    await client.query.iso8601(input=datetime.timedelta(days=40))
-    await client.query.int32_seconds(input=36)
-    await client.query.int32_seconds_array(input=[36, 47])
-    await client.query.float_seconds(input=35.625)
-    await client.query.float64_seconds(input=35.625)
+# @pytest_asyncio.fixture
+# async def client():
+#     async with DurationClient() as client:
+#         yield client
 
 
-@pytest.mark.asyncio
-async def test_property(client: DurationClient):
-    result = await client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
-    assert result.value == datetime.timedelta(days=40)
-    result = await client.property.default(DefaultDurationProperty(value="P40D"))
-    assert result.value == datetime.timedelta(days=40)
-    result = await client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
-    assert result.value == datetime.timedelta(days=40)
-    result = await client.property.iso8601(ISO8601DurationProperty(value="P40D"))
-    assert result.value == datetime.timedelta(days=40)
-    result = await client.property.int32_seconds(Int32SecondsDurationProperty(value=36))
-    assert result.value == 36
-    result = await client.property.float_seconds(FloatSecondsDurationProperty(value=35.625))
-    assert abs(result.value - 35.625) < 0.0001
-    result = await client.property.float64_seconds(FloatSecondsDurationProperty(value=35.625))
-    assert abs(result.value - 35.625) < 0.0001
-    result = await client.property.float_seconds_array(FloatSecondsDurationArrayProperty(value=[35.625, 46.75]))
-    assert abs(result.value[0] - 35.625) < 0.0001
-    assert abs(result.value[1] - 46.75) < 0.0001
+# @pytest.mark.asyncio
+# async def test_query(client: DurationClient):
+#     await client.query.default(input=datetime.timedelta(days=40))
+#     await client.query.iso8601(input=datetime.timedelta(days=40))
+#     await client.query.int32_seconds(input=36)
+#     await client.query.int32_seconds_array(input=[36, 47])
+#     await client.query.float_seconds(input=35.625)
+#     await client.query.float64_seconds(input=35.625)
 
 
-@pytest.mark.asyncio
-async def test_header(client: DurationClient):
-    await client.header.default(duration=datetime.timedelta(days=40))
-    await client.header.iso8601(duration=datetime.timedelta(days=40))
-    await client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
-    await client.header.int32_seconds(duration=36)
-    await client.header.float_seconds(duration=35.625)
-    await client.header.float64_seconds(duration=35.625)
+# @pytest.mark.asyncio
+# async def test_property(client: DurationClient):
+#     result = await client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
+#     assert result.value == datetime.timedelta(days=40)
+#     result = await client.property.default(DefaultDurationProperty(value="P40D"))
+#     assert result.value == datetime.timedelta(days=40)
+#     result = await client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
+#     assert result.value == datetime.timedelta(days=40)
+#     result = await client.property.iso8601(ISO8601DurationProperty(value="P40D"))
+#     assert result.value == datetime.timedelta(days=40)
+#     result = await client.property.int32_seconds(Int32SecondsDurationProperty(value=36))
+#     assert result.value == 36
+#     result = await client.property.float_seconds(FloatSecondsDurationProperty(value=35.625))
+#     assert abs(result.value - 35.625) < 0.0001
+#     result = await client.property.float64_seconds(FloatSecondsDurationProperty(value=35.625))
+#     assert abs(result.value - 35.625) < 0.0001
+#     result = await client.property.float_seconds_array(FloatSecondsDurationArrayProperty(value=[35.625, 46.75]))
+#     assert abs(result.value[0] - 35.625) < 0.0001
+#     assert abs(result.value[1] - 46.75) < 0.0001
+
+
+# @pytest.mark.asyncio
+# async def test_header(client: DurationClient):
+#     await client.header.default(duration=datetime.timedelta(days=40))
+#     await client.header.iso8601(duration=datetime.timedelta(days=40))
+#     await client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
+#     await client.header.int32_seconds(duration=36)
+#     await client.header.float_seconds(duration=35.625)
+#     await client.header.float64_seconds(duration=35.625)

--- a/packages/typespec-python/tests/mock_api/unbranded/test_encode_duration.py
+++ b/packages/typespec-python/tests/mock_api/unbranded/test_encode_duration.py
@@ -1,60 +1,60 @@
-# -------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See License.txt in the project root for
-# license information.
-# --------------------------------------------------------------------------
-import datetime
+# # -------------------------------------------------------------------------
+# # Copyright (c) Microsoft Corporation. All rights reserved.
+# # Licensed under the MIT License. See License.txt in the project root for
+# # license information.
+# # --------------------------------------------------------------------------
+# import datetime
 
-import pytest
-from encode.duration import DurationClient
-from encode.duration.property.models import (
-    Int32SecondsDurationProperty,
-    ISO8601DurationProperty,
-    FloatSecondsDurationProperty,
-    DefaultDurationProperty,
-    FloatSecondsDurationArrayProperty,
-)
-
-
-@pytest.fixture
-def client():
-    with DurationClient() as client:
-        yield client
+# import pytest
+# from encode.duration import DurationClient
+# from encode.duration.property.models import (
+#     Int32SecondsDurationProperty,
+#     ISO8601DurationProperty,
+#     FloatSecondsDurationProperty,
+#     DefaultDurationProperty,
+#     FloatSecondsDurationArrayProperty,
+# )
 
 
-def test_query(client: DurationClient):
-    client.query.default(input=datetime.timedelta(days=40))
-    client.query.iso8601(input=datetime.timedelta(days=40))
-    client.query.int32_seconds(input=36)
-    client.query.int32_seconds_array(input=[36, 47])
-    client.query.float_seconds(input=35.625)
-    client.query.float64_seconds(input=35.625)
+# @pytest.fixture
+# def client():
+#     with DurationClient() as client:
+#         yield client
 
 
-def test_property(client: DurationClient):
-    result = client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
-    assert result.value == datetime.timedelta(days=40)
-    result = client.property.default(DefaultDurationProperty(value="P40D"))
-    assert result.value == datetime.timedelta(days=40)
-    result = client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
-    assert result.value == datetime.timedelta(days=40)
-    result = client.property.iso8601(ISO8601DurationProperty(value="P40D"))
-    assert result.value == datetime.timedelta(days=40)
-    result = client.property.int32_seconds(Int32SecondsDurationProperty(value=36))
-    assert result.value == 36
-    result = client.property.float_seconds(FloatSecondsDurationProperty(value=35.625))
-    assert abs(result.value - 35.625) < 0.0001
-    result = client.property.float64_seconds(FloatSecondsDurationProperty(value=35.625))
-    assert abs(result.value - 35.625) < 0.0001
-    result = client.property.float_seconds_array(FloatSecondsDurationArrayProperty(value=[35.625, 46.75]))
-    assert abs(result.value[0] - 35.625) < 0.0001
-    assert abs(result.value[1] - 46.75) < 0.0001
+# def test_query(client: DurationClient):
+#     client.query.default(input=datetime.timedelta(days=40))
+#     client.query.iso8601(input=datetime.timedelta(days=40))
+#     client.query.int32_seconds(input=36)
+#     client.query.int32_seconds_array(input=[36, 47])
+#     client.query.float_seconds(input=35.625)
+#     client.query.float64_seconds(input=35.625)
 
 
-def test_header(client: DurationClient):
-    client.header.default(duration=datetime.timedelta(days=40))
-    client.header.iso8601(duration=datetime.timedelta(days=40))
-    client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
-    client.header.int32_seconds(duration=36)
-    client.header.float_seconds(duration=35.625)
-    client.header.float64_seconds(duration=35.625)
+# # def test_property(client: DurationClient):
+# #     result = client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
+# #     assert result.value == datetime.timedelta(days=40)
+# #     result = client.property.default(DefaultDurationProperty(value="P40D"))
+# #     assert result.value == datetime.timedelta(days=40)
+# #     result = client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
+# #     assert result.value == datetime.timedelta(days=40)
+# #     result = client.property.iso8601(ISO8601DurationProperty(value="P40D"))
+# #     assert result.value == datetime.timedelta(days=40)
+# #     result = client.property.int32_seconds(Int32SecondsDurationProperty(value=36))
+# #     assert result.value == 36
+# #     result = client.property.float_seconds(FloatSecondsDurationProperty(value=35.625))
+# #     assert abs(result.value - 35.625) < 0.0001
+# #     result = client.property.float64_seconds(FloatSecondsDurationProperty(value=35.625))
+# #     assert abs(result.value - 35.625) < 0.0001
+# #     result = client.property.float_seconds_array(FloatSecondsDurationArrayProperty(value=[35.625, 46.75]))
+# #     assert abs(result.value[0] - 35.625) < 0.0001
+# #     assert abs(result.value[1] - 46.75) < 0.0001
+
+
+# def test_header(client: DurationClient):
+#     client.header.default(duration=datetime.timedelta(days=40))
+#     client.header.iso8601(duration=datetime.timedelta(days=40))
+#     client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
+#     client.header.int32_seconds(duration=36)
+#     client.header.float_seconds(duration=35.625)
+#     client.header.float64_seconds(duration=35.625)


### PR DESCRIPTION
fix CI for https://github.com/microsoft/typespec/pull/10947

## Description

Temporarily comment out the encode duration mock API test cases (`test_encode_duration.py` and `test_encode_duration_async.py` for both `azure` and `unbranded`) until duration is fully supported. These test cases will be reopened once duration support is complete.

## Changes

- Commented out test cases in:
  - `packages/typespec-python/tests/mock_api/azure/test_encode_duration.py`
  - `packages/typespec-python/tests/mock_api/azure/asynctests/test_encode_duration_async.py`
  - `packages/typespec-python/tests/mock_api/unbranded/test_encode_duration.py`
  - `packages/typespec-python/tests/mock_api/unbranded/asynctests/test_encode_duration_async.py`
- Added changelog entry under `.chronus/changes`.