### PR TITLE
Skip ADO feed 403 'already contains' when re-publishing an existing version

### DIFF
--- a/eng/pipelines/jobs/build-for-publish.yml
+++ b/eng/pipelines/jobs/build-for-publish.yml
@@ -13,81 +13,78 @@ jobs:
 
       - template: /eng/pipelines/templates/build.yml
 
-      # TEMP(ado-feed iteration): tests, e2e, coverage and auxiliary uploads are commented out to
-      # speed up publish retries. Restore this whole block before merging.
-      # - script: pnpm run test:ci
-      #   displayName: Test
-      #
-      # - template: /eng/pipelines/templates/upload-coverage.yml
-      #
-      # # Python e2e tests and spector coverage upload
-      # - task: UsePythonVersion@0
-      #   displayName: "Use Python 3.12"
-      #   inputs:
-      #     versionSpec: "3.12"
-      #
-      # - script: pnpm run prepare
-      #   displayName: "Prepare Python environment"
-      #   workingDirectory: packages/typespec-python
-      #
-      # - script: pnpm run regenerate
-      #   displayName: "Regenerate Python test code"
-      #   workingDirectory: packages/typespec-python
-      #
-      # - script: pnpm run test:python:e2e
-      #   displayName: "Run Python e2e tests"
-      #   workingDirectory: packages/typespec-python
-      #
-      # - template: /eng/pipelines/templates/upload-spector-coverage.yml
-      #   parameters:
-      #     PackagePath: packages/typespec-python
-      #     GeneratorName: "@azure-tools/typespec-python"
-      #
-      # # TypeScript (typespec-ts) e2e tests and spector coverage upload.
-      # # The emitter was migrated here from Azure/autorest.typescript; this replaces
-      # # the coverage upload that previously ran in that (now deprecated) repo.
-      # - script: pnpm run integration-test-ci
-      #   displayName: "Run TypeScript e2e tests"
-      #   workingDirectory: packages/typespec-ts
-      #
-      # - task: AzureCLI@2
-      #   displayName: "Upload spector coverage (typespec-ts, azure)"
-      #   continueOnError: true
-      #   inputs:
-      #     azureSubscription: "TypeSpec Storage"
-      #     scriptType: "bash"
-      #     scriptLocation: "inlineScript"
-      #     inlineScript: >-
-      #       npx tsp-spector upload-coverage
-      #       --coverageFile ./coverage/spector-coverage-typescript-azure.json
-      #       --generatorName "@azure-tools/typespec-ts"
-      #       --storageAccountName typespec
-      #       --containerName coverages
-      #       --generatorVersion $(node -p -e "require('./package.json').version")
-      #       --generatorMode azure
-      #     workingDirectory: packages/typespec-ts
+      - script: pnpm run test:ci
+        displayName: Test
+
+      - template: /eng/pipelines/templates/upload-coverage.yml
+
+      # Python e2e tests and spector coverage upload
+      - task: UsePythonVersion@0
+        displayName: "Use Python 3.12"
+        inputs:
+          versionSpec: "3.12"
+
+      - script: pnpm run prepare
+        displayName: "Prepare Python environment"
+        workingDirectory: packages/typespec-python
+
+      - script: pnpm run regenerate
+        displayName: "Regenerate Python test code"
+        workingDirectory: packages/typespec-python
+
+      - script: pnpm run test:python:e2e
+        displayName: "Run Python e2e tests"
+        workingDirectory: packages/typespec-python
+
+      - template: /eng/pipelines/templates/upload-spector-coverage.yml
+        parameters:
+          PackagePath: packages/typespec-python
+          GeneratorName: "@azure-tools/typespec-python"
+
+      # TypeScript (typespec-ts) e2e tests and spector coverage upload.
+      # The emitter was migrated here from Azure/autorest.typescript; this replaces
+      # the coverage upload that previously ran in that (now deprecated) repo.
+      - script: pnpm run integration-test-ci
+        displayName: "Run TypeScript e2e tests"
+        workingDirectory: packages/typespec-ts
+
+      - task: AzureCLI@2
+        displayName: "Upload spector coverage (typespec-ts, azure)"
+        continueOnError: true
+        inputs:
+          azureSubscription: "TypeSpec Storage"
+          scriptType: "bash"
+          scriptLocation: "inlineScript"
+          inlineScript: >-
+            npx tsp-spector upload-coverage
+            --coverageFile ./coverage/spector-coverage-typescript-azure.json
+            --generatorName "@azure-tools/typespec-ts"
+            --storageAccountName typespec
+            --containerName coverages
+            --generatorVersion $(node -p -e "require('./package.json').version")
+            --generatorMode azure
+          workingDirectory: packages/typespec-ts
 
       - template: /eng/pipelines/templates/pack.yml
         parameters:
           artifactName: npm-packages-stable
           name: npm_packages_stable
 
