### PR TITLE
Bump version for hotfix: typespec-ts@0.54.2

### DIFF
--- a/.chronus/changes/fix-do-not-normalize-classical-client-2026-6-17-3-10-0.md
+++ b/.chronus/changes/fix-do-not-normalize-classical-client-2026-6-17-3-10-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Preserve `$DO_NOT_NORMALIZE$` operation-group names in classical client generation to avoid double-normalization that caused unresolved placeholder references.

--- a/.chronus/changes/fix-js-serialize-issue-2026-5-16-7-9-40.md
+++ b/.chronus/changes/fix-js-serialize-issue-2026-5-16-7-9-40.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-[typespec-ts] fix body param serialize issue reported from sdk repo

--- a/.chronus/changes/fix-paged-model-property-prefix-2026-6-17-10-31-0.md
+++ b/.chronus/changes/fix-paged-model-property-prefix-2026-6-17-10-31-0.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-[typespec-ts] Keep paged result model public when also used as a model property

--- a/packages/typespec-ts/CHANGELOG.md
+++ b/packages/typespec-ts/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log - @azure-tools/typespec-ts
 
+## 0.54.2
+
+### Bug Fixes
+
+- [#4647](https://github.com/Azure/typespec-azure/pull/4647) Preserve `$DO_NOT_NORMALIZE$` operation-group names in classical client generation to avoid double-normalization that caused unresolved placeholder references.
+- [#4638](https://github.com/Azure/typespec-azure/pull/4638) [typespec-ts] fix body param serialize issue reported from sdk repo
+- [#4646](https://github.com/Azure/typespec-azure/pull/4646) [typespec-ts] Keep paged result model public when also used as a model property
+
+
 ## 0.54.1
 
 ### Bug Fixes

--- a/packages/typespec-ts/package.json
+++ b/packages/typespec-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-ts",
-  "version": "0.54.1",
+  "version": "0.54.2",
   "description": "An experimental TypeSpec emitter for TypeScript RLC",
   "main": "dist/src/index.js",
   "type": "module",


### PR DESCRIPTION
This PR bumps `@azure-tools/typespec-ts` to **0.54.2** as a hotfix on the `release/june-2026` branch.

### Bug Fixes included
- Fix body param serialize issue reported from sdk repo
- Preserve operation-group names in classical client generation to avoid double-normalization
- Keep paged result model public when also used as a model property