### PR TITLE
Add ExampleRef component to inline samples in docs

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -465,6 +465,9 @@ catalogs:
     rehype:
       specifier: ^13.0.2
       version: 13.0.2
+    remark-gfm:
+      specifier: ^4.0.1
+      version: 4.0.1
     remark-heading-id:
       specifier: ^1.0.1
       version: 1.0.1
@@ -4101,6 +4104,9 @@ importers:
       rehype:
         specifier: 'catalog:'
         version: 13.0.2
+      remark-gfm:
+        specifier: 'catalog:'
+        version: 4.0.1
       remark-heading-id:
         specifier: 'catalog:'
         version: 1.0.1
@@ -21012,7 +21018,7 @@ snapshots:
       algoliasearch: 4.27.0
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       diff: 5.2.2
-      ink: 3.2.0(@types/react@19.2.16)(react@17.0.2)
+      ink: 3.2.0(@types/react@19.2.16)(react@19.2.7)
       ink-text-input: 4.0.3(ink@3.2.0(@types/react@19.2.16)(react@17.0.2))(react@17.0.2)
       react: 17.0.2
       semver: 7.8.1
@@ -21162,7 +21168,7 @@ snapshots:
       '@yarnpkg/plugin-git': 3.2.0(@yarnpkg/core@4.8.0(typanion@3.14.0))(typanion@3.14.0)
       clipanion: 4.0.0-rc.4(typanion@3.14.0)
       es-toolkit: 1.47.0
-      ink: 3.2.0(@types/react@19.2.16)(react@19.2.7)
+      ink: 3.2.0(@types/react@19.2.16)(react@17.0.2)
       react: 17.0.2
       semver: 7.8.1
       tslib: 2.8.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -179,6 +179,7 @@ catalog:
   rehype: ^13.0.2
   rehype-mermaid: ^3.0.0
   remark-heading-id: ^1.0.1
+  remark-gfm: ^4.0.1
   rimraf: ^6.1.3
   rollup-plugin-visualizer: "7.0.1"
   semver: ^7.7.4

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -7,6 +7,7 @@ import astroExpressiveCode from "astro-expressive-code";
 import rehypeAstroRelativeMarkdownLinks from "astro-rehype-relative-markdown-links";
 import { defineConfig } from "astro/config";
 import { resolve } from "path";
+import remarkGfm from "remark-gfm";
 import remarkHeadingID from "remark-heading-id";
 import current from "./src/content/current-sidebar";
 