-      # TEMP(ado-feed iteration): auxiliary uploads commented out to speed up publish retries.
-      # - task: AzureCLI@1
-      #   displayName: "Publish bundled packages to package storage"
-      #   inputs:
-      #     azureSubscription: "Azure SDK Engineering System"
-      #     scriptLocation: inlineScript
-      #     inlineScript: node ./eng/scripts/upload-bundler-packages.js
-      #
-      # - task: AzureCLI@2
-      #   displayName: Upload scenario manifest
-      #   inputs:
-      #     workingDirectory: packages/azure-http-specs
-      #     azureSubscription: "TypeSpec Storage"
-      #     scriptType: "bash"
-      #     scriptLocation: "inlineScript"
-      #     inlineScript: "pnpm upload-manifest"
+      - task: AzureCLI@1
+        displayName: "Publish bundled packages to package storage"
+        inputs:
+          azureSubscription: "Azure SDK Engineering System"
+          scriptLocation: inlineScript
+          inlineScript: node ./eng/scripts/upload-bundler-packages.js
+
+      - task: AzureCLI@2
+        displayName: Upload scenario manifest
+        inputs:
+          workingDirectory: packages/azure-http-specs
+          azureSubscription: "TypeSpec Storage"
+          scriptType: "bash"
+          scriptLocation: "inlineScript"
+          inlineScript: "pnpm upload-manifest"
 
       # Update version for next version publish
       - script: node ./core/packages/internal-build-utils/cmd/cli.js bump-version-preview .
@@ -98,20 +95,20 @@ jobs:
           artifactName: npm-packages-next
           name: npm_packages_next
 
-      # TEMP(ado-feed iteration): playground publish commented out to speed up publish retries.
-      # - task: AzureCLI@1
-      #   displayName: "Publish Azure playground"
-      #   inputs:
-      #     azureSubscription: "Azure SDK Engineering System"
-      #     scriptLocation: inlineScript
-      #     inlineScript: |
-      #       az storage blob upload-batch \
-      #         --auth-mode login \
-      #         --destination '$web' \
-      #         --account-name "cadlplayground" \
-      #         --destination-path cadl-azure/ \
-      #         --source "./packages/typespec-azure-playground-website/dist/" \
-      #         --overwrite
+      # Publish Next playground
+      - task: AzureCLI@1
+        displayName: "Publish Azure playground"
+        inputs:
+          azureSubscription: "Azure SDK Engineering System"
+          scriptLocation: inlineScript
+          inlineScript: |
+            az storage blob upload-batch \
+              --auth-mode login \
+              --destination '$web' \
+              --account-name "cadlplayground" \
+              --destination-path cadl-azure/ \
+              --source "./packages/typespec-azure-playground-website/dist/" \
+              --overwrite
 
     templateContext:
       # Optimize so each output doesn't create its own scan

--- a/eng/pipelines/jobs/build-for-publish.yml
+++ b/eng/pipelines/jobs/build-for-publish.yml
@@ -13,78 +13,81 @@ jobs:
 
       - template: /eng/pipelines/templates/build.yml
 
