### PR TITLE
fix(typespec-ts): preserve $DO_NOT_NORMALIZE$ operation-group names in classical client

### DIFF
--- a/.chronus/changes/fix-do-not-normalize-classical-client-2026-6-16-3-10-0.md
+++ b/.chronus/changes/fix-do-not-normalize-classical-client-2026-6-16-3-10-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Preserve `$DO_NOT_NORMALIZE$` operation-group names in classical client generation to avoid double-normalization that caused unresolved placeholder references.

--- a/packages/typespec-ts/src/modular/build-classical-client.ts
+++ b/packages/typespec-ts/src/modular/build-classical-client.ts
@@ -290,8 +290,8 @@ function buildClientOperationGroups(
     } else {
       // The `rawGroupName` is used to any places where we need normalized name twice so we need to keep the raw as PascalCase.
       const rawGroupName = normalizeName(prefixes[0] ?? "", NameType.Interface);
-      const operationName = `_get${normalizeName(rawGroupName, NameType.OperationGroup)}Operations`;
-      const propertyType = `${normalizeName(rawGroupName, NameType.OperationGroup)}Operations`;
+      const operationName = `_get${rawGroupName}Operations`;
+      const propertyType = `${rawGroupName}Operations`;
       // The `groupName` is used to any places where we don't need normalized name again
       const groupName = normalizeName(rawGroupName, NameType.Property);
       const existProperty = clientClass.getProperties().filter((p) => {


### PR DESCRIPTION
When `@@clientLocation` assigns an operation to a `$DO_NOT_NORMALIZE$`-prefixed group (e.g. `"$DO_NOT_NORMALIZE$wCFRelays"`), the classical client generator was double-normalizing the name: the first pass strips the prefix → `"wCFRelays"`, then a second `normalizeName(..., NameType.OperationGroup)` call converts it to `"WCFRelays"` via PascalCase reconstruction. This produced a refkey mismatch with the names registered by `buildClassicOperationFiles` (which uses single normalization), leaving unresolved placeholders in the output:

```ts
// Before fix
public readonly wCFRelays: __PLACEHOLDER_sWCFRelaysOperations_s0_sclassicOperations__;

// After fix
public readonly wCFRelays: wCFRelaysOperations;
```
fixes #4604