### PR TITLE
Hotfix june-2026: typespec-ts@0.54.2 [skip chg]

### DIFF
--- a/.chronus/changes/fix-do-not-normalize-classical-client-2026-6-17-3-10-0.md
+++ b/.chronus/changes/fix-do-not-normalize-classical-client-2026-6-17-3-10-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Preserve `$DO_NOT_NORMALIZE$` operation-group names in classical client generation to avoid double-normalization that caused unresolved placeholder references.

--- a/.chronus/changes/fix-js-serialize-issue-2026-5-16-7-9-40.md
+++ b/.chronus/changes/fix-js-serialize-issue-2026-5-16-7-9-40.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-[typespec-ts] fix body param serialize issue reported from sdk repo

--- a/.chronus/changes/fix-paged-model-property-prefix-2026-6-17-10-31-0.md
+++ b/.chronus/changes/fix-paged-model-property-prefix-2026-6-17-10-31-0.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-[typespec-ts] Keep paged result model public when also used as a model property

--- a/packages/typespec-ts/CHANGELOG.md
+++ b/packages/typespec-ts/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log - @azure-tools/typespec-ts
 
+## 0.54.2
+
+### Bug Fixes
+
+- [#4647](https://github.com/Azure/typespec-azure/pull/4647) Preserve `$DO_NOT_NORMALIZE# Change Log - @azure-tools/typespec-ts operation-group names in classical client generation to avoid double-normalization that caused unresolved placeholder references.
+- [#4627](https://github.com/Azure/typespec-azure/pull/4627) [typespec-ts] fix body param serialize issue reported from sdk repo
+- [#4627](https://github.com/Azure/typespec-azure/pull/4627) [typespec-ts] Keep paged result model public when also used as a model property
+
+
 ## 0.54.1
 
 ### Bug Fixes

--- a/packages/typespec-ts/package.json
+++ b/packages/typespec-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-ts",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "description": "An experimental TypeSpec emitter for TypeScript RLC",
   "main": "dist/src/index.js",
   "type": "module",

--- a/packages/typespec-ts/test/modular-unit/scenarios/samples/parameters/overrideGroupedParameter.md
+++ b/packages/typespec-ts/test/modular-unit/scenarios/samples/parameters/overrideGroupedParameter.md
@@ -1,0 +1,193 @@
+# When @@override groups query params into a model, samples should nest them
+
+## TypeSpec
+
+```tsp
+import "@typespec/http";
+import "@azure-tools/typespec-client-generator-core";
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+
+@service(#{ title: "Sample Service" })
+@server("{endpoint}", "Sample endpoint", {
+  @doc("The endpoint URL")
+  endpoint: string = "https://example.com",
+})
+namespace SampleService;
+
+model Item {
+  id: string;
+  name: string;
+}
+
+model QueryOptions {
+  @query("$top") top?: int32;
+  @query("$filter") filter?: string;
+  @query("$orderby") orderBy?: string;
+}
+
+@route("/items")
+interface Items {
+  @get
+  listOriginal(@query("$top") top?: int32, @query("$filter") filter?: string, @query("$orderby") orderBy?: string): Item[];
+}
+
+op listCustomized(queryOptions?: QueryOptions): Item[];
+
+@@override(Items.listOriginal, SampleService.listCustomized);
+```
+
+```yaml
+needTCGC: true
+needAzureCore: true
+withRawContent: true
+```
+
+## Example
+
+```json
+{
+  "title": "List items with query options",
+  "operationId": "Items_listOriginal",
+  "parameters": {
+    "$top": 10,
+    "$filter": "name eq 'test'",
+    "$orderby": "name asc"
+  },
+  "responses": {
+    "200": {
+      "body": [
+        {
+          "id": "item1",
+          "name": "test"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Generated Sample
+
+```ts samples
+/** This file path is /samples-dev/listOriginalSample.ts */
+import { SampleServiceClient } from "@azure/internal-test";
+
+/**
+ * This sample demonstrates how to execute listOriginal
+ *
+ * @summary execute listOriginal
+ * x-ms-original-file: 2021-10-01-preview/json.json
+ */
+async function listItemsWithQueryOptions(): Promise<void> {
+  const client = new SampleServiceClient();
+  const result = await client.listOriginal({
+    queryOptions: { top: 10, filter: "name eq 'test'", orderBy: "name asc" },
+  });
+  console.log(result);
+}
+
+async function main(): Promise<void> {
+  await listItemsWithQueryOptions();
+}
+
+main().catch(console.error);
+```
+
+# When @@override groups query params into a required model, samples should nest them positionally
+
+## TypeSpec
+
+```tsp
+import "@typespec/http";
+import "@azure-tools/typespec-client-generator-core";
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+
+@service(#{ title: "Sample Service" })
+@server("{endpoint}", "Sample endpoint", {
+  @doc("The endpoint URL")
+  endpoint: string = "https://example.com",
+})
+namespace SampleService;
+
+model Item {
+  id: string;
+  name: string;
+}
+
+model QueryOptions {
+  @query("$top") top?: int32;
+  @query("$filter") filter?: string;
+  @query("$orderby") orderBy?: string;
+}
+
+@route("/items")
+interface Items {
+  @get
+  listOriginal(@query("$top") top?: int32, @query("$filter") filter?: string, @query("$orderby") orderBy?: string): Item[];
+}
+
+op listCustomized(queryOptions: QueryOptions): Item[];
+
+@@override(Items.listOriginal, SampleService.listCustomized);
+```
+
+```yaml
+needTCGC: true
+needAzureCore: true
+withRawContent: true
+```
+
+## Example
+
+```json
+{
+  "title": "List items with required query options",
+  "operationId": "Items_listOriginal",
+  "parameters": {
+    "$top": 10,
+    "$filter": "name eq 'test'",
+    "$orderby": "name asc"
+  },
+  "responses": {
+    "200": {
+      "body": [
+        {
+          "id": "item1",
+          "name": "test"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Generated Sample
+
+```ts samples
+/** This file path is /samples-dev/listOriginalSample.ts */
+import { SampleServiceClient } from "@azure/internal-test";
+
+/**
+ * This sample demonstrates how to execute listOriginal
+ *
+ * @summary execute listOriginal
+ * x-ms-original-file: 2021-10-01-preview/json.json
+ */
+async function listItemsWithRequiredQueryOptions(): Promise<void> {
+  const client = new SampleServiceClient();
+  const result = await client.listOriginal({
+    top: 10,
+    filter: "name eq 'test'",
+    orderBy: "name asc",
+  });
+  console.log(result);
+}
+
+async function main(): Promise<void> {
+  await listItemsWithRequiredQueryOptions();
+}
+
+main().catch(console.error);
+```


### PR DESCRIPTION
This PR bumps `@azure-tools/typespec-ts` to **0.54.2** as a hotfix on the `release/june-2026` branch.

### Bug Fixes included
- Fix body param serialize issue reported from sdk repo
- Preserve operation-group names in classical client generation to avoid double-normalization
- Keep paged result model public when also used as a model property