### PR TITLE
Bump @typespec/http-client-python to ^0.32.0 and sync tests

### DIFF
--- a/.chronus/changes/bump-http-client-python-0-32-0-2026-6-17-0-0-0.md
+++ b/.chronus/changes/bump-http-client-python-0-32-0-2026-6-17-0-0-0.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: dependencies
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Bump @typespec/http-client-python to ^0.32.0 and sync tests from upstream

--- a/packages/typespec-python/eng/scripts/ci/regenerate-common.ts
+++ b/packages/typespec-python/eng/scripts/ci/regenerate-common.ts
@@ -70,11 +70,7 @@ export interface BuildTaskGroupsOptions {
 
 // ---- Public constants ----
 
-export const SKIP_SPECS: string[] = [
-  "type/file",
-  "service/multiple-services",
-  "azure/client-generator-core/response-as-bool",
-];
+export const SKIP_SPECS: string[] = ["type/file"];
 
 export const SpecialFlags: Record<string, Record<string, any>> = {
   azure: {
@@ -728,6 +724,7 @@ export async function prepareBaselineOfGeneratedCode(generatedFolder: string): P
       "azure/generation-subdir2",
       "unbranded/generation-subdir",
       "unbranded/generation-subdir2",
+      "azure/azure-client-generator-core-alternate-type",
     ];
 
     const sourceRoot = join(tempDir, ...sourceSubdir.split("/"));

--- a/packages/typespec-python/tests/mock_api/azure/asynctests/test_azure_arm_commonproperties_async.py
+++ b/packages/typespec-python/tests/mock_api/azure/asynctests/test_azure_arm_commonproperties_async.py
@@ -12,6 +12,11 @@ from azure.core import exceptions
 SUBSCRIPTION_ID = "00000000-0000-0000-0000-000000000000"
 RESOURCE_GROUP_NAME = "test-rg"
 
+SIMPLE_ARM_ID = f"/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/{RESOURCE_GROUP_NAME}/providers/Microsoft.Network/virtualNetworks/myVnet"
+ARM_ID_WITH_TYPE = SIMPLE_ARM_ID
+ARM_ID_WITH_TYPE_AND_SCOPE = SIMPLE_ARM_ID
+ARM_ID_WITH_ALL_SCOPES = f"/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/{RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/virtualMachines/myVm"
+
 
 @pytest_asyncio.fixture
 async def client(credential, authentication_policy):
@@ -93,3 +98,39 @@ async def test_error_create_for_user_defined_error(client):
     except exceptions.HttpResponseError as e:
         assert e.status_code == 400
         assert e.error.message == "Username should not contain only numbers."
+
+
+@pytest.mark.asyncio
+async def test_arm_resource_identifiers_get(client):
+    result = await client.arm_resource_identifiers.get(
+        resource_group_name=RESOURCE_GROUP_NAME, arm_resource_identifier_resource_name="armId"
+    )
+    assert result.location == "eastus"
+    assert result.properties.provisioning_state == "Succeeded"
+    assert result.properties.simple_arm_id == SIMPLE_ARM_ID
+    assert result.properties.arm_id_with_type == ARM_ID_WITH_TYPE
+    assert result.properties.arm_id_with_type_and_scope == ARM_ID_WITH_TYPE_AND_SCOPE
+    assert result.properties.arm_id_with_all_scopes == ARM_ID_WITH_ALL_SCOPES
+
+
+@pytest.mark.asyncio
+async def test_arm_resource_identifiers_create_or_replace(client):
+    result = await client.arm_resource_identifiers.create_or_replace(
+        resource_group_name=RESOURCE_GROUP_NAME,
+        arm_resource_identifier_resource_name="armId",
+        resource=models.ArmResourceIdentifierResource(
+            location="eastus",
+            properties=models.ArmResourceIdentifierResourceProperties(
+                simple_arm_id=SIMPLE_ARM_ID,
+                arm_id_with_type=ARM_ID_WITH_TYPE,
+                arm_id_with_type_and_scope=ARM_ID_WITH_TYPE_AND_SCOPE,
+                arm_id_with_all_scopes=ARM_ID_WITH_ALL_SCOPES,
+            ),
+        ),
+    )
+    assert result.location == "eastus"
+    assert result.properties.provisioning_state == "Succeeded"
+    assert result.properties.simple_arm_id == SIMPLE_ARM_ID
+    assert result.properties.arm_id_with_type == ARM_ID_WITH_TYPE
+    assert result.properties.arm_id_with_type_and_scope == ARM_ID_WITH_TYPE_AND_SCOPE
+    assert result.properties.arm_id_with_all_scopes == ARM_ID_WITH_ALL_SCOPES

--- a/packages/typespec-python/tests/mock_api/azure/asynctests/test_azure_arm_managementgroup_async.py
+++ b/packages/typespec-python/tests/mock_api/azure/asynctests/test_azure_arm_managementgroup_async.py
@@ -1,0 +1,82 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import pytest
+import pytest_asyncio
+from azure.resourcemanager.managementgroup.aio import ManagementGroupClient
+from azure.resourcemanager.managementgroup import models
+
+MANAGEMENT_GROUP_ID = "test-mg"
+RESOURCE_NAME = "resource"
+
+
+@pytest_asyncio.fixture
+async def client(credential, authentication_policy):
+    async with ManagementGroupClient(
+        credential, "http://localhost:3000", authentication_policy=authentication_policy
+    ) as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_management_group_child_resources_get(client):
+    result = await client.management_group_child_resources.get(
+        management_group_id=MANAGEMENT_GROUP_ID, management_group_child_resource_name=RESOURCE_NAME
+    )
+    assert result.name == RESOURCE_NAME
+    assert result.properties.description == "valid"
+    assert result.properties.provisioning_state == "Succeeded"
+
+
+@pytest.mark.asyncio
+async def test_management_group_child_resources_create_or_update(client):
+    result = await (
+        await client.management_group_child_resources.begin_create_or_update(
+            management_group_id=MANAGEMENT_GROUP_ID,
+            management_group_child_resource_name=RESOURCE_NAME,
+            resource=models.ManagementGroupChildResource(
+                properties=models.ManagementGroupChildResourceProperties(description="valid")
+            ),
+            polling_interval=0,
+        )
+    ).result()
+    assert result.name == RESOURCE_NAME
+    assert result.properties.description == "valid"
+    assert result.properties.provisioning_state == "Succeeded"
+
+
+@pytest.mark.asyncio
+async def test_management_group_child_resources_update(client):
+    result = await client.management_group_child_resources.update(
+        management_group_id=MANAGEMENT_GROUP_ID,
+        management_group_child_resource_name=RESOURCE_NAME,
+        properties=models.ManagementGroupChildResource(
+            properties=models.ManagementGroupChildResourceProperties(description="valid2")
+        ),
+    )
+    assert result.name == RESOURCE_NAME
+    assert result.properties.description == "valid2"
+    assert result.properties.provisioning_state == "Succeeded"
+
+
+@pytest.mark.asyncio
+async def test_management_group_child_resources_delete(client):
+    await client.management_group_child_resources.delete(
+        management_group_id=MANAGEMENT_GROUP_ID, management_group_child_resource_name=RESOURCE_NAME
+    )
+
+
+@pytest.mark.asyncio
+async def test_management_group_child_resources_list_by_management_group(client):
+    result = [
+        item
+        async for item in client.management_group_child_resources.list_by_management_group(
+            management_group_id=MANAGEMENT_GROUP_ID
+        )
+    ]
+    assert len(result) == 1
+    assert result[0].name == RESOURCE_NAME
+    assert result[0].properties.description == "valid"
+    assert result[0].properties.provisioning_state == "Succeeded"

--- a/packages/typespec-python/tests/mock_api/azure/asynctests/test_azure_client_generator_core_alternate_type_async.py
+++ b/packages/typespec-python/tests/mock_api/azure/asynctests/test_azure_client_generator_core_alternate_type_async.py
@@ -1,0 +1,74 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import pytest
+import pytest_asyncio
+import geojson
+from specs.azure.clientgenerator.core.alternatetype.aio import AlternateTypeClient
+from specs.azure.clientgenerator.core.alternatetype import models
+
+# Shared test data
+PROPERTIES = {"name": "A single point of interest", "category": "landmark", "elevation": 100}
+
+GEOMETRY = geojson.Point((-122.25, 37.87))
+
+FEATURE_ID = "feature-1"
+
+
+@pytest_asyncio.fixture
+async def client():
+    async with AlternateTypeClient(endpoint="http://localhost:3000") as client:
+        yield client
+
+
+@pytest.fixture
+def feature_geojson():
+    """Shared GeoJSON Feature for tests."""
+    return geojson.Feature(type="Feature", geometry=GEOMETRY, properties=PROPERTIES, id=FEATURE_ID)
+
+
+@pytest.mark.asyncio
+async def test_external_type_get_model(client: AlternateTypeClient):
+    """Test getting a Feature object with geometry, properties, and optional id fields."""
+    result = await client.external_type.get_model()
+
+    # Validate the response structure based on the TypeSpec example
+    assert result.type == "Feature"
+    assert result.geometry.type == "Point"
+    assert result.geometry.coordinates == [-122.25, 37.87]
+    assert result.properties == PROPERTIES
+    assert result.id == FEATURE_ID
+
+
+@pytest.mark.asyncio
+async def test_external_type_put_model(client: AlternateTypeClient, feature_geojson):
+    """Test putting a Feature object in request body."""
+    # Should return None (204/empty response)
+    result = await client.external_type.put_model(body=feature_geojson)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_external_type_get_property(client: AlternateTypeClient):
+    """Test getting a ModelWithFeatureProperty object with feature and additionalProperty fields."""
+    result = await client.external_type.get_property()
+
+    # Validate the response structure based on the TypeSpec example
+    assert result.feature.type == "Feature"
+    assert result.feature.geometry.type == "Point"
+    assert result.feature.geometry.coordinates == [-122.25, 37.87]
+    assert result.feature.properties == PROPERTIES
+    assert result.feature.id == FEATURE_ID
+    assert result.additional_property == "extra"
+
+
+@pytest.mark.asyncio
+async def test_external_type_put_property(client: AlternateTypeClient, feature_geojson):
+    """Test putting a ModelWithFeatureProperty object in request body."""
+    model_with_feature = models.ModelWithFeatureProperty(feature=feature_geojson, additional_property="extra")
+
+    # Should return None (204/empty response)
+    result = await client.external_type.put_property(body=model_with_feature)
+    assert result is None

--- a/packages/typespec-python/tests/mock_api/azure/asynctests/test_azure_client_generator_core_client_doc_async.py
+++ b/packages/typespec-python/tests/mock_api/azure/asynctests/test_azure_client_generator_core_client_doc_async.py
@@ -1,0 +1,36 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import pytest
+import pytest_asyncio
+from specs.azure.clientgenerator.core.clientdoc.aio import ClientDocClient
+from specs.azure.clientgenerator.core.clientdoc import models
+
+
+@pytest_asyncio.fixture
+async def client():
+    async with ClientDocClient() as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_harvest(client: ClientDocClient):
+    body = models.Plant(name="Rose", species="Rosa")
+    assert await client.documentation.harvest(body) == body
+
+
+def test_model_doc_appended():
+    # @clientDoc in append mode keeps the base @doc and appends the client-specific text.
+    # Only the model description is compared, not the parameter docstrings.
+    doc = models.Plant.__doc__.split(":ivar")[0].strip()
+    assert doc == "A plant in the garden. This model is used to represent a plant in the client SDK."
+
+
+@pytest.mark.asyncio
+async def test_operation_doc_replaced(client: ClientDocClient):
+    # @clientDoc in replace mode overrides the base @doc completely.
+    # Only the operation description is compared, not the parameter docstrings.
+    doc = client.documentation.harvest.__doc__.split(":param")[0].strip()
+    assert doc == "Retrieves a plant from the garden by submitting its name."

--- a/packages/typespec-python/tests/mock_api/azure/asynctests/test_azure_client_generator_core_response_as_bool_async.py
+++ b/packages/typespec-python/tests/mock_api/azure/asynctests/test_azure_client_generator_core_response_as_bool_async.py
@@ -5,20 +5,20 @@
 # --------------------------------------------------------------------------
 import pytest
 import pytest_asyncio
-from parameters.query.aio import QueryClient
+from specs.azure.clientgenerator.core.responseasbool.aio import ResponseAsBoolClient
 
 
 @pytest_asyncio.fixture
 async def client():
-    async with QueryClient() as client:
+    async with ResponseAsBoolClient() as client:
         yield client
 
 
 @pytest.mark.asyncio
-async def test_constant(client: QueryClient):
-    await client.constant.post()
+async def test_exists(client: ResponseAsBoolClient):
+    assert await client.head_as_boolean.exists() is True
 
 
 @pytest.mark.asyncio
-async def test_special_char_dollar_sign(client: QueryClient):
-    await client.special_char.dollar_sign(filter="status eq 'active'")
+async def test_not_exists(client: ResponseAsBoolClient):
+    assert await client.head_as_boolean.not_exists() is False

--- a/packages/typespec-python/tests/mock_api/azure/asynctests/test_azure_client_generator_core_usage_async.py
+++ b/packages/typespec-python/tests/mock_api/azure/asynctests/test_azure_client_generator_core_usage_async.py
@@ -37,3 +37,9 @@ async def test_orphan_model_serializable(client: UsageClient):
     await client.model_in_operation.orphan_model_serializable(
         body=models.OrphanModel(model_name="name", description="desc")
     )
+
+
+@pytest.mark.asyncio
+async def test_namespace_model_serializable(client: UsageClient):
+    namespace_model = models.NamespaceModel(name="test")
+    await client.namespace_usage.namespace_model_serializable(body=namespace_model)

--- a/packages/typespec-python/tests/mock_api/azure/asynctests/test_encode_duration_async.py
+++ b/packages/typespec-python/tests/mock_api/azure/asynctests/test_encode_duration_async.py
@@ -1,64 +1,130 @@
-# # -------------------------------------------------------------------------
-# # Copyright (c) Microsoft Corporation. All rights reserved.
-# # Licensed under the MIT License. See License.txt in the project root for
-# # license information.
-# # --------------------------------------------------------------------------
-# import datetime
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import datetime
 
-# import pytest
-# import pytest_asyncio
-# from encode.duration.aio import DurationClient
-# from encode.duration.models import (
-#     Int32SecondsDurationProperty,
-#     ISO8601DurationProperty,
-#     FloatSecondsDurationProperty,
-#     DefaultDurationProperty,
-#     FloatSecondsDurationArrayProperty,
-# )
-
-
-# @pytest_asyncio.fixture
-# async def client():
-#     async with DurationClient() as client:
-#         yield client
-
-
-# @pytest.mark.asyncio
-# async def test_query(client: DurationClient):
-#     await client.query.default(input=datetime.timedelta(days=40))
-#     await client.query.iso8601(input=datetime.timedelta(days=40))
-#     await client.query.int32_seconds(input=36)
-#     await client.query.int32_seconds_array(input=[36, 47])
-#     await client.query.float_seconds(input=35.625)
-#     await client.query.float64_seconds(input=35.625)
+import pytest
+import pytest_asyncio
+from encode.duration.aio import DurationClient
+from encode.duration.models import (
+    DefaultDurationProperty,
+    ISO8601DurationProperty,
+    Int32SecondsDurationProperty,
+    FloatSecondsDurationProperty,
+    Float64SecondsDurationProperty,
+    Int32MillisecondsDurationProperty,
+    FloatMillisecondsDurationProperty,
+    Float64MillisecondsDurationProperty,
+    FloatSecondsDurationArrayProperty,
+    FloatMillisecondsDurationArrayProperty,
+    Int32SecondsLargerUnitDurationProperty,
+    FloatSecondsLargerUnitDurationProperty,
+    Int32MillisecondsLargerUnitDurationProperty,
+    FloatMillisecondsLargerUnitDurationProperty,
+)
 
 
-# @pytest.mark.asyncio
-# async def test_property(client: DurationClient):
-#     result = await client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
-#     assert result.value == datetime.timedelta(days=40)
-#     result = await client.property.default(DefaultDurationProperty(value="P40D"))
-#     assert result.value == datetime.timedelta(days=40)
-#     result = await client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
-#     assert result.value == datetime.timedelta(days=40)
-#     result = await client.property.iso8601(ISO8601DurationProperty(value="P40D"))
-#     assert result.value == datetime.timedelta(days=40)
-#     result = await client.property.int32_seconds(Int32SecondsDurationProperty(value=36))
-#     assert result.value == 36
-#     result = await client.property.float_seconds(FloatSecondsDurationProperty(value=35.625))
-#     assert abs(result.value - 35.625) < 0.0001
-#     result = await client.property.float64_seconds(FloatSecondsDurationProperty(value=35.625))
-#     assert abs(result.value - 35.625) < 0.0001
-#     result = await client.property.float_seconds_array(FloatSecondsDurationArrayProperty(value=[35.625, 46.75]))
-#     assert abs(result.value[0] - 35.625) < 0.0001
-#     assert abs(result.value[1] - 46.75) < 0.0001
+@pytest_asyncio.fixture
+async def client():
+    async with DurationClient() as client:
+        yield client
 
 
-# @pytest.mark.asyncio
-# async def test_header(client: DurationClient):
-#     await client.header.default(duration=datetime.timedelta(days=40))
-#     await client.header.iso8601(duration=datetime.timedelta(days=40))
-#     await client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
-#     await client.header.int32_seconds(duration=36)
-#     await client.header.float_seconds(duration=35.625)
-#     await client.header.float64_seconds(duration=35.625)
+@pytest.mark.asyncio
+async def test_query(client: DurationClient):
+    await client.query.default(input=datetime.timedelta(days=40))
+    await client.query.iso8601(input=datetime.timedelta(days=40))
+    await client.query.int32_seconds(input=datetime.timedelta(seconds=36))
+    await client.query.int32_seconds_larger_unit(input=datetime.timedelta(seconds=120))
+    await client.query.int32_seconds_array(input=[datetime.timedelta(seconds=36), datetime.timedelta(seconds=47)])
+    await client.query.float_seconds(input=datetime.timedelta(seconds=35.625))
+    await client.query.float_seconds_larger_unit(input=datetime.timedelta(seconds=150))
+    await client.query.float64_seconds(input=datetime.timedelta(seconds=35.625))
+    await client.query.int32_milliseconds(input=datetime.timedelta(milliseconds=36000))
+    await client.query.int32_milliseconds_larger_unit(input=datetime.timedelta(milliseconds=180000))
+    await client.query.int32_milliseconds_array(
+        input=[datetime.timedelta(milliseconds=36000), datetime.timedelta(milliseconds=47000)]
+    )
+    await client.query.float_milliseconds(input=datetime.timedelta(milliseconds=35625))
+    await client.query.float_milliseconds_larger_unit(input=datetime.timedelta(milliseconds=210000))
+    await client.query.float64_milliseconds(input=datetime.timedelta(milliseconds=35625))
+
+
+@pytest.mark.asyncio
+async def test_property(client: DurationClient):
+    result = await client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
+    assert result.value == datetime.timedelta(days=40)
+    result = await client.property.default(DefaultDurationProperty(value="P40D"))
+    assert result.value == datetime.timedelta(days=40)
+    result = await client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
+    assert result.value == datetime.timedelta(days=40)
+    result = await client.property.iso8601(ISO8601DurationProperty(value="P40D"))
+    assert result.value == datetime.timedelta(days=40)
+    result = await client.property.int32_seconds(Int32SecondsDurationProperty(value=datetime.timedelta(seconds=36)))
+    assert result.value == datetime.timedelta(seconds=36)
+    result = await client.property.float_seconds(FloatSecondsDurationProperty(value=datetime.timedelta(seconds=35.625)))
+    assert result.value == datetime.timedelta(seconds=35.625)
+    result = await client.property.float64_seconds(
+        Float64SecondsDurationProperty(value=datetime.timedelta(seconds=35.625))
+    )
+    assert result.value == datetime.timedelta(seconds=35.625)
+    result = await client.property.int32_milliseconds(
+        Int32MillisecondsDurationProperty(value=datetime.timedelta(milliseconds=36000))
+    )
+    assert result.value == datetime.timedelta(milliseconds=36000)
+    result = await client.property.float_milliseconds(
+        FloatMillisecondsDurationProperty(value=datetime.timedelta(milliseconds=35625))
+    )
+    assert result.value == datetime.timedelta(milliseconds=35625)
+    result = await client.property.float64_milliseconds(
+        Float64MillisecondsDurationProperty(value=datetime.timedelta(milliseconds=35625))
+    )
+    assert result.value == datetime.timedelta(milliseconds=35625)
+    result = await client.property.float_seconds_array(
+        FloatSecondsDurationArrayProperty(value=[datetime.timedelta(seconds=35.625), datetime.timedelta(seconds=46.75)])
+    )
+    assert result.value == [datetime.timedelta(seconds=35.625), datetime.timedelta(seconds=46.75)]
+    result = await client.property.float_milliseconds_array(
+        FloatMillisecondsDurationArrayProperty(
+            value=[datetime.timedelta(milliseconds=35625), datetime.timedelta(milliseconds=46750)]
+        )
+    )
+    assert result.value == [datetime.timedelta(milliseconds=35625), datetime.timedelta(milliseconds=46750)]
+    result = await client.property.int32_seconds_larger_unit(
+        Int32SecondsLargerUnitDurationProperty(value=datetime.timedelta(seconds=120))
+    )
+    assert result.value == datetime.timedelta(seconds=120)
+    result = await client.property.float_seconds_larger_unit(
+        FloatSecondsLargerUnitDurationProperty(value=datetime.timedelta(seconds=150))
+    )
+    assert result.value == datetime.timedelta(seconds=150)
+    result = await client.property.int32_milliseconds_larger_unit(
+        Int32MillisecondsLargerUnitDurationProperty(value=datetime.timedelta(milliseconds=180000))
+    )
+    assert result.value == datetime.timedelta(milliseconds=180000)
+    result = await client.property.float_milliseconds_larger_unit(
+        FloatMillisecondsLargerUnitDurationProperty(value=datetime.timedelta(milliseconds=210000))
+    )
+    assert result.value == datetime.timedelta(milliseconds=210000)
+
+
+@pytest.mark.asyncio
+async def test_header(client: DurationClient):
+    await client.header.default(duration=datetime.timedelta(days=40))
+    await client.header.iso8601(duration=datetime.timedelta(days=40))
+    await client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
+    await client.header.int32_seconds(duration=datetime.timedelta(seconds=36))
+    await client.header.int32_seconds_larger_unit(duration=datetime.timedelta(seconds=120))
+    await client.header.float_seconds(duration=datetime.timedelta(seconds=35.625))
+    await client.header.float_seconds_larger_unit(duration=datetime.timedelta(seconds=150))
+    await client.header.float64_seconds(duration=datetime.timedelta(seconds=35.625))
+    await client.header.int32_milliseconds(duration=datetime.timedelta(milliseconds=36000))
+    await client.header.int32_milliseconds_larger_unit(duration=datetime.timedelta(milliseconds=180000))
+    await client.header.int32_milliseconds_array(
+        duration=[datetime.timedelta(milliseconds=36000), datetime.timedelta(milliseconds=47000)]
+    )
+    await client.header.float_milliseconds(duration=datetime.timedelta(milliseconds=35625))
+    await client.header.float_milliseconds_larger_unit(duration=datetime.timedelta(milliseconds=210000))
+    await client.header.float64_milliseconds(duration=datetime.timedelta(milliseconds=35625))

--- a/packages/typespec-python/tests/mock_api/azure/asynctests/test_service_multiple_services_async.py
+++ b/packages/typespec-python/tests/mock_api/azure/asynctests/test_service_multiple_services_async.py
@@ -1,0 +1,41 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import pytest
+import pytest_asyncio
+from service.multipleservices.servicea.aio import ServiceAClient
+from service.multipleservices.serviceb.aio import ServiceBClient
+
+
+@pytest_asyncio.fixture
+async def client_a():
+    async with ServiceAClient() as client:
+        yield client
+
+
+@pytest_asyncio.fixture
+async def client_b():
+    async with ServiceBClient() as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_service_a_op(client_a: ServiceAClient):
+    await client_a.operations.op_a()
+
+
+@pytest.mark.asyncio
+async def test_service_a_sub_namespace_op(client_a: ServiceAClient):
+    await client_a.sub_namespace.sub_op_a()
+
+
+@pytest.mark.asyncio
+async def test_service_b_op(client_b: ServiceBClient):
+    await client_b.operations.op_b()
+
+
+@pytest.mark.asyncio
+async def test_service_b_sub_namespace_op(client_b: ServiceBClient):
+    await client_b.sub_namespace.sub_op_b()

--- a/packages/typespec-python/tests/mock_api/azure/asynctests/test_special_words_async.py
+++ b/packages/typespec-python/tests/mock_api/azure/asynctests/test_special_words_async.py
@@ -70,3 +70,8 @@ async def test_model_properties_with_list(client: SpecialWordsClient):
 async def test_extensible_strings(client: SpecialWordsClient):
     for enum_value in models.ExtensibleString:
         assert enum_value == await client.extensible_strings.put_extensible_string_value(body=enum_value)
+
+
+@pytest.mark.asyncio
+async def test_reserved_operation_body_params_with_items(client: SpecialWordsClient):
+    await client.reserved_operation_body_params.with_items(items=["item"])

--- a/packages/typespec-python/tests/mock_api/azure/test_azure_arm_commonproperties.py
+++ b/packages/typespec-python/tests/mock_api/azure/test_azure_arm_commonproperties.py
@@ -11,6 +11,11 @@ from azure.core import exceptions
 SUBSCRIPTION_ID = "00000000-0000-0000-0000-000000000000"
 RESOURCE_GROUP_NAME = "test-rg"
 
+SIMPLE_ARM_ID = f"/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/{RESOURCE_GROUP_NAME}/providers/Microsoft.Network/virtualNetworks/myVnet"
+ARM_ID_WITH_TYPE = SIMPLE_ARM_ID
+ARM_ID_WITH_TYPE_AND_SCOPE = SIMPLE_ARM_ID
+ARM_ID_WITH_ALL_SCOPES = f"/subscriptions/{SUBSCRIPTION_ID}/resourceGroups/{RESOURCE_GROUP_NAME}/providers/Microsoft.Compute/virtualMachines/myVm"
+
 
 @pytest.fixture
 def client(credential, authentication_policy):
@@ -87,3 +92,37 @@ def test_error_create_for_user_defined_error(client):
     except exceptions.HttpResponseError as e:
         assert e.status_code == 400
         assert e.error.message == "Username should not contain only numbers."
+
+
+def test_arm_resource_identifiers_get(client):
+    result = client.arm_resource_identifiers.get(
+        resource_group_name=RESOURCE_GROUP_NAME, arm_resource_identifier_resource_name="armId"
+    )
+    assert result.location == "eastus"
+    assert result.properties.provisioning_state == "Succeeded"
+    assert result.properties.simple_arm_id == SIMPLE_ARM_ID
+    assert result.properties.arm_id_with_type == ARM_ID_WITH_TYPE
+    assert result.properties.arm_id_with_type_and_scope == ARM_ID_WITH_TYPE_AND_SCOPE
+    assert result.properties.arm_id_with_all_scopes == ARM_ID_WITH_ALL_SCOPES
+
+
+def test_arm_resource_identifiers_create_or_replace(client):
+    result = client.arm_resource_identifiers.create_or_replace(
+        resource_group_name=RESOURCE_GROUP_NAME,
+        arm_resource_identifier_resource_name="armId",
+        resource=models.ArmResourceIdentifierResource(
+            location="eastus",
+            properties=models.ArmResourceIdentifierResourceProperties(
+                simple_arm_id=SIMPLE_ARM_ID,
+                arm_id_with_type=ARM_ID_WITH_TYPE,
+                arm_id_with_type_and_scope=ARM_ID_WITH_TYPE_AND_SCOPE,
+                arm_id_with_all_scopes=ARM_ID_WITH_ALL_SCOPES,
+            ),
+        ),
+    )
+    assert result.location == "eastus"
+    assert result.properties.provisioning_state == "Succeeded"
+    assert result.properties.simple_arm_id == SIMPLE_ARM_ID
+    assert result.properties.arm_id_with_type == ARM_ID_WITH_TYPE
+    assert result.properties.arm_id_with_type_and_scope == ARM_ID_WITH_TYPE_AND_SCOPE
+    assert result.properties.arm_id_with_all_scopes == ARM_ID_WITH_ALL_SCOPES

--- a/packages/typespec-python/tests/mock_api/azure/test_azure_arm_managementgroup.py
+++ b/packages/typespec-python/tests/mock_api/azure/test_azure_arm_managementgroup.py
@@ -1,0 +1,71 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import pytest
+from azure.resourcemanager.managementgroup import ManagementGroupClient
+from azure.resourcemanager.managementgroup import models
+
+MANAGEMENT_GROUP_ID = "test-mg"
+RESOURCE_NAME = "resource"
+
+
+@pytest.fixture
+def client(credential, authentication_policy):
+    with ManagementGroupClient(
+        credential, "http://localhost:3000", authentication_policy=authentication_policy
+    ) as client:
+        yield client
+
+
+def test_management_group_child_resources_get(client):
+    result = client.management_group_child_resources.get(
+        management_group_id=MANAGEMENT_GROUP_ID, management_group_child_resource_name=RESOURCE_NAME
+    )
+    assert result.name == RESOURCE_NAME
+    assert result.properties.description == "valid"
+    assert result.properties.provisioning_state == "Succeeded"
+
+
+def test_management_group_child_resources_create_or_update(client):
+    result = client.management_group_child_resources.begin_create_or_update(
+        management_group_id=MANAGEMENT_GROUP_ID,
+        management_group_child_resource_name=RESOURCE_NAME,
+        resource=models.ManagementGroupChildResource(
+            properties=models.ManagementGroupChildResourceProperties(description="valid")
+        ),
+        polling_interval=0,
+    ).result()
+    assert result.name == RESOURCE_NAME
+    assert result.properties.description == "valid"
+    assert result.properties.provisioning_state == "Succeeded"
+
+
+def test_management_group_child_resources_update(client):
+    result = client.management_group_child_resources.update(
+        management_group_id=MANAGEMENT_GROUP_ID,
+        management_group_child_resource_name=RESOURCE_NAME,
+        properties=models.ManagementGroupChildResource(
+            properties=models.ManagementGroupChildResourceProperties(description="valid2")
+        ),
+    )
+    assert result.name == RESOURCE_NAME
+    assert result.properties.description == "valid2"
+    assert result.properties.provisioning_state == "Succeeded"
+
+
+def test_management_group_child_resources_delete(client):
+    client.management_group_child_resources.delete(
+        management_group_id=MANAGEMENT_GROUP_ID, management_group_child_resource_name=RESOURCE_NAME
+    )
+
+
+def test_management_group_child_resources_list_by_management_group(client):
+    result = list(
+        client.management_group_child_resources.list_by_management_group(management_group_id=MANAGEMENT_GROUP_ID)
+    )
+    assert len(result) == 1
+    assert result[0].name == RESOURCE_NAME
+    assert result[0].properties.description == "valid"
+    assert result[0].properties.provisioning_state == "Succeeded"

--- a/packages/typespec-python/tests/mock_api/azure/test_azure_client_generator_core_alternate_type.py
+++ b/packages/typespec-python/tests/mock_api/azure/test_azure_client_generator_core_alternate_type.py
@@ -1,0 +1,69 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import pytest
+import geojson
+from specs.azure.clientgenerator.core.alternatetype import AlternateTypeClient
+from specs.azure.clientgenerator.core.alternatetype import models
+
+# Shared test data
+PROPERTIES = {"name": "A single point of interest", "category": "landmark", "elevation": 100}
+
+GEOMETRY = geojson.Point((-122.25, 37.87))
+
+FEATURE_ID = "feature-1"
+
+
+@pytest.fixture
+def client():
+    with AlternateTypeClient(endpoint="http://localhost:3000") as client:
+        yield client
+
+
+@pytest.fixture
+def feature_geojson():
+    """Shared GeoJSON Feature for tests."""
+    return geojson.Feature(type="Feature", geometry=GEOMETRY, properties=PROPERTIES, id=FEATURE_ID)
+
+
+def test_external_type_get_model(client: AlternateTypeClient):
+    """Test getting a Feature object with geometry, properties, and optional id fields."""
+    result = client.external_type.get_model()
+
+    # Validate the response structure based on the TypeSpec example
+    assert result.type == "Feature"
+    assert result.geometry.type == "Point"
+    assert result.geometry.coordinates == [-122.25, 37.87]
+    assert result.properties == PROPERTIES
+    assert result.id == FEATURE_ID
+
+
+def test_external_type_put_model(client: AlternateTypeClient, feature_geojson):
+    """Test putting a Feature object in request body."""
+    # Should return None (204/empty response)
+    result = client.external_type.put_model(body=feature_geojson)
+    assert result is None
+
+
+def test_external_type_get_property(client: AlternateTypeClient):
+    """Test getting a ModelWithFeatureProperty object with feature and additionalProperty fields."""
+    result = client.external_type.get_property()
+
+    # Validate the response structure based on the TypeSpec example
+    assert result.feature.type == "Feature"
+    assert result.feature.geometry.type == "Point"
+    assert result.feature.geometry.coordinates == [-122.25, 37.87]
+    assert result.feature.properties == PROPERTIES
+    assert result.feature.id == FEATURE_ID
+    assert result.additional_property == "extra"
+
+
+def test_external_type_put_property(client: AlternateTypeClient, feature_geojson):
+    """Test putting a ModelWithFeatureProperty object in request body."""
+    model_with_feature = models.ModelWithFeatureProperty(feature=feature_geojson, additional_property="extra")
+
+    # Should return None (204/empty response)
+    result = client.external_type.put_property(body=model_with_feature)
+    assert result is None

--- a/packages/typespec-python/tests/mock_api/azure/test_azure_client_generator_core_client_doc.py
+++ b/packages/typespec-python/tests/mock_api/azure/test_azure_client_generator_core_client_doc.py
@@ -1,0 +1,33 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import pytest
+from specs.azure.clientgenerator.core.clientdoc import ClientDocClient
+from specs.azure.clientgenerator.core.clientdoc import models
+
+
+@pytest.fixture
+def client():
+    with ClientDocClient() as client:
+        yield client
+
+
+def test_harvest(client: ClientDocClient):
+    body = models.Plant(name="Rose", species="Rosa")
+    assert client.documentation.harvest(body) == body
+
+
+def test_model_doc_appended():
+    # @clientDoc in append mode keeps the base @doc and appends the client-specific text.
+    # Only the model description is compared, not the parameter docstrings.
+    doc = models.Plant.__doc__.split(":ivar")[0].strip()
+    assert doc == "A plant in the garden. This model is used to represent a plant in the client SDK."
+
+
+def test_operation_doc_replaced(client: ClientDocClient):
+    # @clientDoc in replace mode overrides the base @doc completely.
+    # Only the operation description is compared, not the parameter docstrings.
+    doc = client.documentation.harvest.__doc__.split(":param")[0].strip()
+    assert doc == "Retrieves a plant from the garden by submitting its name."

--- a/packages/typespec-python/tests/mock_api/azure/test_azure_client_generator_core_response_as_bool.py
+++ b/packages/typespec-python/tests/mock_api/azure/test_azure_client_generator_core_response_as_bool.py
@@ -4,18 +4,18 @@
 # license information.
 # --------------------------------------------------------------------------
 import pytest
-from parameters.query import QueryClient
+from specs.azure.clientgenerator.core.responseasbool import ResponseAsBoolClient
 
 
 @pytest.fixture
 def client():
-    with QueryClient() as client:
+    with ResponseAsBoolClient() as client:
         yield client
 
 
-def test_constant(client: QueryClient):
-    client.constant.post()
+def test_exists(client: ResponseAsBoolClient):
+    assert client.head_as_boolean.exists() is True
 
 
-def test_special_char_dollar_sign(client: QueryClient):
-    client.special_char.dollar_sign(filter="status eq 'active'")
+def test_not_exists(client: ResponseAsBoolClient):
+    assert client.head_as_boolean.not_exists() is False

--- a/packages/typespec-python/tests/mock_api/azure/test_azure_client_generator_core_usage.py
+++ b/packages/typespec-python/tests/mock_api/azure/test_azure_client_generator_core_usage.py
@@ -30,3 +30,12 @@ def test_model_usage(client: UsageClient):
 
 def test_orphan_model_serializable(client: UsageClient):
     client.model_in_operation.orphan_model_serializable(body=models.OrphanModel(model_name="name", description="desc"))
+
+
+def test_namespace_model_serializable(client: UsageClient):
+    namespace_model = models.NamespaceModel(name="test")
+    client.namespace_usage.namespace_model_serializable(body=namespace_model)
+
+def test_import():
+    # NestedNamespaceModel shall be exposed
+    from specs.azure.clientgenerator.core.usage.models import NestedNamespaceModel

--- a/packages/typespec-python/tests/mock_api/azure/test_encode_duration.py
+++ b/packages/typespec-python/tests/mock_api/azure/test_encode_duration.py
@@ -1,60 +1,124 @@
-# # -------------------------------------------------------------------------
-# # Copyright (c) Microsoft Corporation. All rights reserved.
-# # Licensed under the MIT License. See License.txt in the project root for
-# # license information.
-# # --------------------------------------------------------------------------
-# import datetime
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import datetime
 
-# import pytest
-# from encode.duration import DurationClient
-# from encode.duration.models import (
-#     Int32SecondsDurationProperty,
-#     ISO8601DurationProperty,
-#     FloatSecondsDurationProperty,
-#     DefaultDurationProperty,
-#     FloatSecondsDurationArrayProperty,
-# )
-
-
-# @pytest.fixture
-# def client():
-#     with DurationClient() as client:
-#         yield client
-
-
-# def test_query(client: DurationClient):
-#     client.query.default(input=datetime.timedelta(days=40))
-#     client.query.iso8601(input=datetime.timedelta(days=40))
-#     client.query.int32_seconds(input=36)
-#     client.query.int32_seconds_array(input=[36, 47])
-#     client.query.float_seconds(input=35.625)
-#     client.query.float64_seconds(input=35.625)
+import pytest
+from encode.duration import DurationClient
+from encode.duration.models import (
+    DefaultDurationProperty,
+    ISO8601DurationProperty,
+    Int32SecondsDurationProperty,
+    FloatSecondsDurationProperty,
+    Float64SecondsDurationProperty,
+    Int32MillisecondsDurationProperty,
+    FloatMillisecondsDurationProperty,
+    Float64MillisecondsDurationProperty,
+    FloatSecondsDurationArrayProperty,
+    FloatMillisecondsDurationArrayProperty,
+    Int32SecondsLargerUnitDurationProperty,
+    FloatSecondsLargerUnitDurationProperty,
+    Int32MillisecondsLargerUnitDurationProperty,
+    FloatMillisecondsLargerUnitDurationProperty,
+)
 
 
-# def test_property(client: DurationClient):
-#     result = client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
-#     assert result.value == datetime.timedelta(days=40)
-#     result = client.property.default(DefaultDurationProperty(value="P40D"))
-#     assert result.value == datetime.timedelta(days=40)
-#     result = client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
-#     assert result.value == datetime.timedelta(days=40)
-#     result = client.property.iso8601(ISO8601DurationProperty(value="P40D"))
-#     assert result.value == datetime.timedelta(days=40)
-#     result = client.property.int32_seconds(Int32SecondsDurationProperty(value=36))
-#     assert result.value == 36
-#     result = client.property.float_seconds(FloatSecondsDurationProperty(value=35.625))
-#     assert abs(result.value - 35.625) < 0.0001
-#     result = client.property.float64_seconds(FloatSecondsDurationProperty(value=35.625))
-#     assert abs(result.value - 35.625) < 0.0001
-#     result = client.property.float_seconds_array(FloatSecondsDurationArrayProperty(value=[35.625, 46.75]))
-#     assert abs(result.value[0] - 35.625) < 0.0001
-#     assert abs(result.value[1] - 46.75) < 0.0001
+@pytest.fixture
+def client():
+    with DurationClient() as client:
+        yield client
 
 
-# def test_header(client: DurationClient):
-#     client.header.default(duration=datetime.timedelta(days=40))
-#     client.header.iso8601(duration=datetime.timedelta(days=40))
-#     client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
-#     client.header.int32_seconds(duration=36)
-#     client.header.float_seconds(duration=35.625)
-#     client.header.float64_seconds(duration=35.625)
+def test_query(client: DurationClient):
+    client.query.default(input=datetime.timedelta(days=40))
+    client.query.iso8601(input=datetime.timedelta(days=40))
+    client.query.int32_seconds(input=datetime.timedelta(seconds=36))
+    client.query.int32_seconds_larger_unit(input=datetime.timedelta(seconds=120))
+    client.query.int32_seconds_array(input=[datetime.timedelta(seconds=36), datetime.timedelta(seconds=47)])
+    client.query.float_seconds(input=datetime.timedelta(seconds=35.625))
+    client.query.float_seconds_larger_unit(input=datetime.timedelta(seconds=150))
+    client.query.float64_seconds(input=datetime.timedelta(seconds=35.625))
+    client.query.int32_milliseconds(input=datetime.timedelta(milliseconds=36000))
+    client.query.int32_milliseconds_larger_unit(input=datetime.timedelta(milliseconds=180000))
+    client.query.int32_milliseconds_array(
+        input=[datetime.timedelta(milliseconds=36000), datetime.timedelta(milliseconds=47000)]
+    )
+    client.query.float_milliseconds(input=datetime.timedelta(milliseconds=35625))
+    client.query.float_milliseconds_larger_unit(input=datetime.timedelta(milliseconds=210000))
+    client.query.float64_milliseconds(input=datetime.timedelta(milliseconds=35625))
+
+
+def test_property(client: DurationClient):
+    result = client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
+    assert result.value == datetime.timedelta(days=40)
+    result = client.property.default(DefaultDurationProperty(value="P40D"))
+    assert result.value == datetime.timedelta(days=40)
+    result = client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
+    assert result.value == datetime.timedelta(days=40)
+    result = client.property.iso8601(ISO8601DurationProperty(value="P40D"))
+    assert result.value == datetime.timedelta(days=40)
+    result = client.property.int32_seconds(Int32SecondsDurationProperty(value=datetime.timedelta(seconds=36)))
+    assert result.value == datetime.timedelta(seconds=36)
+    result = client.property.float_seconds(FloatSecondsDurationProperty(value=datetime.timedelta(seconds=35.625)))
+    assert result.value == datetime.timedelta(seconds=35.625)
+    result = client.property.float64_seconds(Float64SecondsDurationProperty(value=datetime.timedelta(seconds=35.625)))
+    assert result.value == datetime.timedelta(seconds=35.625)
+    result = client.property.int32_milliseconds(
+        Int32MillisecondsDurationProperty(value=datetime.timedelta(milliseconds=36000))
+    )
+    assert result.value == datetime.timedelta(milliseconds=36000)
+    result = client.property.float_milliseconds(
+        FloatMillisecondsDurationProperty(value=datetime.timedelta(milliseconds=35625))
+    )
+    assert result.value == datetime.timedelta(milliseconds=35625)
+    result = client.property.float64_milliseconds(
+        Float64MillisecondsDurationProperty(value=datetime.timedelta(milliseconds=35625))
+    )
+    assert result.value == datetime.timedelta(milliseconds=35625)
+    result = client.property.float_seconds_array(
+        FloatSecondsDurationArrayProperty(value=[datetime.timedelta(seconds=35.625), datetime.timedelta(seconds=46.75)])
+    )
+    assert result.value == [datetime.timedelta(seconds=35.625), datetime.timedelta(seconds=46.75)]
+    result = client.property.float_milliseconds_array(
+        FloatMillisecondsDurationArrayProperty(
+            value=[datetime.timedelta(milliseconds=35625), datetime.timedelta(milliseconds=46750)]
+        )
+    )
+    assert result.value == [datetime.timedelta(milliseconds=35625), datetime.timedelta(milliseconds=46750)]
+    result = client.property.int32_seconds_larger_unit(
+        Int32SecondsLargerUnitDurationProperty(value=datetime.timedelta(seconds=120))
+    )
+    assert result.value == datetime.timedelta(seconds=120)
+    result = client.property.float_seconds_larger_unit(
+        FloatSecondsLargerUnitDurationProperty(value=datetime.timedelta(seconds=150))
+    )
+    assert result.value == datetime.timedelta(seconds=150)
+    result = client.property.int32_milliseconds_larger_unit(
+        Int32MillisecondsLargerUnitDurationProperty(value=datetime.timedelta(milliseconds=180000))
+    )
+    assert result.value == datetime.timedelta(milliseconds=180000)
+    result = client.property.float_milliseconds_larger_unit(
+        FloatMillisecondsLargerUnitDurationProperty(value=datetime.timedelta(milliseconds=210000))
+    )
+    assert result.value == datetime.timedelta(milliseconds=210000)
+
+
+def test_header(client: DurationClient):
+    client.header.default(duration=datetime.timedelta(days=40))
+    client.header.iso8601(duration=datetime.timedelta(days=40))
+    client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
+    client.header.int32_seconds(duration=datetime.timedelta(seconds=36))
+    client.header.int32_seconds_larger_unit(duration=datetime.timedelta(seconds=120))
+    client.header.float_seconds(duration=datetime.timedelta(seconds=35.625))
+    client.header.float_seconds_larger_unit(duration=datetime.timedelta(seconds=150))
+    client.header.float64_seconds(duration=datetime.timedelta(seconds=35.625))
+    client.header.int32_milliseconds(duration=datetime.timedelta(milliseconds=36000))
+    client.header.int32_milliseconds_larger_unit(duration=datetime.timedelta(milliseconds=180000))
+    client.header.int32_milliseconds_array(
+        duration=[datetime.timedelta(milliseconds=36000), datetime.timedelta(milliseconds=47000)]
+    )
+    client.header.float_milliseconds(duration=datetime.timedelta(milliseconds=35625))
+    client.header.float_milliseconds_larger_unit(duration=datetime.timedelta(milliseconds=210000))
+    client.header.float64_milliseconds(duration=datetime.timedelta(milliseconds=35625))

--- a/packages/typespec-python/tests/mock_api/azure/test_service_multiple_services.py
+++ b/packages/typespec-python/tests/mock_api/azure/test_service_multiple_services.py
@@ -1,0 +1,36 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import pytest
+from service.multipleservices.servicea import ServiceAClient
+from service.multipleservices.serviceb import ServiceBClient
+
+
+@pytest.fixture
+def client_a():
+    with ServiceAClient() as client:
+        yield client
+
+
+@pytest.fixture
+def client_b():
+    with ServiceBClient() as client:
+        yield client
+
+
+def test_service_a_op(client_a: ServiceAClient):
+    client_a.operations.op_a()
+
+
+def test_service_a_sub_namespace_op(client_a: ServiceAClient):
+    client_a.sub_namespace.sub_op_a()
+
+
+def test_service_b_op(client_b: ServiceBClient):
+    client_b.operations.op_b()
+
+
+def test_service_b_sub_namespace_op(client_b: ServiceBClient):
+    client_b.sub_namespace.sub_op_b()

--- a/packages/typespec-python/tests/mock_api/azure/test_special_words.py
+++ b/packages/typespec-python/tests/mock_api/azure/test_special_words.py
@@ -61,3 +61,7 @@ def test_model_properties_with_list(client: SpecialWordsClient):
 def test_extensible_strings(client: SpecialWordsClient):
     for enum_value in models.ExtensibleString:
         assert enum_value == client.extensible_strings.put_extensible_string_value(body=enum_value)
+
+
+def test_reserved_operation_body_params_with_items(client: SpecialWordsClient):
+    client.reserved_operation_body_params.with_items(items=["item"])

--- a/packages/typespec-python/tests/mock_api/shared/asynctests/test_parameters_body_root_async.py
+++ b/packages/typespec-python/tests/mock_api/shared/asynctests/test_parameters_body_root_async.py
@@ -5,20 +5,16 @@
 # --------------------------------------------------------------------------
 import pytest
 import pytest_asyncio
-from parameters.query.aio import QueryClient
+from parameters.bodyroot.aio import BodyRootClient
+from parameters.bodyroot.models import BodyRootModel
 
 
 @pytest_asyncio.fixture
 async def client():
-    async with QueryClient() as client:
+    async with BodyRootClient() as client:
         yield client
 
 
 @pytest.mark.asyncio
-async def test_constant(client: QueryClient):
-    await client.constant.post()
-
-
-@pytest.mark.asyncio
-async def test_special_char_dollar_sign(client: QueryClient):
-    await client.special_char.dollar_sign(filter="status eq 'active'")
+async def test_nested(client: BodyRootClient):
+    await client.nested(BodyRootModel(category="widget", link_type="hard", was_successful=True))

--- a/packages/typespec-python/tests/mock_api/shared/asynctests/test_payload_head_async.py
+++ b/packages/typespec-python/tests/mock_api/shared/asynctests/test_payload_head_async.py
@@ -1,0 +1,26 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import pytest
+import pytest_asyncio
+from payload.head.aio import HeadClient
+
+
+@pytest_asyncio.fixture
+async def client():
+    async with HeadClient(endpoint="http://localhost:3000") as client:
+        yield client
+
+
+@pytest.mark.asyncio
+async def test_content_type_header_in_response(client: HeadClient):
+    assert await client.content_type_header_in_response() is True
+
+
+@pytest.mark.asyncio
+async def test_content_type_header_in_response_with_cls(client: HeadClient):
+    headers = await client.content_type_header_in_response(cls=lambda x, y, z: z)
+    assert headers["Content-Type"] == "text/plain; charset=utf-8"
+    assert headers["x-ms-meta"] == "hello"

--- a/packages/typespec-python/tests/mock_api/shared/asynctests/test_response_status_code_range_async.py
+++ b/packages/typespec-python/tests/mock_api/shared/asynctests/test_response_status_code_range_async.py
@@ -16,8 +16,8 @@ async def client():
 
 
 @pytest.mark.asyncio
-async def test_error_response_status_code_in_range(client: StatusCodeRangeClient):
-    with pytest.raises(Exception) as exc_info:
+async def test_error_response_status_code_in_range(client: StatusCodeRangeClient, core_library):
+    with pytest.raises(core_library.exceptions.HttpResponseError) as exc_info:
         await client.error_response_status_code_in_range()
 
     error = exc_info.value.model
@@ -28,8 +28,8 @@ async def test_error_response_status_code_in_range(client: StatusCodeRangeClient
 
 
 @pytest.mark.asyncio
-async def test_error_response_status_code_404(client: StatusCodeRangeClient):
-    with pytest.raises(Exception) as exc_info:
+async def test_error_response_status_code_404(client: StatusCodeRangeClient, core_library):
+    with pytest.raises(core_library.exceptions.ResourceNotFoundError) as exc_info:
         await client.error_response_status_code404()
 
     error = exc_info.value.model

--- a/packages/typespec-python/tests/mock_api/shared/asynctests/test_typetest_model_inheritance_single_discriminator_async.py
+++ b/packages/typespec-python/tests/mock_api/shared/asynctests/test_typetest_model_inheritance_single_discriminator_async.py
@@ -6,7 +6,7 @@
 import pytest
 import pytest_asyncio
 from typetest.model.singlediscriminator.aio import SingleDiscriminatorClient
-from typetest.model.singlediscriminator.models import Sparrow, Eagle, Bird, Dinosaur
+from typetest.model.singlediscriminator.models import Sparrow, Eagle, Bird, Dinosaur, Fish
 
 
 @pytest_asyncio.fixture
@@ -61,6 +61,16 @@ async def test_get_missing_discriminator(client):
 @pytest.mark.asyncio
 async def test_get_wrong_discriminator(client):
     assert await client.get_wrong_discriminator() == Bird(wingspan=1, kind="wrongKind")
+
+
+@pytest.mark.asyncio
+async def test_get_no_subtypes_model(client):
+    assert await client.get_no_subtypes_model() == Fish(kind="salmon", size=10)
+
+
+@pytest.mark.asyncio
+async def test_put_no_subtypes_model(client):
+    await client.put_no_subtypes_model(Fish(kind="salmon", size=10))
 
 
 @pytest.mark.asyncio

--- a/packages/typespec-python/tests/mock_api/shared/asynctests/test_typetest_model_visibility_async.py
+++ b/packages/typespec-python/tests/mock_api/shared/asynctests/test_typetest_model_visibility_async.py
@@ -22,6 +22,11 @@ async def test_get_model(client):
 
 
 @pytest.mark.asyncio
+async def test_head_model(client):
+    assert await client.head_model(models.VisibilityModel(), query_prop=123)
+
+
+@pytest.mark.asyncio
 async def test_put_model(client):
     await client.put_model(models.VisibilityModel(create_prop=["foo", "bar"], update_prop=[1, 2]))
 

--- a/packages/typespec-python/tests/mock_api/shared/test_parameters_body_root.py
+++ b/packages/typespec-python/tests/mock_api/shared/test_parameters_body_root.py
@@ -4,18 +4,15 @@
 # license information.
 # --------------------------------------------------------------------------
 import pytest
-from parameters.query import QueryClient
+from parameters.bodyroot import BodyRootClient
+from parameters.bodyroot.models import BodyRootModel
 
 
 @pytest.fixture
 def client():
-    with QueryClient() as client:
+    with BodyRootClient() as client:
         yield client
 
 
-def test_constant(client: QueryClient):
-    client.constant.post()
-
-
-def test_special_char_dollar_sign(client: QueryClient):
-    client.special_char.dollar_sign(filter="status eq 'active'")
+def test_nested(client: BodyRootClient):
+    client.nested(BodyRootModel(category="widget", link_type="hard", was_successful=True))

--- a/packages/typespec-python/tests/mock_api/shared/test_payload_head.py
+++ b/packages/typespec-python/tests/mock_api/shared/test_payload_head.py
@@ -1,0 +1,23 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import pytest
+from payload.head import HeadClient
+
+
+@pytest.fixture
+def client():
+    with HeadClient(endpoint="http://localhost:3000") as client:
+        yield client
+
+
+def test_content_type_header_in_response(client: HeadClient):
+    assert client.content_type_header_in_response() is True
+
+
+def test_content_type_header_in_response_with_cls(client: HeadClient):
+    headers = client.content_type_header_in_response(cls=lambda x, y, z: z)
+    assert headers["Content-Type"] == "text/plain; charset=utf-8"
+    assert headers["x-ms-meta"] == "hello"

--- a/packages/typespec-python/tests/mock_api/shared/test_response_status_code_range.py
+++ b/packages/typespec-python/tests/mock_api/shared/test_response_status_code_range.py
@@ -14,8 +14,8 @@ def client():
         yield client
 
 
-def test_error_response_status_code_in_range(client: StatusCodeRangeClient):
-    with pytest.raises(Exception) as exc_info:
+def test_error_response_status_code_in_range(client: StatusCodeRangeClient, core_library):
+    with pytest.raises(core_library.exceptions.HttpResponseError) as exc_info:
         client.error_response_status_code_in_range()
 
     error = exc_info.value.model
@@ -25,8 +25,8 @@ def test_error_response_status_code_in_range(client: StatusCodeRangeClient):
     assert exc_info.value.response.status_code == 494
 
 
-def test_error_response_status_code_404(client: StatusCodeRangeClient):
-    with pytest.raises(Exception) as exc_info:
+def test_error_response_status_code_404(client: StatusCodeRangeClient, core_library):
+    with pytest.raises(core_library.exceptions.ResourceNotFoundError) as exc_info:
         client.error_response_status_code404()
 
     error = exc_info.value.model

--- a/packages/typespec-python/tests/mock_api/shared/test_typetest_model_inheritance_single_discriminator.py
+++ b/packages/typespec-python/tests/mock_api/shared/test_typetest_model_inheritance_single_discriminator.py
@@ -5,7 +5,7 @@
 # --------------------------------------------------------------------------
 import pytest
 from typetest.model.singlediscriminator import SingleDiscriminatorClient
-from typetest.model.singlediscriminator.models import Sparrow, Eagle, Bird, Dinosaur
+from typetest.model.singlediscriminator.models import Sparrow, Eagle, Bird, Dinosaur, Fish
 
 
 @pytest.fixture
@@ -54,6 +54,14 @@ def test_get_missing_discriminator(client):
 
 def test_get_wrong_discriminator(client):
     assert client.get_wrong_discriminator() == Bird(wingspan=1, kind="wrongKind")
+
+
+def test_get_no_subtypes_model(client):
+    assert client.get_no_subtypes_model() == Fish(kind="salmon", size=10)
+
+
+def test_put_no_subtypes_model(client):
+    client.put_no_subtypes_model(Fish(kind="salmon", size=10))
 
 
 def test_get_legacy_model(client):

--- a/packages/typespec-python/tests/mock_api/shared/test_typetest_model_visibility.py
+++ b/packages/typespec-python/tests/mock_api/shared/test_typetest_model_visibility.py
@@ -18,6 +18,10 @@ def test_get_model(client):
     assert result == models.VisibilityModel(read_prop="abc")
 
 
+def test_head_model(client):
+    assert client.head_model(models.VisibilityModel(), query_prop=123)
+
+
 def test_put_model(client):
     client.put_model(models.VisibilityModel(create_prop=["foo", "bar"], update_prop=[1, 2]))
 

--- a/packages/typespec-python/tests/mock_api/unbranded/asynctests/test_encode_duration_async.py
+++ b/packages/typespec-python/tests/mock_api/unbranded/asynctests/test_encode_duration_async.py
@@ -1,64 +1,130 @@
-# # -------------------------------------------------------------------------
-# # Copyright (c) Microsoft Corporation. All rights reserved.
-# # Licensed under the MIT License. See License.txt in the project root for
-# # license information.
-# # --------------------------------------------------------------------------
-# import datetime
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import datetime
 
-# import pytest
-# import pytest_asyncio
-# from encode.duration.aio import DurationClient
-# from encode.duration.property.models import (
-#     Int32SecondsDurationProperty,
-#     ISO8601DurationProperty,
-#     FloatSecondsDurationProperty,
-#     DefaultDurationProperty,
-#     FloatSecondsDurationArrayProperty,
-# )
-
-
-# @pytest_asyncio.fixture
-# async def client():
-#     async with DurationClient() as client:
-#         yield client
-
-
-# @pytest.mark.asyncio
-# async def test_query(client: DurationClient):
-#     await client.query.default(input=datetime.timedelta(days=40))
-#     await client.query.iso8601(input=datetime.timedelta(days=40))
-#     await client.query.int32_seconds(input=36)
-#     await client.query.int32_seconds_array(input=[36, 47])
-#     await client.query.float_seconds(input=35.625)
-#     await client.query.float64_seconds(input=35.625)
+import pytest
+import pytest_asyncio
+from encode.duration.aio import DurationClient
+from encode.duration.property.models import (
+    DefaultDurationProperty,
+    ISO8601DurationProperty,
+    Int32SecondsDurationProperty,
+    FloatSecondsDurationProperty,
+    Float64SecondsDurationProperty,
+    Int32MillisecondsDurationProperty,
+    FloatMillisecondsDurationProperty,
+    Float64MillisecondsDurationProperty,
+    FloatSecondsDurationArrayProperty,
+    FloatMillisecondsDurationArrayProperty,
+    Int32SecondsLargerUnitDurationProperty,
+    FloatSecondsLargerUnitDurationProperty,
+    Int32MillisecondsLargerUnitDurationProperty,
+    FloatMillisecondsLargerUnitDurationProperty,
+)
 
 
-# @pytest.mark.asyncio
-# async def test_property(client: DurationClient):
-#     result = await client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
-#     assert result.value == datetime.timedelta(days=40)
-#     result = await client.property.default(DefaultDurationProperty(value="P40D"))
-#     assert result.value == datetime.timedelta(days=40)
-#     result = await client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
-#     assert result.value == datetime.timedelta(days=40)
-#     result = await client.property.iso8601(ISO8601DurationProperty(value="P40D"))
-#     assert result.value == datetime.timedelta(days=40)
-#     result = await client.property.int32_seconds(Int32SecondsDurationProperty(value=36))
-#     assert result.value == 36
-#     result = await client.property.float_seconds(FloatSecondsDurationProperty(value=35.625))
-#     assert abs(result.value - 35.625) < 0.0001
-#     result = await client.property.float64_seconds(FloatSecondsDurationProperty(value=35.625))
-#     assert abs(result.value - 35.625) < 0.0001
-#     result = await client.property.float_seconds_array(FloatSecondsDurationArrayProperty(value=[35.625, 46.75]))
-#     assert abs(result.value[0] - 35.625) < 0.0001
-#     assert abs(result.value[1] - 46.75) < 0.0001
+@pytest_asyncio.fixture
+async def client():
+    async with DurationClient() as client:
+        yield client
 
 
-# @pytest.mark.asyncio
-# async def test_header(client: DurationClient):
-#     await client.header.default(duration=datetime.timedelta(days=40))
-#     await client.header.iso8601(duration=datetime.timedelta(days=40))
-#     await client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
-#     await client.header.int32_seconds(duration=36)
-#     await client.header.float_seconds(duration=35.625)
-#     await client.header.float64_seconds(duration=35.625)
+@pytest.mark.asyncio
+async def test_query(client: DurationClient):
+    await client.query.default(input=datetime.timedelta(days=40))
+    await client.query.iso8601(input=datetime.timedelta(days=40))
+    await client.query.int32_seconds(input=datetime.timedelta(seconds=36))
+    await client.query.int32_seconds_larger_unit(input=datetime.timedelta(seconds=120))
+    await client.query.int32_seconds_array(input=[datetime.timedelta(seconds=36), datetime.timedelta(seconds=47)])
+    await client.query.float_seconds(input=datetime.timedelta(seconds=35.625))
+    await client.query.float_seconds_larger_unit(input=datetime.timedelta(seconds=150))
+    await client.query.float64_seconds(input=datetime.timedelta(seconds=35.625))
+    await client.query.int32_milliseconds(input=datetime.timedelta(milliseconds=36000))
+    await client.query.int32_milliseconds_larger_unit(input=datetime.timedelta(milliseconds=180000))
+    await client.query.int32_milliseconds_array(
+        input=[datetime.timedelta(milliseconds=36000), datetime.timedelta(milliseconds=47000)]
+    )
+    await client.query.float_milliseconds(input=datetime.timedelta(milliseconds=35625))
+    await client.query.float_milliseconds_larger_unit(input=datetime.timedelta(milliseconds=210000))
+    await client.query.float64_milliseconds(input=datetime.timedelta(milliseconds=35625))
+
+
+@pytest.mark.asyncio
+async def test_property(client: DurationClient):
+    result = await client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
+    assert result.value == datetime.timedelta(days=40)
+    result = await client.property.default(DefaultDurationProperty(value="P40D"))
+    assert result.value == datetime.timedelta(days=40)
+    result = await client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
+    assert result.value == datetime.timedelta(days=40)
+    result = await client.property.iso8601(ISO8601DurationProperty(value="P40D"))
+    assert result.value == datetime.timedelta(days=40)
+    result = await client.property.int32_seconds(Int32SecondsDurationProperty(value=datetime.timedelta(seconds=36)))
+    assert result.value == datetime.timedelta(seconds=36)
+    result = await client.property.float_seconds(FloatSecondsDurationProperty(value=datetime.timedelta(seconds=35.625)))
+    assert result.value == datetime.timedelta(seconds=35.625)
+    result = await client.property.float64_seconds(
+        Float64SecondsDurationProperty(value=datetime.timedelta(seconds=35.625))
+    )
+    assert result.value == datetime.timedelta(seconds=35.625)
+    result = await client.property.int32_milliseconds(
+        Int32MillisecondsDurationProperty(value=datetime.timedelta(milliseconds=36000))
+    )
+    assert result.value == datetime.timedelta(milliseconds=36000)
+    result = await client.property.float_milliseconds(
+        FloatMillisecondsDurationProperty(value=datetime.timedelta(milliseconds=35625))
+    )
+    assert result.value == datetime.timedelta(milliseconds=35625)
+    result = await client.property.float64_milliseconds(
+        Float64MillisecondsDurationProperty(value=datetime.timedelta(milliseconds=35625))
+    )
+    assert result.value == datetime.timedelta(milliseconds=35625)
+    result = await client.property.float_seconds_array(
+        FloatSecondsDurationArrayProperty(value=[datetime.timedelta(seconds=35.625), datetime.timedelta(seconds=46.75)])
+    )
+    assert result.value == [datetime.timedelta(seconds=35.625), datetime.timedelta(seconds=46.75)]
+    result = await client.property.float_milliseconds_array(
+        FloatMillisecondsDurationArrayProperty(
+            value=[datetime.timedelta(milliseconds=35625), datetime.timedelta(milliseconds=46750)]
+        )
+    )
+    assert result.value == [datetime.timedelta(milliseconds=35625), datetime.timedelta(milliseconds=46750)]
+    result = await client.property.int32_seconds_larger_unit(
+        Int32SecondsLargerUnitDurationProperty(value=datetime.timedelta(seconds=120))
+    )
+    assert result.value == datetime.timedelta(seconds=120)
+    result = await client.property.float_seconds_larger_unit(
+        FloatSecondsLargerUnitDurationProperty(value=datetime.timedelta(seconds=150))
+    )
+    assert result.value == datetime.timedelta(seconds=150)
+    result = await client.property.int32_milliseconds_larger_unit(
+        Int32MillisecondsLargerUnitDurationProperty(value=datetime.timedelta(milliseconds=180000))
+    )
+    assert result.value == datetime.timedelta(milliseconds=180000)
+    result = await client.property.float_milliseconds_larger_unit(
+        FloatMillisecondsLargerUnitDurationProperty(value=datetime.timedelta(milliseconds=210000))
+    )
+    assert result.value == datetime.timedelta(milliseconds=210000)
+
+
+@pytest.mark.asyncio
+async def test_header(client: DurationClient):
+    await client.header.default(duration=datetime.timedelta(days=40))
+    await client.header.iso8601(duration=datetime.timedelta(days=40))
+    await client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
+    await client.header.int32_seconds(duration=datetime.timedelta(seconds=36))
+    await client.header.int32_seconds_larger_unit(duration=datetime.timedelta(seconds=120))
+    await client.header.float_seconds(duration=datetime.timedelta(seconds=35.625))
+    await client.header.float_seconds_larger_unit(duration=datetime.timedelta(seconds=150))
+    await client.header.float64_seconds(duration=datetime.timedelta(seconds=35.625))
+    await client.header.int32_milliseconds(duration=datetime.timedelta(milliseconds=36000))
+    await client.header.int32_milliseconds_larger_unit(duration=datetime.timedelta(milliseconds=180000))
+    await client.header.int32_milliseconds_array(
+        duration=[datetime.timedelta(milliseconds=36000), datetime.timedelta(milliseconds=47000)]
+    )
+    await client.header.float_milliseconds(duration=datetime.timedelta(milliseconds=35625))
+    await client.header.float_milliseconds_larger_unit(duration=datetime.timedelta(milliseconds=210000))
+    await client.header.float64_milliseconds(duration=datetime.timedelta(milliseconds=35625))

--- a/packages/typespec-python/tests/mock_api/unbranded/asynctests/test_special_words_async.py
+++ b/packages/typespec-python/tests/mock_api/unbranded/asynctests/test_special_words_async.py
@@ -72,3 +72,8 @@ async def test_model_properties_with_list(client: SpecialWordsClient):
 async def test_extensible_strings(client: SpecialWordsClient):
     for enum_value in extensible_strings_models.ExtensibleString:
         assert enum_value == await client.extensible_strings.put_extensible_string_value(body=enum_value)
+
+
+@pytest.mark.asyncio
+async def test_reserved_operation_body_params_with_items(client: SpecialWordsClient):
+    await client.reserved_operation_body_params.with_items(items=["item"])

--- a/packages/typespec-python/tests/mock_api/unbranded/test_encode_duration.py
+++ b/packages/typespec-python/tests/mock_api/unbranded/test_encode_duration.py
@@ -1,60 +1,124 @@
-# # -------------------------------------------------------------------------
-# # Copyright (c) Microsoft Corporation. All rights reserved.
-# # Licensed under the MIT License. See License.txt in the project root for
-# # license information.
-# # --------------------------------------------------------------------------
-# import datetime
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import datetime
 
-# import pytest
-# from encode.duration import DurationClient
-# from encode.duration.property.models import (
-#     Int32SecondsDurationProperty,
-#     ISO8601DurationProperty,
-#     FloatSecondsDurationProperty,
-#     DefaultDurationProperty,
-#     FloatSecondsDurationArrayProperty,
-# )
-
-
-# @pytest.fixture
-# def client():
-#     with DurationClient() as client:
-#         yield client
-
-
-# def test_query(client: DurationClient):
-#     client.query.default(input=datetime.timedelta(days=40))
-#     client.query.iso8601(input=datetime.timedelta(days=40))
-#     client.query.int32_seconds(input=36)
-#     client.query.int32_seconds_array(input=[36, 47])
-#     client.query.float_seconds(input=35.625)
-#     client.query.float64_seconds(input=35.625)
+import pytest
+from encode.duration import DurationClient
+from encode.duration.property.models import (
+    DefaultDurationProperty,
+    ISO8601DurationProperty,
+    Int32SecondsDurationProperty,
+    FloatSecondsDurationProperty,
+    Float64SecondsDurationProperty,
+    Int32MillisecondsDurationProperty,
+    FloatMillisecondsDurationProperty,
+    Float64MillisecondsDurationProperty,
+    FloatSecondsDurationArrayProperty,
+    FloatMillisecondsDurationArrayProperty,
+    Int32SecondsLargerUnitDurationProperty,
+    FloatSecondsLargerUnitDurationProperty,
+    Int32MillisecondsLargerUnitDurationProperty,
+    FloatMillisecondsLargerUnitDurationProperty,
+)
 
 
-# # def test_property(client: DurationClient):
-# #     result = client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
-# #     assert result.value == datetime.timedelta(days=40)
-# #     result = client.property.default(DefaultDurationProperty(value="P40D"))
-# #     assert result.value == datetime.timedelta(days=40)
-# #     result = client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
-# #     assert result.value == datetime.timedelta(days=40)
-# #     result = client.property.iso8601(ISO8601DurationProperty(value="P40D"))
-# #     assert result.value == datetime.timedelta(days=40)
-# #     result = client.property.int32_seconds(Int32SecondsDurationProperty(value=36))
-# #     assert result.value == 36
-# #     result = client.property.float_seconds(FloatSecondsDurationProperty(value=35.625))
-# #     assert abs(result.value - 35.625) < 0.0001
-# #     result = client.property.float64_seconds(FloatSecondsDurationProperty(value=35.625))
-# #     assert abs(result.value - 35.625) < 0.0001
-# #     result = client.property.float_seconds_array(FloatSecondsDurationArrayProperty(value=[35.625, 46.75]))
-# #     assert abs(result.value[0] - 35.625) < 0.0001
-# #     assert abs(result.value[1] - 46.75) < 0.0001
+@pytest.fixture
+def client():
+    with DurationClient() as client:
+        yield client
 
 
-# def test_header(client: DurationClient):
-#     client.header.default(duration=datetime.timedelta(days=40))
-#     client.header.iso8601(duration=datetime.timedelta(days=40))
-#     client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
-#     client.header.int32_seconds(duration=36)
-#     client.header.float_seconds(duration=35.625)
-#     client.header.float64_seconds(duration=35.625)
+def test_query(client: DurationClient):
+    client.query.default(input=datetime.timedelta(days=40))
+    client.query.iso8601(input=datetime.timedelta(days=40))
+    client.query.int32_seconds(input=datetime.timedelta(seconds=36))
+    client.query.int32_seconds_larger_unit(input=datetime.timedelta(seconds=120))
+    client.query.int32_seconds_array(input=[datetime.timedelta(seconds=36), datetime.timedelta(seconds=47)])
+    client.query.float_seconds(input=datetime.timedelta(seconds=35.625))
+    client.query.float_seconds_larger_unit(input=datetime.timedelta(seconds=150))
+    client.query.float64_seconds(input=datetime.timedelta(seconds=35.625))
+    client.query.int32_milliseconds(input=datetime.timedelta(milliseconds=36000))
+    client.query.int32_milliseconds_larger_unit(input=datetime.timedelta(milliseconds=180000))
+    client.query.int32_milliseconds_array(
+        input=[datetime.timedelta(milliseconds=36000), datetime.timedelta(milliseconds=47000)]
+    )
+    client.query.float_milliseconds(input=datetime.timedelta(milliseconds=35625))
+    client.query.float_milliseconds_larger_unit(input=datetime.timedelta(milliseconds=210000))
+    client.query.float64_milliseconds(input=datetime.timedelta(milliseconds=35625))
+
+
+def test_property(client: DurationClient):
+    result = client.property.default(DefaultDurationProperty(value=datetime.timedelta(days=40)))
+    assert result.value == datetime.timedelta(days=40)
+    result = client.property.default(DefaultDurationProperty(value="P40D"))
+    assert result.value == datetime.timedelta(days=40)
+    result = client.property.iso8601(ISO8601DurationProperty(value=datetime.timedelta(days=40)))
+    assert result.value == datetime.timedelta(days=40)
+    result = client.property.iso8601(ISO8601DurationProperty(value="P40D"))
+    assert result.value == datetime.timedelta(days=40)
+    result = client.property.int32_seconds(Int32SecondsDurationProperty(value=datetime.timedelta(seconds=36)))
+    assert result.value == datetime.timedelta(seconds=36)
+    result = client.property.float_seconds(FloatSecondsDurationProperty(value=datetime.timedelta(seconds=35.625)))
+    assert result.value == datetime.timedelta(seconds=35.625)
+    result = client.property.float64_seconds(Float64SecondsDurationProperty(value=datetime.timedelta(seconds=35.625)))
+    assert result.value == datetime.timedelta(seconds=35.625)
+    result = client.property.int32_milliseconds(
+        Int32MillisecondsDurationProperty(value=datetime.timedelta(milliseconds=36000))
+    )
+    assert result.value == datetime.timedelta(milliseconds=36000)
+    result = client.property.float_milliseconds(
+        FloatMillisecondsDurationProperty(value=datetime.timedelta(milliseconds=35625))
+    )
+    assert result.value == datetime.timedelta(milliseconds=35625)
+    result = client.property.float64_milliseconds(
+        Float64MillisecondsDurationProperty(value=datetime.timedelta(milliseconds=35625))
+    )
+    assert result.value == datetime.timedelta(milliseconds=35625)
+    result = client.property.float_seconds_array(
+        FloatSecondsDurationArrayProperty(value=[datetime.timedelta(seconds=35.625), datetime.timedelta(seconds=46.75)])
+    )
+    assert result.value == [datetime.timedelta(seconds=35.625), datetime.timedelta(seconds=46.75)]
+    result = client.property.float_milliseconds_array(
+        FloatMillisecondsDurationArrayProperty(
+            value=[datetime.timedelta(milliseconds=35625), datetime.timedelta(milliseconds=46750)]
+        )
+    )
+    assert result.value == [datetime.timedelta(milliseconds=35625), datetime.timedelta(milliseconds=46750)]
+    result = client.property.int32_seconds_larger_unit(
+        Int32SecondsLargerUnitDurationProperty(value=datetime.timedelta(seconds=120))
+    )
+    assert result.value == datetime.timedelta(seconds=120)
+    result = client.property.float_seconds_larger_unit(
+        FloatSecondsLargerUnitDurationProperty(value=datetime.timedelta(seconds=150))
+    )
+    assert result.value == datetime.timedelta(seconds=150)
+    result = client.property.int32_milliseconds_larger_unit(
+        Int32MillisecondsLargerUnitDurationProperty(value=datetime.timedelta(milliseconds=180000))
+    )
+    assert result.value == datetime.timedelta(milliseconds=180000)
+    result = client.property.float_milliseconds_larger_unit(
+        FloatMillisecondsLargerUnitDurationProperty(value=datetime.timedelta(milliseconds=210000))
+    )
+    assert result.value == datetime.timedelta(milliseconds=210000)
+
+
+def test_header(client: DurationClient):
+    client.header.default(duration=datetime.timedelta(days=40))
+    client.header.iso8601(duration=datetime.timedelta(days=40))
+    client.header.iso8601_array(duration=[datetime.timedelta(days=40), datetime.timedelta(days=50)])
+    client.header.int32_seconds(duration=datetime.timedelta(seconds=36))
+    client.header.int32_seconds_larger_unit(duration=datetime.timedelta(seconds=120))
+    client.header.float_seconds(duration=datetime.timedelta(seconds=35.625))
+    client.header.float_seconds_larger_unit(duration=datetime.timedelta(seconds=150))
+    client.header.float64_seconds(duration=datetime.timedelta(seconds=35.625))
+    client.header.int32_milliseconds(duration=datetime.timedelta(milliseconds=36000))
+    client.header.int32_milliseconds_larger_unit(duration=datetime.timedelta(milliseconds=180000))
+    client.header.int32_milliseconds_array(
+        duration=[datetime.timedelta(milliseconds=36000), datetime.timedelta(milliseconds=47000)]
+    )
+    client.header.float_milliseconds(duration=datetime.timedelta(milliseconds=35625))
+    client.header.float_milliseconds_larger_unit(duration=datetime.timedelta(milliseconds=210000))
+    client.header.float64_milliseconds(duration=datetime.timedelta(milliseconds=35625))

--- a/packages/typespec-python/tests/mock_api/unbranded/test_special_words.py
+++ b/packages/typespec-python/tests/mock_api/unbranded/test_special_words.py
@@ -64,3 +64,7 @@ def test_model_properties_with_list(client: SpecialWordsClient):
 def test_extensible_strings(client: SpecialWordsClient):
     for enum_value in extensible_strings_models.ExtensibleString:
         assert enum_value == client.extensible_strings.put_extensible_string_value(body=enum_value)
+
+
+def test_reserved_operation_body_params_with_items(client: SpecialWordsClient):
+    client.reserved_operation_body_params.with_items(items=["item"])

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -232,8 +232,8 @@ catalogs:
       specifier: ^8.58.1
       version: 8.60.0
     '@typespec/http-client-python':
-      specifier: ^0.31.1
-      version: 0.31.1
+      specifier: ^0.32.0
+      version: 0.32.0
     '@typespec/ts-http-runtime':
       specifier: 0.3.5
       version: 0.3.5
@@ -3788,7 +3788,7 @@ importers:
     dependencies:
       '@typespec/http-client-python':
         specifier: 'catalog:'
-        version: 0.31.1(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)
+        version: 0.32.0(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)
       semver:
         specifier: 'catalog:'
         version: 7.8.1
@@ -8239,14 +8239,14 @@ packages:
     resolution: {integrity: sha512-9WI52t8ZGLVGrPMBet25yAftqY/n95+zmoUUtJBBQTKDSKUu7OsPTroT2op7U9JatkoRccL0YkWDNMFfC4Sjxg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@typespec/http-client-python@0.31.1':
-    resolution: {integrity: sha512-69lB3EzV/eVprES14ud6hDf6EgIuPu/Q/lhkCEzDZ9qNH5Q7ntScSweWDp71uoT56vpyl2rr41Zjb+FixQhS2g==}
+  '@typespec/http-client-python@0.32.0':
+    resolution: {integrity: sha512-O/awfKVCi1nVJbgUviv8Aw3uGXBDFYzI3AH9BH1v2cAuUkvx8uHmQ+6cj06xMvepKh5UHRoGtDLwHDXBi07y8Q==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
-      '@azure-tools/typespec-autorest': '>=0.69.0 <1.0.0'
+      '@azure-tools/typespec-autorest': '>=0.69.1 <1.0.0'
       '@azure-tools/typespec-azure-core': '>=0.69.0 <1.0.0'
-      '@azure-tools/typespec-azure-resource-manager': '>=0.69.0 <1.0.0'
-      '@azure-tools/typespec-azure-rulesets': '>=0.69.0 <1.0.0'
+      '@azure-tools/typespec-azure-resource-manager': '>=0.69.1 <1.0.0'
+      '@azure-tools/typespec-azure-rulesets': '>=0.69.1 <1.0.0'
       '@azure-tools/typespec-client-generator-core': '>=0.69.0 <1.0.0'
       '@typespec/compiler': ^1.13.0
       '@typespec/events': '>=0.83.0 <1.0.0'
@@ -20467,7 +20467,7 @@ snapshots:
       '@typescript-eslint/types': 8.60.0
       eslint-visitor-keys: 5.0.1
 
-  '@typespec/http-client-python@0.31.1(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)':
+  '@typespec/http-client-python@0.32.0(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)':
     dependencies:
       '@azure-tools/typespec-autorest': link:packages/typespec-autorest
       '@azure-tools/typespec-azure-core': link:packages/typespec-azure-core

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -95,7 +95,7 @@ catalog:
   "@typescript-eslint/rule-tester": ^8.58.1
   "@typescript-eslint/types": ^8.58.1
   "@typescript-eslint/utils": ^8.58.1
-  "@typespec/http-client-python": ^0.31.1
+  "@typespec/http-client-python": ^0.32.0
   "@typespec/ts-http-runtime": "0.3.5"
   "@vitejs/plugin-react": ^6.0.1
   "@vitest/coverage-v8": ^4.1.3


### PR DESCRIPTION
This PR:
1. Bumps @typespec/http-client-python from ^0.31.1 to ^0.32.0 in pnpm-workspace.yaml
2. Runs pnpm sync under packages/typespec-python to sync tests from upstream