### PR TITLE
Bump version for hotfix: @azure-tools/typespec-ts@0.55.0

### DIFF
--- a/.chronus/changes/add-ts-emitter-playground-2026-5-10-14-24-35.md
+++ b/.chronus/changes/add-ts-emitter-playground-2026-5-10-14-24-35.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Update to make emitter browser compatible

--- a/.chronus/changes/fix-sample-grouped-parameters-2026-6-26-9-40-28.md
+++ b/.chronus/changes/fix-sample-grouped-parameters-2026-6-26-9-40-28.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-[typespec-ts] Fix sample generation for grouped and nested method parameters by resolving every HTTP parameter through `methodParameterSegments`, so flat, nested, and grouped parameters are emitted correctly without special casing.

--- a/.chronus/changes/kazrael2119-patch-1-2026-5-15-8-32-26.md
+++ b/.chronus/changes/kazrael2119-patch-1-2026-5-15-8-32-26.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-[typespec-ts] Rename AAD / Azure Active Directory references to Microsoft Entra branding

--- a/.chronus/changes/remove-branded-flavor-options-2026-6-17-0-0-0.md
+++ b/.chronus/changes/remove-branded-flavor-options-2026-6-17-0-0-0.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: breaking
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Remove the `branded` and `flavor` emitter options. `@azure-tools/typespec-ts` now only generates Azure-branded packages; use `@typespec/http-client-js` for unbranded emit.

--- a/.chronus/changes/remove-rlc-support-2026-6-18-0-0-0.md
+++ b/.chronus/changes/remove-rlc-support-2026-6-18-0-0-0.md
@@ -1,7 +1,0 @@
----
-changeKind: breaking
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Remove RLC (Rest Level Client) generation support. The emitter now always generates a Modular library, so the `is-modular-library` option has been removed (it is treated as always `true`). The following deprecated RLC-legacy options have also been removed: `include-shortcuts`, `multi-client`, `batch`, `azure-output-directory`, `title`, `dependency-info`, `product-doc-link`, `service-info`, and `default-value-object`.

--- a/.chronus/changes/speed-up-typespec-ts-tests-2026-03-04-00-00-00.md
+++ b/.chronus/changes/speed-up-typespec-ts-tests-2026-03-04-00-00-00.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Speed up the `unit-modular` test suite: migrate the test compile host to the compiler's `createTester` framework so the TypeSpec libraries are loaded once per worker (and the in-memory filesystem cloned per compile) instead of being re-read from disk on every compile, split the monolithic scenario test into per-directory suites for parallelism, trim each scenario's imported library surface to only what it references, add a per-scenario compile cache to avoid recompiling identical TypeSpec inputs across output blocks, lower the test heap from 8 GB to 1 GB, and convert two module-level emitter caches to `WeakMap` to reduce cross-call retention.

--- a/.chronus/changes/typespec-ts-compiler-host-vfs-2026-6-11-16-17-0.md
+++ b/.chronus/changes/typespec-ts-compiler-host-vfs-2026-6-11-16-17-0.md
@@ -1,7 +1,0 @@
----
-changeKind: feature
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Use CompilerHost for all filesystem operations, enabling the emitter to run in the TypeSpec playground browser environment

--- a/.chronus/changes/typespec-ts-remove-module-kind-azure-sdk-for-js-2026-6-11-0-0-0.md
+++ b/.chronus/changes/typespec-ts-remove-module-kind-azure-sdk-for-js-2026-6-11-0-0-0.md
@@ -1,7 +1,0 @@
----
-changeKind: breaking
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Remove the `module-kind` and `azure-sdk-for-js` emitter options. Generation now always targets ESM and the Azure SDK for JS monorepo layout. The standalone-package and CommonJS-only generation paths have been removed.

--- a/.chronus/changes/typespec-ts-remove-source-from-2026-6-11-0-0-1.md
+++ b/.chronus/changes/typespec-ts-remove-source-from-2026-6-11-0-0-1.md
@@ -1,7 +1,0 @@
----
-changeKind: breaking
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Remove the internal `source-from` emitter option. Generation always targets TypeSpec sources, so the option and all Swagger-specific generation branches it gated have been removed.

--- a/.chronus/changes/typespec-ts-update-node-engine-2026-6-23-20-26-0.md
+++ b/.chronus/changes/typespec-ts-update-node-engine-2026-6-23-20-26-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Update node engine requirement to `>=20.0.0` in generated package.json

--- a/packages/typespec-ts/CHANGELOG.md
+++ b/packages/typespec-ts/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Change Log - @azure-tools/typespec-ts
 
+## 0.55.0
+
+### Breaking Changes
+
+- [#4668](https://github.com/Azure/typespec-azure/pull/4668) Remove the `branded` and `flavor` emitter options. `@azure-tools/typespec-ts` now only generates Azure-branded packages; use `@typespec/http-client-js` for unbranded emit.
+- [#4694](https://github.com/Azure/typespec-azure/pull/4694) Remove RLC (Rest Level Client) generation support. The emitter now always generates a Modular library, so the `is-modular-library` option has been removed (it is treated as always `true`). The following deprecated RLC-legacy options have also been removed: `include-shortcuts`, `multi-client`, `batch`, `azure-output-directory`, `title`, `dependency-info`, `product-doc-link`, `service-info`, and `default-value-object`.
+- [#4682](https://github.com/Azure/typespec-azure/pull/4682) Remove the `module-kind` and `azure-sdk-for-js` emitter options. Generation now always targets ESM and the Azure SDK for JS monorepo layout. The standalone-package and CommonJS-only generation paths have been removed.
+- [#4682](https://github.com/Azure/typespec-azure/pull/4682) Remove the internal `source-from` emitter option. Generation always targets TypeSpec sources, so the option and all Swagger-specific generation branches it gated have been removed.
+
+### Features
+
+- [#4617](https://github.com/Azure/typespec-azure/pull/4617) Use CompilerHost for all filesystem operations, enabling the emitter to run in the TypeSpec playground browser environment
+
+### Bug Fixes
+
+- [#4606](https://github.com/Azure/typespec-azure/pull/4606) Update to make emitter browser compatible
+- [#4718](https://github.com/Azure/typespec-azure/pull/4718) [typespec-ts] Fix sample generation for grouped and nested method parameters by resolving every HTTP parameter through `methodParameterSegments`, so flat, nested, and grouped parameters are emitted correctly without special casing.
+- [#4624](https://github.com/Azure/typespec-azure/pull/4624) [typespec-ts] Rename AAD / Azure Active Directory references to Microsoft Entra branding
+- [#4692](https://github.com/Azure/typespec-azure/pull/4692) Update node engine requirement to `>=20.0.0` in generated package.json
+
+
 ## 0.54.2
 
 ### Bug Fixes

--- a/packages/typespec-ts/package.json
+++ b/packages/typespec-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-ts",
-  "version": "0.54.2",
+  "version": "0.55.0",
   "description": "An experimental TypeSpec emitter for TypeScript",
   "main": "dist/src/index.js",
   "type": "module",


### PR DESCRIPTION
Hotfix version bump for `@azure-tools/typespec-ts` to 0.55.0 via `pnpm chronus version --ignore-policies --only @azure-tools/typespec-ts`.