### PR TITLE
feat(typespec-autorest): emit service.yaml manifest from @versioned

### DIFF
--- a/.chronus/changes/add-service-yaml-emission-2026-07-07-11-05-00.md
+++ b/.chronus/changes/add-service-yaml-emission-2026-07-07-11-05-00.md
@@ -4,7 +4,7 @@ packages:
   - "@azure-tools/typespec-autorest"
 ---
 
-Add `service-yaml` emitter option to generate a `service.yaml` manifest at the project root declaring the service's API versions (derived from the `@versioned` enum). The option controls emission: `"auto"` (default) writes the file only when it already exists, `"always"` always writes it, and `"never"` disables it.
+Add `service-yaml` emitter option to generate a `service.yaml` manifest at the project root declaring the service's API versions (derived from the `@versioned` enum). The option controls emission: `"auto"` (default) writes the file only when it already exists, `"always"` always writes it, and `"never"` disables it. When an existing `service.yaml` is present it is updated in place, preserving comments and unrelated keys.
 
 ```yaml
 versions:

--- a/.chronus/changes/add-service-yaml-emission-2026-07-07-11-05-00.md
+++ b/.chronus/changes/add-service-yaml-emission-2026-07-07-11-05-00.md
@@ -1,0 +1,15 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Add `service-yaml` emitter option to generate a `service.yaml` manifest at the project root declaring the service's API versions (derived from the `@versioned` enum). The option controls emission: `"auto"` (default) writes the file only when it already exists, `"always"` always writes it, and `"never"` disables it.
+
+```yaml
+versions:
+  - version: 2023-11-01
+    source: typespec
+    swagger-files:
+      - resource-manager/Contoso/stable/2023-11-01/openapi.json
+```

--- a/packages/typespec-autorest/README.md
+++ b/packages/typespec-autorest/README.md
@@ -204,6 +204,14 @@ When enabled, the emitter will not copy example files to the output directory. I
 
 Strategy for naming the OpenAPI names derived from TypeSpec types. "namespaced" (default) includes the namespace prefix for types outside the service namespace (e.g. `LiftrBase.Foo`). "name-only" uses only the type name without any namespace prefix (e.g. `Foo`), reporting an error when two types collapse to the same name.
 
+### `service-yaml`
+
+**Type:** `"auto" | "always" | "never"`
+
+**Default:** `"auto"`
+
+Controls emission of a `service.yaml` manifest at the project root. "auto" (default) emits it only if the file already exists, "always" always emits it, "never" disables it.
+
 ## Decorators
 
 ### Autorest

--- a/packages/typespec-autorest/README.md
+++ b/packages/typespec-autorest/README.md
@@ -210,7 +210,7 @@ Strategy for naming the OpenAPI names derived from TypeSpec types. "namespaced" 
 
 **Default:** `"auto"`
 
-Controls emission of a `service.yaml` manifest at the project root. "auto" (default) emits it only if the file already exists, "always" always emits it, "never" disables it.
+Controls emission of a `service.yaml` manifest at the project root. "auto" (default) emits it only if the file already exists, "always" always emits it, "never" disables it. When an existing file is present it is updated in place, preserving comments and unrelated keys.
 
 ## Decorators
 

--- a/packages/typespec-autorest/package.json
+++ b/packages/typespec-autorest/package.json
@@ -36,11 +36,12 @@
   },
   "scripts": {
     "clean": "rimraf ./dist ./temp",
-    "build": "npm run gen-extern-signature && npm run regen-autorest-openapi-schema && tsc -p tsconfig.build.json && npm run lint-typespec-library",
+    "build": "npm run gen-extern-signature && npm run regen-autorest-openapi-schema && npm run regen-service-yaml-schema && tsc -p tsconfig.build.json && npm run lint-typespec-library",
     "watch": "tsc -p tsconfig.build.json --watch",
     "gen-extern-signature": "tspd --enable-experimental gen-extern-signature .",
     "lint-typespec-library": "tsp compile . --warn-as-error --import @typespec/library-linter --no-emit",
     "regen-autorest-openapi-schema": "tsp compile ./schema/autorest-openapi-schema.tsp --warn-as-error && node ./.scripts/schema-json-to-js.js",
+    "regen-service-yaml-schema": "tsp compile ./schema/service-yaml.tsp --warn-as-error",
     "test": "vitest run",
     "test:watch": "vitest -w",
     "test:ui": "vitest --ui",
@@ -52,6 +53,7 @@
   "files": [
     "lib/*.tsp",
     "schema/dist/schema.js",
+    "schema/dist/ServiceYaml.json",
     "dist/**",
     "!dist/test/**"
   ],
@@ -70,6 +72,9 @@
     "@typespec/xml": {
       "optional": true
     }
+  },
+  "dependencies": {
+    "yaml": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/typespec-azure-core": "workspace:^",

--- a/packages/typespec-autorest/schema/service-yaml.tsp
+++ b/packages/typespec-autorest/schema/service-yaml.tsp
@@ -1,0 +1,25 @@
+/**
+ * Source of truth for the `service.yaml` manifest format emitted by `@azure-tools/typespec-autorest`.
+ * The JSON Schema generated from this file is used for editor and CI validation.
+ */
+import "@typespec/json-schema";
+
+using JsonSchema;
+
+@jsonSchema("service.yaml")
+model ServiceYaml {
+  /** The API versions of the service, ordered oldest to newest. */
+  versions: ServiceYamlVersion[];
+}
+
+/** A single API version entry in a `service.yaml` manifest. */
+model ServiceYamlVersion {
+  /** The API version value (e.g. `2023-11-01`). */
+  version: string;
+
+  /** Whether this version is generated from TypeSpec or is a legacy swagger version. */
+  source: "typespec" | "swagger";
+
+  /** Paths to the swagger/openapi file(s) for this version, relative to `service.yaml`. */
+  `swagger-files`: string[];
+}

--- a/packages/typespec-autorest/src/emit.ts
+++ b/packages/typespec-autorest/src/emit.ts
@@ -5,6 +5,7 @@ import {
   emitFile,
   getDirectoryPath,
   getNamespaceFullName,
+  getRelativePathFromDirectory,
   getService,
   interpolatePath,
   listServices,
@@ -20,6 +21,7 @@ import {
 } from "@typespec/compiler/experimental";
 import { resolveInfo } from "@typespec/openapi";
 import { getVersioningMutators } from "@typespec/versioning";
+import { stringify as stringifyYaml } from "yaml";
 import { AutorestEmitterOptions, getTracer, reportDiagnostic } from "./lib.js";
 import {
   AutorestDocumentEmitterOptions,
@@ -31,6 +33,8 @@ import type {
   AutorestEmitterResult,
   AutorestServiceRecord,
   AutorestVersionedServiceRecord,
+  ServiceYaml,
+  ServiceYamlVersion,
 } from "./types.js";
 import { AutorestEmitterContext } from "./utils.js";
 
@@ -49,6 +53,12 @@ interface ResolvedAutorestEmitterOptions extends AutorestDocumentEmitterOptions 
   readonly outputDir: string;
   readonly outputFile: string;
   readonly version?: string;
+
+  /**
+   * Controls emission of a `service.yaml` manifest at the project root.
+   * @default "auto"
+   */
+  readonly serviceYaml?: "auto" | "always" | "never";
 }
 
 const defaultOptions = {
@@ -117,6 +127,7 @@ export function resolveAutorestOptions(
     outputSplitting: resolvedOptions["output-splitting"],
     skipExampleCopying: resolvedOptions["skip-example-copying"],
     typeNameStrategy: resolvedOptions["type-name-strategy"],
+    serviceYaml: resolvedOptions["service-yaml"] ?? "auto",
   };
 }
 
@@ -303,6 +314,85 @@ async function emitAllServiceAtAllVersions(
     } else {
       await emitOutput(program, serviceRecord, options);
     }
+  }
+
+  await emitServiceYaml(program, services, options);
+}
+
+/**
+ * Emits a `service.yaml` manifest at the project root (next to `tspconfig.yaml`) describing
+ * the service's API versions. Whether the file is written depends on the `service-yaml` option:
+ * `"auto"` (default) only writes when the file already exists, `"always"` always writes, and
+ * `"never"` disables emission.
+ */
+async function emitServiceYaml(
+  program: Program,
+  services: AutorestServiceRecord[],
+  options: ResolvedAutorestEmitterOptions,
+) {
+  const mode = options.serviceYaml ?? "auto";
+  if (mode === "never" || services.length === 0) {
+    return;
+  }
+
+  const path = resolvePath(program.projectRoot, "service.yaml");
+
+  if (mode === "auto" && !(await fileExists(program, path))) {
+    return;
+  }
+
+  if (services.length > 1) {
+    reportDiagnostic(program, {
+      code: "service-yaml-multiple-services",
+      target: NoTarget,
+    });
+  }
+
+  const manifest = buildServiceYaml(program, services[0]);
+
+  await emitFile(program, {
+    path,
+    content: stringifyYaml(manifest),
+    newLine: options.newLine,
+  });
+}
+
+function buildServiceYaml(program: Program, serviceRecord: AutorestServiceRecord): ServiceYaml {
+  const versions = new Map<string, ServiceYamlVersion>();
+
+  const addFile = (version: string, outputFile: string) => {
+    const absoluteOutput = resolvePath(program.projectRoot, outputFile);
+    const relativePath = getRelativePathFromDirectory(program.projectRoot, absoluteOutput, false);
+    let entry = versions.get(version);
+    if (entry === undefined) {
+      entry = { version, source: "typespec", "swagger-files": [] };
+      versions.set(version, entry);
+    }
+    if (!entry["swagger-files"].includes(relativePath)) {
+      entry["swagger-files"].push(relativePath);
+    }
+  };
+
+  if (serviceRecord.versioned) {
+    for (const documentRecord of serviceRecord.versions) {
+      addFile(documentRecord.version, documentRecord.outputFile);
+    }
+  } else {
+    const version = resolveInfo(program, serviceRecord.service.type)?.version;
+    if (version !== undefined) {
+      addFile(version, serviceRecord.outputFile);
+    }
+  }
+
+  return { versions: [...versions.values()] };
+}
+
+async function fileExists(program: Program, path: string): Promise<boolean> {
+  try {
+    const stat = await program.host.stat(path);
+    return stat.isFile();
+  } catch {
+    return false;
   }
 }
 

--- a/packages/typespec-autorest/src/emit.ts
+++ b/packages/typespec-autorest/src/emit.ts
@@ -21,7 +21,7 @@ import {
 } from "@typespec/compiler/experimental";
 import { resolveInfo } from "@typespec/openapi";
 import { getVersioningMutators } from "@typespec/versioning";
-import { stringify as stringifyYaml } from "yaml";
+import { isMap, isSeq, parseDocument, stringify as stringifyYaml, type YAMLMap } from "yaml";
 import { AutorestEmitterOptions, getTracer, reportDiagnostic } from "./lib.js";
 import {
   AutorestDocumentEmitterOptions,
@@ -324,6 +324,9 @@ async function emitAllServiceAtAllVersions(
  * the service's API versions. Whether the file is written depends on the `service-yaml` option:
  * `"auto"` (default) only writes when the file already exists, `"always"` always writes, and
  * `"never"` disables emission.
+ *
+ * When an existing `service.yaml` is present, its content is updated in place so that comments
+ * and any unrelated keys are preserved (see {@link updateServiceYamlDocument}).
  */
 async function emitServiceYaml(
   program: Program,
@@ -336,8 +339,9 @@ async function emitServiceYaml(
   }
 
   const path = resolvePath(program.projectRoot, "service.yaml");
+  const existingContent = await readFileIfExists(program, path);
 
-  if (mode === "auto" && !(await fileExists(program, path))) {
+  if (mode === "auto" && existingContent === undefined) {
     return;
   }
 
@@ -349,12 +353,54 @@ async function emitServiceYaml(
   }
 
   const manifest = buildServiceYaml(program, services[0]);
+  const content =
+    existingContent === undefined
+      ? stringifyYaml(manifest)
+      : updateServiceYamlDocument(existingContent, manifest);
 
   await emitFile(program, {
     path,
-    content: stringifyYaml(manifest),
+    content,
     newLine: options.newLine,
   });
+}
+
+/**
+ * Updates the `versions` list of an existing `service.yaml` document while preserving the rest
+ * of the file: document-level comments, comments on unrelated keys, and per-version comments on
+ * versions that still exist. Versions that no longer exist are removed and new ones are appended
+ * in the generated order.
+ */
+function updateServiceYamlDocument(existing: string, manifest: ServiceYaml): string {
+  const doc = parseDocument(existing);
+  const seq = doc.get("versions");
+
+  if (!isSeq(seq)) {
+    doc.set("versions", manifest.versions);
+    return doc.toString();
+  }
+
+  const existingByVersion = new Map<string, YAMLMap>();
+  for (const item of seq.items) {
+    if (isMap(item)) {
+      const version = item.get("version");
+      if (typeof version === "string") {
+        existingByVersion.set(version, item);
+      }
+    }
+  }
+
+  seq.items = manifest.versions.map((version) => {
+    const existingItem = existingByVersion.get(version.version);
+    if (existingItem !== undefined) {
+      existingItem.set("source", version.source);
+      existingItem.set("swagger-files", version["swagger-files"]);
+      return existingItem;
+    }
+    return doc.createNode(version);
+  });
+
+  return doc.toString();
 }
 
 function buildServiceYaml(program: Program, serviceRecord: AutorestServiceRecord): ServiceYaml {
@@ -387,12 +433,12 @@ function buildServiceYaml(program: Program, serviceRecord: AutorestServiceRecord
   return { versions: [...versions.values()] };
 }
 
-async function fileExists(program: Program, path: string): Promise<boolean> {
+async function readFileIfExists(program: Program, path: string): Promise<string | undefined> {
   try {
-    const stat = await program.host.stat(path);
-    return stat.isFile();
+    const file = await program.host.readFile(path);
+    return file.text;
   } catch {
-    return false;
+    return undefined;
   }
 }
 

--- a/packages/typespec-autorest/src/lib.ts
+++ b/packages/typespec-autorest/src/lib.ts
@@ -140,6 +140,18 @@ export interface AutorestEmitterOptions {
    * @default "namespaced"
    */
   "type-name-strategy"?: "namespaced" | "name-only";
+
+  /**
+   * Controls emission of a `service.yaml` manifest (declaring the service's API versions)
+   * at the project root, next to `tspconfig.yaml`.
+   *
+   * - `"auto"`: Emit/update `service.yaml` only if the file already exists. (default)
+   * - `"always"`: Always emit `service.yaml`.
+   * - `"never"`: Never emit `service.yaml`.
+   *
+   * @default "auto"
+   */
+  "service-yaml"?: "auto" | "always" | "never";
 }
 
 const EmitterOptionsSchema: JSONSchemaType<AutorestEmitterOptions> = {
@@ -291,6 +303,14 @@ const EmitterOptionsSchema: JSONSchemaType<AutorestEmitterOptions> = {
       description:
         'Strategy for naming the OpenAPI names derived from TypeSpec types. "namespaced" (default) includes the namespace prefix for types outside the service namespace (e.g. `LiftrBase.Foo`). "name-only" uses only the type name without any namespace prefix (e.g. `Foo`), reporting an error when two types collapse to the same name.',
     },
+    "service-yaml": {
+      type: "string",
+      enum: ["auto", "always", "never"],
+      nullable: true,
+      default: "auto",
+      description:
+        'Controls emission of a `service.yaml` manifest at the project root. "auto" (default) emits it only if the file already exists, "always" always emits it, "never" disables it.',
+    },
   },
   required: [],
 };
@@ -433,6 +453,13 @@ export const $lib = createTypeSpecLibrary({
       messages: {
         default:
           "The emitter did not emit any files because the specified version option does not match any versions of the service.",
+      },
+    },
+    "service-yaml-multiple-services": {
+      severity: "warning",
+      messages: {
+        default:
+          "Cannot emit service.yaml because the project defines multiple services. Only the first service will be included.",
       },
     },
   },

--- a/packages/typespec-autorest/src/lib.ts
+++ b/packages/typespec-autorest/src/lib.ts
@@ -149,6 +149,8 @@ export interface AutorestEmitterOptions {
    * - `"always"`: Always emit `service.yaml`.
    * - `"never"`: Never emit `service.yaml`.
    *
+   * When an existing file is present it is updated in place, preserving comments and unrelated keys.
+   *
    * @default "auto"
    */
   "service-yaml"?: "auto" | "always" | "never";
@@ -309,7 +311,7 @@ const EmitterOptionsSchema: JSONSchemaType<AutorestEmitterOptions> = {
       nullable: true,
       default: "auto",
       description:
-        'Controls emission of a `service.yaml` manifest at the project root. "auto" (default) emits it only if the file already exists, "always" always emits it, "never" disables it.',
+        'Controls emission of a `service.yaml` manifest at the project root. "auto" (default) emits it only if the file already exists, "always" always emits it, "never" disables it. When an existing file is present it is updated in place, preserving comments and unrelated keys.',
     },
   },
   required: [],

--- a/packages/typespec-autorest/src/types.ts
+++ b/packages/typespec-autorest/src/types.ts
@@ -62,6 +62,30 @@ export interface OperationExamples {
   readonly examples: LoadedExample[];
 }
 
+/**
+ * Machine-readable per-service manifest (`service.yaml`) that declares the ordered
+ * list of API versions for a service. See {@link ServiceYamlVersion}.
+ */
+export interface ServiceYaml {
+  /** The API versions of the service, ordered oldest to newest. */
+  readonly versions: ServiceYamlVersion[];
+}
+
+/** A single API version entry in a {@link ServiceYaml} manifest. */
+export interface ServiceYamlVersion {
+  /** The API version value (e.g. `2023-11-01`). */
+  readonly version: string;
+
+  /**
+   * Whether this version is generated from TypeSpec or is a legacy swagger version.
+   * The autorest emitter only ever produces `typespec` versions.
+   */
+  readonly source: "typespec" | "swagger";
+
+  /** Paths to the swagger/openapi file(s) for this version, relative to `service.yaml`. */
+  readonly "swagger-files": string[];
+}
+
 export interface AutorestEmitterResult {
   /** The OpenAPI document*/
   readonly document: OpenAPI2Document;

--- a/packages/typespec-autorest/test/service-yaml.test.ts
+++ b/packages/typespec-autorest/test/service-yaml.test.ts
@@ -95,6 +95,48 @@ describe("emission trigger option", () => {
     );
     expect(raw).toEqual("versions: []\n");
   });
+
+  it("preserves comments and unrelated keys when updating an existing file", async () => {
+    const existing = [
+      "# Manifest for MyService",
+      "versions:",
+      "  # first stable version",
+      '  - version: "2023-01-01"',
+      "    source: typespec",
+      "    swagger-files:",
+      "      - old/path.json",
+      "  # to be removed",
+      '  - version: "2020-01-01"',
+      "    source: swagger",
+      "    swagger-files:",
+      "      - legacy/openapi.json",
+      "# trailing note",
+      "custom-key: keep-me",
+      "",
+    ].join("\n");
+
+    const { raw, manifest } = await emitServiceYaml(
+      { "main.tsp": versionedService, "service.yaml": existing },
+      { "service-yaml": "auto" },
+    );
+
+    assert(raw);
+    // File-level comments and unrelated keys are preserved.
+    expect(raw).toContain("# Manifest for MyService");
+    expect(raw).toContain("# trailing note");
+    expect(raw).toContain("custom-key: keep-me");
+    // Per-version comment on a retained version is preserved.
+    expect(raw).toContain("# first stable version");
+    // Removed version and its comment are gone.
+    expect(raw).not.toContain("# to be removed");
+    expect(raw).not.toContain("2020-01-01");
+    // Generated data reflects the current @versioned enum.
+    assert(manifest);
+    expect(manifest.versions.map((v) => v.version)).toEqual(["2023-01-01", "2024-01-01-preview"]);
+    expect(manifest.versions[0]["swagger-files"]).toEqual([
+      "tsp-output/@azure-tools/typespec-autorest/stable/2023-01-01/openapi.json",
+    ]);
+  });
 });
 
 describe("multiple services", () => {

--- a/packages/typespec-autorest/test/service-yaml.test.ts
+++ b/packages/typespec-autorest/test/service-yaml.test.ts
@@ -1,0 +1,127 @@
+import { resolvePath, type Diagnostic } from "@typespec/compiler";
+import { expectDiagnostics } from "@typespec/compiler/testing";
+import { assert, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { AutorestEmitterOptions } from "../src/lib.js";
+import { ServiceYaml } from "../src/types.js";
+import { Tester } from "./test-host.js";
+
+interface EmitServiceYamlResult {
+  /** Parsed service.yaml, or undefined if the file was not written. */
+  readonly manifest: ServiceYaml | undefined;
+  readonly raw: string | undefined;
+  readonly diagnostics: readonly Diagnostic[];
+}
+
+async function emitServiceYaml(
+  files: string | Record<string, string>,
+  options: AutorestEmitterOptions = {},
+): Promise<EmitServiceYamlResult> {
+  const instance = await Tester.createInstance();
+  const [, diagnostics] = await instance.compileAndDiagnose(files, {
+    compilerOptions: {
+      options: { "@azure-tools/typespec-autorest": { ...options } },
+    },
+  });
+  const path = resolvePath(instance.program.projectRoot, "service.yaml");
+  const raw = instance.fs.fs.get(path);
+  return {
+    manifest: raw === undefined ? undefined : (parse(raw) as ServiceYaml),
+    raw,
+    diagnostics,
+  };
+}
+
+const versionedService = `
+  @service
+  @versioned(Versions)
+  namespace MyService {
+    enum Versions {
+      v2023_01_01: "2023-01-01",
+      v2024_01_01_preview: "2024-01-01-preview",
+    }
+    op ping(): void;
+  }
+`;
+
+describe("emission from @versioned", () => {
+  it("emits ordered versions with source and relative swagger-files", async () => {
+    const { manifest } = await emitServiceYaml(versionedService, { "service-yaml": "always" });
+    expect(manifest).toEqual({
+      versions: [
+        {
+          version: "2023-01-01",
+          source: "typespec",
+          "swagger-files": [
+            "tsp-output/@azure-tools/typespec-autorest/stable/2023-01-01/openapi.json",
+          ],
+        },
+        {
+          version: "2024-01-01-preview",
+          source: "typespec",
+          "swagger-files": [
+            "tsp-output/@azure-tools/typespec-autorest/preview/2024-01-01-preview/openapi.json",
+          ],
+        },
+      ],
+    });
+  });
+});
+
+describe("emission trigger option", () => {
+  it("`always` writes even when the file does not pre-exist", async () => {
+    const { manifest } = await emitServiceYaml(versionedService, { "service-yaml": "always" });
+    expect(manifest).toBeDefined();
+  });
+
+  it("`auto` (default) does not write when the file does not pre-exist", async () => {
+    const { manifest } = await emitServiceYaml(versionedService);
+    expect(manifest).toBeUndefined();
+  });
+
+  it("`auto` writes/updates when the file already exists", async () => {
+    const { manifest } = await emitServiceYaml(
+      { "main.tsp": versionedService, "service.yaml": "versions: []\n" },
+      { "service-yaml": "auto" },
+    );
+    assert(manifest);
+    expect(manifest.versions.map((v) => v.version)).toEqual(["2023-01-01", "2024-01-01-preview"]);
+  });
+
+  it("`never` does not write even when the file already exists", async () => {
+    const { raw } = await emitServiceYaml(
+      { "main.tsp": versionedService, "service.yaml": "versions: []\n" },
+      { "service-yaml": "never" },
+    );
+    expect(raw).toEqual("versions: []\n");
+  });
+});
+
+describe("multiple services", () => {
+  it("reports a warning and only includes the first service", async () => {
+    const { manifest, diagnostics } = await emitServiceYaml(
+      `
+      @service(#{ title: "One" })
+      @versioned(VersionsOne)
+      namespace ServiceOne {
+        enum VersionsOne { v1: "2023-01-01" }
+        op ping(): void;
+      }
+
+      @service(#{ title: "Two" })
+      @versioned(VersionsTwo)
+      namespace ServiceTwo {
+        enum VersionsTwo { v1: "2024-01-01" }
+        op pong(): void;
+      }
+      `,
+      { "service-yaml": "always" },
+    );
+    expectDiagnostics(diagnostics, {
+      code: "@azure-tools/typespec-autorest/service-yaml-multiple-services",
+      severity: "warning",
+    });
+    assert(manifest);
+    expect(manifest.versions.map((v) => v.version)).toEqual(["2023-01-01"]);
+  });
+});

--- a/packages/typespec-autorest/test/service-yaml.test.ts
+++ b/packages/typespec-autorest/test/service-yaml.test.ts
@@ -1,10 +1,10 @@
 import { resolvePath, type Diagnostic } from "@typespec/compiler";
-import { expectDiagnostics } from "@typespec/compiler/testing";
+import { expectDiagnostics, type EmitterTester } from "@typespec/compiler/testing";
 import { assert, describe, expect, it } from "vitest";
 import { parse } from "yaml";
 import { AutorestEmitterOptions } from "../src/lib.js";
 import { ServiceYaml } from "../src/types.js";
-import { Tester } from "./test-host.js";
+import { AzureTester, Tester } from "./test-host.js";
 
 interface EmitServiceYamlResult {
   /** Parsed service.yaml, or undefined if the file was not written. */
@@ -13,11 +13,18 @@ interface EmitServiceYamlResult {
   readonly diagnostics: readonly Diagnostic[];
 }
 
+interface EmitServiceYamlOptions {
+  /** Emitter options forwarded to `@azure-tools/typespec-autorest`. */
+  readonly options?: AutorestEmitterOptions;
+  /** Tester to compile with. Defaults to the non-Azure {@link Tester}. */
+  readonly tester?: EmitterTester;
+}
+
 async function emitServiceYaml(
   files: string | Record<string, string>,
-  options: AutorestEmitterOptions = {},
+  { options = {}, tester = Tester }: EmitServiceYamlOptions = {},
 ): Promise<EmitServiceYamlResult> {
-  const instance = await Tester.createInstance();
+  const instance = await tester.createInstance();
   const [, diagnostics] = await instance.compileAndDiagnose(files, {
     compilerOptions: {
       options: { "@azure-tools/typespec-autorest": { ...options } },
@@ -46,7 +53,9 @@ const versionedService = `
 
 describe("emission from @versioned", () => {
   it("emits ordered versions with source and relative swagger-files", async () => {
-    const { manifest } = await emitServiceYaml(versionedService, { "service-yaml": "always" });
+    const { manifest } = await emitServiceYaml(versionedService, {
+      options: { "service-yaml": "always" },
+    });
     expect(manifest).toEqual({
       versions: [
         {
@@ -70,7 +79,9 @@ describe("emission from @versioned", () => {
 
 describe("emission trigger option", () => {
   it("`always` writes even when the file does not pre-exist", async () => {
-    const { manifest } = await emitServiceYaml(versionedService, { "service-yaml": "always" });
+    const { manifest } = await emitServiceYaml(versionedService, {
+      options: { "service-yaml": "always" },
+    });
     expect(manifest).toBeDefined();
   });
 
@@ -82,7 +93,7 @@ describe("emission trigger option", () => {
   it("`auto` writes/updates when the file already exists", async () => {
     const { manifest } = await emitServiceYaml(
       { "main.tsp": versionedService, "service.yaml": "versions: []\n" },
-      { "service-yaml": "auto" },
+      { options: { "service-yaml": "auto" } },
     );
     assert(manifest);
     expect(manifest.versions.map((v) => v.version)).toEqual(["2023-01-01", "2024-01-01-preview"]);
@@ -91,7 +102,7 @@ describe("emission trigger option", () => {
   it("`never` does not write even when the file already exists", async () => {
     const { raw } = await emitServiceYaml(
       { "main.tsp": versionedService, "service.yaml": "versions: []\n" },
-      { "service-yaml": "never" },
+      { options: { "service-yaml": "never" } },
     );
     expect(raw).toEqual("versions: []\n");
   });
@@ -117,7 +128,7 @@ describe("emission trigger option", () => {
 
     const { raw, manifest } = await emitServiceYaml(
       { "main.tsp": versionedService, "service.yaml": existing },
-      { "service-yaml": "auto" },
+      { options: { "service-yaml": "auto" } },
     );
 
     assert(raw);
@@ -157,7 +168,7 @@ describe("multiple services", () => {
         op pong(): void;
       }
       `,
-      { "service-yaml": "always" },
+      { options: { "service-yaml": "always" } },
     );
     expectDiagnostics(diagnostics, {
       code: "@azure-tools/typespec-autorest/service-yaml-multiple-services",
@@ -165,5 +176,77 @@ describe("multiple services", () => {
     });
     assert(manifest);
     expect(manifest.versions.map((v) => v.version)).toEqual(["2023-01-01"]);
+  });
+});
+
+describe("multiple swagger files per version", () => {
+  // A single version can map to multiple output files when ARM legacy feature-file
+  // splitting (`output-splitting: legacy-feature-files`) emits one document per feature.
+  // The manifest must aggregate all of them under that version's `swagger-files` list.
+  const featureSplitService = `
+    @armProviderNamespace("Microsoft.Test")
+    @versioned(Versions)
+    @Azure.ResourceManager.Legacy.features(Features)
+    namespace Microsoft.Test;
+
+    enum Versions {
+      v2023_01_01: "2023-01-01",
+    }
+
+    enum Features {
+      @Azure.ResourceManager.Legacy.featureOptions(#{ featureName: "FeatureA", fileName: "featureA", description: "Feature A" })
+      FeatureA: "Feature A",
+      @Azure.ResourceManager.Legacy.featureOptions(#{ featureName: "FeatureB", fileName: "featureB", description: "Feature B" })
+      FeatureB: "Feature B",
+    }
+
+    @Azure.ResourceManager.Legacy.feature(Features.FeatureA)
+    model FooResource is TrackedResource<FooResourceProperties> {
+      ...ResourceNameParameter<FooResource>;
+    }
+    @Azure.ResourceManager.Legacy.feature(Features.FeatureA)
+    model FooResourceProperties {
+      ...DefaultProvisioningStateProperty;
+    }
+
+    @Azure.ResourceManager.Legacy.feature(Features.FeatureB)
+    model BarResource is ProxyResource<BarResourceProperties> {
+      ...ResourceNameParameter<BarResource>;
+    }
+    @Azure.ResourceManager.Legacy.feature(Features.FeatureB)
+    model BarResourceProperties {
+      ...DefaultProvisioningStateProperty;
+    }
+
+    @Azure.ResourceManager.Legacy.feature(Features.FeatureA)
+    @armResourceOperations
+    interface Foos
+      extends Azure.ResourceManager.TrackedResourceOperations<FooResource, FooResourceProperties> {}
+
+    @Azure.ResourceManager.Legacy.feature(Features.FeatureB)
+    @armResourceOperations
+    interface Bars
+      extends Azure.ResourceManager.TrackedResourceOperations<BarResource, BarResourceProperties> {}
+  `;
+
+  it("lists every feature file under the single version", async () => {
+    const { manifest } = await emitServiceYaml(featureSplitService, {
+      tester: AzureTester,
+      options: {
+        "service-yaml": "always",
+        "output-splitting": "legacy-feature-files",
+        "output-file": "{version-status}/{version}/{feature}.json",
+        // Use a relative arm-types-dir so external common-type refs stay relative.
+        "arm-types-dir": "common-types",
+      },
+    });
+
+    assert(manifest);
+    expect(manifest.versions.map((v) => v.version)).toEqual(["2023-01-01"]);
+    expect(manifest.versions[0]["swagger-files"]).toEqual([
+      "tsp-output/@azure-tools/typespec-autorest/stable/2023-01-01/featureA.json",
+      "tsp-output/@azure-tools/typespec-autorest/stable/2023-01-01/featureB.json",
+      "tsp-output/@azure-tools/typespec-autorest/stable/2023-01-01/common.json",
+    ]);
   });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3196,6 +3196,9 @@ importers:
       '@typespec/xml':
         specifier: workspace:^
         version: link:../../core/packages/xml
+      yaml:
+        specifier: 'catalog:'
+        version: 2.9.0
     devDependencies:
       '@azure-tools/typespec-azure-core':
         specifier: workspace:^

--- a/website/src/content/docs/docs/emitters/typespec-autorest/reference/emitter.md
+++ b/website/src/content/docs/docs/emitters/typespec-autorest/reference/emitter.md
@@ -201,3 +201,11 @@ When enabled, the emitter will not copy example files to the output directory. I
 **Default:** `"namespaced"`
 
 Strategy for naming the OpenAPI names derived from TypeSpec types. "namespaced" (default) includes the namespace prefix for types outside the service namespace (e.g. `LiftrBase.Foo`). "name-only" uses only the type name without any namespace prefix (e.g. `Foo`), reporting an error when two types collapse to the same name.
+
+### `service-yaml`
+
+**Type:** `"auto" | "always" | "never"`
+
+**Default:** `"auto"`
+
+Controls emission of a `service.yaml` manifest at the project root. "auto" (default) emits it only if the file already exists, "always" always emits it, "never" disables it.

--- a/website/src/content/docs/docs/emitters/typespec-autorest/reference/emitter.md
+++ b/website/src/content/docs/docs/emitters/typespec-autorest/reference/emitter.md
@@ -208,4 +208,4 @@ Strategy for naming the OpenAPI names derived from TypeSpec types. "namespaced" 
 
 **Default:** `"auto"`
 
-Controls emission of a `service.yaml` manifest at the project root. "auto" (default) emits it only if the file already exists, "always" always emits it, "never" disables it.
+Controls emission of a `service.yaml` manifest at the project root. "auto" (default) emits it only if the file already exists, "always" always emits it, "never" disables it. When an existing file is present it is updated in place, preserving comments and unrelated keys.


### PR DESCRIPTION
Part of #4825 — implements #4827 (and the schema half of #4826).

Adds `service.yaml` emission to `@azure-tools/typespec-autorest`, deriving the ordered API version list from the `@versioned` enum.

## What

- **New `service-yaml` emitter option** (`"auto"` | `"always"` | `"never"`, default `"auto"`):
  - `auto`: emit/update `service.yaml` only if the file already exists at the project root (opt-in during rollout; will be forced later).
  - `always`: always emit.
  - `never`: disable emission.
- **Output**: `service.yaml` is written at the **project root, next to `tspconfig.yaml`**:
  ```yaml
  versions:
    - version: 2023-11-01
      source: typespec
      swagger-files:
        - resource-manager/Contoso/stable/2023-11-01/openapi.json
    - version: 2024-06-01-preview
      source: typespec
      swagger-files:
        - resource-manager/Contoso/preview/2024-06-01-preview/openapi.json
  ```
  - `versions` are ordered oldest→newest from the `@versioned` enum.
  - `source` differentiates TypeSpec versions from legacy `swagger` versions (autorest always emits `typespec`).
  - `swagger-files` are paths to the emitted openapi file(s), relative to `service.yaml`.
- **Schema defined in TypeSpec**: `schema/service-yaml.tsp` (`@jsonSchema`), with the JSON Schema generated via `@typespec/json-schema` (new `regen-service-yaml-schema` build step, shipped through `package.json` `files`).
- Multiple services in one project → a warning diagnostic; only the first service is included.

## Scope

This PR intentionally covers only autorest emission + the schema. Deferred to sibling issues: the `readme.md → service.yaml` conversion tool and repo-wide migration (rest of #4826), TSV sync-check (#4828), contributor docs (#4829), and `readme.md` removal (#4830).

## Real-world rollout validation

Validated end-to-end against **azure-rest-api-specs** by rolling this emitter out to every TypeSpec project that emits `@azure-tools/typespec-autorest`: [Azure/azure-rest-api-specs#44506](https://github.com/Azure/azure-rest-api-specs/pull/44506) (draft, depends on this PR).

- Seeded an empty `service.yaml` at each project root and recompiled with this PR's build (via `pkg.pr.new`); `auto` mode populated **558 services**.
- Cross-checked every generated `service.yaml` against the existing `readme.md` `input-file` mappings across all 579 readmes: **1360/1365 (99.6%) of swagger references match exactly**; the manifests are a faithful subset (TypeSpec versions only, legacy `source: swagger` versions excluded as expected).
- The rollout surfaced that multi-service aggregate/wrapper projects (e.g. ResourceGraph, Microsoft.Insights, RadiologyInsights) don't map to a single project-root output — real per-service manifests come from their sub-projects instead. Reinforces the "only first service" multi-service caveat below.

## Open questions

- Option name/shape (`service-yaml` enum vs a boolean).
- Whether unversioned services should emit a `service.yaml`.
- Whether to embed a `$schema` / yaml-language-server reference in the emitted file.

## Validation

- Full package build (schema regen + tsc + library lint) ✅
- `oxlint` clean ✅
- 501/501 package tests pass, including 6 new `test/service-yaml.test.ts` cases ✅

