### PR TITLE
[Automated][azure-resource-manager] Add no-override-props rule to RPC guidelines coverage

### DIFF
--- a/eng/scripts/doc-updater/knowledge/azure-resource-manager.meta.json
+++ b/eng/scripts/doc-updater/knowledge/azure-resource-manager.meta.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "d0d2d7c83897ad72314d55ebae0dcbc28e62ee61",
-  "lastUpdated": "2026-06-01T11:07:13.329Z",
+  "lastCommit": "9992d3a0d858aa782c58e87b3c344932ae930923",
+  "lastUpdated": "2026-06-15T11:18:18.569Z",
   "analyzedPaths": [
     "packages/typespec-azure-resource-manager/src",
     "packages/typespec-azure-resource-manager/lib",

--- a/website/src/content/docs/docs/howtos/ARM/rpc-guidelines-coverage.md
+++ b/website/src/content/docs/docs/howtos/ARM/rpc-guidelines-coverage.md
@@ -190,6 +190,7 @@ The following TypeSpec linting rules enforce ARM conventions that are not explic
 | `arm/improper-subscription-list-operation`                                                              | Ensures tenant and extension resources don't define list-by-subscription operations.               |
 | [`arm/missing-x-ms-identifiers`](/docs/libraries/azure-resource-manager/rules/missing-x-ms-identifiers) | Requires array properties to describe identifying properties with `x-ms-identifiers`.              |
 | [`arm/no-empty-model`](/docs/libraries/azure-resource-manager/rules/no-empty-model)                     | Prevents ARM properties with `type: object` that don't reference a model definition.               |
+| [`arm/no-override-props`](/docs/libraries/azure-resource-manager/rules/no-override-props)               | Disallows redefining properties already defined in a base type.                                    |
 | [`arm/unsupported-type`](/docs/libraries/azure-resource-manager/rules/unsupported-type)                 | Checks for unsupported ARM types.                                                                  |
 
 ## Rules Not Enforceable Through Linting — Service Owner Responsibility


### PR DESCRIPTION
…lines coverage

Add the new no-override-props linter rule to the Additional ARM TypeSpec Rules table in rpc-guidelines-coverage.md. The rule was added in recent source changes and is enabled by default in the ARM resource-manager ruleset but was not yet listed in the RPC guidelines coverage page.