### PR TITLE
Upgrade http-client-python dependency

### DIFF
--- a/.chronus/changes/upgrade-http-client-python-2026-6-7-5-21-40.md
+++ b/.chronus/changes/upgrade-http-client-python-2026-6-7-5-21-40.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+update docs

--- a/packages/typespec-python/website/src/content/docs/docs/emitters/clients/typespec-python/reference/emitter.md
+++ b/packages/typespec-python/website/src/content/docs/docs/emitters/clients/typespec-python/reference/emitter.md
@@ -1,12 +1,6 @@
-# @azure-tools/typespec-python
-
-TypeSpec emitter for Python SDKs
-
-## Install
-
-```bash
-npm install @azure-tools/typespec-python
-```
+---
+title: "Emitter usage"
+---
 
 ## Emitter usage
 

--- a/packages/typespec-python/website/src/content/docs/docs/emitters/clients/typespec-python/reference/index.mdx
+++ b/packages/typespec-python/website/src/content/docs/docs/emitters/clients/typespec-python/reference/index.mdx
@@ -1,0 +1,33 @@
+---
+title: Overview
+sidebar_position: 0
+toc_min_heading_level: 2
+toc_max_heading_level: 3
+---
+
+import { Tabs, TabItem } from '@astrojs/starlight/components';
+
+TypeSpec emitter for Python SDKs
+
+## Install
+
+<Tabs>
+<TabItem  label="In a spec" default>
+
+```bash
+npm install @azure-tools/typespec-python
+```
+
+</TabItem>
+<TabItem  label="In a library" default>
+
+```bash
+npm install --save-peer @azure-tools/typespec-python
+```
+
+</TabItem>
+</Tabs>
+
+## Emitter usage
+
+[See documentation](./emitter.md)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,8 +235,8 @@ catalogs:
       specifier: ^17.0.35
       version: 17.0.35
     '@typespec/http-client-python':
-      specifier: '>=0.34.0 <1.0.0'
-      version: 0.34.0
+      specifier: '>=0.34.1 <1.0.0'
+      version: 0.34.1
     '@typespec/ts-http-runtime':
       specifier: 0.3.6
       version: 0.3.6
@@ -3807,7 +3807,7 @@ importers:
     dependencies:
       '@typespec/http-client-python':
         specifier: 'catalog:'
-        version: 0.34.0(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)
+        version: 0.34.1(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)
       semver:
         specifier: 'catalog:'
         version: 7.8.5
@@ -8477,8 +8477,8 @@ packages:
   '@types/yoga-layout@1.9.2':
     resolution: {integrity: sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==}
 
-  '@typespec/http-client-python@0.34.0':
-    resolution: {integrity: sha512-JWPxy6vioNNajgWiE1FqX9BOaEqTfD5JXthpcHT/TlnT/DrOuAcBtaByxwFzTooGfObhQLRiszeXvvqls3n8Ew==}
+  '@typespec/http-client-python@0.34.1':
+    resolution: {integrity: sha512-ts5eI67WdDeMZEQ8SVNI1BOlU34gqTTBGZEicKqgZ99O1q61mDCbMIcC3Aphgdgvh/dmSCWU4XteQpy/gg1LAA==}
     engines: {node: '>=22.0.0'}
     peerDependencies:
       '@azure-tools/typespec-autorest': '>=0.69.1 <1.0.0'
@@ -20365,7 +20365,7 @@ snapshots:
 
   '@types/yoga-layout@1.9.2': {}
 
-  '@typespec/http-client-python@0.34.0(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)':
+  '@typespec/http-client-python@0.34.1(@azure-tools/typespec-autorest@packages+typespec-autorest)(@azure-tools/typespec-azure-core@packages+typespec-azure-core)(@azure-tools/typespec-azure-resource-manager@packages+typespec-azure-resource-manager)(@azure-tools/typespec-azure-rulesets@packages+typespec-azure-rulesets)(@azure-tools/typespec-client-generator-core@packages+typespec-client-generator-core)(@typespec/compiler@core+packages+compiler)(@typespec/events@core+packages+events)(@typespec/http@core+packages+http)(@typespec/openapi@core+packages+openapi)(@typespec/rest@core+packages+rest)(@typespec/sse@core+packages+sse)(@typespec/streams@core+packages+streams)(@typespec/versioning@core+packages+versioning)(@typespec/xml@core+packages+xml)':
     dependencies:
       '@azure-tools/typespec-autorest': link:packages/typespec-autorest
       '@azure-tools/typespec-azure-core': link:packages/typespec-azure-core

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -99,7 +99,7 @@ catalog:
   "@types/swagger-ui-express": ^4.1.8
   "@types/which": ^3.0.4
   "@types/yargs": ^17.0.35
-  "@typespec/http-client-python": ">=0.34.0 <1.0.0"
+  "@typespec/http-client-python": ">=0.34.1 <1.0.0"
   "@typespec/ts-http-runtime": "0.3.6"
   "@vitejs/plugin-react": ^6.0.1
   "@vitest/coverage-v8": ^4.1.3


### PR DESCRIPTION
## Summary
- Upgrade the http-client-python workspace dependency
- Sync generated Python emitter reference docs
- Add changelog entry

## Testing
- Not run (PR creation only)