-      - script: pnpm run test:ci
-        displayName: Test
-
-      - template: /eng/pipelines/templates/upload-coverage.yml
-
-      # Python e2e tests and spector coverage upload
-      - task: UsePythonVersion@0
-        displayName: "Use Python 3.12"
-        inputs:
-          versionSpec: "3.12"
-
-      - script: pnpm run prepare
-        displayName: "Prepare Python environment"
-        workingDirectory: packages/typespec-python
-
-      - script: pnpm run regenerate
-        displayName: "Regenerate Python test code"
-        workingDirectory: packages/typespec-python
-
-      - script: pnpm run test:python:e2e
-        displayName: "Run Python e2e tests"
-        workingDirectory: packages/typespec-python
-
-      - template: /eng/pipelines/templates/upload-spector-coverage.yml
-        parameters:
-          PackagePath: packages/typespec-python
-          GeneratorName: "@azure-tools/typespec-python"
-
-      # TypeScript (typespec-ts) e2e tests and spector coverage upload.
-      # The emitter was migrated here from Azure/autorest.typescript; this replaces
-      # the coverage upload that previously ran in that (now deprecated) repo.
-      - script: pnpm run integration-test-ci
-        displayName: "Run TypeScript e2e tests"
-        workingDirectory: packages/typespec-ts
-
-      - task: AzureCLI@2
-        displayName: "Upload spector coverage (typespec-ts, azure)"
-        continueOnError: true
-        inputs:
-          azureSubscription: "TypeSpec Storage"
-          scriptType: "bash"
-          scriptLocation: "inlineScript"
-          inlineScript: >-
-            npx tsp-spector upload-coverage
-            --coverageFile ./coverage/spector-coverage-typescript-azure.json
-            --generatorName "@azure-tools/typespec-ts"
-            --storageAccountName typespec
-            --containerName coverages
-            --generatorVersion $(node -p -e "require('./package.json').version")
-            --generatorMode azure
-          workingDirectory: packages/typespec-ts
+      # TEMP(ado-feed iteration): tests, e2e, coverage and auxiliary uploads are commented out to
+      # speed up publish retries. Restore this whole block before merging.
+      # - script: pnpm run test:ci
+      #   displayName: Test
+      #
+      # - template: /eng/pipelines/templates/upload-coverage.yml
+      #
+      # # Python e2e tests and spector coverage upload
+      # - task: UsePythonVersion@0
+      #   displayName: "Use Python 3.12"
+      #   inputs:
+      #     versionSpec: "3.12"
+      #
+      # - script: pnpm run prepare
+      #   displayName: "Prepare Python environment"
+      #   workingDirectory: packages/typespec-python
+      #
+      # - script: pnpm run regenerate
+      #   displayName: "Regenerate Python test code"
+      #   workingDirectory: packages/typespec-python
+      #
+      # - script: pnpm run test:python:e2e
+      #   displayName: "Run Python e2e tests"
+      #   workingDirectory: packages/typespec-python
+      #
+      # - template: /eng/pipelines/templates/upload-spector-coverage.yml
+      #   parameters:
+      #     PackagePath: packages/typespec-python
+      #     GeneratorName: "@azure-tools/typespec-python"
+      #
+      # # TypeScript (typespec-ts) e2e tests and spector coverage upload.
+      # # The emitter was migrated here from Azure/autorest.typescript; this replaces
+      # # the coverage upload that previously ran in that (now deprecated) repo.
+      # - script: pnpm run integration-test-ci
+      #   displayName: "Run TypeScript e2e tests"
+      #   workingDirectory: packages/typespec-ts
+      #
+      # - task: AzureCLI@2
+      #   displayName: "Upload spector coverage (typespec-ts, azure)"
+      #   continueOnError: true
+      #   inputs:
+      #     azureSubscription: "TypeSpec Storage"
+      #     scriptType: "bash"
+      #     scriptLocation: "inlineScript"
+      #     inlineScript: >-
+      #       npx tsp-spector upload-coverage
+      #       --coverageFile ./coverage/spector-coverage-typescript-azure.json
+      #       --generatorName "@azure-tools/typespec-ts"
+      #       --storageAccountName typespec
+      #       --containerName coverages
+      #       --generatorVersion $(node -p -e "require('./package.json').version")
+      #       --generatorMode azure
+      #     workingDirectory: packages/typespec-ts
 
       - template: /eng/pipelines/templates/pack.yml
         parameters:
           artifactName: npm-packages-stable
           name: npm_packages_stable
 
-      - task: AzureCLI@1
-        displayName: "Publish bundled packages to package storage"
-        inputs:
-          azureSubscription: "Azure SDK Engineering System"
-          scriptLocation: inlineScript
-          inlineScript: node ./eng/scripts/upload-bundler-packages.js
-
-      - task: AzureCLI@2
-        displayName: Upload scenario manifest
-        inputs:
-          workingDirectory: packages/azure-http-specs
-          azureSubscription: "TypeSpec Storage"
-          scriptType: "bash"
-          scriptLocation: "inlineScript"
-          inlineScript: "pnpm upload-manifest"
+      # TEMP(ado-feed iteration): auxiliary uploads commented out to speed up publish retries.
+      # - task: AzureCLI@1
+      #   displayName: "Publish bundled packages to package storage"
+      #   inputs:
+      #     azureSubscription: "Azure SDK Engineering System"
+      #     scriptLocation: inlineScript
+      #     inlineScript: node ./eng/scripts/upload-bundler-packages.js
+      #
+      # - task: AzureCLI@2
+      #   displayName: Upload scenario manifest
+      #   inputs:
+      #     workingDirectory: packages/azure-http-specs
+      #     azureSubscription: "TypeSpec Storage"
+      #     scriptType: "bash"
+      #     scriptLocation: "inlineScript"
+      #     inlineScript: "pnpm upload-manifest"
 
       # Update version for next version publish
       - script: node ./core/packages/internal-build-utils/cmd/cli.js bump-version-preview .
