### PR TITLE
docs: reference new spec structure where main.tsp imports client.tsp

### DIFF
--- a/eng/feeds/__snapshots__/azure-core/main.tsp
+++ b/eng/feeds/__snapshots__/azure-core/main.tsp
@@ -1,6 +1,7 @@
 import "@typespec/rest";
 import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
+import "./client.tsp";
 
 using Http;
 using Rest;

--- a/eng/feeds/__snapshots__/azure-core_stand_alone/main.tsp
+++ b/eng/feeds/__snapshots__/azure-core_stand_alone/main.tsp
@@ -1,6 +1,7 @@
 import "@typespec/rest";
 import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
+import "./client.tsp";
 
 using Http;
 using Rest;

--- a/eng/feeds/data-plane/main.tsp
+++ b/eng/feeds/data-plane/main.tsp
@@ -1,6 +1,7 @@
 import "@typespec/rest";
 import "@typespec/versioning";
 import "@azure-tools/typespec-azure-core";
+import "./client.tsp";
 
 using Http;
 using Rest;

--- a/website/src/content/docs/docs/howtos/Generate client libraries/01setup.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/01setup.mdx
@@ -23,7 +23,13 @@ Ensure that your `package.json` includes a link to the customization library, `t
 }
 ```
 
-Customization should be implemented in a file named `client.tsp`, which should be used alongside with the `main.tsp`.
+Customization should be implemented in a file named `client.tsp`, which should be used alongside with the `main.tsp`. The `main.tsp` imports `client.tsp` so that the whole specification, including client customizations, compiles from the single `main.tsp` entrypoint.
+
+```typespec
+// main.tsp
+import "./client.tsp";
+// ... rest of the service definition
+```
 
 ```typespec
 // client.tsp
@@ -35,8 +41,8 @@ using Azure.ClientGenerator.Core;
 // Add your customizations here
 ```
 
-After you've created your customization file, use the command `tsp compile client.tsp` to generate output that includes your customizations:
+After you've created your customization file, compile the project from the `main.tsp` entrypoint to generate output that includes your customizations:
 
 ```shell
-tsp compile client.tsp
+tsp compile .
 ```

--- a/website/src/content/docs/docs/howtos/Generate client libraries/01setup.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/01setup.mdx
@@ -23,7 +23,7 @@ Ensure that your `package.json` includes a link to the customization library, `t
 }
 ```
 
-Customization should be implemented in a file named `client.tsp`, which should be used alongside with the `main.tsp`. The `main.tsp` imports `client.tsp` so that the whole specification, including client customizations, compiles from the single `main.tsp` entrypoint.
+Customization should be implemented in a file named `client.tsp`, which should be used alongside the `main.tsp`. The `main.tsp` imports `client.tsp` so that the whole specification, including client customizations, compiles from the single `main.tsp` entrypoint.
 
 ```typespec
 // main.tsp

--- a/website/src/content/docs/docs/howtos/Generate client libraries/03client.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/03client.mdx
@@ -592,7 +592,7 @@ petStorePetsActionsClient.Pet(context.Background(), &PetStorePetsActionsClientPe
 
 ## Customizations
 
-Customizations SHOULD always be made in a file named `client.tsp` alongside `main.tsp`.
+Customizations SHOULD always be made in a file named `client.tsp` alongside `main.tsp`. The `main.tsp` imports `client.tsp`, so the project compiles from the single `main.tsp` entrypoint with `tsp compile .`.
 
 There are two ways to customize the client hierarchy: using `@clientLocation` to change the location of the operations, or use `@client` to restructure the client hierarchy.
 Be careful when you use both of them since `@clientLocation` could not move the client that is no longer exist with `@client` customization.

--- a/website/src/content/docs/docs/migrate-swagger/checklists/migrate-arm-tips.md
+++ b/website/src/content/docs/docs/migrate-swagger/checklists/migrate-arm-tips.md
@@ -73,7 +73,7 @@ union WidgetColor {
 
 ❌ **DON'T** import or use `@azure-tools/typespec-client-generator-core` in files other than `client.tsp` or `back-compat.tsp`
 
-❌ **DON'T** reference `client.tsp` in `main.tsp`
+✅ **DO** reference `client.tsp` in `main.tsp` (add `import "./client.tsp";` so `main.tsp` is the single entrypoint)
 
 ✅ **DO** reference `back-compat.tsp` in `main.tsp`
 

--- a/website/src/content/docs/docs/migrate-swagger/checklists/migrate-dp-tips.md
+++ b/website/src/content/docs/docs/migrate-swagger/checklists/migrate-dp-tips.md
@@ -87,6 +87,8 @@ union WidgetColor {
 
 ✅ **DO** make client customizations in a `client.tsp` file
 
+✅ **DO** reference `client.tsp` in `main.tsp` (add `import "./client.tsp";` so `main.tsp` is the single entrypoint)
+
 ❌ **DON'T** import or use `@azure-tools/typespec-client-generator-core` in other files aside from client.tsp.
 
 ✅ **DO** run `tsp compile .` on your specification and address all warnings

--- a/website/src/content/docs/docs/migrate-swagger/faq/frequentquestions.md
+++ b/website/src/content/docs/docs/migrate-swagger/faq/frequentquestions.md
@@ -16,11 +16,11 @@ options:
 
 For ARM services, use the following file structure:
 
-- **main.tsp**: Entry point for the TypeSpec specification containing service information
+- **main.tsp**: Entry point for the TypeSpec specification containing service information. It imports `client.tsp` so the whole specification (including client customizations) compiles from `main.tsp`.
 - **{resource-name}.tsp**: Resource-specific operations for each ARM resource type
 - **routes.tsp**: All other operations that don't belong to specific resources
 - **models.tsp**: All the model definitions used across operations
-- **(optional) client.tsp**: Client-specific customizations and configurations
+- **(optional) client.tsp**: Client-specific customizations and configurations, imported by `main.tsp`
 - **(optional) back-compatible.tsp**: Backward compatibility definitions and legacy support
 
 This structure helps maintain a clear separation of concerns between the API description and the client SDK and makes the TypeSpec specification easier to navigate and maintain.


### PR DESCRIPTION
Part of the migration in #4564 (Phase 3 — documentation/tooling).

Updates scaffold templates and documentation to reflect the new spec repo service structure where **`main.tsp` is the single entrypoint that imports `client.tsp`** (transitional Phase 1: `client.tsp` still imports `main.tsp`).

## Scaffold templates (`eng/feeds/`)
- `data-plane/main.tsp` now adds `import "./client.tsp";`.
- Regenerated snapshots (`__snapshots__/azure-core/main.tsp`, `azure-core_stand_alone/main.tsp`) via the e2e test (6/6 pass, including `tsp compile .` validation).
- ARM templates left untouched — they have no existing `client.tsp` (only updating where `client.tsp` already exists).

## Docs
- `migrate-arm-tips.md` — reversed "❌ DON'T reference client.tsp in main.tsp" → "✅ DO reference client.tsp in main.tsp".
- `migrate-dp-tips.md` — added "✅ DO reference client.tsp in main.tsp".
- `frequentquestions.md` — updated ARM file-layout to note `main.tsp` imports `client.tsp`.
- `01setup.mdx` — added the `main.tsp` import example; changed `tsp compile client.tsp` → `tsp compile .`.
- `03client.mdx` — clarified the `main.tsp` entrypoint wording.

## Out of scope
- Phase 3 structure test fixtures under `packages/azure-http-specs/specs/client/structure/*` (tracked separately in #4564).
