### PR TITLE
[Automated][tcgc] Document `@override` path-param and `@clientLocation` type-conflict diagnostics

### DIFF
--- a/eng/scripts/doc-updater/knowledge/tcgc.md
+++ b/eng/scripts/doc-updater/knowledge/tcgc.md
@@ -121,6 +121,8 @@ namespace (@clientNamespace), naming (@clientName), overload, structure (@client
 - `operation-not-in-client`: REMOVED in May 2026. This diagnostic no longer exists.
 - `inconsistent-multiple-service-dependency` (warning): Emitted when services merged into the same client depend on different versions of a shared library dependency. Documented in 03client.mdx under the "One Client from Multiple Services" section and in guideline.md under "Client Detection".
 - `legacy-hierarchy-building-conflict` (warning): Now only has `property-type-mismatch` message ID (the old `property-missing` and `type-mismatch` message IDs were removed). Emitted during property reconciliation when a dropped property's type is incompatible with the same-named property on the new base chain.
+- `override-parameters-mismatch` (error): In addition to the general "different parameters definition" case, `@override` now reports this when the override operation drops a parameter that is realized as a `@path` parameter in the original operation's HTTP route, or redeclares it without `@path` (the underlying route still needs it). The check is skipped when any override parameter carries `@clientLocation` (intentional relocation). Matching between original/override parameters is by **name**, not position (so overrides may add/remove/regroup parameters). "Realized path parameter" is resolved from `getHttpOperation(...).parameters` (route ground truth), not from the `@path` decorator alone, because templated params (e.g. ARM scope models) can carry `@path` without appearing in the route. Documented in 04method.mdx `@override` section as a `:::caution`.
+- `client-location-conflict` / `parameterTypeConflict` (warning): `@clientLocation` cannot move multiple parameters that share a name but have different types to the same client. Common when `@clientLocation` is on a templated parameter instantiated with different types across operations; the client parameter collapses to a single (last) type, breaking the SDK. Fix: move the parameter on each operation instead. Validated in `src/validations/types.ts` (`validateClientLocationParameterTypes`). Documented in 04method.mdx `@clientLocation` section as a `:::caution`.
 
 ## External Type Usage Propagation
 
@@ -233,3 +235,26 @@ namespace (@clientNamespace), naming (@clientName), overload, structure (@client
 - No Spector spec was added for this feature — it's a code-generation-time config behavior, not a wire-level behavior. The unit tests in `test/package/api-versions-metadata.test.ts` and `test/clients/structure.test.ts` thoroughly cover it.
 - The guideline.md was updated to document `SdkPackage.metadata` (both `apiVersion` and `apiVersions`).
 - The 10versioning.mdx was updated to mention the Record form and add a "Per-service versioning (multi-service packages)" section.
+
+## Linter Rules Documentation
+
+- Linter rules live in `packages/typespec-client-generator-core/src/rules/` and are registered in `src/linter.ts` (both the general `rules` array and the `csharpRules` array for C#-specific rules).
+- Each rule has a user-facing doc page under `website/src/content/docs/docs/libraries/typespec-client-generator-core/rules/<rule-name>.md` and a row in the auto-listed `reference/linter.md` table. These are typically added by the rule's own source PR — verify they exist before adding.
+- Rule doc page format: frontmatter `title:`, a `Full name` code block with the fully-qualified rule id, a one-line description, then `#### ❌ Incorrect` and `#### ✅ Correct` `tsp` examples (no `<ClientTabs>` needed — rule docs use plain `tsp` blocks).
+
+### csharp-no-url-suffix (PR #4541)
+
+- Warning rule: flags model properties whose **C#-resolved** name ends with `Url`, suggesting `Uri` instead (.NET convention). Uses `getLibraryName(tcgcContext, property, "csharp")`, so it respects `@clientName` overrides (both directions — it can also fire when `@clientName` introduces a `Url` suffix for C#). Case-sensitive (`imageurl` is not flagged); `Urls` plural is not flagged.
+- Provides a codefix that writes `@@clientName(Model.prop, "<name>Uri", "csharp")` into `client.tsp`.
+- Codefix helpers added in `src/rules/codefix-helpers.ts` are reusable by other rules:
+  - `createAugmentDecoratorCodeFix(target, decoratorName, args?)` — appends an `@@`-augment decorator at the end of the SAME file as the target.
+  - `createClientTspAugmentDecoratorCodeFix(target, decoratorName, program, args?)` — writes the augment decorator to `client.tsp` (creates imports/usings as needed, uses short refs when the namespace `using` is in scope, else FQN). Assumes `client.tsp` is imported via tspconfig.
+
+## doc-updater Mechanics
+
+- The incremental `changes.commits[].diff` only contains `packages/typespec-client-generator-core/src/` (source) diffs — NOT the doc files those same PRs may have changed. So a source PR that adds a linter rule, reference table row, or howto section will already have those docs in the tree at checkout. Always check the current doc state before adding; the doc work may already be done, leaving only cross-cutting howto notes for you.
+- Validation/diagnostic-only changes (new warnings/errors) and linter rules do not need Spector coverage — Spector demonstrates positive wire-level client generation, not error conditions. Document them as `:::caution`/`:::note` admonitions in the relevant howto section instead of new `<ClientTabs>` blocks.
+
+## Feedback Lessons (PR #4683)
+
+- In versioning (and any API-version) examples, use realistic **date-based** api-version identifiers (e.g. `2024-01-01`, enum members like `v2024_01_01: "2024-01-01"`) — NOT placeholder names like `av1`/`bv1`. Human reviewers rewrote placeholder versions to date-based ones. Keep the enum member name and its string value consistent (e.g. `v2024_05_01: "2024-05-01"`).

--- a/eng/scripts/doc-updater/knowledge/tcgc.meta.json
+++ b/eng/scripts/doc-updater/knowledge/tcgc.meta.json
@@ -1,6 +1,6 @@
 {
-  "lastCommit": "d4128efda9bb5edc8f80d1e10a0c2c9ab3019068",
-  "lastUpdated": "2026-06-22T11:44:15.998Z",
+  "lastCommit": "d56eaffca7c3b134f1ee790f980c6b041d956e8e",
+  "lastUpdated": "2026-07-06T11:11:21.564Z",
   "analyzedPaths": [
     "packages/typespec-client-generator-core/src",
     "packages/typespec-client-generator-core/lib",

--- a/website/src/content/docs/docs/howtos/Generate client libraries/04method.mdx
+++ b/website/src/content/docs/docs/howtos/Generate client libraries/04method.mdx
@@ -1795,6 +1795,10 @@ func (client *ContosoProviderHubClient) Get(ctx context.Context, subscriptionID 
 
 </ClientTabs>
 
+:::caution
+`@clientLocation` cannot move multiple parameters that share the same name but have **different types** to the same client. This commonly happens when `@clientLocation` is applied to a templated parameter that is instantiated with different types across operations. Doing so emits a `client-location-conflict` warning and produces a broken client where the parameter collapses to a single type. Move the parameter on each operation instead, so it keeps a consistent type on the client.
+:::
+
 ## Customizing method signatures with `@override`
 
 The `@override` decorator allows you to customize method signatures in generated client SDKs. This is useful when you need to:
@@ -1815,6 +1819,10 @@ The `@override` decorator takes a target operation and a custom operation that d
 ```
 
 When applied, the method parameters come from the override operation while the underlying HTTP operation remains unchanged. TCGC maps method parameters to operation parameters based on name matching.
+
+:::caution
+The override operation must preserve every parameter that is realized as a path parameter in the original operation's HTTP route, keeping its `@path` decorator. Dropping such a parameter — or redeclaring it without `@path` — reports an `override-parameters-mismatch` error, because the underlying route still requires that value. To relocate a parameter instead of dropping it, use [`@clientLocation`](#using-clientlocation-to-control-parameter-placement).
+:::
 
 ### Simple parameter customization
 


### PR DESCRIPTION
Add two caution admonitions to the client-library method howto:
- @clientLocation cannot move multiple same-named params of different types to the same client (client-location-conflict warning).
- @override must preserve realized @path parameters; dropping or redeclaring them without @path triggers override-parameters-mismatch.

Update the doc-updater knowledge base with the new diagnostics, linter rule documentation conventions (csharp-no-url-suffix), incremental doc-updater mechanics, and the PR #4683 feedback lesson. Record the checkout commit in the tcgc metadata.

Resolve: https://github.com/Azure/typespec-azure/issues/4821