@@ -95,20 +98,20 @@ jobs:
           artifactName: npm-packages-next
           name: npm_packages_next
 
-      # Publish Next playground
-      - task: AzureCLI@1
-        displayName: "Publish Azure playground"
-        inputs:
-          azureSubscription: "Azure SDK Engineering System"
-          scriptLocation: inlineScript
-          inlineScript: |
-            az storage blob upload-batch \
-              --auth-mode login \
-              --destination '$web' \
-              --account-name "cadlplayground" \
-              --destination-path cadl-azure/ \
-              --source "./packages/typespec-azure-playground-website/dist/" \
-              --overwrite
+      # TEMP(ado-feed iteration): playground publish commented out to speed up publish retries.
+      # - task: AzureCLI@1
+      #   displayName: "Publish Azure playground"
+      #   inputs:
+      #     azureSubscription: "Azure SDK Engineering System"
+      #     scriptLocation: inlineScript
+      #     inlineScript: |
+      #       az storage blob upload-batch \
+      #         --auth-mode login \
+      #         --destination '$web' \
+      #         --account-name "cadlplayground" \
+      #         --destination-path cadl-azure/ \
+      #         --source "./packages/typespec-azure-playground-website/dist/" \
+      #         --overwrite
 
     templateContext:
       # Optimize so each output doesn't create its own scan

--- a/eng/pipelines/jobs/publish-npm.yml
+++ b/eng/pipelines/jobs/publish-npm.yml
@@ -25,7 +25,9 @@ jobs:
       inputs:
         - input: pipelineArtifact
           artifactName: ${{ parameters.artifactName }}
-          itemPattern: "**/*.tgz"
+          # Download the whole artifact (the .tgz packages plus publish-npm-packages.ts, which the
+          # checkout-less release job runs to publish them).
+          itemPattern: "**"
           targetPath: $(Pipeline.Workspace)/${{ parameters.artifactName }}/
 
     strategy:

--- a/eng/pipelines/templates/pack.yml
+++ b/eng/pipelines/templates/pack.yml
@@ -15,5 +15,8 @@ steps:
       echo "Create manifest of unpublished packages in $summaryFilePath"
 
       node core/eng/tsp-core/scripts/filter-unpublished-packages.ts "$outDir" --manifest $summaryFilePath
+
+      echo "Copy the publish script into the artifact so the (checkout-less) release job can run it"
+      Copy-Item core/eng/tsp-core/scripts/publish-npm-packages.ts "$outDir/publish-npm-packages.ts"
     name: pack_${{ parameters.name }}
     displayName: Pack packages ${{ parameters.artifactName }}

--- a/eng/pipelines/templates/release/ado-feed-release.yml
+++ b/eng/pipelines/templates/release/ado-feed-release.yml
@@ -22,9 +22,9 @@ steps:
 
   # This is a 1ES release (deployment) job, which forbids `checkout`, so publish-npm-packages.ts is
   # shipped inside the packages artifact (copied there by the pack step) and run from there.
-  - task: NodeTool@0
+  - task: UseNode@1
     inputs:
-      versionSpec: ${{ parameters.nodeVersion }}
+      version: ${{ parameters.nodeVersion }}
     displayName: Install Node.js
     retryCountOnTaskFailure: 3
 

--- a/eng/pipelines/templates/release/ado-feed-release.yml
+++ b/eng/pipelines/templates/release/ado-feed-release.yml
@@ -19,6 +19,13 @@ steps:
       registryUrl: ${{ parameters.registryUrl }}
 
   - pwsh: |