@@ -62,7 +63,7 @@ export default defineConfig({
   ],
   markdown: {
     // @ts-expect-error wrong type
-    remarkPlugins: [remarkHeadingID],
+    remarkPlugins: [remarkHeadingID, remarkGfm],
     rehypePlugins: [
       [rehypeAstroRelativeMarkdownLinks, { base, collectionBase: false, trailingSlash: "always" }],
     ],

--- a/website/package.json
+++ b/website/package.json
@@ -50,6 +50,7 @@
     "astro-rehype-relative-markdown-links": "catalog:",
     "hast-util-to-html": "catalog:",
     "rehype": "catalog:",
+    "remark-gfm": "catalog:",
     "remark-heading-id": "catalog:",
     "unist-util-visit": "catalog:",
     "yaml": "catalog:"

--- a/website/src/components/sample/example-ref.astro
+++ b/website/src/components/sample/example-ref.astro
@@ -5,9 +5,11 @@ import SampleContent from "./sample-content.astro";
 interface Props {
   /** Sample id, i.e. the directory relative to `packages/samples/specs` (e.g. `resource-manager/resource-types/tracked`). */
   path: string;
+  /** Render the sample inside a collapsed `<details>` to reduce noise on pages that inline many samples. */
+  collapsed?: boolean;
 }
 
-const { path } = Astro.props;
+const { path, collapsed } = Astro.props;
 
 const { samples } = await getSampleStructure();
 const sample = samples.find((x) => x.id === path);
@@ -23,12 +25,24 @@ const base = import.meta.env.BASE_URL.replace(/\/$/, "");
 const sampleHref = `${base}/docs/samples/${sample.id}/`;
 ---
 
-<section class="example-ref">
-  <div class="example-ref-header">
-    <a href={sampleHref}>{sample.title}</a>
-  </div>
-  <SampleContent sample={sample} />
-</section>
+{
+  collapsed ? (
+    <details class="example-ref">
+      <summary class="example-ref-header">{sample.title}</summary>
+      <a class="example-ref-link" href={sampleHref}>
+        View full sample →
+      </a>
+      <SampleContent sample={sample} />
+    </details>
+  ) : (
+    <section class="example-ref">
+      <div class="example-ref-header">
+        <a href={sampleHref}>{sample.title}</a>
+      </div>
+      <SampleContent sample={sample} />
+    </section>
+  )
+}
 
 <style>
   .example-ref {
@@ -40,5 +54,15 @@ const sampleHref = `${base}/docs/samples/${sample.id}/`;
   .example-ref-header {
     font-weight: 600;
     margin-block: 0.75rem 0.25rem;
+  }
+  summary.example-ref-header {
+    cursor: pointer;
+    margin-block: 0;
+    padding-block: 0.75rem;
+  }
+  .example-ref-link {
+    display: inline-block;
+    font-size: var(--sl-text-sm);
+    margin-block: 0.25rem 0.5rem;
   }
 </style>

--- a/website/src/components/sample/example-ref.astro
+++ b/website/src/components/sample/example-ref.astro
@@ -1,0 +1,44 @@
+---
+import { getSampleStructure } from "src/utils/samples";
+import SampleContent from "./sample-content.astro";
+
+interface Props {
+  /** Sample id, i.e. the directory relative to `packages/samples/specs` (e.g. `resource-manager/resource-types/tracked`). */
+  path: string;
+}
+
+const { path } = Astro.props;
+
+const { samples } = await getSampleStructure();
+const sample = samples.find((x) => x.id === path);
+
+if (!sample) {
+  const available = samples.map((x) => x.id).join(", ");
+  throw new Error(
+    `ExampleRef: no sample found with path "${path}". Available samples: ${available}`,
+  );
+}
+
+const base = import.meta.env.BASE_URL.replace(/\/$/, "");
+const sampleHref = `${base}/docs/samples/${sample.id}/`;
+---
+
+<section class="example-ref">
+  <div class="example-ref-header">
+    <a href={sampleHref}>{sample.title}</a>
+  </div>
+  <SampleContent sample={sample} />
+</section>
+
+<style>
+  .example-ref {
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    padding: 0 1rem 1rem;
+    margin-block: 1rem;
+  }
+  .example-ref-header {
+    font-weight: 600;
+    margin-block: 0.75rem 0.25rem;
+  }
+</style>

--- a/website/src/components/sample/index.ts
+++ b/website/src/components/sample/index.ts
@@ -1,0 +1,2 @@
+export { default as ExampleRef } from "./example-ref.astro";
+export { default as SampleContent } from "./sample-content.astro";

--- a/website/src/components/sample/sample-content.astro
+++ b/website/src/components/sample/sample-content.astro
@@ -1,0 +1,43 @@
+---
+import { Aside, Code, TabItem } from "@astrojs/starlight/components";
+import EditorTabs from "@typespec/astro-utils/components/editor-tabs.astro";
+import type { SampleConfig } from "src/utils/samples";
+
+interface Props {
+  sample: SampleConfig;
+}
+
+const { sample } = Astro.props;
+
+// Sort files: main.tsp first, then alphabetically
+const sortedFiles = Object.entries(sample.files).sort(([a], [b]) => {
+  if (a === "main.tsp") return -1;
+  if (b === "main.tsp") return 1;
+  return a.localeCompare(b);
+});
+
+const hasMultipleFiles = sortedFiles.length > 1;
+---
+
+{sample.danger && <Aside type="danger">{sample.danger}</Aside>}
+
+<p>{sample.description}</p>
+
+{
+  hasMultipleFiles ? (
+    <EditorTabs>
+      {sortedFiles.map(([fileName, content]) => (
+        <TabItem label={fileName}>
+          <Code lang="typespec" code={content} />
+        </TabItem>
+      ))}
+    </EditorTabs>
+  ) : (
+    <Code
+      lang="typespec"
+      title="main.tsp"
+      meta={`tryit="${JSON.stringify({ emit: ["@azure-tools/typespec-autorest"] })}"`}
+      code={sample.files["main.tsp"]!}
+    />
+  )
+}

--- a/website/src/content/docs/docs/getstarted/azure-core/step10.md
+++ b/website/src/content/docs/docs/getstarted/azure-core/step10.md
@@ -1,7 +1,0 @@
----
-title: 10. Complete Example
----
-
-A complete version of the `Contoso.WidgetManager` specification can be found in the [`widget-manager` sample folder](https://github.com/Azure/typespec-azure/blob/main/packages/samples/specs/data-plane/widget-manager/main.tsp).
-
-You can experiment with the full sample on the [TypeSpec Azure Playground](https://cadlplayground.z22.web.core.windows.net/cadl-azure/?sample=Azure+Core+Data+Plane+Service)!

--- a/website/src/content/docs/docs/getstarted/azure-core/step10.mdx
+++ b/website/src/content/docs/docs/getstarted/azure-core/step10.mdx
@@ -1,0 +1,11 @@
+---
+title: 10. Complete Example
+---
+
+import { ExampleRef } from "@components/sample";
+
+A complete version of the `Contoso.WidgetManager` specification is shown below.
+
+<ExampleRef path="data-plane/widget-manager" />
+
+You can experiment with the full sample on the [TypeSpec Azure Playground](https://cadlplayground.z22.web.core.windows.net/cadl-azure/?sample=Azure+Core+Data+Plane+Service)!

--- a/website/src/content/docs/docs/howtos/ARM/network-security-perimeter.mdx
+++ b/website/src/content/docs/docs/howtos/ARM/network-security-perimeter.mdx
@@ -4,6 +4,8 @@ description: Adding Network Security Perimeter (NSP) Configuration operations to
 llmstxt: true
 ---
 
+import { ExampleRef } from "@components/sample";
+
 Network Security Perimeter (NSP) configurations allow users to manage perimeter-based network
 access to a resource. Resource providers that support NSP configurations must declare an NSP
 configuration resource type in their provider namespace and use the standard `NspConfigurations`
@@ -60,75 +62,7 @@ The `NspConfigurations` interface provides the following operations:
 
 The following example shows a complete service with NSP configuration support:
 
-```typespec
-import "@typespec/rest";
-import "@typespec/versioning";
-import "@azure-tools/typespec-azure-core";
-import "@azure-tools/typespec-azure-resource-manager";
-
-using Rest;
-using Versioning;
-using Azure.Core;
-using Azure.ResourceManager;
-
-@armProviderNamespace
-@service(#{ title: "ContosoProviderHubClient" })
-@versioned(Versions)
-namespace Microsoft.ContosoProviderHub;
-
-enum Versions {
-  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
-  `2025-11-19-preview`,
-}
-
-model Employee is TrackedResource<EmployeeProperties> {
-  ...ResourceNameParameter<Employee>;
-}
-
-model EmployeeProperties {
-  /** Age of employee */
-  age?: int32;
-
-  /** City of employee */
-  city?: string;
-
-  /** The status of the last operation. */
-  @visibility(Lifecycle.Read)
-  provisioningState?: ProvisioningState;
-}
-
-@lroStatus
-union ProvisioningState {
-  ResourceProvisioningState,
-  Provisioning: "Provisioning",
-  Updating: "Updating",
-  Deleting: "Deleting",
-  Accepted: "Accepted",
-  string,
-}
-
-interface Operations extends Azure.ResourceManager.Operations {}
-
-// 1. Define the NSP configuration resource model
-model NetworkSecurityPerimeterConfiguration is Azure.ResourceManager.NspConfiguration;
-
-// 2. Create the operations alias
-alias NspConfigurationOps = Azure.ResourceManager.NspConfigurations<NetworkSecurityPerimeterConfiguration>;
-
-// 3. Add operations to the resource interface
-@armResourceOperations
-interface Employees {
-  get is ArmResourceRead<Employee>;
-  createOrUpdate is ArmResourceCreateOrReplaceAsync<Employee>;
-  delete is ArmResourceDeleteSync<Employee>;
-  listByResourceGroup is ArmResourceListByParent<Employee>;
-  listBySubscription is ArmListBySubscription<Employee>;
-
-  // NSP configuration operations
-  getNsp is NspConfigurationOps.Read<Employee>;
-  listNsp is NspConfigurationOps.ListByParent<Employee>;
-}
-```
+<ExampleRef path="resource-manager/resource-types/nsp" />
 
 ## Using NSP Configurations with Child Resources
 

--- a/website/src/content/docs/docs/howtos/ARM/private-endpoints.mdx
+++ b/website/src/content/docs/docs/howtos/ARM/private-endpoints.mdx
@@ -4,6 +4,8 @@ description: Adding Private Endpoint Connection operations to ARM resources
 llmstxt: true
 ---
 
+import { ExampleRef } from "@components/sample";
+
 Private Endpoint Connections allow users to manage private network access to a resource. Resource
 providers that support private endpoint connections must declare a private endpoint connection
 resource type in their provider namespace and use the standard `PrivateEndpoints` interface to
@@ -63,78 +65,7 @@ The `PrivateEndpoints` interface provides the following operations:
 
 The following example shows a complete service with private endpoint connection support:
 
-```typespec
-import "@typespec/rest";
-import "@typespec/versioning";
-import "@azure-tools/typespec-azure-core";
-import "@azure-tools/typespec-azure-resource-manager";
-
-using Rest;
-using Versioning;
-using Azure.Core;
-using Azure.ResourceManager;
-
-@armProviderNamespace
-@service(#{ title: "ContosoProviderHubClient" })
-@versioned(Versions)
-namespace Microsoft.ContosoProviderHub;
-
-enum Versions {
-  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
-  `2021-10-01-preview`,
-}
-
-model Employee is TrackedResource<EmployeeProperties> {
-  ...ResourceNameParameter<Employee>;
-}
-
-model EmployeeProperties {
-  /** Age of employee */
-  age?: int32;
-
-  /** City of employee */
-  city?: string;
-
-  /** The status of the last operation. */
-  @visibility(Lifecycle.Read)
-  provisioningState?: ProvisioningState;
-}
-
-@lroStatus
-union ProvisioningState {
-  ResourceProvisioningState,
-  Provisioning: "Provisioning",
-  Updating: "Updating",
-  Deleting: "Deleting",
-  Accepted: "Accepted",
-  string,
-}
-
-interface Operations extends Azure.ResourceManager.Operations {}
-
-// 1. Define the private endpoint connection resource model
-model PrivateEndpointConnection is PrivateEndpointConnectionResource;
-
-// 2. Create the operations alias
-alias PrivateEndpointOps = PrivateEndpoints<PrivateEndpointConnection>;
-
-// 3. Add operations to the resource interface
-@armResourceOperations
-interface Employees {
-  get is ArmResourceRead<Employee>;
-  createOrUpdate is ArmResourceCreateOrReplaceAsync<Employee>;
-  delete is ArmResourceDeleteSync<Employee>;
-  listByResourceGroup is ArmResourceListByParent<Employee>;
-  listBySubscription is ArmListBySubscription<Employee>;
-
-  // Private endpoint connection operations
-  getPrivateEndpointConnection is PrivateEndpointOps.Read<Employee>;
-  createOrUpdatePrivateEndpointConnection is PrivateEndpointOps.CreateOrUpdateAsync<Employee>;
-  updatePrivateEndpointConnection is PrivateEndpointOps.CustomPatchAsync<Employee>;
-  deletePrivateEndpointConnection is PrivateEndpointOps.DeleteAsync<Employee>;
-  listPrivateEndpointConnections is PrivateEndpointOps.ListByParent<Employee>;
-}
-```
+<ExampleRef path="resource-manager/resource-types/private-endpoints" />
 
 ## Using Private Endpoints with Child Resources
 

--- a/website/src/content/docs/docs/howtos/ARM/private-links.mdx
+++ b/website/src/content/docs/docs/howtos/ARM/private-links.mdx
@@ -4,6 +4,8 @@ description: Adding Private Link operations to ARM resources
 llmstxt: true
 ---
 
+import { ExampleRef } from "@components/sample";
+
 Private Link resources allow users to discover which connection types are available for a resource.
 Resource providers that support private link resources must declare a private link resource type in
 their provider namespace and use the standard `PrivateLinks` interface to expose operations.
@@ -51,75 +53,7 @@ The `PrivateLinks` interface provides the following operations:
 
 The following example shows a complete service with private link support:
 
-```typespec
-import "@typespec/rest";
-import "@typespec/versioning";
-import "@azure-tools/typespec-azure-core";
-import "@azure-tools/typespec-azure-resource-manager";
-
-using Rest;
-using Versioning;
-using Azure.Core;
-using Azure.ResourceManager;
-
-@armProviderNamespace
-@service(#{ title: "ContosoProviderHubClient" })
-@versioned(Versions)
-namespace Microsoft.ContosoProviderHub;
-
-enum Versions {
-  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
-  `2021-10-01-preview`,
-}
-
-model Employee is TrackedResource<EmployeeProperties> {
-  ...ResourceNameParameter<Employee>;
-}
-
-model EmployeeProperties {
-  /** Age of employee */
-  age?: int32;
-
-  /** City of employee */
-  city?: string;
-
-  /** The status of the last operation. */
-  @visibility(Lifecycle.Read)
-  provisioningState?: ProvisioningState;
-}
-
-@lroStatus
-union ProvisioningState {
-  ResourceProvisioningState,
-  Provisioning: "Provisioning",
-  Updating: "Updating",
-  Deleting: "Deleting",
-  Accepted: "Accepted",
-  string,
-}
-
-interface Operations extends Azure.ResourceManager.Operations {}
-
-// 1. Define the private link resource model
-model MyPrivateLinkResource is PrivateLink;
-
-// 2. Create the operations alias
-alias PrivateLinkOps = PrivateLinks<MyPrivateLinkResource>;
-
-// 3. Add operations to the resource interface
-@armResourceOperations
-interface Employees {
-  get is ArmResourceRead<Employee>;
-  createOrUpdate is ArmResourceCreateOrReplaceAsync<Employee>;
-  delete is ArmResourceDeleteSync<Employee>;
-  listByResourceGroup is ArmResourceListByParent<Employee>;
-  listBySubscription is ArmListBySubscription<Employee>;
-
-  // Private link operations
-  getPrivateLink is PrivateLinkOps.Read<Employee>;
-  listPrivateLinks is PrivateLinkOps.ListByParent<Employee>;
-}
-```
+<ExampleRef path="resource-manager/resource-types/private-links" />
 
 ## Using Private Links with Child Resources
 

--- a/website/src/content/docs/docs/howtos/ARM/resource-type.mdx
+++ b/website/src/content/docs/docs/howtos/ARM/resource-type.mdx
@@ -4,6 +4,8 @@ description: Choosing and modeling ARM resources
 llmstxt: true
 ---
 
+import { ExampleRef } from "@components/sample";
+
 ## Introductions
 
 Introduction
@@ -45,7 +47,9 @@ model Employee is TrackedResource<EmployeeProperties> {
 
 `...ResourceNameParameter<Employee>`: spreads in the standard resource name parameter, which automatically defines the resource type name, parameter name, and path segment based on the resource model.
 
-You can find samples of Tracked Resources [in the Tracked Resource sample](https://github.com/Azure/typespec-azure/blob/main/packages/samples/specs/resource-manager/resource-types/tracked/main.tsp).
+You can find a complete sample of Tracked Resources below.
+
+<ExampleRef path="resource-manager/resource-types/tracked" />
 
 ### Tenant Resources
 
@@ -61,7 +65,9 @@ model Employee is ProxyResource<EmployeeProperties> {
 `@tenantResource`: designates this resource as being a cross-tenant resource, with scope across all customer subscriptions in the tenant.
 `...ResourceNameParameter<Employee>`: spreads in the standard resource name parameter, which automatically defines the resource type name, parameter name, and path segment based on the resource model.
 
-You can find samples of Tenant Resources [in the TenantResource sample](https://github.com/Azure/typespec-azure/blob/main/packages/samples/specs/resource-manager/resource-types/tenant/main.tsp).
+You can find a complete sample of Tenant Resources below.
+
+<ExampleRef path="resource-manager/resource-types/tenant" />
 
 ### Extension Resource
 
@@ -188,7 +194,9 @@ alias VirtualMachineScaleSetVm = Extension.ExternalChildResource<
 interface ScaleSetVms extends EmplOps<VirtualMachineScaleSetVm> {}
 ```
 
-You can find the complete sample of Extension Resources [in the specific-extension sample](https://github.com/Azure/typespec-azure/blob/main/packages/samples/specs/resource-manager/resource-types/specific-extension/main.tsp).
+You can find the complete sample of Extension Resources below.
+
+<ExampleRef path="resource-manager/resource-types/specific-extension" />
 
 ### Child Resource
 
@@ -204,7 +212,9 @@ model Job is ProxyResource<JobProperties> {
 `@parentResource`: designates the model type for the parent of this child resource. The resource identifier for this resource will be prepended with the resource identity of the parent.
 `...ResourceNameParameter<Job>`: spreads in the standard resource name parameter, which automatically defines the resource type name, parameter name, and path segment based on the resource model.
 
-You can find samples of Child Resources [in the Proxy Resource sample](https://github.com/Azure/typespec-azure/blob/main/packages/samples/specs/resource-manager/resource-types/proxy/main.tsp).
+You can find a complete sample of Child Resources below.
+
+<ExampleRef path="resource-manager/resource-types/proxy" />
 
 ### Subscription-based Resource
 
@@ -220,7 +230,9 @@ model Employee is ProxyResource<EmployeeProperties> {
 `@subscriptionResource`: designates this resource as being a cross-subscription resource, with scope across all resource groups in the subscription.
 `...ResourceNameParameter<Employee>`: spreads in the standard resource name parameter, which automatically defines the resource type name, parameter name, and path segment based on the resource model.
 
-You can find samples of Subscription Resources [in the OperationTemplates sample](/docs/samples/resource-manager/resource-types/tracked/).
+You can find a complete sample of Subscription Resources below.
+
+<ExampleRef path="resource-manager/resource-types/tracked" />
 
 ### Location-based Resource
 
@@ -242,7 +254,9 @@ model Employee is TrackedResource<EmployeeProperties> {
 The `@locationResource` decorator is deprecated. Use `@parentResource(ArmLocationResource<...>)` instead.
 :::
 
-You can find samples of Location Resources [in the Location Resource sample](/docs/samples/resource-manager/resource-types/location/).
+You can find a complete sample of Location Resources below.
+
+<ExampleRef path="resource-manager/resource-types/location" />
 
 ### Singleton Resource
 
@@ -260,7 +274,9 @@ model EmployeeAgreement is ProxyResource<EmployeeAgreementProperties> {
 `@tenantResource`: designates this resource as being a cross-tenant resource, with scope across all customer subscriptions in the tenant.
 `...ResourceNameParameter<EmployeeAgreement>`: spreads in the standard resource name parameter, which automatically defines the resource type name, parameter name, and path segment based on the resource model.
 
-You can find samples of Singleton Resources [in the Singleton sample](https://github.com/Azure/typespec-azure/blob/main/packages/samples/specs/resource-manager/resource-types/singleton/main.tsp).
+You can find a complete sample of Singleton Resources below.
+
+<ExampleRef path="resource-manager/resource-types/singleton" />
 
 ## Designing Resource-specific Properties
 

--- a/website/src/content/docs/docs/howtos/ARM/resource-type.mdx
+++ b/website/src/content/docs/docs/howtos/ARM/resource-type.mdx
@@ -49,7 +49,7 @@ model Employee is TrackedResource<EmployeeProperties> {
 
 You can find a complete sample of Tracked Resources below.
 
-<ExampleRef path="resource-manager/resource-types/tracked" />
+<ExampleRef path="resource-manager/resource-types/tracked" collapsed />
 
 ### Tenant Resources
 
@@ -67,7 +67,7 @@ model Employee is ProxyResource<EmployeeProperties> {
 
 You can find a complete sample of Tenant Resources below.
 
-<ExampleRef path="resource-manager/resource-types/tenant" />
+<ExampleRef path="resource-manager/resource-types/tenant" collapsed />
 
 ### Extension Resource
 
@@ -196,7 +196,7 @@ interface ScaleSetVms extends EmplOps<VirtualMachineScaleSetVm> {}
 
 You can find the complete sample of Extension Resources below.
 
-<ExampleRef path="resource-manager/resource-types/specific-extension" />
+<ExampleRef path="resource-manager/resource-types/specific-extension" collapsed />
 
 ### Child Resource
 
@@ -214,7 +214,7 @@ model Job is ProxyResource<JobProperties> {
 
 You can find a complete sample of Child Resources below.
 
-<ExampleRef path="resource-manager/resource-types/proxy" />
+<ExampleRef path="resource-manager/resource-types/proxy" collapsed />
 
 ### Subscription-based Resource
 
@@ -232,7 +232,7 @@ model Employee is ProxyResource<EmployeeProperties> {
 
 You can find a complete sample of Subscription Resources below.
 
-<ExampleRef path="resource-manager/resource-types/tracked" />
+<ExampleRef path="resource-manager/resource-types/tracked" collapsed />
 
 ### Location-based Resource
 
@@ -256,7 +256,7 @@ The `@locationResource` decorator is deprecated. Use `@parentResource(ArmLocatio
 
 You can find a complete sample of Location Resources below.
 
-<ExampleRef path="resource-manager/resource-types/location" />
+<ExampleRef path="resource-manager/resource-types/location" collapsed />
 
 ### Singleton Resource
 
@@ -276,7 +276,7 @@ model EmployeeAgreement is ProxyResource<EmployeeAgreementProperties> {
 
 You can find a complete sample of Singleton Resources below.
 
-<ExampleRef path="resource-manager/resource-types/singleton" />
+<ExampleRef path="resource-manager/resource-types/singleton" collapsed />
 
 ## Designing Resource-specific Properties
 

--- a/website/src/pages/docs/samples/[...sample].astro
+++ b/website/src/pages/docs/samples/[...sample].astro
@@ -1,7 +1,6 @@
 ---
-import { Aside, Code, TabItem } from "@astrojs/starlight/components";
 import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
-import EditorTabs from "@typespec/astro-utils/components/editor-tabs.astro";
+import SampleContent from "@components/sample/sample-content.astro";
 import { type SampleConfig, getSampleStructure } from "src/utils/samples";
 
 interface Props {
@@ -14,38 +13,8 @@ export async function getStaticPaths() {
 }
 
 const { sample } = Astro.props;
-
-// Sort files: main.tsp first, then alphabetically
-const sortedFiles = Object.entries(sample.files).sort(([a], [b]) => {
-  if (a === "main.tsp") return -1;
-  if (b === "main.tsp") return 1;
-  return a.localeCompare(b);
-});
-
-const hasMultipleFiles = sortedFiles.length > 1;
 ---
 
 <StarlightPage frontmatter={{ title: sample.title }}>
-  {sample.danger && <Aside type="danger">{sample.danger}</Aside>}
-
-  <p>{sample.description}</p>
-
-  {
-    hasMultipleFiles ? (
-      <EditorTabs>
-        {sortedFiles.map(([fileName, content]) => (
-          <TabItem label={fileName}>
-            <Code lang="typespec" code={content} />
-          </TabItem>
-        ))}
-      </EditorTabs>
-    ) : (
-      <Code
-        lang="typespec"
-        title="main.tsp"
-        meta={`tryit="${JSON.stringify({ emit: ["@azure-tools/typespec-autorest"] })}"`}
-        code={sample.files["main.tsp"]!}
-      />
-    )
-  }
+  <SampleContent sample={sample} />
 </StarlightPage>


### PR DESCRIPTION
Fixes #3968

## What

Adds an `<ExampleRef>` Astro component so guides/how-tos can showcase a sample from `packages/samples` **inline**, instead of duplicating the spec or linking out to the standalone sample page.

```tsx
import { ExampleRef } from "@components/sample";

<ExampleRef path="resource-manager/resource-types/tracked" />
```

`path` is the sample id (the directory relative to `packages/samples/specs`). The component reuses the exact same rendering as the `/docs/samples/...` pages (title + description + file tabs / single-file `Code` with **Try it**) and links its header to the full sample page. An unknown `path` fails the build with an error listing the available sample ids.

Pages that reference many samples can pass `collapsed` to render each one inside a closed `<details>` and keep the page tidy:

```tsx
<ExampleRef path="resource-manager/resource-types/tracked" collapsed />
```

## How

- Extracted the sample rendering out of `pages/docs/samples/[...sample].astro` into a shared `components/sample/sample-content.astro`.
- Added `components/sample/example-ref.astro` (+ `index.ts` re-export via `@components/sample`).
- Refactored the sample page to reuse `SampleContent` (no duplicated markup).
- Converted candidate docs from `.md` → `.mdx` and replaced their sample links / inline duplicate specs with `<ExampleRef>`.

## Affected pages

> ℹ️ The website only deploys on push to `main`, so there is no per-PR website preview. These are the published URLs that will reflect the change once merged.

| Page | Change | Sample referenced |
| --- | --- | --- |
| [ARM Resource Types](https://azure.github.io/typespec-azure/docs/howtos/ARM/resource-type/) | 7 sample links → inline (`collapsed`) | `resource-types/{tracked, tenant, specific-extension, proxy, location, singleton}` |
| [Azure Core · 10. Complete Example](https://azure.github.io/typespec-azure/docs/getstarted/azure-core/step10/) | link → inline | `data-plane/widget-manager` |
| [ARM · Private Links](https://azure.github.io/typespec-azure/docs/howtos/ARM/private-links/) | inline duplicate spec → `ExampleRef` | `resource-types/private-links` |
| [ARM · Private Endpoints](https://azure.github.io/typespec-azure/docs/howtos/ARM/private-endpoints/) | inline duplicate spec → `ExampleRef` | `resource-types/private-endpoints` |
| [ARM · Network Security Perimeter](https://azure.github.io/typespec-azure/docs/howtos/ARM/network-security-perimeter/) | inline duplicate spec → `ExampleRef` | `resource-types/nsp` |

> The three ARM how-tos previously carried a hand-maintained "Complete Example" spec that had drifted from the canonical sample (fewer operations, different alias names). `ExampleRef` now renders the single source of truth.

## Screenshots

<details>
<summary><b>ARM Resource Types</b> — samples inlined as collapsed <code>&lt;details&gt;</code> (this page has 7)</summary>

Because this page references many samples, each is `collapsed` by default to avoid noise; clicking expands the full sample.

| Before | After (collapsed) | After (expanded) |
| --- | --- | --- |
| ![](https://raw.githubusercontent.com/timotheeguerin/typespec-azure/pr-assets/example-ref/before-resource-type.png) | ![](https://raw.githubusercontent.com/timotheeguerin/typespec-azure/pr-assets/example-ref/collapsed-resource-type.png) | ![](https://raw.githubusercontent.com/timotheeguerin/typespec-azure/pr-assets/example-ref/collapsed-open-resource-type.png) |

</details>

<details>
<summary><b>Azure Core · 10. Complete Example</b> — widget-manager inlined</summary>

| Before | After |
| --- | --- |
| ![](https://raw.githubusercontent.com/timotheeguerin/typespec-azure/pr-assets/example-ref/before-step10-full.png) | ![](https://raw.githubusercontent.com/timotheeguerin/typespec-azure/pr-assets/example-ref/step10-full.png) |

</details>

<details>
<summary><b>ARM · Private Links</b> — inline duplicate replaced by canonical sample</summary>

| Before | After |
| --- | --- |
| ![](https://raw.githubusercontent.com/timotheeguerin/typespec-azure/pr-assets/example-ref/before-private-links.png) | ![](https://raw.githubusercontent.com/timotheeguerin/typespec-azure/pr-assets/example-ref/after-private-links.png) |

</details>

<details>
<summary><b>ARM · Private Endpoints</b> — inline duplicate replaced by canonical sample</summary>

| Before | After |
| --- | --- |
| ![](https://raw.githubusercontent.com/timotheeguerin/typespec-azure/pr-assets/example-ref/before-private-endpoints.png) | ![](https://raw.githubusercontent.com/timotheeguerin/typespec-azure/pr-assets/example-ref/after-private-endpoints.png) |

</details>

<details>
<summary><b>ARM · Network Security Perimeter</b> — inline duplicate replaced by canonical sample</summary>

| Before | After |
| --- | --- |
| ![](https://raw.githubusercontent.com/timotheeguerin/typespec-azure/pr-assets/example-ref/before-network-security-perimeter.png) | ![](https://raw.githubusercontent.com/timotheeguerin/typespec-azure/pr-assets/example-ref/after-network-security-perimeter.png) |

</details>

## Notes

- No changeset: `@azure-tools/typespec-azure-website` is `private`.
- Skipped (out of scope): the generated `decorators.md` reference, historical release notes, the getting-started page that links to `microsoft/typespec` samples, and the `azure-core` step-by-step tutorial snippets (intentionally progressive/partial).
