### PR TITLE
fix(tcgc): warn when @clientLocation moves same-named params with different types to a client

### DIFF
--- a/.chronus/changes/clientLocation-param-type-collision-2026-6-25-13-39-44.md
+++ b/.chronus/changes/clientLocation-param-type-collision-2026-6-25-13-39-44.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Add a `client-location-conflict` warning when `@clientLocation` moves multiple parameters with the same name but different types to the same client. This commonly happens when `@clientLocation` is applied to a templated parameter that is instantiated with different types, which previously produced a broken, hard-to-understand client. Move the parameter on each operation instead so it has a consistent type on the client.

--- a/packages/typespec-client-generator-core/src/lib.ts
+++ b/packages/typespec-client-generator-core/src/lib.ts
@@ -401,6 +401,7 @@ export const $lib = createTypeSpecLibrary({
         modelPropertyToClientInitialization: paramMessage`There is already a parameter called '${"parameterName"}' in the client initialization.`,
         modelPropertyToString:
           "`@clientLocation` can only move model properties to interfaces or namespaces.",
+        parameterTypeConflict: paramMessage`@clientLocation cannot move multiple parameters named '${"parameterName"}' with different types to the same client. This often happens when @clientLocation is applied to a templated parameter that is instantiated with different types. Move the parameter on each operation instead, so that it has a consistent type on the client.`,
       },
     },
     "client-location-wrong-type": {

--- a/packages/typespec-client-generator-core/src/validations/types.ts
+++ b/packages/typespec-client-generator-core/src/validations/types.ts
@@ -27,6 +27,7 @@ import { reportDiagnostic } from "../lib.js";
 
 export function validateTypes(context: TCGCContext) {
   validateClientNames(context);
+  validateClientLocationParameterTypes(context);
 }
 
 /**
@@ -89,6 +90,83 @@ function validateClientNames(tcgcContext: TCGCContext) {
     [...newClients.values()].map((operations) => {
       validateClientNamesCore(tcgcContext, scope, operations);
     });
+  }
+}
+
+/**
+ * Validate that `@clientLocation` does not move parameters with the same name but
+ * different types to the same client.
+ *
+ * When `@clientLocation` is applied to a templated parameter (e.g. on an alias), each
+ * operation can instantiate the template with a different type. Moving all of them to the
+ * same client produces conflicting client parameters that share a name but differ in type,
+ * which results in a broken SDK. We forbid this so the user moves the parameter on each
+ * operation instead, keeping a consistent type on the client.
+ *
+ * @param tcgcContext The context for the TypeSpec Client Generator.
+ */
+function validateClientLocationParameterTypes(tcgcContext: TCGCContext) {
+  const languageScopes = getDefinedLanguageScopes(tcgcContext.program);
+
+  for (const scope of languageScopes) {
+    // For each target client (namespace/interface), track the parameters moved under each name.
+    const movedByTarget = new Map<Namespace | Interface, Map<string, ModelProperty[]>>();
+
+    for (const [type, target] of listScopedDecoratorData(
+      tcgcContext,
+      clientLocationKey,
+      scope,
+    ).entries()) {
+      if (unsafe_Realm.realmForType.has(type)) {
+        // Skip `@clientLocation` on versioning types
+        continue;
+      }
+      // Only parameters (model properties) moved to an existing client (namespace/interface).
+      if (
+        type.kind !== "ModelProperty" ||
+        typeof target === "string" ||
+        (target.kind !== "Namespace" && target.kind !== "Interface")
+      ) {
+        continue;
+      }
+
+      let byName = movedByTarget.get(target);
+      if (!byName) {
+        byName = new Map<string, ModelProperty[]>();
+        movedByTarget.set(target, byName);
+      }
+      let params = byName.get(type.name);
+      if (!params) {
+        params = [];
+        byName.set(type.name, params);
+      }
+      params.push(type);
+    }
+
+    for (const byName of movedByTarget.values()) {
+      for (const [name, params] of byName.entries()) {
+        const distinctTypes = new Set<Type>(params.map((p) => p.type));
+        if (distinctTypes.size <= 1) {
+          continue;
+        }
+        // Same parameter name moved to the client with conflicting types. Report once per
+        // distinct syntax node so a templated parameter that produces several internal copies
+        // does not generate duplicate diagnostics.
+        const reportedNodes = new Set<unknown>();
+        for (const param of params) {
+          if (param.node && reportedNodes.has(param.node)) {
+            continue;
+          }
+          reportedNodes.add(param.node);
+          reportDiagnostic(tcgcContext.program, {
+            code: "client-location-conflict",
+            messageId: "parameterTypeConflict",
+            format: { parameterName: name },
+            target: param,
+          });
+        }
+      }
+    }
   }
 }
 

--- a/packages/typespec-client-generator-core/test/decorators/client-location.test.ts
+++ b/packages/typespec-client-generator-core/test/decorators/client-location.test.ts
@@ -512,6 +512,128 @@ describe("Parameter", () => {
     ]);
   });
 