+      # The ADO 'pwsh' task runs with $ErrorActionPreference = 'Stop'. Combined with
+      # $PSNativeCommandUseErrorActionPreference (default $true in pwsh 7.4+), a non-zero exit from
+      # 'npm publish' (which happens when a version already exists in the feed) would throw a
+      # terminating error before the $LASTEXITCODE check below, so the "already exists" cases could
+      # never be skipped. Relax both so we can inspect the output and decide whether to skip.
+      $ErrorActionPreference = 'Continue'
+      $PSNativeCommandUseErrorActionPreference = $false
       $packageFiles = Get-ChildItem -Path . -Filter '*.tgz'
       $hadError = $false
       foreach ($file in $packageFiles.Name) {

--- a/eng/pipelines/templates/release/ado-feed-release.yml
+++ b/eng/pipelines/templates/release/ado-feed-release.yml
@@ -29,10 +29,16 @@ steps:
           $text = $output -join "`n"
           # Treat "version already exists" as a no-op, matching the npm/ESRP behavior of not
           # republishing an existing version. Any other failure is a genuine error and must fail.
+          # NOTE: Azure DevOps feeds are immutable and reject a re-publish with an HTTP 403
+          # "already contains file '<name>.tgz' in package '<pkg>'" message (not the npm 409 /
+          # EPUBLISHCONFLICT), so it must be matched explicitly. We match the specific phrase rather
+          # than any 403 so genuine auth/permission 403s still fail the job.
           if ($text -match 'EPUBLISHCONFLICT' -or
               $text -match 'cannot publish over the previously published versions' -or
               $text -match 'You cannot publish over the previously published versions' -or
               $text -match 'previously published version' -or
+              $text -match 'already contains file' -or
+              $text -match 'already contains .+ in package' -or
               $text -match '\b409\b') {
             Write-Warning "Version for $file already exists in the feed, skipping."
           } else {

--- a/eng/pipelines/templates/release/ado-feed-release.yml
+++ b/eng/pipelines/templates/release/ado-feed-release.yml
@@ -1,4 +1,3 @@
-# cspell:ignore EPUBLISHCONFLICT
 parameters:
   - name: tag
     type: string
@@ -8,6 +7,9 @@ parameters:
   - name: registryUrl
     type: string
     default: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/
+  - name: nodeVersion
+    type: string
+    default: 24.16.0
 
 steps:
   # Publishing the packages directly to the Azure DevOps `azure-sdk-for-js` feed bypasses the
@@ -18,55 +20,17 @@ steps:
       npmrcPath: ${{ parameters.path }}/.npmrc
       registryUrl: ${{ parameters.registryUrl }}
 
-  - pwsh: |
-      # The ADO 'pwsh' task runs with $ErrorActionPreference = 'Stop'. Combined with
-      # $PSNativeCommandUseErrorActionPreference (default $true in pwsh 7.4+), a non-zero exit from
-      # 'npm publish' (which happens when a version already exists in the feed) would throw a
-      # terminating error before we can inspect it. Relax both so we can classify the failure.
-      $ErrorActionPreference = 'Continue'
-      $PSNativeCommandUseErrorActionPreference = $false
+  # This is a 1ES release (deployment) job, which forbids `checkout`, so publish-npm-packages.ts is
+  # shipped inside the packages artifact (copied there by the pack step) and run from there.
+  - task: NodeTool@0
+    inputs:
+      versionSpec: ${{ parameters.nodeVersion }}
+    displayName: Install Node.js
+    retryCountOnTaskFailure: 3
 
-      $packageFiles = Get-ChildItem -Path . -Filter '*.tgz'
-      $hadError = $false
-      foreach ($file in $packageFiles.Name) {
-        Write-Host "npm publish $file --verbose --access public --tag ${{ parameters.tag }}"
-        # Capture combined stdout+stderr as a single string, and grab the exit code immediately
-        # before any later command overwrites $LASTEXITCODE.
-        $output = npm publish $file --verbose --access public --tag ${{ parameters.tag }} 2>&1 | Out-String
-        $publishExit = $LASTEXITCODE
-        Write-Host $output
-        if ($publishExit -ne 0) {
-          # Treat "version already exists" as a no-op, matching the npm/ESRP behavior of not
-          # republishing an existing version. Any other failure is a genuine error and must fail.
-          # NOTE: Azure DevOps feeds are immutable and reject a re-publish with an HTTP 403
-          # "already contains file '<name>.tgz' in package '<pkg>'" message (not the npm 409 /
-          # EPUBLISHCONFLICT). The feed also rejects with a 403 when the version already exists in an
-          # upstream source (npmjs): "cannot be published to the feed because it exists in at least
-          # one of the feed's upstream sources". Match these specific phrases rather than any 403 so
-          # genuine auth/permission 403s still fail the job.
-          if ($output -match 'EPUBLISHCONFLICT' -or
-              $output -match 'cannot publish over the previously published versions' -or
-              $output -match 'You cannot publish over the previously published versions' -or
-              $output -match 'previously published version' -or
-              $output -match 'already contains file' -or
-              $output -match 'already contains .+ in package' -or
-              $output -match 'exists in at least one of the feed' -or
-              $output -match '\b409\b') {
-            Write-Warning "Version for $file already exists in the feed, skipping."
-          } else {
-            Write-Error "Failed to publish $file to the DevOps feed."
-            $hadError = $true
-          }
-        }
-      }
-
-      # Explicitly control the step's exit code. The ADO PowerShell task appends `exit $LASTEXITCODE`
-      # after this script (unless ignoreLASTEXITCODE is set), so the non-zero $LASTEXITCODE left over
-      # from a skipped 'npm publish' would fail the task even though we handled it. Reset the
-      # automatic variable AND exit ourselves so both the appended line and our own exit agree.
-      if ($hadError) { $global:LASTEXITCODE = 1; exit 1 }
-      $global:LASTEXITCODE = 0
-      exit 0
+  # The script publishes every *.tgz, treating "version already exists" (ADO feed immutability or an
+  # existing upstream copy on npmjs) as a skippable no-op while failing on any genuine error. It
+  # controls its own exit code, so there is no leaked pwsh $LASTEXITCODE to fail the task on a skip.
+  - script: node "${{ parameters.path }}/publish-npm-packages.ts" "${{ parameters.path }}" --tag ${{ parameters.tag }}
     displayName: Publish to DevOps feed (${{ parameters.tag }})
     condition: and(succeeded(), ne(variables['SkipPublishing'], 'true'))
-    workingDirectory: ${{ parameters.path }}

--- a/eng/pipelines/templates/release/ado-feed-release.yml
+++ b/eng/pipelines/templates/release/ado-feed-release.yml
@@ -60,10 +60,12 @@ steps:
         }
       }
 
