### PR TITLE
Release typespec-metadata 0.2.1

### DIFF
--- a/.chronus/changes/copilot-update-package-name-parsing-2026-5-12-22-20-57.md
+++ b/.chronus/changes/copilot-update-package-name-parsing-2026-5-12-22-20-57.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-metadata"
+---
+
+Release typespec-metadata 0.2.1

--- a/.chronus/changes/copilot-update-package-name-parsing-2026-5-12-22-20-57.md
+++ b/.chronus/changes/copilot-update-package-name-parsing-2026-5-12-22-20-57.md
@@ -1,6 +1,6 @@
 ---
 # Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
+changeKind: internal
 packages:
   - "@azure-tools/typespec-metadata"
 ---

--- a/.chronus/changes/fix-go-package-name-output-dir-2026-6-11.md
+++ b/.chronus/changes/fix-go-package-name-output-dir-2026-6-11.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-metadata"
----
-
-Fix incorrect Go package name parsing in `tspconfig.yaml`. The Go package name is now derived from the emitter output directory instead of the module path, which correctly excludes version suffixes (e.g., `/v4`) and uses the language-specific `service-dir` for accurate path resolution.

--- a/packages/typespec-metadata/CHANGELOG.md
+++ b/packages/typespec-metadata/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @azure-tools/typespec-metadata
 
+## 0.2.1
+
+### Bug Fixes
+
+- [#4616](https://github.com/Azure/typespec-azure/pull/4616) Fix incorrect Go package name parsing in `tspconfig.yaml`. The Go package name is now derived from the emitter output directory instead of the module path, which correctly excludes version suffixes (e.g., `/v4`) and uses the language-specific `service-dir` for accurate path resolution.
+
+
 ## 0.2.0
 - Group emitters by normalized language key in the `languages` output. Each language key now maps to an array of emitter configs instead of a single config, allowing multiple emitters per language (e.g. two C# emitters). Unrecognized emitters are grouped under `"unknown"`. Language is inferred by heuristic when the emitter is not in the built-in registry.
 

--- a/packages/typespec-metadata/package.json
+++ b/packages/typespec-metadata/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-metadata",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "TypeSpec emitter that produces structured metadata snapshots for APIView and other tooling.",
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Follow up to: https://github.com/Azure/typespec-azure/pull/4616

The PR was merged but the version not bumped. 