### PR TITLE
Replace deprecated pipeline tasks (NodeTool@0, AzureCLI@1)

### DIFF
--- a/eng/pipelines/jobs/build-for-publish.yml
+++ b/eng/pipelines/jobs/build-for-publish.yml
@@ -70,10 +70,11 @@ jobs:
           artifactName: npm-packages-stable
           name: npm_packages_stable
 
-      - task: AzureCLI@1
+      - task: AzureCLI@2
         displayName: "Publish bundled packages to package storage"
         inputs:
           azureSubscription: "Azure SDK Engineering System"
+          scriptType: "bash"
           scriptLocation: inlineScript
           inlineScript: node ./eng/scripts/upload-bundler-packages.js
 
@@ -96,10 +97,11 @@ jobs:
           name: npm_packages_next
 
       # Publish Next playground
-      - task: AzureCLI@1
+      - task: AzureCLI@2
         displayName: "Publish Azure playground"
         inputs:
           azureSubscription: "Azure SDK Engineering System"
+          scriptType: "bash"
           scriptLocation: inlineScript
           inlineScript: |
             az storage blob upload-batch \

--- a/eng/pipelines/pr-tools.yml
+++ b/eng/pipelines/pr-tools.yml
@@ -32,10 +32,11 @@ extends:
               - script: pnpm run build
                 displayName: Build
 
-              - task: AzureCLI@1
+              - task: AzureCLI@2
                 displayName: "Publish playground to PR endpoint"
                 inputs:
                   azureSubscription: "Azure SDK Engineering System"
+                  scriptType: "bash"
                   scriptLocation: inlineScript
                   inlineScript: |
                     az storage blob upload-batch \
@@ -46,10 +47,11 @@ extends:
                       --source "./packages/typespec-azure-playground-website/dist/" \
                       --overwrite
 
-              - task: AzureCLI@1
+              - task: AzureCLI@2
                 displayName: "Publish website to PR endpoint"
                 inputs:
                   azureSubscription: "Azure SDK Engineering System"
+                  scriptType: "bash"
                   scriptLocation: inlineScript
                   inlineScript: |
                     az storage blob upload-batch \

--- a/eng/pipelines/templates/install.yml
+++ b/eng/pipelines/templates/install.yml
@@ -11,9 +11,9 @@ steps:
     inputs:
       version: 8.0.x
 
-  - task: NodeTool@0
+  - task: UseNode@1
     inputs:
-      versionSpec: ${{ parameters.nodeVersion }}
+      version: ${{ parameters.nodeVersion }}
     displayName: Install Node.js
     retryCountOnTaskFailure: 3
 


### PR DESCRIPTION
Silences the 1ES/pipeline deprecation warnings:

- `NodeTool@0` ("Node.js tool installer", deprecated) → `UseNode@1` (UseNodeV1) in `install.yml`. Input `versionSpec` → `version` (both accept a version spec like `24.16.0`).
- `AzureCLI@1` (deprecated) → `AzureCLI@2` in `build-for-publish.yml` (bundled packages + Azure playground) and `pr-tools.yml` (PR playground + website), adding the now-required `scriptType: bash`.

No behavior change.