### PR TITLE
Fix stale typespec-ts modular-unit snapshot after ARM doc changes (#4795)

### DIFF
--- a/.chronus/changes/fix-typespec-ts-stale-modular-snapshots-2026-07-01-15-20-0.md
+++ b/.chronus/changes/fix-typespec-ts-stale-modular-snapshots-2026-07-01-15-20-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Regenerate stale `modular-unit` scenario snapshot to match the ARM library doc changes from #4494, which moved the `ArmResourceActionAsync` operation doc to `@dev` (`@doc("")`) so those operations no longer emit a public doc comment.

--- a/packages/typespec-ts/test/modular-unit/scenarios/samples/parameters/bodyOptionalParameterName.md
+++ b/packages/typespec-ts/test/modular-unit/scenarios/samples/parameters/bodyOptionalParameterName.md
@@ -191,7 +191,6 @@ export async function _backupDeserialize(result: PathUncheckedResponse): Promise
   return backupResultDeserializer(result.body);
 }
 
-/** A long-running resource action. */
 export function backup(
   context: Client,
   resourceGroupName: string,
@@ -218,9 +217,9 @@ import { HardwareSecurityModulesClient } from "@azure/internal-test";
 import { DefaultAzureCredential } from "@azure/identity";
 
 /**
- * This sample demonstrates how to a long-running resource action.
+ * This sample demonstrates how to
  *
- * @summary a long-running resource action.
+ * @summary
  * x-ms-original-file: 2021-10-01-preview/json_for_CloudHsmClusters_backup.json
  */
 async function cloudHsmClustersBackup(): Promise<void> {


### PR DESCRIPTION
## Why

PR #4494 ("Improve documentation for ARM library decorators, interfaces, and models") added `@doc("")` to the ARM `ArmResourceActionAsync` operation template, so those operations no longer emit a public doc comment. Because #4494 did not touch `packages/typespec-ts/**`, `ci-typescript.yml` never ran on it, and the stale `modular-unit` scenario snapshot landed on `main` unnoticed. This made the **typespec-ts / CI -> Run unit tests** job red on `main` and on every typespec-ts PR (including #4788).

## What changed

- Updated the `bodyOptionalParameterName.md` modular-unit scenario to drop the now-empty ARM operation doc comment (`/** A long-running resource action. */`) and the corresponding sample summary text, matching what the current ARM library emits.
- Added an `internal` chronus changeset for `@azure-tools/typespec-ts`.

## Notes for reviewers

- The drift was narrower than the issue implied. Only `bodyOptionalParameterName.md` actually failed: its `backup` op uses `ArmResourceActionAsync` (which got `@doc("")`). `lroPaging.md` still passes because its `suspend` op uses `ArmResourceActionAsyncBase`, which #4494 left with a public doc, so it correctly still emits `A long-running resource action.`
- I did not commit the full `SCENARIOS_UPDATE=true` output. Write mode reformats every scenario through prettier and produced 46 changed files (+1039/-763), but 44 of those were pure formatting noise: the runner's assertion is whitespace-normalized (`ignoreWeirdLine`), so those never actually failed. I discarded the noise and hand-applied only the 3 genuine doc removals to keep the diff minimal and reviewable.

## Verification

- `pnpm unit-test` -> 657 passed
- `pnpm test-next` -> 252 passed
- `pnpm chronus verify` -> clean
- prettier `--check` on changed files -> clean

## Follow-up (out of scope)

ARM library (`typespec-azure-resource-manager`) changes can alter typespec-ts emitted output but do not trigger `ci-typescript.yml`, so this drift class can recur. Consider widening the workflow `paths` triggers to include the emitter's TypeSpec library dependencies. Tracked separately.

Fixes: #4795