### PR TITLE
docs: add Reviewer advice to linter rule documentation

### DIFF
--- a/packages/typespec-azure-core/src/rules/auth-required.md
+++ b/packages/typespec-azure-core/src/rules/auth-required.md
@@ -1,5 +1,11 @@
 Ensure Azure services define their authentication requirements. See https://azure.github.io/typespec-azure/docs/reference/azure-style-guide#security-definitions
 
+## Impact
+
+- **Area:** API, SDK
+
+All ARM APIs share the same authentication, so a violation has no runtime effect on the API or SDK. It usually indicates the root namespace is missing its provider registration.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -36,3 +42,7 @@ namespace Contoso.WidgetManager;
 /** The secret key for your Azure Cognitive Services subscription. */
 model AzureKey is ApiKeyAuth<ApiKeyLocation.header, "Ocp-Apim-Subscription-Key">;
 ```
+
+## Suppression
+
+This should essentially never occur. Rather than suppressing, add `@armProviderNamespace` to the root namespace.

--- a/packages/typespec-azure-core/src/rules/bad-record-type.md
+++ b/packages/typespec-azure-core/src/rules/bad-record-type.md
@@ -3,6 +3,12 @@ Use of `Record<X>` should be limited in Azure services.
 1. It is recommended to use `Record<string>` instead of `Record<unknown>`
 2. Specifying a type with Record and some known properties is also not recommended.
 
+## Impact
+
+- **Area:** SDK, API
+
+Records typed with non-concrete element types cannot be represented cleanly in SDKs and force clients to work with untyped dictionaries.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -28,3 +34,7 @@ model Pet {
 ```tsp
 model Pet is Record<string>;
 ```
+
+## Suppression
+
+Suppress only when an open-ended dictionary is genuinely required; otherwise give the record a concrete element type.

--- a/packages/typespec-azure-core/src/rules/byos.md
+++ b/packages/typespec-azure-core/src/rules/byos.md
@@ -2,6 +2,12 @@ Operations that upload binary data (using content types like `application/octet-
 
 See the [Azure REST API Guidelines - BYOS](https://github.com/microsoft/api-guidelines/blob/vNext/azure/Guidelines.md#bring-your-own-storage-byos) for more details.
 
+## Impact
+
+- **Area:** API
+
+The API transfers large artifacts through the service (upload/download) instead of using a storage account, which scales poorly and diverges from Azure guidance.
+
 #### ❌ Incorrect
 
 Uploading binary data with `application/octet-stream`:
@@ -35,3 +41,7 @@ op download(): {
   @header contentType: "application/octet-stream";
 };
 ```
+
+## Suppression
+
+Suppress when direct upload/download is appropriate for the API; otherwise use a storage account for large artifacts.

--- a/packages/typespec-azure-core/src/rules/casing-style.md
+++ b/packages/typespec-azure-core/src/rules/casing-style.md
@@ -1,5 +1,15 @@
 Validate names follow the [TypeSpec Style guide](https://typespec.io/docs/handbook/style-guide)
 
+## Impact
+
+- **Area:** API, SDK
+
+On properties this produces non-standard wire casing that hurts API usability; on other declarations emitters substitute the correct casing for their language.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [DefinitionsPropertiesNamesCamelCase](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r3016) (partial - covers the serious property-casing violation).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -41,3 +51,7 @@ op createPet(): void;
 ```tsp
 interface PetStores {}
 ```
+
+## Suppression
+
+Suppression is acceptable on non-property declarations, where the effect is cosmetic. Avoid suppressing on properties - use standard casing (PascalCase for namespaces, interfaces, models, unions, enums; camelCase for properties, parameters, operations, scalars).

--- a/packages/typespec-azure-core/src/rules/composition-over-inheritance.md
+++ b/packages/typespec-azure-core/src/rules/composition-over-inheritance.md
@@ -1,5 +1,11 @@
 Models that extend a base model without a discriminator should use composition (`...` spread or `model is`) instead of inheritance (`extends`). If polymorphism is intended, add the `@discriminator` decorator on the base model.
 
+## Impact
+
+- **Area:** SDK
+
+Deep inheritance is hard for SDKs to represent and reduces client usability.
+
 #### ❌ Incorrect
 
 Inheritance without a discriminator:
@@ -70,3 +76,7 @@ model Dog extends Pet {
   bark: boolean;
 }
 ```
+
+## Suppression
+
+Suppress when inheritance is genuinely required; otherwise prefer `model is` or spread (`...`) instead of `extends`.

--- a/packages/typespec-azure-core/src/rules/documentation-required.md
+++ b/packages/typespec-azure-core/src/rules/documentation-required.md
@@ -1,5 +1,15 @@
 Enums, models, operations, and their members/properties should have documentation. Use doc comments (`/** */`) to provide descriptions.
 
+## Impact
+
+- **Area:** API, SDK
+
+Missing documentation produces poor SDK reference docs and API documentation.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [SummaryOrDescription](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
+
 #### ❌ Incorrect
 
 Model without documentation:
@@ -50,3 +60,7 @@ enum PetKind {
 :::note
 Version enums and discriminator enums/unions are exempt from this rule as they are considered self-documenting.
 :::
+
+## Suppression
+
+Do not suppress. Add a `/** */` doc comment or an `@doc` decorator.

--- a/packages/typespec-azure-core/src/rules/friendly-name.md
+++ b/packages/typespec-azure-core/src/rules/friendly-name.md
@@ -1,5 +1,11 @@
 Ensures that `@friendlyName` is used as intended. The `@friendlyName` decorator should only be applied to template declarations and should reference template parameter properties in the friendly name string.
 
+## Impact
+
+- **Area:** API
+
+`@friendlyName` is an unscoped way to rename a type for every emitter; it should be replaced by targeted client naming.
+
 #### ❌ Incorrect
 
 Using `@friendlyName` on a non-template type:
@@ -40,3 +46,7 @@ model Page<T> {
 @friendlyName("List{name}", T)
 op listTemplate<T>(): Page<T>;
 ```
+
+## Suppression
+
+Do not suppress. Use `@clientName` instead.

--- a/packages/typespec-azure-core/src/rules/key-visibility-required.md
+++ b/packages/typespec-azure-core/src/rules/key-visibility-required.md
@@ -1,5 +1,11 @@
 Key properties need to have an explicit Lifecycle visibility setting. Use the `@visibility` decorator to specify the appropriate visibility for key properties. Without explicit visibility, the key property uses default visibility which may not match the intended behavior.
 
+## Impact
+
+- **Area:** API, SDK
+
+Missing key visibility can misrepresent the mutability of identity fields in the API and generated SDKs.
+
 #### ❌ Incorrect
 
 Key property without explicit visibility:
@@ -22,3 +28,7 @@ model Foo {
   name: string;
 }
 ```
+
+## Suppression
+
+Suppress only if an identity field is genuinely mutable; otherwise add a visibility decorator with the appropriate lifecycle visibility.

--- a/packages/typespec-azure-core/src/rules/known-encoding.md
+++ b/packages/typespec-azure-core/src/rules/known-encoding.md
@@ -8,6 +8,16 @@ Known supported encodings:
 | `duration`                       | `ISO8601`, `seconds`                  |
 | `bytes`                          | `base64`, `base64url`                 |
 
+## Impact
+
+- **Area:** API, SDK
+
+Non-standard formats are transmitted as the raw, unencoded wire type, which hurts API and SDK usability.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [ValidFormats](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r2003).
+
 #### ❌ Incorrect
 
 Unknown encoding on a model property:
@@ -43,3 +53,7 @@ Known encoding on a scalar:
 @encode("rfc3339")
 scalar myDateTime extends utcDateTime;
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use a standard format, encoding, or type.

--- a/packages/typespec-azure-core/src/rules/long-running-polling-operation-required.md
+++ b/packages/typespec-azure-core/src/rules/long-running-polling-operation-required.md
@@ -1,5 +1,11 @@
 Long-running operations that return an `Operation-Location` header should have a linked polling operation. Use the `@pollingOperation` decorator to link a status polling operation.
 
+## Impact
+
+- **Area:** API, SDK
+
+Does not apply to ARM LROs, but flags an operation that cannot be represented as a long-running operation.
+
 #### ❌ Incorrect
 
 Operation returning `Operation-Location` header without a linked polling operation:
@@ -35,3 +41,7 @@ op readWithCustomHeader(): {
   @header("Operation-Location") location: string;
 };
 ```
+
+## Suppression
+
+Do not suppress unless it is a false positive. Use the standard Async operation templates.

--- a/packages/typespec-azure-core/src/rules/no-case-mismatch.md
+++ b/packages/typespec-azure-core/src/rules/no-case-mismatch.md
@@ -4,6 +4,12 @@ Validate that no two types have the same name with different casing. Having type
 Template instances are not checked by this rule since they are not distinct type declarations.
 :::
 
+## Impact
+
+- **Area:** SDK
+
+Type names that differ only by casing cannot be generated into most SDK languages.
+
 #### ❌ Incorrect
 
 Two models that differ only by casing:
@@ -39,3 +45,7 @@ model FailOver {
   priority: int32;
 }
 ```
+
+## Suppression
+
+Suppress only if the API somehow allows it, and then rename the types with client SDK decorators. Otherwise make type names unique when compared case-insensitively.

--- a/packages/typespec-azure-core/src/rules/no-closed-literal-union.md
+++ b/packages/typespec-azure-core/src/rules/no-closed-literal-union.md
@@ -1,6 +1,12 @@
 Azure services favor extensible enums to avoid breaking changes as new enum values are added. When using a union of only string or numeric literals it is the equivalent to a closed enum.
 Adding the base scalar(`string`, `int32`, `int64`, etc.) as a variant to the union makes it extensible.
 
+## Impact
+
+- **Area:** SDK, API
+
+A closed set of values makes it a breaking change to add new values in later api-versions.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -31,3 +37,7 @@ model Pet {
   kind: "cat" | "dog" | string;
 }
 ```
+
+## Suppression
+
+Suppress only when the set of values is inherently immutable (e.g. IPv4 vs IPv6). Otherwise use an open union, such as `union These { This: "this", That: "that", string }`.

--- a/packages/typespec-azure-core/src/rules/no-enum.md
+++ b/packages/typespec-azure-core/src/rules/no-enum.md
@@ -1,6 +1,12 @@
 Azure services favor extensible enums to avoid breaking changes as new enum values are added. TypeSpec enums are closed.
 Using a union with the base scalar(`string`, `int32`, `int64`, etc.) as a variant instead of an enum makes it extensible.
 
+## Impact
+
+- **Area:** SDK, API
+
+A closed enum makes it a breaking change to add new values in later api-versions.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -28,3 +34,7 @@ enum Version {
   2022_01_01: "2022-01-01",
 }
 ```
+
+## Suppression
+
+Suppress only when the set of values is inherently immutable (e.g. IPv4 vs IPv6). Otherwise use an open union, such as `union These { This: "this", That: "that", string }`.

--- a/packages/typespec-azure-core/src/rules/no-error-status-codes.md
+++ b/packages/typespec-azure-core/src/rules/no-error-status-codes.md
@@ -1,5 +1,15 @@
 Azure REST API guidelines recommend using the `default` error response for all error cases. Avoid defining custom 4xx or 5xx error status codes individually.
 
+## Impact
+
+- **Area:** API, SDK
+
+Using error status codes in a non-standard way makes the API difficult to consume.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [NoErrorCodeResponses](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
+
 #### ❌ Incorrect
 
 Custom 4xx error status code:
@@ -36,3 +46,7 @@ op readWidget(name: string):
       @body error: Error;
     };
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use the standard operation templates.

--- a/packages/typespec-azure-core/src/rules/no-explicit-routes-resource-ops.md
+++ b/packages/typespec-azure-core/src/rules/no-explicit-routes-resource-ops.md
@@ -1,5 +1,11 @@
 The `@route` decorator should not be used on standard resource operation signatures. Standard resource operations already have well-defined routes. If you need to add a route prefix, use `@route` on an interface or namespace instead.
 
+## Impact
+
+- **Area:** API
+
+May indicate non-standard resource paths, though a static route is sometimes legitimate.
+
 #### ❌ Incorrect
 
 Using `@route` directly on resource operations:
@@ -32,3 +38,7 @@ op readWidget is Azure.Core.StandardResourceOperations.ResourceRead<Widget>;
 // route: /widgets
 op listWidgets is Azure.Core.StandardResourceOperations.ResourceList<Widget>;
 ```
+
+## Suppression
+
+Suppress when the path is most naturally expressed as a static route (e.g. Network implementing Microsoft.Compute APIs for Virtual Machine Scale Sets); otherwise use the standard operation templates.

--- a/packages/typespec-azure-core/src/rules/no-format.md
+++ b/packages/typespec-azure-core/src/rules/no-format.md
@@ -1,5 +1,11 @@
 Using the `@format` decorator is disallowed. While in OpenAPI `format:` was used to both represent a known string format and a more precise type, in TypeSpec `@format` is only meant to represent a known pattern for a string. This means that using `@format` would result in a `string` type with some validation.
 
+## Impact
+
+- **Area:** API, SDK
+
+`@format` may specify an invalid or non-standard format.
+
 ## Mapping of format to types
 
 | Format   | Type                               |
@@ -32,3 +38,7 @@ model Pet {
   id: Azure.Core.uuid;
 }
 ```
+
+## Suppression
+
+Suppression is acceptable when a valid format is used. Prefer standard types (which apply the correct wire format automatically), or `@encode` when a non-standard format such as base64url is required.

--- a/packages/typespec-azure-core/src/rules/no-generic-numeric.md
+++ b/packages/typespec-azure-core/src/rules/no-generic-numeric.md
@@ -1,5 +1,15 @@
 Azure services should use numeric types that specify the bit-width instead of generic types.
 
+## Impact
+
+- **Area:** SDK, API
+
+Generic numeric types lose precision or cannot be represented by a strong numeric type in language SDKs.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [ValidFormats](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r2003).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -37,3 +47,7 @@ model Widget {
   id: safeint;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use the defined numeric types for floating-point, fixed-point, or integer values.

--- a/packages/typespec-azure-core/src/rules/no-header-explode.md
+++ b/packages/typespec-azure-core/src/rules/no-header-explode.md
@@ -1,6 +1,12 @@
 Azure services favor serializing header parameter of array type using the simple style(Where each values is joined by a `,`)
 Using `explode: true` property specify that each individual value of the array should be sent as a separate header parameter.
 
+## Impact
+
+- **Area:** API
+
+Allowing explode on multi-valued headers is mainly a data-plane concern but should be avoided.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -25,3 +31,7 @@ op list(
   select: string[],
 ): Pet[];
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use a different separator for multi-valued headers.

--- a/packages/typespec-azure-core/src/rules/no-legacy-usage.md
+++ b/packages/typespec-azure-core/src/rules/no-legacy-usage.md
@@ -1,5 +1,11 @@
 Types, decorators and other constructs from located under a `.Legacy` namespace are considered legacy and should not be used in new code. The only acceptable usage is for brownfield services which have their existing pattern grandfathered in.
 
+## Impact
+
+- **Area:** API, SDK
+
+Indicates use of legacy patterns instead of the current standard patterns.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -30,3 +36,7 @@ model Page {
   @nextLink nextLink: url;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use the standard types and templates.

--- a/packages/typespec-azure-core/src/rules/no-multiple-discriminator.md
+++ b/packages/typespec-azure-core/src/rules/no-multiple-discriminator.md
@@ -1,5 +1,11 @@
 Using a nested polymophic relationship is not allowed in Azure services. Most JSON serializers and deserializers do not support this feature.
 
+## Impact
+
+- **Area:** SDK, API
+
+Multiple discriminators are not supported by SDKs, nor by Swagger without extensions.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -35,3 +41,7 @@ model WhiteShark extends Fish {
   fishtype: "white-shark";
 }
 ```
+
+## Suppression
+
+Suppress only with SDK approval. Use a single discriminator and refactor additional discriminators onto child or sibling properties.

--- a/packages/typespec-azure-core/src/rules/no-nullable.md
+++ b/packages/typespec-azure-core/src/rules/no-nullable.md
@@ -1,6 +1,12 @@
 Properties are most often not nullable but optional.
 Do not use `| null` to specify that a property is nullable. Instead, use the `?` operator to indicate that a property is optional.
 
+## Impact
+
+- **Area:** API, SDK
+
+A nullable property is usually a mistake where an optional property was intended.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -18,3 +24,7 @@ model Pet {
   owner?: string;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use an optional property.

--- a/packages/typespec-azure-core/src/rules/no-offsetdatetime.md
+++ b/packages/typespec-azure-core/src/rules/no-offsetdatetime.md
@@ -1,5 +1,11 @@
 Prefer using `utcDateTime` when representing a datetime unless an offset is necessary. Most Azure services work with UTC times and `offsetDateTime` adds unnecessary complexity.
 
+## Impact
+
+- **Area:** SDK, API
+
+Times are clearest when expressed in UTC; `offsetDateTime` obscures intent.
+
 #### ❌ Incorrect
 
 As a model property:
@@ -41,3 +47,7 @@ model Bar {
 ```tsp
 op getTimestamp(): utcDateTime;
 ```
+
+## Suppression
+
+Suppress when there is a clear rationale for `offsetDateTime`; otherwise use `utcDateTime`.

--- a/packages/typespec-azure-core/src/rules/no-openapi.md
+++ b/packages/typespec-azure-core/src/rules/no-openapi.md
@@ -3,6 +3,12 @@ Using those decorators is usually a sign that the spec is either not following t
 
 Those decorators are only meant to be read by the openapi emitters which means this might achieve the correct OpenAPI output but other emitters(client SDK, service, etc.) will not be able to understand them and will see a broken representation of the spec.
 
+## Impact
+
+- **Area:** API, SDK, Emitters
+
+Raw OpenAPI (`@openapi` and extensions) changes the OpenAPI output without informing other emitters such as SDKs, so SDKs can misrepresent the wire API.
+
 ## Decorators and their alternatives
 
 | OpenAPI Decorator                    | Alternative                                                                                                                                                     |
@@ -100,3 +106,7 @@ interface Pet {
   get(): Pet;
 }
 ```
+
+## Suppression
+
+Suppression is acceptable when the extension does not affect the API or SDK - for example `@externalDocs`, or extensions like `x-ms-identifiers`. Extensions that do affect behavior should never be suppressed: use `@list` instead of `x-ms-pageable`, the Async operation templates instead of `x-ms-long-running-operation*`, `@secret` or a password type instead of `x-ms-secret`, and `@clientLocation` or `@clientName` instead of `@operationId`.

--- a/packages/typespec-azure-core/src/rules/no-private-usage.md
+++ b/packages/typespec-azure-core/src/rules/no-private-usage.md
@@ -1,5 +1,11 @@
 Verify that a spec is not referencing items from another library using a private namespace.
 
+## Impact
+
+- **Area:** API, SDK
+
+Using private or internal declarations risks a spec break when they change.
+
 #### ❌ Incorrect
 
 ```ts
@@ -22,3 +28,7 @@ namespace Private {
   extern dec myPrivateDecorator(target);
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use the standard types and templates.

--- a/packages/typespec-azure-core/src/rules/no-query-explode.md
+++ b/packages/typespec-azure-core/src/rules/no-query-explode.md
@@ -1,6 +1,12 @@
 Azure services favor serializing query parameter of array type using the simple style(Where each values is joined by a `,`)
 Using the `*` uri template modifier or `explode: true` property specify that each individual value of the array should be sent as a separate query parameter.
 
+## Impact
+
+- **Area:** API
+
+Allowing explode on multi-valued query parameters is mainly a data-plane concern but should be avoided.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -25,3 +31,7 @@ op list(
   select: string[],
 ): Pet[];
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use a different separator for multi-valued query parameters.

--- a/packages/typespec-azure-core/src/rules/no-rest-library-interfaces.md
+++ b/packages/typespec-azure-core/src/rules/no-rest-library-interfaces.md
@@ -1,5 +1,11 @@
 Resource interfaces from the `TypeSpec.Rest.Resource` library are incompatible with `Azure.Core`. Use the Azure.Core resource operation patterns instead.
 
+## Impact
+
+- **Area:** SDK, Emitters
+
+Describing resource APIs with raw REST-library interfaces can prevent emitters from recognizing them as resources, though that usually surfaces as other violations too.
+
 #### ❌ Incorrect
 
 Extending from `TypeSpec.Rest.Resource.ResourceOperations`:
@@ -20,3 +26,7 @@ interface MyResourceOperations<TResource extends TypeSpec.Reflection.Model> {
 
 interface Widgets extends MyResourceOperations<Widget> {}
 ```
+
+## Suppression
+
+Suppression is acceptable when there are no other related violations; otherwise use the standard operation templates.

--- a/packages/typespec-azure-core/src/rules/no-route-parameter-name-mismatch.md
+++ b/packages/typespec-azure-core/src/rules/no-route-parameter-name-mismatch.md
@@ -1,5 +1,11 @@
 Operations over the same resource or using the same path structure should use consistent path parameter names. When two operations resolve to the same resource or path structure but use different names for corresponding path parameters, it typically indicates an inadvertent mismatch in path parameter names.
 
+## Impact
+
+- **Area:** SDK
+
+For resource operations, a route/parameter name mismatch can produce awkward SDK operation signatures. This rule has a relatively high false-positive rate.
+
 #### ❌ Incorrect
 
 Two operations with the same path structure but different parameter names:
@@ -44,3 +50,7 @@ op getFoo(@path fooName: string): void;
 @route("/providers/Microsoft.Contoso/bars/{barName}")
 op getBar(@path barName: string): void;
 ```
+
+## Suppression
+
+Suppress when it is a false positive; otherwise use the standard resource operation templates.

--- a/packages/typespec-azure-core/src/rules/no-string-discriminator.md
+++ b/packages/typespec-azure-core/src/rules/no-string-discriminator.md
@@ -1,5 +1,11 @@
 Azure services favor using an extensible union to define the discriminator property. This allow the service to add new discriminated models without being breaking.
 
+## Impact
+
+- **Area:** SDK
+
+A string discriminator leaves the discriminant values unknown, making SDKs less usable.
+
 #### ❌ Incorrect
 
 - Missing explicit property
@@ -51,3 +57,7 @@ union PetKind {
   string,
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use an open union as the discriminator.

--- a/packages/typespec-azure-core/src/rules/no-unknown.md
+++ b/packages/typespec-azure-core/src/rules/no-unknown.md
@@ -1,5 +1,11 @@
 Azure services must not have properties of type `unknown`. All properties should have well-defined types to ensure proper serialization and client SDK generation.
 
+## Impact
+
+- **Area:** API, SDK
+
+Allowing any JSON type makes the API and SDK unusable without extensive documentation.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -25,3 +31,7 @@ model Widget {
   metadata: Record<string>;
 }
 ```
+
+## Suppression
+
+Treat like a type with no schema. Suppress only in the same cases you would accept `additionalProperties`; otherwise use a concrete type.

--- a/packages/typespec-azure-core/src/rules/no-unnamed-types.md
+++ b/packages/typespec-azure-core/src/rules/no-unnamed-types.md
@@ -1,5 +1,11 @@
 Azure services should not define anonymous models, union expressions, enum expressions, or scalar expressions inline. Instead, types must be defined as named declarations.
 
+## Impact
+
+- **Area:** SDK, API
+
+Anonymous inline types - models, unions, enums, or scalars - cannot be represented directly by many target languages, forcing awkward or unusable SDK types.
+
 ## Rationale
 
 Many target languages cannot represent inline union types or anonymous models directly and require them to be named types. By requiring named types in the specification, we ensure:
@@ -72,3 +78,7 @@ The following patterns are **not** flagged:
 - HTTP response envelope models (containing `@statusCode`, `@body`, `@header`, etc.)
 - Types defined inside standard library namespaces (`TypeSpec.*`, `Azure.*`)
 - Unions where all non-null variants are scalars (e.g. `string | int32`)
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise define the type as a named declaration.

--- a/packages/typespec-azure-core/src/rules/non-breaking-versioning.md
+++ b/packages/typespec-azure-core/src/rules/non-breaking-versioning.md
@@ -1,5 +1,11 @@
 Verify that only backward compatible changes are made to the API.
 
+## Impact
+
+- **Area:** API, SDK
+
+Flags versioning changes that would break existing clients across api-versions.
+
 #### ❌ Incorrect
 
 - Removed
@@ -71,3 +77,7 @@ model Foo {
   bar?: string = "default";
 }
 ```
+
+## Suppression
+
+Suppress only when the break is intentional and unavoidable; otherwise model the change in a non-breaking way.

--- a/packages/typespec-azure-core/src/rules/operation-missing-api-version.md
+++ b/packages/typespec-azure-core/src/rules/operation-missing-api-version.md
@@ -4,6 +4,16 @@ Ensure all operations have an `apiVersion` parameter.
 Seeing this error is also a sign that you are not using the Azure Standard templates. First double check why you cannot use them.
 :::
 
+## Impact
+
+- **Area:** API, SDK
+
+An operation without an api-version parameter cannot evolve across api-versions.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [ApiVersionParameterRequired](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -15,3 +25,7 @@ op createPet(pet: Pet): void;
 ```tsp
 op createPet(pet: Pet, ...Azure.Core.Foundations.ApiVersionParameter): void;
 ```
+
+## Suppression
+
+Do not suppress unless it is a false positive. Use the standard operation templates.

--- a/packages/typespec-azure-core/src/rules/request-body-problem.md
+++ b/packages/typespec-azure-core/src/rules/request-body-problem.md
@@ -1,5 +1,11 @@
 Request body should not be of raw array type. Using an array as the top-level request body prevents adding new properties in the future without introducing breaking changes. Instead, create a container model that wraps the array.
 
+## Impact
+
+- **Area:** API, SDK
+
+A request body typed as a bare array is difficult to evolve, since new properties cannot be added later.
+
 #### ❌ Incorrect
 
 Raw array as request body:
@@ -27,3 +33,7 @@ Arrays in _responses_ are allowed since response schemas are less likely to requ
 ```tsp
 op list(@body body: string): string[];
 ```
+
+## Suppression
+
+Suppress for actions where an array body is appropriate; otherwise wrap the array in a keyed model property so new properties can be added in the future.

--- a/packages/typespec-azure-core/src/rules/require-versioned.md
+++ b/packages/typespec-azure-core/src/rules/require-versioned.md
@@ -1,5 +1,11 @@
 Azure services should always use the versioning library even if they have a single version. This ensures that the service is ready for future versions and generate the OpenAPI 2.0 in the correct location.
 
+## Impact
+
+- **Area:** API, SDK
+
+Without versioning, the API cannot be updated with new api-versions.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -31,3 +37,7 @@ enum Versions {
   2021_01_01: "2021-01-01",
 }
 ```
+
+## Suppression
+
+Do not suppress. Add a Versions enum and reference it from the `@versioned` decorator on the root namespace.

--- a/packages/typespec-azure-core/src/rules/response-schema-problem.md
+++ b/packages/typespec-azure-core/src/rules/response-schema-problem.md
@@ -1,5 +1,11 @@
 Warn about operations having multiple non-error response schemas. If an operation has multiple response types for different success status codes, you may have forgotten to add `@error` to one of them.
 
+## Impact
+
+- **Area:** API, SDK
+
+May indicate a missing response status code, since a response is modeled as an inline union.
+
 #### ❌ Incorrect
 
 Multiple success responses with different body schemas:
@@ -51,3 +57,7 @@ model WidgetResponse {
 
 op test(): WidgetResponse | Error;
 ```
+
+## Suppression
+
+Suppress only in the unlikely case a single response is best represented as an inline union; otherwise use the standard operation templates.

--- a/packages/typespec-azure-core/src/rules/rpc-operation-request-body.md
+++ b/packages/typespec-azure-core/src/rules/rpc-operation-request-body.md
@@ -4,6 +4,12 @@ Validates that `RpcOperation` request bodies are used correctly. Operations usin
 This rule only applies to `@get` and `@delete` operations. Other HTTP verbs like `@post`, `@put`, and `@patch` can have request bodies.
 :::
 
+## Impact
+
+- **Area:** API
+
+An `RpcOperation` with an improperly modeled request body produces an unclear API contract.
+
 #### ❌ Incorrect
 
 GET operation with a request body:
@@ -71,3 +77,7 @@ op createWidget is RpcOperation<
   Widget
 >;
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise model the request body with the standard patterns.

--- a/packages/typespec-azure-core/src/rules/spread-discriminated-model.md
+++ b/packages/typespec-azure-core/src/rules/spread-discriminated-model.md
@@ -1,6 +1,12 @@
 A model using `@discriminator` is meant to be used in a polymorphic context. It should be extended to represent the relation.
 Spreading this model is a sign that either the `@discriminator` decorator is unnecessary or that `model extends` should have been used instead.
 
+## Impact
+
+- **Area:** SDK
+
+Spreading a discriminated model silently drops the discriminator, which is usually a mistake.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -39,3 +45,7 @@ model Cat extends Pet {
   meow: boolean;
 }
 ```
+
+## Suppression
+
+Suppress only when intended (unlikely); only spread non-discriminated types.

--- a/packages/typespec-azure-core/src/rules/use-standard-names.md
+++ b/packages/typespec-azure-core/src/rules/use-standard-names.md
@@ -10,6 +10,12 @@ Ensure Azure Service operations follow the naming recommendations.
 | `PATCH` returning `201`              | Start with `create`, `update` or `createOrUpdate` |
 | `DELETE`                             | Start with `delete`                               |
 
+## Impact
+
+- **Area:** API, SDK
+
+Non-standard operation names reduce consistency across Azure APIs and their SDKs.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -29,3 +35,7 @@ op createPet is ResourceCreate<Pet>;
 ```tsp
 op listPets is ResourceList<Pet>;
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise follow the standard naming conventions.

--- a/packages/typespec-azure-core/src/rules/use-standard-operations.md
+++ b/packages/typespec-azure-core/src/rules/use-standard-operations.md
@@ -1,5 +1,11 @@
 Azure Data Plane services should use standard operations defined in the Azure Core library.
 
+## Impact
+
+- **Area:** API, SDK
+
+Custom operations that bypass the standard templates can lose the resource semantics used by emitters and tooling.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -26,3 +32,7 @@ alias Operations = Azure.Core.ResourceOperations<ServiceTraits>;
 op myResourceRead is Operations.ResourceRead<MyResource>;
 op myResourceCreate is Operations.ResourceCreate<MyResource>;
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use the standard operation templates.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-agent-base-type-child-resources.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-agent-base-type-child-resources.md
@@ -1,5 +1,11 @@
 Resources decorated with `@azureBaseType` for the Agent base type must have both a Conversation and a Response child resource.
 
+## Impact
+
+- **Area:** API, SDK
+
+Agent base types must correctly model their child resources; violations can misrepresent the resource for emitters and tooling.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -42,3 +48,7 @@ model MyResponse is AgentResponse<MyResponseProperties, MyAgent> {
   ...ResourceNameParameter<MyResponse>;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use the standard agent base type patterns.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-agent-base-type-lifecycle-operations.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-agent-base-type-lifecycle-operations.md
@@ -1,5 +1,11 @@
 Conversation and Response child resources of an Agent must define create, read, update, and delete lifecycle operations.
 
+## Impact
+
+- **Area:** API, SDK
+
+Agent base types must correctly model their lifecycle operations; violations can misrepresent the resource for emitters and tooling.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -47,3 +53,7 @@ interface Conversations {
   listByAgent is ArmResourceListByParent<MyConversation>;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use the standard agent base type patterns.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-common-types-version.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-common-types-version.md
@@ -1,5 +1,11 @@
 ARM services must specify the ARM common-types version using the `@armCommonTypesVersion` decorator. If the same common types version is used across all service versions, this decorator should be applied either on the service namespace or on each version enum member. If the common types version is updated in later versions, the decorator should appear on each version enum member.
 
+## Impact
+
+- **Area:** API, SDK
+
+Indicates common-types are not being used, which normally surfaces as other violations too.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -33,3 +39,7 @@ enum Versions {
   v2,
 }
 ```
+
+## Suppression
+
+Suppress only if no common-types are ever used and that is valid; otherwise associate a common-types version with each version in the Versions enum.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-custom-resource-no-key.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-custom-resource-no-key.md
@@ -4,6 +4,12 @@
 
 Custom Azure resource models must define a key property using the `@key` decorator, especially if the custom resource will be used in operations. Without a key, operation paths may be duplicated.
 
+## Impact
+
+- **Area:** API, SDK
+
+Mainly a correctness issue: the resource's name property should be marked with `@key`.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -22,3 +28,7 @@ model CustomResource {
   someId: string;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise add `@key` to the name parameter of the resource.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-custom-resource-usage-discourage.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-custom-resource-usage-discourage.md
@@ -1,5 +1,11 @@
 Avoid using the `@customAzureResource` decorator. It doesn't provide validation for ARM resources, and its usage should be limited to brownfield services migration.
 
+## Impact
+
+- **Area:** API
+
+The resource does not use the ARM common-types resource base types.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -18,3 +24,7 @@ model Employee is TrackedResource<EmployeeProperties> {
   ...ResourceNameParameter<Employee>;
 }
 ```
+
+## Suppression
+
+Treat like any resource that does not use common-types. Use `TrackedResource`, `ProxyResource`, or `ExtensionResource`.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-delete-operation-response-codes.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-delete-operation-response-codes.md
@@ -1,5 +1,19 @@
 ## Synchronous
 
+````
+
+## Impact
+
+- **Area:** API
+
+The delete operation returns response codes that violate the RPC contract.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [DeleteResponseCodes](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
+
+## Synchronous
+
 Synchronous delete operations should use the `ArmResourceDeleteSync` template. They must have 200, 204, default and no other responses.
 
 #### ❌ Incorrect
@@ -13,7 +27,7 @@ interface Employees {
     result: boolean;
   };
 }
-```
+````
 
 #### ✅ Correct
 
@@ -45,3 +59,7 @@ interface Employees {
   delete is ArmResourceDeleteWithoutOkAsync<Employee>;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use the standard delete operation templates.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-no-path-casing-conflicts.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-no-path-casing-conflicts.md
@@ -4,6 +4,12 @@ paths differ only by character casing (for example `/foos` and `/Foos`, or
 are part of the comparison: paths whose parameter names differ (for example
 `/{resourceUri}/...` versus `/{scope}/...`) are treated as distinct.
 
+## Impact
+
+- **Area:** API, SDK
+
+Different-cased paths to the same resource can cause ARM manifest failures.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -43,3 +49,7 @@ model Bar is ProxyResource<{}> {
   name: string;
 }
 ```
+
+## Suppression
+
+Do not suppress unless it is a false positive. Normalize the path casing.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-no-record.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-no-record.md
@@ -4,6 +4,16 @@
 
 ARM requires Resource provider teams to define types explicitly. This is to ensure good customer experience in terms of the discoverability of concrete type definitions.
 
+## Impact
+
+- **Area:** API, SDK
+
+`Record<>` (additionalProperties) types are difficult to use from both the API and generated SDKs.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [AvoidAdditionalProperties](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -61,3 +71,7 @@ model Address {
   postalCode: string;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use a defined type.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-post-operation-response-codes.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-post-operation-response-codes.md
@@ -1,5 +1,19 @@
 ## Synchronous
 
+````
+
+## Impact
+
+- **Area:** API
+
+The POST operation returns response codes that violate the RPC contract.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [PostResponseCodes](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
+
+## Synchronous
+
 Synchronous post operations should have one of the following combinations of responses - 200 and default, or 204 and default. They must have no other responses.
 
 #### ❌ Incorrect
@@ -13,7 +27,7 @@ interface Employees {
     result: boolean;
   };
 }
-```
+````
 
 #### ✅ Correct
 
@@ -45,3 +59,7 @@ interface Employees {
   delete is ArmResourceDeleteWithoutOkAsync<Employee>;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use the standard resource action or provider action templates.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-put-operation-response-codes.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-put-operation-response-codes.md
@@ -1,5 +1,15 @@
 Put operations should use the `ArmResourceCreateOrReplaceAsync` or `ArmResourceCreateOrReplaceSync` template. They must have 200, 201, default and no other responses.
 
+## Impact
+
+- **Area:** API
+
+The PUT operation returns response codes that violate the RPC contract.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [PutResponseCodes](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -21,3 +31,7 @@ interface Employees {
   createOrUpdate is ArmResourceCreateOrReplaceAsync<Employee>;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use the standard createOrUpdate operation templates.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-action-no-segment.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-action-no-segment.md
@@ -1,5 +1,15 @@
 The `@armResourceAction` decorator should not be used together with `@segment`. If you need to rename the action, use `@action(...)` instead or omit the segment entirely.
 
+## Impact
+
+- **Area:** API, SDK
+
+May indicate a resource action path that does not follow the standard segment layout.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [PathForResourceAction](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md) (partial).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -25,3 +35,7 @@ op doAction(...ApiVersionParameter): void;
 @post
 op doAction(...ApiVersionParameter): void;
 ```
+
+## Suppression
+
+Suppress when the resulting path is correct; otherwise use `@action` to define the final path segment with the standard resource action templates.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-duplicate-property.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-duplicate-property.md
@@ -1,5 +1,15 @@
 Warns when a property defined in the resource envelope is also defined in the resource-specific properties bag. Envelope properties should not be duplicated in the `properties` model.
 
+## Impact
+
+- **Area:** API, SDK
+
+Reusing an envelope property name inside the RP-specific property bag violates the RPC contract.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [ArmResourcePropertiesBag](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r3019).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -32,3 +42,7 @@ model FooProperties {
   displayName?: string;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise do not reuse envelope property names in the rp-specific property bag.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-action-verb.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-action-verb.md
@@ -4,6 +4,16 @@
 
 For ARM http operations, the action verb must be `@post` or `@get`. Any other action verb is flagged as incorrect.
 
+## Impact
+
+- **Area:** API, SDK
+
+A resource action that does not use POST or GET produces an improper HTTP API and can break the C# SDK and emitters that model resource actions (service, portal).
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [InvalidVerbUsed](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r2044).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -39,3 +49,7 @@ op postAction is ArmProviderActionAsync<
   SubscriptionActionScope
 >;
 ```
+
+## Suppression
+
+Suppress only when needed to match an existing API. Use the standard resource action templates and do not override the verb with `@put`, `@patch`, `@delete`, or `@head`.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-envelope-property.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-envelope-property.md
@@ -1,5 +1,15 @@
 Resource envelope properties must originate from the `Azure.ResourceManager` namespace. Custom properties that are not part of the standard ARM resource envelope should be placed in the resource-specific property bag instead.
 
+## Impact
+
+- **Area:** API
+
+Defining non-standard top-level envelope properties violates the RPC contract.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [BodyTopLevelProperties](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r3006).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -23,3 +33,7 @@ model FooResource is TrackedResource<{}> {
   ...ManagedServiceIdentityProperty;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use the standard property mix-ins.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-version-format.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-version-format.md
@@ -1,5 +1,15 @@
 ARM resource versions must follow the `YYYY-MM-DD` format, with an optional suffix such as `-preview` or a versioned suffix like `-alpha.1`.
 
+## Impact
+
+- **Area:** API
+
+The api-version does not follow the required format, violating the RPC contract.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [ApiVersionPattern](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r3012).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -24,3 +34,7 @@ enum Versions {
   v2024_06_01_preview: "2024-06-01-preview",
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use the `YYYY-MM-DD[-preview]` format.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-key-invalid-chars.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-key-invalid-chars.md
@@ -1,5 +1,11 @@
 ARM resource key must contain only alphanumeric characters or dashes, starting with a lowercase letter.
 
+## Impact
+
+- **Area:** SDK
+
+Invalid characters in a resource key produce invalid parameter names in SDKs.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -15,3 +21,7 @@ model Employee is TrackedResource<EmployeeProperties> {
   ...ResourceNameParameter<Employee>;
 }
 ```
+
+## Suppression
+
+Do not suppress. Use the correct name in `@key` or the `ResourceNameParameter` template.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-name-pattern.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-name-pattern.md
@@ -1,5 +1,15 @@
 Resource names must specify a pattern string using `@pattern`, providing a regular expression that the name must match.
 
+## Impact
+
+- **Area:** API
+
+The resource name lacks the required pattern restriction, violating the RPC contract.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [ResourceNameRestriction](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -18,3 +28,7 @@ model Employee is ProxyResource<{}> {
   ...ResourceNameParameter<Employee>;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use `@pattern` or the `ResourceNameParameter` template with a pattern string or union type.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-operation-response.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-operation-response.md
@@ -4,6 +4,16 @@ PUT, GET, PATCH & LIST must return the same resource schema. Operations on a res
 ARM RPC rule: [`RPC-008`](https://armwiki.azurewebsites.net/api_contracts/guidelines/rpc.html)
 :::
 
+## Impact
+
+- **Area:** API
+
+The resource operation returns a response schema that violates the RPC contract.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [PutGetPatchResponseSchema](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r3007) (the TypeSpec rule also covers `list`).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -26,3 +36,7 @@ interface FooResources {
   get(...ResourceInstanceParameters<FooResource>): ArmResponse<FooResource> | ErrorResponse;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use the standard operation templates and do not override the response parameter.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-operation.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-operation.md
@@ -1,5 +1,11 @@
 Validate that all ARM Resource operations are defined inside an interface, include an `api-version` parameter, and use the correct decorator for the HTTP verb.
 
+## Impact
+
+- **Area:** API, SDK, Emitters
+
+Missing the resource decorators can leave operations unassociated with their resource - breaking the C# SDK and preventing resource-based reasoning, linting, and generation of resource-centric content (service generation, tests, portal).
+
 #### ❌ Incorrect
 
 Operations must be inside an interface:
@@ -33,3 +39,7 @@ interface FooResources {
   createOrUpdate is ArmResourceCreateOrReplaceAsync<FooResource>;
 }
 ```
+
+## Suppression
+
+Requires C# SDK sign-off and careful review of any other violations. Use the standard resource types, or decorate with `@customAzureResource` when that is not possible, and use the operation templates.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-patch.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-patch.md
@@ -1,5 +1,15 @@
 Validate ARM PATCH operations. The request body of a PATCH must be a model with a subset of the resource properties. The PATCH body must not contain properties that do not exist on the resource.
 
+## Impact
+
+- **Area:** API
+
+Inconsistent PATCH properties violate the RPC contract.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [ConsistentPatchProperties](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -27,3 +37,7 @@ model FooPatch {
   properties?: FooProperties;
 }
 ```
+
+## Suppression
+
+Suppress per the RPC guidelines; otherwise use the standard PATCH operations.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-path-segment-invalid-chars.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-path-segment-invalid-chars.md
@@ -1,5 +1,11 @@
 ARM resource path segments must contain only alphanumeric characters or dashes, starting with a lowercase letter.
 
+## Impact
+
+- **Area:** API, SDK
+
+Invalid characters in a path segment produce an invalid ARM API and invalid parameter names.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -15,3 +21,7 @@ model FooResource is TrackedResource<{}> {
   ...ResourceNameParameter<FooResource>;
 }
 ```
+
+## Suppression
+
+Treat like any invalid path segment and require a fix. Use only valid characters in the `@key` for the path segment.

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-provisioning-state.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-provisioning-state.md
@@ -8,6 +8,16 @@
 - readonly
 - must at least contain `Succeeded`, `Canceled`, and `Failed`
 
+## Impact
+
+- **Area:** API
+
+A missing or invalid provisioning state violates the RPC and RPaaS contracts.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [ProvisioningStateValidation](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md) (also ProvisioningStateSpecifiedForLROPut, ProvisioningStateSpecifiedForLROPatch, and RpaaS_ResourceProvisioningState).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -24,3 +34,7 @@ model ResourceProperties {
   provisioningState?: ResourceProvisioningState;
 }
 ```
+
+## Suppression
+
+Suppress per the RPC guidelines; otherwise define a provisioning state property with `Succeeded`, `Failed`, and `Canceled` states.

--- a/packages/typespec-azure-resource-manager/src/rules/beyond-nesting-levels.md
+++ b/packages/typespec-azure-resource-manager/src/rules/beyond-nesting-levels.md
@@ -1,5 +1,15 @@
 Tracked Resources must use 3 or fewer levels of nesting. Deeply nested resources make the API harder to use and are discouraged by ARM guidelines.
 
+## Impact
+
+- **Area:** API
+
+Nesting resources beyond three levels violates the RPC contract.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [TrackedResourceBeyondThirdLevel](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -48,3 +58,7 @@ model C is TrackedResource<{}> {
   ...ResourceNameParameter<C>;
 }
 ```
+
+## Suppression
+
+Suppress per the RPC guidelines; otherwise restructure so the resource layout has no more than three levels of nesting.

--- a/packages/typespec-azure-resource-manager/src/rules/empty-updateable-properties.md
+++ b/packages/typespec-azure-resource-manager/src/rules/empty-updateable-properties.md
@@ -1,5 +1,11 @@
 Resources with update operations should have updateable properties. The RP-specific properties of the resource (as defined in the `properties` property) should have at least one updateable property. Properties are updateable if they do not have a `@visibility` decorator, or if they include `Lifecycle.Update` in the `@visibility` decorator arguments.
 
+## Impact
+
+- **Area:** API
+
+Covered by the patch-specific rules; indicates the properties bag has no updateable properties.
+
 #### ❌ Incorrect
 
 All properties are read-only:
@@ -23,3 +29,7 @@ model FooResourceProperties {
   displayName?: string;
 }
 ```
+
+## Suppression
+
+Suppress when required to match an existing API, or when using the Tags patch; otherwise ensure not all properties in the properties bag are updateable.

--- a/packages/typespec-azure-resource-manager/src/rules/improper-subscription-list-operation.md
+++ b/packages/typespec-azure-resource-manager/src/rules/improper-subscription-list-operation.md
@@ -1,5 +1,11 @@
 Tenant and Extension resources should not define a list by subscription operation. These resource types are not scoped to a subscription, so listing them by subscription is not appropriate.
 
+## Impact
+
+- **Area:** API
+
+Likely a modeling error - only subscription-based resources should have subscription list operations.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -27,3 +33,7 @@ interface FooResources {
   get is ArmResourceRead<FooResource>;
 }
 ```
+
+## Suppression
+
+Suppress per the RPC guidelines. Ensure tenant resources have only a tenant list, and use the standard resource operations.

--- a/packages/typespec-azure-resource-manager/src/rules/lro-location-header.md
+++ b/packages/typespec-azure-resource-manager/src/rules/lro-location-header.md
@@ -4,6 +4,16 @@
 
 Long-running (LRO) operations with 202 responses must have a "Location" response header.
 
+## Impact
+
+- **Area:** API
+
+A long-running operation without the standard Location header violates the RPC contract.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [LroLocationHeader](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -21,3 +31,7 @@ interface Employees {
   delete is ArmResourceDeleteWithoutOkAsync<Employee, EmployeeProperties>;
 }
 ```
+
+## Suppression
+
+Suppress per the RPC guidelines; otherwise use the standard Async templates.

--- a/packages/typespec-azure-resource-manager/src/rules/missing-operations-endpoint.md
+++ b/packages/typespec-azure-resource-manager/src/rules/missing-operations-endpoint.md
@@ -1,5 +1,15 @@
 Check for missing Operations interface. All Azure Resource Manager services must expose the operations endpoint. Add the Operations interface to your service namespace.
 
+## Impact
+
+- **Area:** API
+
+The service is missing the standard Operations endpoint required by the RPC contract.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [OperationsAPIImplementation](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r3023).
+
 #### ❌ Incorrect
 
 ```tsp title="main.tsp"
@@ -15,3 +25,7 @@ namespace MyService;
 
 interface Operations extends Azure.ResourceManager.Operations {}
 ```
+
+## Suppression
+
+A few specs may legitimately not need this; otherwise use the standard Operations template.

--- a/packages/typespec-azure-resource-manager/src/rules/missing-x-ms-identifiers.md
+++ b/packages/typespec-azure-resource-manager/src/rules/missing-x-ms-identifiers.md
@@ -4,6 +4,16 @@
 
 Array of models must explicity define which keys are used as identifiers using the `@identifiers` decorator.
 
+## Impact
+
+- **Area:** API
+
+An old-pattern warning with no real runtime impact.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [XmsIdentifierValidation](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r4041) (warning).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -25,3 +35,7 @@ model ResourceProperties {
   array: Address[];
 }
 ```
+
+## Suppression
+
+Suppress at will.

--- a/packages/typespec-azure-resource-manager/src/rules/no-empty-model.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-empty-model.md
@@ -4,6 +4,16 @@
 
 ARM Properties with type:object that don't reference a model definition are not allowed. ARM doesn't allow generic type definitions as this leads to bad customer experience.
 
+## Impact
+
+- **Area:** API, SDK
+
+A model that accepts any schema is difficult to use from both the API and generated SDKs.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [MissingTypeObject](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r4037).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -45,3 +55,7 @@ model Information {
   postalCode: string;
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise use a defined type.

--- a/packages/typespec-azure-resource-manager/src/rules/no-override-props.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-override-props.md
@@ -5,6 +5,12 @@ Overriding an inherited property is allowed when:
 - The overriding property has the **same type** as the inherited one (by identity). Type aliases resolve to the same underlying type, and template instantiations are cached, so this naturally covers cases such as redefining `systemData: SystemData` (alias) where the parent uses `systemData: Foundations.SystemData`, or the implicit `tags: Record<string>` cloned into a model that uses `is TrackedResource<...>`.
 - Both the inherited property and the overriding property are **compatible scalars** — that is, both reduce to the same scalar family (`string`, `numeric`, or `boolean`). For example, an inherited property of type `string` may be overridden by a `string`, by a scalar that extends `string`, by a string literal, by a string-valued enum, or by an open or closed string union.
 
+## Impact
+
+- **Area:** SDK, Tooling
+
+Overridden properties can crash the breaking-change tool and are unsupported by most languages.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -61,3 +67,7 @@ model Cat extends Pet {
   meow: boolean;
 }
 ```
+
+## Suppression
+
+Requires SDK sign-off. Remove overridden properties from the base type - they should be represented only in leaf types.

--- a/packages/typespec-azure-resource-manager/src/rules/no-resource-delete-operation.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-resource-delete-operation.md
@@ -4,6 +4,16 @@
 
 Every ARM resource that provides a create operation must also provide a delete operation.
 
+## Impact
+
+- **Area:** API
+
+A tracked resource without a delete operation violates the RPC contract.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [AllTrackedResourcesMustHaveDelete](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -32,3 +42,7 @@ interface EmployeeOperations {
   delete is ArmResourceDeleteWithoutOkAsync<Employee>;
 }
 ```
+
+## Suppression
+
+Suppress per the RPC guidelines; otherwise add a standard delete operation for the resource.

--- a/packages/typespec-azure-resource-manager/src/rules/no-response-body.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-response-body.md
@@ -7,6 +7,12 @@ ARM operation responses with status code 202 or 204 should not contain a respons
 
 ### For 202 and 204 status codes (response body should be empty)
 
+## Impact
+
+- **Area:** API
+
+A response - usually a 202 - carries a body that should be empty.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -88,3 +94,7 @@ op walk(): ArmCreatedResponse<{
   }
 }
 ```
+
+## Suppression
+
+Suppress at will for 202, but never for 204. Use the standard operation and response templates.

--- a/packages/typespec-azure-resource-manager/src/rules/patch-envelope.md
+++ b/packages/typespec-azure-resource-manager/src/rules/patch-envelope.md
@@ -1,5 +1,11 @@
 Patch envelope properties should match the resource properties. If a resource defines envelope properties such as `identity`, `managedBy`, `plan`, `sku`, or `tags`, these properties must also be present in the PATCH request body so they can be updated.
 
+## Impact
+
+- **Area:** API
+
+The PATCH operation is missing updateable envelope properties.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -45,3 +51,7 @@ interface FooResources {
   update is ArmCustomPatchAsync<FooResource, PatchFoo>;
 }
 ```
+
+## Suppression
+
+There are no hard-and-fast rules, but patchable envelope properties should generally be standard - include patchable versions of the envelope properties.

--- a/packages/typespec-azure-resource-manager/src/rules/resource-name.md
+++ b/packages/typespec-azure-resource-manager/src/rules/resource-name.md
@@ -1,5 +1,11 @@
 Check the resource name. ARM resource model names must contain only alphanumeric characters (starting with an uppercase letter), and the `name` property must be a read-only `@path` parameter.
 
+## Impact
+
+- **Area:** API, SDK
+
+Invalid characters in a resource name violate the RPC contract and produce invalid client parameter names, preventing SDK generation.
+
 #### ❌ Incorrect
 
 Missing `@path` decorator on `name`:
@@ -29,3 +35,7 @@ model FooResource is TrackedResource<{}> {
   ...ResourceNameParameter<FooResource>;
 }
 ```
+
+## Suppression
+
+Treat like any invalid resource name and require a fix. Use only valid characters.

--- a/packages/typespec-azure-resource-manager/src/rules/retry-after.md
+++ b/packages/typespec-azure-resource-manager/src/rules/retry-after.md
@@ -1,5 +1,11 @@
 Check if the `Retry-After` header appears in the response for long-running operations. For long-running operations, the `Retry-After` header indicates how long the client should wait before polling the operation status. This header should be included in 201 or 202 responses.
 
+## Impact
+
+- **Area:** API
+
+Long-running or throttled operations should expose a standard Retry-After header so clients can poll correctly.
+
 #### ❌ Incorrect
 
 Custom long-running operation missing `Retry-After` header:
@@ -42,3 +48,7 @@ interface FooResources {
   };
 }
 ```
+
+## Suppression
+
+Suppress only when required to match an existing API; otherwise add the standard Retry-After header.

--- a/packages/typespec-azure-resource-manager/src/rules/secret-prop.md
+++ b/packages/typespec-azure-resource-manager/src/rules/secret-prop.md
@@ -8,6 +8,16 @@ When defining the model returned in an ARM operation, any property that contains
 ARM RPC rule: [`RPC-v1-13`](https://armwiki.azurewebsites.net/api_contracts/guidelines/rpc.html)
 :::
 
+## Impact
+
+- **Area:** SDK, API
+
+Returning a secret in a response violates the RPC contract unless the property is genuinely not a secret.
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule [XMSSecretInResponse](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
+
 #### ❌ Incorrect
 
 ```tsp
@@ -34,3 +44,7 @@ Or create a reusable scalar marked with `@secret`:
 @secret
 scalar apiKey extends string;
 ```
+
+## Suppression
+
+Suppress only if the property is not actually a secret; otherwise mark it as a `password` type or with the `@secret` decorator.

--- a/packages/typespec-azure-resource-manager/src/rules/unsupported-type.md
+++ b/packages/typespec-azure-resource-manager/src/rules/unsupported-type.md
@@ -9,6 +9,12 @@ Primitive types currently unsupported in ARM:
 - uint32
 - uint64
 
+## Impact
+
+- **Area:** SDK
+
+The data type cannot be modeled in SDKs.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -24,3 +30,7 @@ model ResourceProperties {
   count: int32;
 }
 ```
+
+## Suppression
+
+Requires SDK sign-off. Use standard schemas and built-in types.

--- a/packages/typespec-azure-resource-manager/src/rules/version-progression.md
+++ b/packages/typespec-azure-resource-manager/src/rules/version-progression.md
@@ -5,6 +5,12 @@ ARM service api-versions must:
 
 This rule complements [`arm-resource-invalid-version-format`](./arm-resource-invalid-version-format.md), which validates the format of each individual version string. `arm-version-progression` does not flag malformed version strings — those are reported by the format rule.
 
+## Impact
+
+- **Area:** API, SDK, Tooling
+
+Out-of-order versions, or versions with matching dates, make specs unmaintainable and cause SDK problems.
+
 #### ❌ Incorrect
 
 A preview and a stable version share the same date:
@@ -60,3 +66,7 @@ enum Versions {
   v2024_06_02_preview: "2024-06-02-preview",
 }
 ```
+
+## Suppression
+
+Do not suppress. Ensure new api-versions are unique and monotonically increasing from top to bottom in the Versions enum.


### PR DESCRIPTION
## Summary

Adds a **Reviewer advice** section to the linter rule documentation pages under `website/src/content/docs/docs/libraries/*/rules/`. Each section gives spec reviewers concise, natural-language guidance on how to evaluate a rule violation, covering:

- **Impact** — the affected area(s) (API, SDK, emitters, tooling) and what a violation causes.
- **How to fix** — the change that resolves the violation.
- **When to suppress** — whether/when a suppression is acceptable.

This helps reviewers judge how seriously to treat each violation and whether a suppression should be accepted.

## Details

73 rule docs updated across three libraries:

- `@azure-tools/typespec-azure-core` (35 rules)
- `@azure-tools/typespec-azure-resource-manager` (36 rules)
- `@azure-tools/typespec-client-generator-core` (2 rules)

Content is derived from the impact / how-to-fix / when-to-suppress guidance for each rule, including LintDiff correspondences where applicable. Docs-only change; no code or package behavior is affected. Files verified to be unchanged by `prettier`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
