### PR TITLE
Use authenticated npmrc

### DIFF
--- a/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+++ b/eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
@@ -1,0 +1,41 @@
+parameters:
+  - name: npmrcPath
+    type: string
+    # When empty, defaults to the agent user's .npmrc ($HOME/.npmrc on
+    # Linux/macOS, %USERPROFILE%\.npmrc on Windows) so every subsequent
+    # npm / pnpm / npx call in the job inherits the registry + auth.
+    default: ""
+  - name: registryUrl
+    type: string
+    default: "https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/"
+  - name: CustomCondition
+    type: string
+    default: succeeded()
+  - name: ServiceConnection
+    type: string
+    default: ""
+
+steps:
+  - pwsh: |
+      $npmrcPath = '${{ parameters.npmrcPath }}'
+      if (-not $npmrcPath) { $npmrcPath = Join-Path $HOME '.npmrc' }
+
+      Write-Host "Creating .npmrc file $npmrcPath for registry ${{ parameters.registryUrl }}"
+      $parentFolder = Split-Path -Path $npmrcPath -Parent
+
+      if ($parentFolder -and -not (Test-Path $parentFolder)) {
+        Write-Host "Creating folder $parentFolder"
+        New-Item -Path $parentFolder -ItemType Directory | Out-Null
+      }
+
+      "registry=${{ parameters.registryUrl }}" | Out-File $npmrcPath
+      Write-Host "##vso[task.setvariable variable=resolvedNpmrcPath]$npmrcPath"
+    displayName: "Create .npmrc"
+    condition: ${{ parameters.CustomCondition }}
+
+  - task: npmAuthenticate@0
+    displayName: Authenticate .npmrc
+    condition: ${{ parameters.CustomCondition }}
+    inputs:
+      workingFile: $(resolvedNpmrcPath)
+      azureDevOpsServiceConnection: ${{ parameters.ServiceConnection }}

--- a/eng/pipelines/templates/install.yml
+++ b/eng/pipelines/templates/install.yml
@@ -25,17 +25,8 @@ steps:
       path: ${{ parameters.pnpmStorePath }}
     displayName: Cache pnpm store
 
-  - script: npm install -g pnpm # Pnpm manage-package-manager-versions will respect packageManager field
+  - script: npm install -g pnpm@10.30.2 # Pnpm manage-package-manager-versions will respect packageManager field
     displayName: Install pnpm
-
-  - script: |
-      node -e "
-        const fs = require('fs');
-        const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
-        delete pkg.packageManager;
-        fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
-      "
-    displayName: Remove packageManager for pipeline
 
   - script: pnpm config set store-dir ${{ parameters.pnpmStorePath }}
     displayName: Setup pnpm cache dir

--- a/eng/pipelines/templates/install.yml
+++ b/eng/pipelines/templates/install.yml
@@ -18,26 +18,27 @@ steps:
     retryCountOnTaskFailure: 3
 
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
-    parameters:
-      npmrcPath: $(Agent.TempDirectory)/install/.npmrc
 
   - task: Cache@2
     inputs:
       key: 'pnpm | "$(Agent.OS)" | pnpm-lock.yaml'
       path: ${{ parameters.pnpmStorePath }}
     displayName: Cache pnpm store
-    env:
-      npm_config_userconfig: "$(Agent.TempDirectory)/install/.npmrc"
 
   - script: npm install -g pnpm # Pnpm manage-package-manager-versions will respect packageManager field
     displayName: Install pnpm
-    env:
-      npm_config_userconfig: "$(Agent.TempDirectory)/install/.npmrc"
+
+  - script: |
+      node -e "
+        const fs = require('fs');
+        const pkg = JSON.parse(fs.readFileSync('package.json', 'utf8'));
+        delete pkg.packageManager;
+        fs.writeFileSync('package.json', JSON.stringify(pkg, null, 2));
+      "
+    displayName: Remove packageManager for pipeline
 
   - script: pnpm config set store-dir ${{ parameters.pnpmStorePath }}
     displayName: Setup pnpm cache dir