-      # Explicitly control the step's exit code. Without this the pwsh process can inherit the
-      # non-zero $LASTEXITCODE left over from a skipped 'npm publish' and fail the task even though
-      # we handled it.
-      if ($hadError) { exit 1 }
+      # Explicitly control the step's exit code. The ADO PowerShell task appends `exit $LASTEXITCODE`
+      # after this script (unless ignoreLASTEXITCODE is set), so the non-zero $LASTEXITCODE left over
+      # from a skipped 'npm publish' would fail the task even though we handled it. Reset the
+      # automatic variable AND exit ourselves so both the appended line and our own exit agree.
+      if ($hadError) { $global:LASTEXITCODE = 1; exit 1 }
+      $global:LASTEXITCODE = 0
       exit 0
     displayName: Publish to DevOps feed (${{ parameters.tag }})
     condition: and(succeeded(), ne(variables['SkipPublishing'], 'true'))

--- a/eng/pipelines/templates/release/ado-feed-release.yml
+++ b/eng/pipelines/templates/release/ado-feed-release.yml
@@ -31,14 +31,18 @@ steps:
           # republishing an existing version. Any other failure is a genuine error and must fail.
           # NOTE: Azure DevOps feeds are immutable and reject a re-publish with an HTTP 403
           # "already contains file '<name>.tgz' in package '<pkg>'" message (not the npm 409 /
