### PR TITLE
Add @kashifkhan as CODEOWNER for typespec-python

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,4 @@
 
 /docs/howtos/DataPlane*/ @lmazuel @m-nash @iscai-msft @srnagar @joheredi
 
-/packages/typespec-python @iscai-msft @msyyc @tadelesh @l0lawrence @ChenxiJiang333
+/packages/typespec-python @iscai-msft @msyyc @tadelesh @l0lawrence @ChenxiJiang333 @kashifkhan


### PR DESCRIPTION
Adds @kashifkhan to the CODEOWNERS entry for \/packages/typespec-python\.