-    env:
-      npm_config_userconfig: "$(Agent.TempDirectory)/install/.npmrc"
 
   - script: |
       echo "Node:"
@@ -50,5 +51,3 @@ steps:
   - script: pnpm install
     displayName: Install JavaScript Dependencies
     retryCountOnTaskFailure: 3
-    env:
-      npm_config_userconfig: "$(Agent.TempDirectory)/install/.npmrc"

--- a/eng/pipelines/templates/install.yml
+++ b/eng/pipelines/templates/install.yml
@@ -25,7 +25,9 @@ steps:
       path: ${{ parameters.pnpmStorePath }}
     displayName: Cache pnpm store
 
-  - script: npm install -g pnpm@10.30.2 # Pnpm manage-package-manager-versions will respect packageManager field
+  - pwsh: |
+      $packageJson = Get-Content -Raw "$(Build.SourcesDirectory)/package.json" | ConvertFrom-Json
+      npm install -g $packageJson.packageManager # Pnpm manage-package-manager-versions will respect packageManager field
     displayName: Install pnpm
 
   - script: pnpm config set store-dir ${{ parameters.pnpmStorePath }}

--- a/eng/pipelines/templates/install.yml
+++ b/eng/pipelines/templates/install.yml
@@ -17,15 +17,27 @@ steps:
     displayName: Install Node.js
     retryCountOnTaskFailure: 3
 
+  - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
+    parameters:
+      npmrcPath: $(Agent.TempDirectory)/install/.npmrc
+
   - task: Cache@2
     inputs:
       key: 'pnpm | "$(Agent.OS)" | pnpm-lock.yaml'
       path: ${{ parameters.pnpmStorePath }}
     displayName: Cache pnpm store
+    env:
+      npm_config_userconfig: "$(Agent.TempDirectory)/install/.npmrc"
+
   - script: npm install -g pnpm # Pnpm manage-package-manager-versions will respect packageManager field
     displayName: Install pnpm
+    env:
+      npm_config_userconfig: "$(Agent.TempDirectory)/install/.npmrc"
+
   - script: pnpm config set store-dir ${{ parameters.pnpmStorePath }}
     displayName: Setup pnpm cache dir
+    env:
+      npm_config_userconfig: "$(Agent.TempDirectory)/install/.npmrc"
 
   - script: |
       echo "Node:"
@@ -38,3 +50,5 @@ steps:
   - script: pnpm install
     displayName: Install JavaScript Dependencies
     retryCountOnTaskFailure: 3
+    env:
+      npm_config_userconfig: "$(Agent.TempDirectory)/install/.npmrc"


### PR DESCRIPTION
This pull request updates the `eng/pipelines/templates/install.yml` pipeline template to improve npm authentication and ensure consistent usage of a custom `.npmrc` file throughout the installation steps. The main focus is on securely handling npm credentials and making sure all relevant tasks use the authenticated configuration.

**Authentication and Environment Configuration:**

* Added a step to create an authenticated `.npmrc` file using the `create-authenticated-npmrc.yml` template and set its path to `$(Agent.TempDirectory)/install/.npmrc` to ensure npm commands use the correct credentials.
* Updated all relevant pipeline steps (`Cache@2`, `Install pnpm`, `Setup pnpm cache dir`, and `Install JavaScript Dependencies`) to set the `npm_config_userconfig` environment variable, pointing to the authenticated `.npmrc` file, ensuring that npm and pnpm commands use the correct authentication context. [[1]](diffhunk://#diff-2189476a30e22dd483222dc1d283882d6a6a4d79d164a0dccf3a8ea417410d40R20-R40) [[2]](diffhunk://#diff-2189476a30e22dd483222dc1d283882d6a6a4d79d164a0dccf3a8ea417410d40R53-R54)