### PR TITLE
[typespec-ts] Fix sample generation for grouped and nested method parameters

### DIFF
--- a/.chronus/changes/fix-sample-grouped-parameters-2026-6-26-9-40-28.md
+++ b/.chronus/changes/fix-sample-grouped-parameters-2026-6-26-9-40-28.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+[typespec-ts] Fix sample generation for grouped and nested method parameters by resolving every HTTP parameter through `methodParameterSegments`, so flat, nested, and grouped parameters are emitted correctly without special casing.

--- a/packages/typespec-ts/src/modular/emit-samples.ts
+++ b/packages/typespec-ts/src/modular/emit-samples.ts
@@ -316,12 +316,36 @@ function prepareExampleParameters(
 
   let subscriptionIdValue = `"00000000-0000-0000-0000-000000000000"`;
   let isSubscriptionIdAdded = false;
-  // required parameters
+
+  // Map each HTTP parameter to its method parameter via `methodParameterSegments`
+  // and place its example value at that path, yielding one argument per method
+  // parameter regardless of flat, nested, or grouped shape. Client- and
+  // body-carried roots are emitted by their own sections and skipped here.
+  const bodyParam = method.operation.bodyParam;
+  let bodyRootName: string | undefined;
+  if (
+    bodyParam &&
+    !isSpreadBodyParameter(bodyParam) &&
+    bodyParam.methodParameterSegments.length === 1 &&
+    bodyParam.methodParameterSegments[0] !== undefined &&
+    bodyParam.methodParameterSegments[0].length >= 1
+  ) {
+    bodyRootName = bodyParam.methodParameterSegments[0][0]!.name;
+  }
+
+  const methodArguments = new Map<
+    string,
+    { name: string; isOptional: boolean; value: ValueTreeNode | string }
+  >();
   for (const param of method.operation.parameters) {
-    if (param.optional === true || param.type.kind === "constant" || param.clientDefaultValue) {
+    if (param.type.kind === "constant" || param.clientDefaultValue) {
       continue;
     }
-
+    const path = param.methodParameterSegments[0];
+    if (path === undefined || path.length === 0) {
+      continue;
+    }
+    const root = path[0]!;
     const exampleValue = parameterMap[param.serializedName];
 
     // Handle subscriptionId parameter separately for ARM clients
@@ -343,28 +367,27 @@ function prepareExampleParameters(
       continue;
     }
 
-    if (!exampleValue || !exampleValue.value) {
-      // report diagnostic if required parameter is missing
-      reportDiagnostic(dpgContext.program, {
-        code: "required-sample-parameter",
-        format: {
-          exampleName: method.oriName ?? method.name,
-          paramName: param.name,
-        },
-        target: NoTarget,
-      });
+    // Roots emitted by the client and body sections.
+    if (root.onClient || (bodyRootName !== undefined && root.name === bodyRootName)) {
       continue;
     }
 
-    result.push(
-      prepareExampleValue(
-        dpgContext,
-        exampleValue.parameter.name,
-        exampleValue.value,
-        param.optional,
-        param.onClient,
-      ),
-    );
+    if (!exampleValue || !exampleValue.value) {
+      // report diagnostic if required parameter is missing
+      if (path.length === 1 && !param.optional) {
+        reportDiagnostic(dpgContext.program, {
+          code: "required-sample-parameter",
+          format: {
+            exampleName: method.oriName ?? method.name,
+            paramName: param.name,
+          },
+          target: NoTarget,
+        });
+      }
+      continue;
+    }
+
+    placeMethodArgument(methodArguments, path, getParameterValue(dpgContext, exampleValue.value));
   }
 
   // If client-level subscriptionId is needed on the client for this method, then add it
@@ -381,7 +404,6 @@ function prepareExampleParameters(
   }
 
   // required/optional body parameters
-  const bodyParam = method.operation.bodyParam;
   const bodySerializeName = bodyParam?.serializedName;
   const bodyExample = parameterMap[bodySerializeName ?? ""];
   if (bodyParam && bodyExample && bodyExample.value) {
@@ -441,26 +463,85 @@ function prepareExampleParameters(
       }
     }
   }
-  // optional parameters
-  method.operation.parameters
-    .filter(
-      (param) =>
-        param.optional === true && parameterMap[param.serializedName] && !param.clientDefaultValue,
-    )
-    .map((param) => parameterMap[param.serializedName]!)
-    .forEach((param) => {
-      result.push(
-        prepareExampleValue(
-          dpgContext,
-          param.parameter.name,
-          param.value,
-          true,
-          param.parameter.onClient,
-        ),
-      );
+  // Emit one argument per top-level method parameter. A normal parameter carries
+  // a scalar value; a parameter with nested leaves carries an object literal.
+  for (const arg of methodArguments.values()) {
+    result.push({
+      name: normalizeName(arg.name, NameType.Parameter, true),
+      value: serializeNestedValue(arg.value),
+      isOptional: arg.isOptional,
+      onClient: false,
     });
+  }
 
   return result;
+}
+
+/** A nested value tree: leaves are TypeScript value expressions, interior nodes are objects. */
+interface ValueTreeNode {
+  [key: string]: ValueTreeNode | string;
+}
+
+/**
+ * Records `leaf` for the method parameter addressed by `path`. `path[0]` is the
+ * top-level method parameter (the argument key); a single-segment path stores a
+ * scalar, a longer path stores the leaf inside a nested object merged with
+ * sibling leaves sharing the same root.
+ */
+function placeMethodArgument(
+  methodArguments: Map<
+    string,
+    { name: string; isOptional: boolean; value: ValueTreeNode | string }
+  >,
+  path: readonly { name: string; optional?: boolean }[],
+  leaf: string,
+): void {
+  const root = path[0]!;
+  let arg = methodArguments.get(root.name);
+  if (!arg) {
+    arg = { name: root.name, isOptional: Boolean(root.optional), value: {} };
+    methodArguments.set(root.name, arg);
+  }
+  if (path.length === 1) {
+    arg.value = leaf;
+    return;
+  }
+  if (typeof arg.value !== "object") {
+    arg.value = {};
+  }
+  setNestedValue(arg.value, path.slice(1), leaf);
+}
+
+/** Places `leaf` at `path` (segments after the root), creating intermediate objects as needed. */
+function setNestedValue(
+  root: ValueTreeNode,
+  path: readonly { name: string }[],
+  leaf: string,
+): void {
+  let node = root;
+  for (let i = 0; i < path.length; i++) {
+    const key = normalizeName(path[i]!.name, NameType.Property, true);
+    if (i === path.length - 1) {
+      node[key] = leaf;
+    } else {
+      const existing = node[key];
+      if (typeof existing !== "object" || existing === null) {
+        node[key] = {};
+      }
+      node = node[key] as ValueTreeNode;
+    }
+  }
+}
+
+/** Serializes a {@link ValueTreeNode} into a TypeScript object literal string. */
+function serializeNestedValue(node: ValueTreeNode | string): string {
+  if (typeof node === "string") {
+    return node;
+  }
+  const entries = Object.entries(node).map(
+    ([key, value]) => `${key}: ${serializeNestedValue(value)}`,
+  );
+  return `{ ${entries.join(", ")} }`;
 }
 
 function getCredentialExampleValue(

--- a/packages/typespec-ts/test/modular-unit/scenarios/samples/parameters/groupedParameter.md
+++ b/packages/typespec-ts/test/modular-unit/scenarios/samples/parameters/groupedParameter.md
@@ -1,0 +1,297 @@
+# When a method mixes a flat parameter with a grouped model, samples should emit each once
+
+A flat required query parameter and a grouped query model live on the same operation.
+The flat parameter is emitted positionally while the grouped model is nested inside the
+options bag, proving both are resolved through the same `methodParameterSegments` path
+without special casing.
+
+## TypeSpec
+
+```tsp
+import "@typespec/http";
+import "@azure-tools/typespec-client-generator-core";
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+
+@service(#{ title: "Sample Service" })
+@server(
+  "{endpoint}",
+  "Sample endpoint",
+  {
+    @doc("The endpoint URL")
+    endpoint: string = "https://example.com",
+  }
+)
+namespace SampleService;
+
+model Item {
+  id: string;
+  name: string;
+}
+
+model QueryOptions {
+  @query("$top") top?: int32;
+  @query("$filter") filter?: string;
+  @query("$orderby") orderBy?: string;
+}
+
+@route("/items")
+interface Items {
+  @get
+  list(@query("category") category: string, queryOptions?: QueryOptions): Item[];
+}
+```
+
+```yaml
+needTCGC: true
+needAzureCore: true
+withRawContent: true
+```
+
+## Example
+
+```json
+{
+  "title": "List items with a flat parameter and grouped query options",
+  "operationId": "Items_list",
+  "parameters": {
+    "category": "books",
+    "$top": 10,
+    "$filter": "name eq 'test'",
+    "$orderby": "name asc"
+  },
+  "responses": {
+    "200": {
+      "body": [
+        {
+          "id": "item1",
+          "name": "test"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Generated Sample
+
+```ts samples
+/** This file path is /samples-dev/listSample.ts */
+import { SampleServiceClient } from "@azure/internal-test";
+
+/**
+ * This sample demonstrates how to execute list
+ *
+ * @summary execute list
+ * x-ms-original-file: 2021-10-01-preview/json.json
+ */
+async function listItemsWithAFlatParameterAndGroupedQueryOptions(): Promise<void> {
+  const client = new SampleServiceClient();
+  const result = await client.list("books", {
+    queryOptions: { top: 10, filter: "name eq 'test'", orderBy: "name asc" },
+  });
+  console.log(result);
+}
+
+async function main(): Promise<void> {
+  await listItemsWithAFlatParameterAndGroupedQueryOptions();
+}
+
+main().catch(console.error);
+```
+
+# When a grouped query model is optional, samples should nest it inside the options bag
+
+An optional grouped query model is the only method parameter. It is resolved through its
+`methodParameterSegments` path and nested under its root name inside the options bag.
+
+## TypeSpec
+
+```tsp
+import "@typespec/http";
+import "@azure-tools/typespec-client-generator-core";
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+
+@service(#{ title: "Sample Service" })
+@server(
+  "{endpoint}",
+  "Sample endpoint",
+  {
+    @doc("The endpoint URL")
+    endpoint: string = "https://example.com",
+  }
+)
+namespace SampleService;
+
+model Item {
+  id: string;
+  name: string;
+}
+
+model QueryOptions {
+  @query("$top") top?: int32;
+  @query("$filter") filter?: string;
+  @query("$orderby") orderBy?: string;
+}
+
+@route("/items")
+interface Items {
+  @get
+  list(queryOptions?: QueryOptions): Item[];
+}
+```
+
+```yaml
+needTCGC: true
+needAzureCore: true
+withRawContent: true
+```
+
+## Example
+
+```json
+{
+  "title": "List items with optional query options",
+  "operationId": "Items_list",
+  "parameters": {
+    "$top": 10,
+    "$filter": "name eq 'test'",
+    "$orderby": "name asc"
+  },
+  "responses": {
+    "200": {
+      "body": [
+        {
+          "id": "item1",
+          "name": "test"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Generated Sample
+
+```ts samples
+/** This file path is /samples-dev/listSample.ts */
+import { SampleServiceClient } from "@azure/internal-test";
+
+/**
+ * This sample demonstrates how to execute list
+ *
+ * @summary execute list
+ * x-ms-original-file: 2021-10-01-preview/json.json
+ */
+async function listItemsWithOptionalQueryOptions(): Promise<void> {
+  const client = new SampleServiceClient();
+  const result = await client.list({
+    queryOptions: { top: 10, filter: "name eq 'test'", orderBy: "name asc" },
+  });
+  console.log(result);
+}
+
+async function main(): Promise<void> {
+  await listItemsWithOptionalQueryOptions();
+}
+
+main().catch(console.error);
+```
+
+# When a grouped query model is required, samples should nest it positionally
+
+A required grouped query model is the only method parameter. It is emitted positionally as
+the model itself, resolved through its `methodParameterSegments` path.
+
+## TypeSpec
+
+```tsp
+import "@typespec/http";
+import "@azure-tools/typespec-client-generator-core";
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+
+@service(#{ title: "Sample Service" })
+@server(
+  "{endpoint}",
+  "Sample endpoint",
+  {
+    @doc("The endpoint URL")
+    endpoint: string = "https://example.com",
+  }
+)
+namespace SampleService;
+
+model Item {
+  id: string;
+  name: string;
+}
+
+model QueryOptions {
+  @query("$top") top?: int32;
+  @query("$filter") filter?: string;
+  @query("$orderby") orderBy?: string;
+}
+
+@route("/items")
+interface Items {
+  @get
+  list(queryOptions: QueryOptions): Item[];
+}
+```
+
+```yaml
+needTCGC: true
+needAzureCore: true
+withRawContent: true
+```
+
+## Example
+
+```json
+{
+  "title": "List items with required query options",
+  "operationId": "Items_list",
+  "parameters": {
+    "$top": 10,
+    "$filter": "name eq 'test'",
+    "$orderby": "name asc"
+  },
+  "responses": {
+    "200": {
+      "body": [
+        {
+          "id": "item1",
+          "name": "test"
+        }
+      ]
+    }
+  }
+}
+```
+
+## Generated Sample
+
+```ts samples
+/** This file path is /samples-dev/listSample.ts */
+import { SampleServiceClient } from "@azure/internal-test";
+
+/**
+ * This sample demonstrates how to execute list
+ *
+ * @summary execute list
+ * x-ms-original-file: 2021-10-01-preview/json.json
+ */
+async function listItemsWithRequiredQueryOptions(): Promise<void> {
+  const client = new SampleServiceClient();
+  const result = await client.list({ top: 10, filter: "name eq 'test'", orderBy: "name asc" });
+  console.log(result);
+}
+
+async function main(): Promise<void> {
+  await listItemsWithRequiredQueryOptions();
+}
+
+main().catch(console.error);
+```


### PR DESCRIPTION
## Description

Fixes sample generation for grouped and nested method parameters.

When a method parameter is model-typed (e.g. an `@@override` that groups query params into `queryOptions?: QueryOptions`, a directly-defined grouped model parameter, or body-extracted query/header params), the sample generator previously emitted those parameters **flat**, producing TypeScript compile errors in the generated `*Sample.ts` files.

## Fix

`prepareExampleParameters` now resolves every HTTP parameter to its method parameter through `methodParameterSegments` — the same source of truth the operation generator uses — and places each example value at its path. This yields exactly one argument per method parameter, regardless of whether the parameter is flat, nested, or grouped, without special-casing any of those shapes:

- `path.length === 1` -> scalar positional argument
- longer path -> value nested under its root (e.g. `{ queryOptions: { top, filter, orderBy } }`)
- the root segment's `optional` flag decides positional vs. options-bag placement

A `bodyRootName` guard skips the root that the dedicated body section already emits, preventing double-emission when a query/header parameter shares the body's model root.

## Tests

Added `test/modular-unit/scenarios/samples/parameters/groupedParameter.md` covering three structural outcomes:
1. flat + optional grouped together -> `client.list("books", { queryOptions: { ... } })`
2. optional grouped only -> `client.list({ queryOptions: { ... } })`
3. required grouped only -> `client.list({ top, filter, orderBy })`

All 59 samples scenarios pass.

Fixes #4649
