### PR TITLE
Internal: Begin typed `effect` Context for modular emitter (OutputProject, Dependencies)

### DIFF
--- a/.chronus/changes/typespec-ts-effect-reader-context-2026-06-26.md
+++ b/.chronus/changes/typespec-ts-effect-reader-context-2026-06-26.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Internal refactor: Begin using `effect` for modular emitter context management. This refactors `buildClientContext` to be executed within an `Effect` using a typed `Layer` for dependencies and the ts-morph project.

--- a/packages/typespec-ts/package.json
+++ b/packages/typespec-ts/package.json
@@ -90,6 +90,7 @@
     "@typespec/xml": "workspace:^"
   },
   "dependencies": {
+    "effect": "catalog:",
     "fast-xml-parser": "catalog:",
     "handlebars": "catalog:",
     "prettier": "catalog:",

--- a/packages/typespec-ts/src/framework/effect-context.ts
+++ b/packages/typespec-ts/src/framework/effect-context.ts
@@ -1,0 +1,30 @@
+import { Context, Effect, Layer } from "effect";
+import { Project } from "ts-morph";
+import { ExternalDependencies } from "./dependency.js";
+
+export class OutputProject extends Context.Tag("OutputProject")<
+  OutputProject,
+  Project
+>() {}
+
+export class Dependencies extends Context.Tag("Dependencies")<
+  Dependencies,
+  ExternalDependencies
+>() {}
+
+export function makeClientReaderLayer(params: {
+  project: Project;
+  dependencies: ExternalDependencies;
+}): Layer.Layer<OutputProject | Dependencies, never, never> {
+  return Layer.mergeAll(
+    Layer.succeed(OutputProject, params.project),
+    Layer.succeed(Dependencies, params.dependencies)
+  );
+}
+
+export function runClientContextSync<A, E>(
+  effect: Effect.Effect<A, E, OutputProject | Dependencies>,
+  layer: Layer.Layer<OutputProject | Dependencies, never, never>
+): A {
+  return Effect.runSync(Effect.provide(effect, layer));
+}

--- a/packages/typespec-ts/src/index.ts
+++ b/packages/typespec-ts/src/index.ts
@@ -74,6 +74,8 @@ import {
 } from "@azure-tools/typespec-client-generator-core";
 import { Project } from "ts-morph";
 import { provideBinder } from "./framework/hooks/binder.js";
+import { useDependencies } from "./framework/hooks/use-dependencies.js";
+import { makeClientReaderLayer, runClientContextSync } from "./framework/effect-context.js";
 import { provideSdkTypes } from "./framework/hooks/sdk-types.js";
 import { loadStaticHelpers } from "./framework/load-static-helpers.js";
 import { EmitterOptions } from "./lib.js";
@@ -276,6 +278,8 @@ export async function $onEmit(context: EmitContext) {
   async function generateModularSources() {
     const modularSourcesRoot = dpgContext.generationPathDetail?.modularSourcesDir ?? "src";
     const project = useContext("outputProject");
+    const dependencies = useDependencies();
+    const effectReaderLayer = makeClientReaderLayer({ project, dependencies });
     modularEmitterOptions = transformModularEmitterOptions(dpgContext, modularSourcesRoot, {
       casing: "camel",
     });
@@ -300,7 +304,10 @@ export async function $onEmit(context: EmitContext) {
       await renameClientName(subClient[1], modularEmitterOptions);
       buildApiOptions(dpgContext, subClient, modularEmitterOptions);
       buildOperationFiles(dpgContext, subClient, modularEmitterOptions);
-      buildClientContext(dpgContext, subClient, modularEmitterOptions);
+      runClientContextSync(
+        buildClientContext(dpgContext, subClient, modularEmitterOptions),
+        effectReaderLayer
+      );
       buildRestorePoller(dpgContext, subClient, modularEmitterOptions);
       if (dpgContext.rlcOptions?.hierarchyClient) {
         buildSubpathIndexFile(modularEmitterOptions, "api", subClient, {

--- a/packages/typespec-ts/src/modular/build-client-context.ts
+++ b/packages/typespec-ts/src/modular/build-client-context.ts
@@ -1,10 +1,5 @@
 import { Effect } from "effect";
-import {
-  Dependencies,
-  OutputProject,
-  makeClientReaderLayer,
-  runClientContextSync,
-} from "../framework/effect-context.js";
+import { Dependencies, OutputProject } from "../framework/effect-context.js";
 import { NameType, normalizeName } from "../rlc-common/index.js";
 import {
   buildGetClientCredentialParam,
@@ -26,8 +21,6 @@ import {
 } from "@azure-tools/typespec-client-generator-core";
 import { NoTarget } from "@typespec/compiler";
 import { SourceFile } from "ts-morph";
-import { useContext } from "../context-manager.js";
-import { useDependencies } from "../framework/hooks/use-dependencies.js";
 import { resolveReference } from "../framework/reference.js";
 import { refkey } from "../framework/refkey.js";
 import { reportDiagnostic } from "../lib.js";
@@ -63,10 +56,7 @@ export function buildClientContext(
   dpgContext: SdkContext,
   clientMap: [string[], SdkClientType<SdkServiceOperation>],
   emitterOptions: ModularEmitterOptions,
-): SourceFile {
-  const project = useContext("outputProject");
-  const dependencies = useDependencies();
-
+): Effect.Effect<SourceFile, never, OutputProject | Dependencies> {
   const effect = Effect.gen(function* () {
     const project = yield* OutputProject;
     const dependencies = yield* Dependencies;
@@ -309,7 +299,7 @@ export function buildClientContext(
   return clientContextFile;
   });
 
-  return runClientContextSync(effect, makeClientReaderLayer({ project, dependencies }));
+  return effect;
 }
 
 function getDocsWithKnownVersion(

--- a/packages/typespec-ts/src/modular/build-client-context.ts
+++ b/packages/typespec-ts/src/modular/build-client-context.ts
@@ -1,3 +1,10 @@
+import { Effect } from "effect";
+import {
+  Dependencies,
+  OutputProject,
+  makeClientReaderLayer,
+  runClientContextSync,
+} from "../framework/effect-context.js";
 import { NameType, normalizeName } from "../rlc-common/index.js";
 import {
   buildGetClientCredentialParam,
@@ -59,7 +66,11 @@ export function buildClientContext(
 ): SourceFile {
   const project = useContext("outputProject");
   const dependencies = useDependencies();
-  const [hierarchy, client] = clientMap;
+
+  const effect = Effect.gen(function* () {
+    const project = yield* OutputProject;
+    const dependencies = yield* Dependencies;
+    const [hierarchy, client] = clientMap;
   const name = getClientName(client);
   const { rlcClientName } = getModularClientOptions(clientMap);
   const requiredParams = getClientParametersDeclaration(client, dpgContext, {
@@ -296,6 +307,9 @@ export function buildClientContext(
 
   clientContextFile.fixUnusedIdentifiers();
   return clientContextFile;
+  });
+
+  return runClientContextSync(effect, makeClientReaderLayer({ project, dependencies }));
 }
 
 function getDocsWithKnownVersion(

--- a/packages/typespec-ts/test/util/emit-util.ts
+++ b/packages/typespec-ts/test/util/emit-util.ts
@@ -14,7 +14,9 @@ import {
 
 import { expectDiagnosticEmpty } from "@typespec/compiler/testing";
 import { useContext } from "../../src/context-manager.js";
+import { makeClientReaderLayer, runClientContextSync } from "../../src/framework/effect-context.js";
 import { useBinder } from "../../src/framework/hooks/binder.js";
+import { useDependencies } from "../../src/framework/hooks/use-dependencies.js";
 import { renameClientName } from "../../src/index.js";
 import { buildClassicalClient } from "../../src/modular/build-classical-client.js";
 import { buildClientContext } from "../../src/modular/build-client-context.js";
@@ -261,7 +263,14 @@ export async function emitModularClientContextFromTypeSpec(
     emitTypes(dpgContext, { sourceRoot: "" });
     renameClientName(dpgContext.sdkPackage.clients[0], modularEmitterOptions);
     const clientMap = Array.from(getClientHierarchyMap(dpgContext));
-    const res = buildClientContext(dpgContext, clientMap[0]!, modularEmitterOptions);
+    
+    const project = useContext("outputProject");
+    const dependencies = useDependencies();
+    const effectReaderLayer = makeClientReaderLayer({ project, dependencies });
+    const res = runClientContextSync(
+      buildClientContext(dpgContext, clientMap[0]!, modularEmitterOptions),
+      effectReaderLayer
+    );
     binder.resolveAllReferences("/");
     return res;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -333,6 +333,9 @@ catalogs:
     ecmarkup:
       specifier: ~23.0.2
       version: 23.0.2
+    effect:
+      specifier: ^3.21.4
+      version: 3.21.4
     env-paths:
       specifier: ^4.0.0
       version: 4.0.0
@@ -3883,6 +3886,9 @@ importers:
 
   packages/typespec-ts:
     dependencies:
+      effect:
+        specifier: 'catalog:'
+        version: 3.21.4
       fast-xml-parser:
         specifier: 'catalog:'
         version: 5.8.0
@@ -9880,6 +9886,9 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
+  effect@3.21.4:
+    resolution: {integrity: sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ==}
+
   electron-to-chromium@1.5.364:
     resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
 
@@ -10222,6 +10231,10 @@ packages:
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -12757,6 +12770,9 @@ packages:
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
   pyodide@0.26.2:
     resolution: {integrity: sha512-8VCRdFX83gBsWs6XP2rhG8HMaB+JaVyyav4q/EMzoV8fXH8HN6T5IISC92SNma6i1DRA3SVXA61S1rJcB8efgA==}
@@ -22571,6 +22587,11 @@ snapshots:
 
   ee-first@1.1.1: {}
 
+  effect@3.21.4:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
   electron-to-chromium@1.5.364: {}
 
   embla-carousel-autoplay@8.6.0(embla-carousel@8.6.0):
@@ -23101,6 +23122,10 @@ snapshots:
       is-extendable: 0.1.1
 
   extend@3.0.2: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
 
   fast-deep-equal@3.1.3: {}
 
@@ -26216,6 +26241,8 @@ snapshots:
   punycode.js@2.3.1: {}
 
   punycode@2.3.1: {}
+
+  pure-rand@6.1.0: {}
 
   pyodide@0.26.2:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -132,6 +132,7 @@ catalog:
   decimal.js: ^10.6.0
   dotenv: ^17.2.3
   ecmarkup: ~23.0.2
+  effect: ^3.21.4
   env-paths: ^4.0.0
   es-module-shims: ^2.8.0
   esbuild: ^0.28.0


### PR DESCRIPTION
This PR is the first in a series that incrementally refactors the `typespec-ts` modular emitter to use [`effect`](https://github.com/Effect-TS/effect) for dependency injection and state management.

### Motivation
As explored in the [emitter rewrite PR #3981](https://github.com/Azure/typespec-azure/pull/3981), the current architecture relies on a global, untyped `ContextManager` map and ambient hooks (e.g. `useDependencies()` or `useBinder()`). This PR proves the feasibility of using `effect` for context passing while preserving total backward compatibility.
Specifically, this introduces the `effect` runtime as a dependency and migrates the outermost layer, `buildClientContext` (which only requires a `Project` and `ExternalDependencies`), to run within a typed `Effect`.

Because we explicitly list `OutputProject | Dependencies` in the requirement (`R`) type of the returned `Effect`, missing a dependency is now a **compile-time error**, as opposed to a runtime throw deep inside an ambient hook.

### Changes
*   **Add `effect`:** Pinned `effect` `^3.21.4` as a core dependency for the modular emitter.
*   **Define Tags:** Created `OutputProject` and `Dependencies` `Context.Tag`s, along with an explicit-parameter factory `makeClientReaderLayer`.
*   **Refactor `buildClientContext`:** It now internally builds an `Effect` that `yield*`s its dependencies.
*   **Boundary Execution:** The layer evaluation and synchronous execution (`Effect.runSync`) is pushed out to its call sites (`src/index.ts:308` and the test utility `emit-util.ts:270`).
*   **Private APIs Only:** `effect-context.ts` is strictly internal. The API-Extractor surface of `typespec-ts` is **100% unchanged**.

### Guarantees
*   **Byte-identity:** A full regeneration of `azure-modular` using the new baseline yields a strictly empty `jj diff`. There are zero logic changes, only structural DI.
*   **Tests:** `test-next` and `unit-modular` are fully green without modification to any test cases.