### PR TITLE
Align Agent base type ResponseStatus enum and createdAt with ARM guidelines

### DIFF
--- a/.chronus/changes/agent-base-type-enum-values-pascalcase-2026-7-9-16-0-0.md
+++ b/.chronus/changes/agent-base-type-enum-values-pascalcase-2026-7-9-16-0-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Align the experimental Agent base type with ARM naming and datatype guidelines: use PascalCase values for the `ResponseStatus` enum (for example `Completed`, `InProgress`), and use `utcDateTime` instead of `unixTimestamp32` for the `createdAt` timestamp properties (on `ConversationProperties` and `ResponseProperties`) to match other ARM datetime properties.

--- a/packages/samples/test/output/azure/resource-manager/resource-types/agent/@azure-tools/typespec-autorest/2024-06-01/openapi.json
+++ b/packages/samples/test/output/azure/resource-manager/resource-types/agent/@azure-tools/typespec-autorest/2024-06-01/openapi.json
@@ -2017,12 +2017,12 @@
       "type": "string",
       "description": "The status of a response.",
       "enum": [
-        "completed",
-        "failed",
-        "cancelled",
-        "incomplete",
-        "queued",
-        "in_progress"
+        "Completed",
+        "Failed",
+        "Cancelled",
+        "Incomplete",
+        "Queued",
+        "InProgress"
       ],
       "x-ms-enum": {
         "name": "ResponseStatus",
@@ -2030,32 +2030,32 @@
         "values": [
           {
             "name": "Completed",
-            "value": "completed",
+            "value": "Completed",
             "description": "The response completed successfully."
           },
           {
             "name": "Failed",
-            "value": "failed",
+            "value": "Failed",
             "description": "The response failed."
           },
           {
             "name": "Cancelled",
-            "value": "cancelled",
+            "value": "Cancelled",
             "description": "The response was cancelled."
           },
           {
             "name": "Incomplete",
-            "value": "incomplete",
+            "value": "Incomplete",
             "description": "The response is incomplete."
           },
           {
             "name": "Queued",
-            "value": "queued",
+            "value": "Queued",
             "description": "The response is queued for execution."
           },
           {
             "name": "InProgress",
-            "value": "in_progress",
+            "value": "InProgress",
             "description": "The response is in progress."
           }
         ]
@@ -2243,8 +2243,8 @@
           "readOnly": true
         },
         "createdAt": {
-          "type": "integer",
-          "format": "int32",
+          "type": "string",
+          "format": "date-time",
           "description": "Timestamp of when the conversation was created. Read-only.",
           "readOnly": true
         },
@@ -2384,8 +2384,8 @@
           "readOnly": true
         },
         "createdAt": {
-          "type": "integer",
-          "format": "int32",
+          "type": "string",
+          "format": "date-time",
           "description": "Timestamp of when the response was created. Read-only.",
           "readOnly": true
         },

--- a/packages/typespec-azure-resource-manager/lib/base-types/agent.tsp
+++ b/packages/typespec-azure-resource-manager/lib/base-types/agent.tsp
@@ -189,7 +189,7 @@ model ConversationProperties {
 
   /** Timestamp of when the conversation was created. Read-only. */
   @visibility(Lifecycle.Read)
-  createdAt?: unixTimestamp32;
+  createdAt?: utcDateTime;
 }
 
 /**
@@ -226,24 +226,24 @@ model ConversationOutput {
 union ResponseStatus {
   /** The response completed successfully. */
   @Azure.Core.lroSucceeded
-  Completed: "completed",
+  Completed: "Completed",
 
   /** The response failed. */
   @Azure.Core.lroFailed
-  Failed: "failed",
+  Failed: "Failed",
 
   /** The response was cancelled. */
   @Azure.Core.lroCanceled
-  Cancelled: "cancelled",
+  Cancelled: "Cancelled",
 
   /** The response is incomplete. */
-  Incomplete: "incomplete",
+  Incomplete: "Incomplete",
 
   /** The response is queued for execution. */
-  Queued: "queued",
+  Queued: "Queued",
 
   /** The response is in progress. */
-  InProgress: "in_progress",
+  InProgress: "InProgress",
 
   string,
 }