+  it("detect type conflict when moving templated parameter to client", async () => {
+    const diagnostics = await SimpleTester.diagnose(
+      `
+      @service
+      namespace Default;
+
+      union FeatureOptInKeys {
+        insights_v1_preview: "Insights.V1Preview",
+        schedules_v1_preview: "Schedules.V1Preview",
+      }
+
+      alias WithPreviewHeader<T extends FeatureOptInKeys> = {
+        @clientLocation(Default)
+        @header("x-preview-features")
+        previewFeatures: T;
+      };
+
+      @route("/insights")
+      op getInsights(...WithPreviewHeader<FeatureOptInKeys.insights_v1_preview>): void;
+
+      @route("/schedules")
+      op getSchedules(...WithPreviewHeader<FeatureOptInKeys.schedules_v1_preview>): void;
+      `,
+    );
+    expectDiagnostics(diagnostics, [
+      {
+        code: "@azure-tools/typespec-client-generator-core/client-location-conflict",
+        message: /different types/,
+      },
+    ]);
+  });
+
+  it("templated parameter type conflict reproduces broken client/method parameters", async () => {
+    // This characterizes the broken behavior the validation guards against (issue #4671):
+    // `@clientLocation` on a templated parameter that is instantiated with different types
+    // collapses, by name, into a single client parameter typed as the *last* method's
+    // instantiation. As a result the last method loses its parameter, while other methods
+    // keep a method-level parameter with their own type.
+    const [{ program }, diagnostics] = await SimpleTester.compileAndDiagnose(
+      `
+      @service
+      namespace Default;
+
+      union FeatureOptInKeys {
+        insights_v1_preview: "Insights.V1Preview",
+        schedules_v1_preview: "Schedules.V1Preview",
+      }
+
+      alias WithPreviewHeader<T extends FeatureOptInKeys> = {
+        @clientLocation(Default)
+        @header("x-preview-features")
+        previewFeatures: T;
+      };
+
+      @route("/insights")
+      op getInsights(...WithPreviewHeader<FeatureOptInKeys.insights_v1_preview>): void;
+
+      @route("/schedules")
+      op getSchedules(...WithPreviewHeader<FeatureOptInKeys.schedules_v1_preview>): void;
+      `,
+    );
+    // The validation still only warns, so the broken SDK output below is produced.
+    expectDiagnostics(diagnostics, [
+      {
+        code: "@azure-tools/typespec-client-generator-core/client-location-conflict",
+        message: /different types/,
+      },
+    ]);
+
+    const context = await createSdkContextForTester(program);
+    const client = context.sdkPackage.clients[0];
+    ok(client);
+
+    // The single elevated client parameter is typed as the *last* method's instantiation.
+    const clientPreviewParam = client.clientInitialization.parameters.find(
+      (p) => p.name === "previewFeatures",
+    );
+    ok(clientPreviewParam);
+    strictEqual(clientPreviewParam.type.kind, "enumvalue");
+    strictEqual((clientPreviewParam.type as { name: string }).name, "schedules_v1_preview");
+
+    const getInsights = client.methods.find((m) => m.name === "getInsights");
+    const getSchedules = client.methods.find((m) => m.name === "getSchedules");
+    ok(getInsights);
+    ok(getSchedules);
+
+    // The non-last method keeps a method-level parameter with its own type ...
+    const insightsParam = getInsights.parameters.find((p) => p.name === "previewFeatures");
+    ok(insightsParam);
+    strictEqual(insightsParam.onClient, false);
+    strictEqual(insightsParam.type.kind, "enumvalue");
+    strictEqual((insightsParam.type as { name: string }).name, "insights_v1_preview");
+
+    // ... while the last method loses its parameter entirely.
+    strictEqual(
+      getSchedules.parameters.find((p) => p.name === "previewFeatures"),
+      undefined,
+    );
+  });
+
+  it("no type conflict when moving same-typed parameter to client from multiple operations", async () => {
+    const diagnostics = await SimpleTester.diagnose(
+      `
+      @service
+      namespace Default;
+
+      alias WithPreviewHeader = {
+        @clientLocation(Default)
+        @header("x-preview-features")
+        previewFeatures: string;
+      };
+
+      @route("/insights")
+      op getInsights(...WithPreviewHeader): void;
+
+      @route("/schedules")
+      op getSchedules(...WithPreviewHeader): void;
+      `,
+    );
+    expectDiagnostics(diagnostics, []);
+  });
+
   it("can not move model properties to string", async () => {
     const diagnostics = await SimpleTester.diagnose(
       `


### PR DESCRIPTION
Fixes #4671

## Problem

When `@clientLocation` is applied to a **templated** parameter (e.g. on an alias), each operation can instantiate the template with a different type. Moving all of them to the same client collapses—by name—into a single client parameter typed as the *last* method's instantiation. As a result the last method loses its parameter, while other methods keep a method-level parameter with their own type, producing a broken, hard-to-understand client.

This matches @tadelesh's conclusion in the issue:

> The root problem here in TCGC is the parameter location does not check type collision... I think we should forbid using `@clientLocation` to move a parameter to the client with the same name but a different type.

## Change

- Add a new `client-location-conflict` validation (warning) in `validations/types.ts` that fires when `@clientLocation` moves multiple parameters sharing a name but with **different types** to the same client. Deduped by syntax node so a templated parameter that produces several internal copies does not generate duplicate diagnostics.
- Add the `parameterTypeConflict` message to the existing `client-location-conflict` diagnostic in `lib.ts`.

## Tests

- Positive: templated parameter instantiated with two different union members → warning.
- Negative: same-typed parameter moved from multiple operations → no warning.
- Characterization: builds the `sdkPackage` and asserts the exact broken collision (client param typed as the last method's instantiation, last method loses its param, other method keeps a method-level param with its own type).

A changeset is included.
