### PR TITLE
[Automated][tcgc] docs(tcgc): document per-service api-version for multi-service packages

### DIFF
--- a/eng/scripts/doc-updater/knowledge/tcgc.md
+++ b/eng/scripts/doc-updater/knowledge/tcgc.md
@@ -221,3 +221,15 @@ namespace (@clientNamespace), naming (@clientName), overload, structure (@client
 - Only ONE `#suppress "experimental-feature" "exact"` directive is needed per property — it covers all subsequent `@clientName(exact(...))` decorators on that property.
 - When creating exact-name Spector specs, the namespace needs `@clientNamespace` for BOTH Java (`"azure.clientgenerator.core.exactname"`) AND Python (`"specs.azure.clientgenerator.core.exactname"`) so tests pass in both language emitter test suites.
 - The @clientNamespace for python should be formatted multi-line if it exceeds a reasonable line length.
+
+## Per-Service API Version (June 2026)
+
+- The `api-version` emitter option now accepts `string | Record<string, string>`. The Record form maps service namespace full names to version strings, enabling per-service API version control in multi-service packages.
+- `resolveApiVersionForService` in `src/internal-utils.ts` is the central resolution function (internal, not exported). It handles string vs Record config dispatch.
+- For multi-service packages, `"all"` is NOT supported — it falls back to `undefined` (latest version). This applies in both the string and Record forms.
+- `"latest"` is a global keyword that applies regardless of single/multi-service.
+- In the Record form, services not listed in the map return `undefined` (latest version).
+- `SdkPackage.metadata.apiVersions` (Map) stores the resolved version per service. `metadata.apiVersion` (string, deprecated) is `undefined` for multi-service.
+- No Spector spec was added for this feature — it's a code-generation-time config behavior, not a wire-level behavior. The unit tests in `test/package/api-versions-metadata.test.ts` and `test/clients/structure.test.ts` thoroughly cover it.
+- The guideline.md was updated to document `SdkPackage.metadata` (both `apiVersion` and `apiVersions`).
+- The 10versioning.mdx was updated to mention the Record form and add a "Per-service versioning (multi-service packages)" section.

--- a/eng/scripts/doc-updater/knowledge/tcgc.meta.json
+++ b/eng/scripts/doc-updater/knowledge/tcgc.meta.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "a04ee76e9f6f1d7918955269c7a54af2c0e9c685",
-  "lastUpdated": "2026-06-08T10:59:23.790Z",
+  "lastCommit": "d4128efda9bb5edc8f80d1e10a0c2c9ab3019068",
+  "lastUpdated": "2026-06-22T11:44:15.998Z",
   "analyzedPaths": [
     "packages/typespec-client-generator-core/src",
     "packages/typespec-client-generator-core/lib",

--- a/website/src/content/docs/docs/howtos/Generate client libraries/10versioning.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/10versioning.mdx
@@ -474,8 +474,8 @@ Services not listed in the object default to their latest version.
 options:
   "@azure-tools/typespec-python":
     api-version:
-      ServiceA: "av1"
-      ServiceB: "bv1"
+      ServiceA: "2024-01-01"
+      ServiceB: "2024-05-01"
 ```
 
 For example, given two versioned services:
@@ -491,8 +491,8 @@ using TypeSpec.Http;
 @versioned(VersionsA)
 namespace ServiceA {
   enum VersionsA {
-    av1,
-    av2,
+    v2024_01_01: "2024-01-01",
+    v2024_06_01: "2024-06-01",
   }
   @route("/aTest")
   op aTest(@query("api-version") apiVersion: VersionsA): void;
@@ -502,17 +502,17 @@ namespace ServiceA {
 @versioned(VersionsB)
 namespace ServiceB {
   enum VersionsB {
-    bv1,
-    bv2,
+    v2024_05_01: "2024-05-01",
+    v2024_09_01: "2024-09-01",
   }
   @route("/bTest")
   op bTest(@query("api-version") apiVersion: VersionsB): void;
 }
 ```
 
-With `api-version: { ServiceA: "av1", ServiceB: "bv1" }`, the generated client will use version `av1` for ServiceA operations and `bv1` for ServiceB operations.
+With `api-version: { ServiceA: "2024-01-01", ServiceB: "2024-05-01" }`, the generated client will use version `2024-01-01` for ServiceA operations and `2024-05-01` for ServiceB operations.
 
-With `api-version: { ServiceA: "av1" }` (ServiceB omitted), ServiceA will use `av1` while ServiceB will default to its latest version `bv2`.
+With `api-version: { ServiceA: "2024-01-01" }` (ServiceB omitted), ServiceA will use `2024-01-01` while ServiceB will default to its latest version `2024-09-01`.
 
 > NOTE: The special value `"all"` is **not supported** for multi-service packages. If specified (either as a top-level string or as a per-service value), it is ignored and the service falls back to its latest version. The `"latest"` value works as expected and applies to all services.
 

--- a/website/src/content/docs/docs/howtos/Generate client libraries/10versioning.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/10versioning.mdx
@@ -130,7 +130,7 @@ func (client *ServiceClient) StableFunctionality(ctx context.Context, stableMode
 
 ## Multiple api versions
 
-The configuration flag `api-version` allows you to toggle the behavior that our emitters will generate.
+The configuration flag `api-version` allows you to toggle the behavior that our emitters will generate. For single-service packages, it accepts a string value. For multi-service packages, it can also be an object mapping each service namespace's full name to a version string (see [Per-service versioning](#per-service-versioning-multi-service-packages)).
 
 We will get the versioning information from the `Versions` enum that you pass to the `@versioned` decorator from the `@typespec/versioning` library.
 
@@ -463,6 +463,58 @@ func (client *ServiceClient) StableFunctionality(ctx context.Context, stableMode
 ```
 
 </ClientTabs>
+
+### Per-service versioning (multi-service packages)
+
+When your spec defines multiple services merged into a single client (using `@client({service: [ServiceA, ServiceB]})`), you can specify a different API version for each service by passing an object instead of a string. The keys are the full namespace names of each service, and the values are the desired version strings.
+
+Services not listed in the object default to their latest version.
+
+```yaml title=tspconfig.yaml
+options:
+  "@azure-tools/typespec-python":
+    api-version:
+      ServiceA: "av1"
+      ServiceB: "bv1"
+```
+
+For example, given two versioned services:
+
+```typespec
+import "@typespec/versioning";
+import "@typespec/http";
+
+using TypeSpec.Versioning;
+using TypeSpec.Http;
+
+@service
+@versioned(VersionsA)
+namespace ServiceA {
+  enum VersionsA {
+    av1,
+    av2,
+  }
+  @route("/aTest")
+  op aTest(@query("api-version") apiVersion: VersionsA): void;
+}
+
+@service
+@versioned(VersionsB)
+namespace ServiceB {
+  enum VersionsB {
+    bv1,
+    bv2,
+  }
+  @route("/bTest")
+  op bTest(@query("api-version") apiVersion: VersionsB): void;
+}
+```
+
+With `api-version: { ServiceA: "av1", ServiceB: "bv1" }`, the generated client will use version `av1` for ServiceA operations and `bv1` for ServiceB operations.
+
+With `api-version: { ServiceA: "av1" }` (ServiceB omitted), ServiceA will use `av1` while ServiceB will default to its latest version `bv2`.
+
+> NOTE: The special value `"all"` is **not supported** for multi-service packages. If specified (either as a top-level string or as a per-service value), it is ignored and the service falls back to its latest version. The `"latest"` value works as expected and applies to all services.
 
 ### New model/operation added in new api version
 

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/guideline.md
@@ -112,6 +112,13 @@ Clients, models, enums, and unions include namespace information. Emitters can u
 - A flattened structure (`SdkPackage.clients`, `SdkPackage.enums`, `SdkPackage.models`, `SdkPackage.unions`)
 - A hierarchical structure (`SdkPackage.namespaces`) requiring iteration through nested namespaces.
 
+### Package Metadata
+
+Emitters can get package metadata from `SdkPackage.metadata`. The metadata currently contains API version information:
+
+- **`apiVersion`** _(deprecated)_: A single string representing the resolved API version for single-service packages. For multi-service packages this is `undefined`. Use `apiVersions` instead.
+- **`apiVersions`**: A `Map<string, string>` where each key is a service namespace's full qualified name and each value is the resolved API version for that service. For single-service packages, the map has one entry. For multi-service packages, each service has its own entry. If the `api-version` config is set to `"all"` (single-service only), the value is the string `"all"`.
+
 ### License Information
 
 Emitters can get package license info from `SdkPackage.licenseInfo`. The [`LicenseInfo`](../reference/js-api/interfaces/licenseinfo/) contains license details for client code comments or license file generation.


### PR DESCRIPTION
Update versioning documentation and emitter developer guide to reflect the new api-version option that accepts Record<string, string> for multi-service packages, enabling per-service API version control.

Resolve: https://github.com/Azure/typespec-azure/issues/4673