@@ -259,7 +259,7 @@ model ResponseProperties {
 
   /** Timestamp of when the response was created. Read-only. */
   @visibility(Lifecycle.Read)
-  createdAt?: unixTimestamp32;
+  createdAt?: utcDateTime;
 
   /** Model ID used to generate the response. May be specified on request to override the agent default; read-only in GET. */
   `model`?: string;

--- a/website/src/content/docs/docs/libraries/azure-resource-manager/reference/data-types.md
+++ b/website/src/content/docs/docs/libraries/azure-resource-manager/reference/data-types.md
@@ -1770,10 +1770,10 @@ model Azure.ResourceManager.BaseTypes.Agents.ConversationProperties
 
 #### Properties
 
-| Name            | Type              | Description                                                                 |
-| --------------- | ----------------- | --------------------------------------------------------------------------- |
-| conversationId? | `string`          | Unique conversation identifier. Read-only (set by the service on creation). |
-| createdAt?      | `unixTimestamp32` | Timestamp of when the conversation was created. Read-only.                  |
+| Name            | Type          | Description                                                                 |
+| --------------- | ------------- | --------------------------------------------------------------------------- |
+| conversationId? | `string`      | Unique conversation identifier. Read-only (set by the service on creation). |
+| createdAt?      | `utcDateTime` | Timestamp of when the conversation was created. Read-only.                  |
 
 ### `InputMessage` {#Azure.ResourceManager.BaseTypes.Agents.InputMessage}
 
@@ -1878,7 +1878,7 @@ model Azure.ResourceManager.BaseTypes.Agents.ResponseProperties
 | Name        | Type                                                                                      | Description                                                                                                          |
 | ----------- | ----------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
 | responseId? | `string`                                                                                  | Unique response identifier. Read-only (set by the service).                                                          |
-| createdAt?  | `unixTimestamp32`                                                                         | Timestamp of when the response was created. Read-only.                                                               |
+| createdAt?  | `utcDateTime`                                                                             | Timestamp of when the response was created. Read-only.                                                               |
 | model?      | `string`                                                                                  | Model ID used to generate the response. May be specified on request to override the agent default; read-only in GET. |
 | status?     | [`ResponseStatus`](./data-types.md#Azure.ResourceManager.BaseTypes.Agents.ResponseStatus) | The status of the response. Read-only.                                                                               |
 | input       | [`InputMessage`](./data-types.md#Azure.ResourceManager.BaseTypes.Agents.InputMessage)     | Content input to the model. Required on create.                                                                      |
@@ -1893,14 +1893,14 @@ union Azure.ResourceManager.BaseTypes.Agents.ResponseStatus
 
 #### Variants
 
-| Name       | Type            | Description                           |
-| ---------- | --------------- | ------------------------------------- |
-| Completed  | `"completed"`   | The response completed successfully.  |
-| Failed     | `"failed"`      | The response failed.                  |
-| Cancelled  | `"cancelled"`   | The response was cancelled.           |
-| Incomplete | `"incomplete"`  | The response is incomplete.           |
-| Queued     | `"queued"`      | The response is queued for execution. |
-| InProgress | `"in_progress"` | The response is in progress.          |
+| Name       | Type           | Description                           |
+| ---------- | -------------- | ------------------------------------- |
+| Completed  | `"Completed"`  | The response completed successfully.  |
+| Failed     | `"Failed"`     | The response failed.                  |
+| Cancelled  | `"Cancelled"`  | The response was cancelled.           |
+| Incomplete | `"Incomplete"` | The response is incomplete.           |
+| Queued     | `"Queued"`     | The response is queued for execution. |
+| InProgress | `"InProgress"` | The response is in progress.          |
 
 ## Azure.ResourceManager.CommonTypes
 


### PR DESCRIPTION
Addresses Agent base type feedback by aligning the experimental Agent base type with ARM guidelines.

## Changes
- **`ResponseStatus` enum**: use PascalCase values (`Completed`, `Failed`, `Cancelled`, `Incomplete`, `Queued`, `InProgress`) per ARM naming guidelines.
- **`createdAt` properties** (on `ConversationProperties` and `ResponseProperties`): use `utcDateTime` instead of `unixTimestamp32` to match other ARM datetime properties (e.g. `SystemData.createdAt`). Generated OpenAPI now emits `type: string, format: date-time`.

## Validation
- Regenerated ARM reference docs (`data-types.md`) and the agent sample OpenAPI output.
- ARM TypeSpec library compiles clean (`lint-typespec-library`, `--warn-as-error`).
- Chronus `fix` changelog entry included.