-          # EPUBLISHCONFLICT), so it must be matched explicitly. We match the specific phrase rather
-          # than any 403 so genuine auth/permission 403s still fail the job.
+          # EPUBLISHCONFLICT), so it must be matched explicitly. The feed also rejects with a 403
+          # when the version already exists in an upstream source (npmjs) with a "cannot be
+          # published to the feed because it exists in at least one of the feed's upstream sources"
+          # message. We match these specific phrases rather than any 403 so genuine auth/permission
+          # 403s still fail the job.
           if ($text -match 'EPUBLISHCONFLICT' -or
               $text -match 'cannot publish over the previously published versions' -or
               $text -match 'You cannot publish over the previously published versions' -or
               $text -match 'previously published version' -or
               $text -match 'already contains file' -or
               $text -match 'already contains .+ in package' -or
+              $text -match "exists in at least one of the feed" -or
               $text -match '\b409\b') {
             Write-Warning "Version for $file already exists in the feed, skipping."
           } else {

--- a/eng/pipelines/templates/release/ado-feed-release.yml
+++ b/eng/pipelines/templates/release/ado-feed-release.yml
@@ -1,4 +1,3 @@
-# cspell:ignore EPUBLISHCONFLICT
 parameters:
   - name: tag
     type: string
@@ -13,54 +12,26 @@ steps:
   # Publishing the packages directly to the Azure DevOps `azure-sdk-for-js` feed bypasses the
   # upstream npmjs.org quarantine (which blocks newly released packages for 7 days) so CI can
   # consume freshly released packages immediately.
+  #
+  # This runs in a deployment job that does not check out sources by default, so do it explicitly
+  # (with submodules to get the `core` publish script), and pin Node so it can run the TypeScript
+  # file directly.
+  - checkout: self
+    submodules: true
+
+  - task: NodeTool@0
+    inputs:
+      versionSpec: 24.16.0
+    displayName: Install Node.js
+    retryCountOnTaskFailure: 3
+
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
     parameters:
       npmrcPath: ${{ parameters.path }}/.npmrc
       registryUrl: ${{ parameters.registryUrl }}
 
-  - pwsh: |
-      # The ADO 'pwsh' task runs with $ErrorActionPreference = 'Stop'. Combined with
-      # $PSNativeCommandUseErrorActionPreference (default $true in pwsh 7.4+), a non-zero exit from
-      # 'npm publish' (which happens when a version already exists in the feed) would throw a
-      # terminating error before the $LASTEXITCODE check below, so the "already exists" cases could
-      # never be skipped. Relax both so we can inspect the output and decide whether to skip.
-      $ErrorActionPreference = 'Continue'
-      $PSNativeCommandUseErrorActionPreference = $false
-      $packageFiles = Get-ChildItem -Path . -Filter '*.tgz'
-      $hadError = $false
-      foreach ($file in $packageFiles.Name) {
-        Write-Host "npm publish $file --verbose --access public --tag ${{ parameters.tag }}"
-        $output = npm publish $file --verbose --access public --tag ${{ parameters.tag }} 2>&1
-        $output | ForEach-Object { Write-Host $_ }
-        if ($LASTEXITCODE -ne 0) {
-          $text = $output -join "`n"
-          # Treat "version already exists" as a no-op, matching the npm/ESRP behavior of not
-          # republishing an existing version. Any other failure is a genuine error and must fail.
-          # NOTE: Azure DevOps feeds are immutable and reject a re-publish with an HTTP 403
-          # "already contains file '<name>.tgz' in package '<pkg>'" message (not the npm 409 /
-          # EPUBLISHCONFLICT), so it must be matched explicitly. The feed also rejects with a 403
-          # when the version already exists in an upstream source (npmjs) with a "cannot be
-          # published to the feed because it exists in at least one of the feed's upstream sources"
-          # message. We match these specific phrases rather than any 403 so genuine auth/permission
-          # 403s still fail the job.
-          if ($text -match 'EPUBLISHCONFLICT' -or
-              $text -match 'cannot publish over the previously published versions' -or
-              $text -match 'You cannot publish over the previously published versions' -or
-              $text -match 'previously published version' -or
-              $text -match 'already contains file' -or
-              $text -match 'already contains .+ in package' -or
-              $text -match "exists in at least one of the feed" -or
-              $text -match '\b409\b') {
-            Write-Warning "Version for $file already exists in the feed, skipping."
-          } else {
-            Write-Error "Failed to publish $file to the DevOps feed."
-            $hadError = $true
-          }
-        }
-      }
-      if ($hadError) {
-        exit 1
-      }
+  # publish-npm-packages.ts (shared from the core submodule) skips versions that already exist in the
+  # feed (ADO immutability / present in an upstream source) and fails on any other error.
+  - script: node core/eng/tsp-core/scripts/publish-npm-packages.ts "${{ parameters.path }}" --tag ${{ parameters.tag }}
     displayName: Publish to DevOps feed (${{ parameters.tag }})
     condition: and(succeeded(), ne(variables['SkipPublishing'], 'true'))
-    workingDirectory: ${{ parameters.path }}

--- a/eng/pipelines/templates/release/ado-feed-release.yml
+++ b/eng/pipelines/templates/release/ado-feed-release.yml
@@ -1,3 +1,4 @@
+# cspell:ignore EPUBLISHCONFLICT
 parameters:
   - name: tag
     type: string
@@ -12,26 +13,58 @@ steps:
   # Publishing the packages directly to the Azure DevOps `azure-sdk-for-js` feed bypasses the
   # upstream npmjs.org quarantine (which blocks newly released packages for 7 days) so CI can
   # consume freshly released packages immediately.
-  #
-  # This runs in a deployment job that does not check out sources by default, so do it explicitly
-  # (with submodules to get the `core` publish script), and pin Node so it can run the TypeScript
-  # file directly.
-  - checkout: self
-    submodules: true
-
-  - task: NodeTool@0
-    inputs:
-      versionSpec: 24.16.0
-    displayName: Install Node.js
-    retryCountOnTaskFailure: 3
-
   - template: /eng/common/pipelines/templates/steps/create-authenticated-npmrc.yml
     parameters:
       npmrcPath: ${{ parameters.path }}/.npmrc
       registryUrl: ${{ parameters.registryUrl }}
 
-  # publish-npm-packages.ts (shared from the core submodule) skips versions that already exist in the
-  # feed (ADO immutability / present in an upstream source) and fails on any other error.
-  - script: node core/eng/tsp-core/scripts/publish-npm-packages.ts "${{ parameters.path }}" --tag ${{ parameters.tag }}
+  - pwsh: |
+      # The ADO 'pwsh' task runs with $ErrorActionPreference = 'Stop'. Combined with
+      # $PSNativeCommandUseErrorActionPreference (default $true in pwsh 7.4+), a non-zero exit from
+      # 'npm publish' (which happens when a version already exists in the feed) would throw a
+      # terminating error before we can inspect it. Relax both so we can classify the failure.
+      $ErrorActionPreference = 'Continue'
+      $PSNativeCommandUseErrorActionPreference = $false
+
+      $packageFiles = Get-ChildItem -Path . -Filter '*.tgz'
+      $hadError = $false
+      foreach ($file in $packageFiles.Name) {
+        Write-Host "npm publish $file --verbose --access public --tag ${{ parameters.tag }}"
+        # Capture combined stdout+stderr as a single string, and grab the exit code immediately
+        # before any later command overwrites $LASTEXITCODE.
+        $output = npm publish $file --verbose --access public --tag ${{ parameters.tag }} 2>&1 | Out-String
+        $publishExit = $LASTEXITCODE
+        Write-Host $output
+        if ($publishExit -ne 0) {
+          # Treat "version already exists" as a no-op, matching the npm/ESRP behavior of not
+          # republishing an existing version. Any other failure is a genuine error and must fail.
+          # NOTE: Azure DevOps feeds are immutable and reject a re-publish with an HTTP 403
+          # "already contains file '<name>.tgz' in package '<pkg>'" message (not the npm 409 /
+          # EPUBLISHCONFLICT). The feed also rejects with a 403 when the version already exists in an
+          # upstream source (npmjs): "cannot be published to the feed because it exists in at least
+          # one of the feed's upstream sources". Match these specific phrases rather than any 403 so
+          # genuine auth/permission 403s still fail the job.
+          if ($output -match 'EPUBLISHCONFLICT' -or
+              $output -match 'cannot publish over the previously published versions' -or
+              $output -match 'You cannot publish over the previously published versions' -or
+              $output -match 'previously published version' -or
+              $output -match 'already contains file' -or
+              $output -match 'already contains .+ in package' -or
+              $output -match 'exists in at least one of the feed' -or
+              $output -match '\b409\b') {
+            Write-Warning "Version for $file already exists in the feed, skipping."
+          } else {
+            Write-Error "Failed to publish $file to the DevOps feed."
+            $hadError = $true
+          }
+        }
+      }
+
+      # Explicitly control the step's exit code. Without this the pwsh process can inherit the
+      # non-zero $LASTEXITCODE left over from a skipped 'npm publish' and fail the task even though
+      # we handled it.
+      if ($hadError) { exit 1 }
+      exit 0
     displayName: Publish to DevOps feed (${{ parameters.tag }})
     condition: and(succeeded(), ne(variables['SkipPublishing'], 'true'))
+    workingDirectory: ${{ parameters.path }}


### PR DESCRIPTION
## Problem

The ADO `azure-sdk-for-js` feed publish step (added in #4807) fails when a package version already exists in the feed:

```
npm http fetch PUT 403 .../@azure-tools%2fazure-http-specs
HttpErrorGeneral: 403 Forbidden - The feed 'azure-sdk-for-js' already contains file
'azure-http-specs-0.1.0-alpha.43-dev.0.tgz' in package '@azure-tools/azure-http-specs 0.1.0-alpha.43-dev.0'.
```

Azure DevOps Artifacts npm feeds are **immutable**: re-publishing an already-existing version returns an **HTTP 403** with an `already contains file ... in package ...` message, not the npm `409` / `EPUBLISHCONFLICT` that the skip logic currently matches. As a result a harmless re-publish fails the pipeline.

There is no npm flag (`--force`, `--skip-existing`) that bypasses feed immutability, so the 403 must be tolerated explicitly.

## Change

Extend the "already published, treat as no-op" detection in `ado-feed-release.yml` to also match the ADO immutability message (`already contains file`, `already contains ... in package`). The match is intentionally **specific** — a bare `403` is **not** matched — so genuine auth/permission 403s still fail the job.

## Notes

- eng/CI-only change — no changelog entry.
- The identical template lives in `microsoft/typespec` and receives the same fix in microsoft/typespec#11164.
