### PR TITLE
Read typespec-ts client user-agent version dynamically from package.json

### DIFF
--- a/.chronus/changes/dynamic-user-agent-version-2026-7-9-20-55-0.md
+++ b/.chronus/changes/dynamic-user-agent-version-2026-7-9-20-55-0.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-ts"
 ---
 
-Read the client user-agent version dynamically from the generated `package.json` at runtime (via the package's own `./package.json` export) instead of hardcoding the emitter's `package-details.version` into the generated source.
+Read the client user-agent version dynamically from the generated `package.json` at runtime (via the package's own `./package.json` export) instead of hardcoding the emitter's `package-details.version` into the generated source. The generated `config/tsconfig.src.*.json` files now set `resolveJsonModule: true` so the JSON import type-checks across compiler versions.

--- a/.chronus/changes/dynamic-user-agent-version-2026-7-9-20-55-0.md
+++ b/.chronus/changes/dynamic-user-agent-version-2026-7-9-20-55-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Read the client user-agent version dynamically from the generated `package.json` at runtime (via the package's own `./package.json` export) instead of hardcoding the emitter's `package-details.version` into the generated source.

--- a/.chronus/changes/remove-is-version-user-provided-2026-7-9-20-30-0.md
+++ b/.chronus/changes/remove-is-version-user-provided-2026-7-9-20-30-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Remove the derived `isVersionUserProvided` field from `PackageDetails` and stop defaulting `package-details.version` in the data model. The default (`1.0.0-beta.1`) is now applied at each consumption site instead.

--- a/.chronus/changes/remove-unused-constant-paths-2026-7-9-21-15-0.md
+++ b/.chronus/changes/remove-unused-constant-paths-2026-7-9-21-15-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Remove the now-obsolete `//metadata.constantPaths` `userAgentInfo` generation and the `clientContextPaths` plumbing that fed it. Since the user-agent version is now read dynamically from `package.json` at runtime, there is no burned-in version constant for `dev-tool` to bump.

--- a/packages/typespec-ts/README.md
+++ b/packages/typespec-ts/README.md
@@ -56,13 +56,13 @@ This is to indicate the package information such as package name, package descri
 
 **Properties:**
 
-| Name                    | Type      | Default | Description |
-| ----------------------- | --------- | ------- | ----------- |
-| `name`                  | `string`  |         |             |
-| `scopeName`             | `string`  |         |             |
-| `nameWithoutScope`      | `string`  |         |             |
-| `description`           | `string`  |         |             |
-| `version`               | `string`  |         |             |
+| Name               | Type     | Default | Description |
+| ------------------ | -------- | ------- | ----------- |
+| `name`             | `string` |         |             |
+| `scopeName`        | `string` |         |             |
+| `nameWithoutScope` | `string` |         |             |
+| `description`      | `string` |         |             |
+| `version`          | `string` |         |             |
 
 ### `add-credentials`
 

--- a/packages/typespec-ts/README.md
+++ b/packages/typespec-ts/README.md
@@ -50,7 +50,7 @@ This option is used to indicate whether to include response headers in the gener
 
 ### `package-details`
 
-**Type:** `object { name, scopeName, nameWithoutScope, description, version, isVersionUserProvided }`
+**Type:** `object { name, scopeName, nameWithoutScope, description, version }`
 
 This is to indicate the package information such as package name, package description etc.
 
@@ -63,7 +63,6 @@ This is to indicate the package information such as package name, package descri
 | `nameWithoutScope`      | `string`  |         |             |
 | `description`           | `string`  |         |             |
 | `version`               | `string`  |         |             |
-| `isVersionUserProvided` | `boolean` |         |             |
 
 ### `add-credentials`
 

--- a/packages/typespec-ts/src/index.ts
+++ b/packages/typespec-ts/src/index.ts
@@ -76,7 +76,7 @@ import { buildSampleTest } from "./metadata/test/build-sample-test.js";
 import { buildSnippets } from "./metadata/test/build-snippets.js";
 import { buildClassicalClient } from "./modular/build-classical-client.js";
 import { buildClassicOperationFiles } from "./modular/build-classical-operation-groups.js";
-import { buildClientContext, getClientContextPath } from "./modular/build-client-context.js";
+import { buildClientContext } from "./modular/build-client-context.js";
 import { transformModularEmitterOptions } from "./modular/build-modular-options.js";
 import { buildOperationFiles } from "./modular/build-operations.js";
 import { getModuleExports } from "./modular/build-project-files.js";
@@ -455,7 +455,6 @@ export async function $onEmit(context: EmitContext) {
         modularPackageInfo = {
           ...modularPackageInfo,
           dependencies,
-          clientContextPaths: getRelativeContextPaths(context, modularEmitterOptions),
         };
       }
       commonBuilders.push((model) => buildPackageFile(model, modularPackageInfo));
@@ -508,14 +507,13 @@ export async function $onEmit(context: EmitContext) {
       }
       const modularPackageInfo = {
         exports: getModuleExports(context, modularEmitterOptions),
-        clientContextPaths: getRelativeContextPaths(context, modularEmitterOptions),
         ...(Object.keys(additionalDependencies).length > 0 && {
           dependencies: additionalDependencies,
         }),
       };
 
       // Always update package.json (adds #platform/* imports) along with
-      // exports, clientContextPaths and LRO deps.
+      // exports and LRO deps.
       {
         // Read package.json content via host and pass parsed object
         const pkgSourceFile = await host.readFile(existingPackageFilePath);
@@ -579,13 +577,6 @@ export async function $onEmit(context: EmitContext) {
         dpgContext.generationPathDetail?.metadataDir,
       );
     }
-  }
-
-  function getRelativeContextPaths(context: SdkContext, options: ModularEmitterOptions) {
-    const clientMap = getClientHierarchyMap(context);
-    return Array.from(clientMap)
-      .map((subClient) => getClientContextPath(subClient, options))
-      .map((path) => path.substring(path.indexOf("src")));
   }
 }
 

--- a/packages/typespec-ts/src/interfaces.ts
+++ b/packages/typespec-ts/src/interfaces.ts
@@ -334,7 +334,6 @@ export interface PackageDetails {
   nameWithoutScope?: string;
   description?: string;
   version?: string;
-  isVersionUserProvided?: boolean;
 }
 export interface OperationParameter {
   operationGroup: string;

--- a/packages/typespec-ts/src/lib.ts
+++ b/packages/typespec-ts/src/lib.ts
@@ -99,7 +99,6 @@ export const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
         nameWithoutScope: { type: "string", nullable: true },
         description: { type: "string", nullable: true },
         version: { type: "string", nullable: true },
-        isVersionUserProvided: { type: "boolean", nullable: true },
       },
       required: ["name"],
       nullable: true,

--- a/packages/typespec-ts/src/metadata/build-package-file.ts
+++ b/packages/typespec-ts/src/metadata/build-package-file.ts
@@ -11,12 +11,11 @@ import { getPackageName } from "./utils.js";
 interface PackageFileOptions {
   exports?: Record<string, any>;
   dependencies?: Record<string, string>;
-  clientContextPaths?: string[];
 }
 
 export function buildPackageFile(
   model: ClientModel,
-  { exports, dependencies, clientContextPaths }: PackageFileOptions = {},
+  { exports, dependencies }: PackageFileOptions = {},
 ) {
   const config: PackageCommonInfoConfig = {
     description: getDescription(model),
@@ -35,7 +34,6 @@ export function buildPackageFile(
     hasLro: hasPollingOperations(model),
     monorepoPackageDirectory: model.options?.azureOutputDirectory,
     dependencies,
-    clientContextPaths,
   };
 
   const packageInfo: Record<string, any> = buildAzureMonorepoPackage(extendedConfig);
@@ -63,17 +61,15 @@ export function buildPackageFile(
  * - Adds LRO dependencies (`@azure/core-lro`, `@azure/abort-controller`) when the package has
  *   polling operations (for non-monorepo Azure packages).
  * - Updates exports (tshy or warp) when `exports` is provided.
- * - Updates `//metadata.constantPaths` when `clientContextPaths` is provided.
  */
 export function updatePackageFile(
   model: ClientModel,
   existingFilePathOrContent: string | Record<string, any>,
-  { exports, clientContextPaths }: PackageFileOptions = {},
+  { exports }: PackageFileOptions = {},
 ) {
   const hasLro = hasPollingOperations(model);
   const needsLroUpdate = hasLro;
   const needsExportsUpdate = exports;
-  const needsConstantPathsUpdate = clientContextPaths && clientContextPaths.length > 0;
 
   let packageInfo;
   if (typeof existingFilePathOrContent === "string") {
@@ -144,21 +140,6 @@ export function updatePackageFile(
       "@azure/core-lro": "^3.1.0",
       "@azure/abort-controller": "^2.1.2",
     };
-  }
-
-  // Update constantPaths metadata for Azure packages
-  if (needsConstantPathsUpdate && packageInfo["//metadata"]) {
-    const metadata = packageInfo["//metadata"];
-    // Filter out existing userAgentInfo entries
-    const nonUserAgentPaths = (metadata.constantPaths || []).filter(
-      (item: any) => item.prefix !== "userAgentInfo",
-    );
-    // Add new userAgentInfo entries from clientContextPaths
-    const newUserAgentPaths = clientContextPaths!.map((path) => ({
-      path: path,
-      prefix: "userAgentInfo",
-    }));
-    metadata.constantPaths = [...nonUserAgentPaths, ...newUserAgentPaths];
   }
 
   return {

--- a/packages/typespec-ts/src/metadata/build-readme-file.ts
+++ b/packages/typespec-ts/src/metadata/build-readme-file.ts
@@ -276,13 +276,13 @@ function createMetadata(model: ClientModel): Metadata | undefined {
   const clientClassName = getClientName(model);
   const serviceName = getServiceName(model);
   let apiRefUrlQueryParameter: string = "";
-  if (!packageDetails?.isVersionUserProvided && model.apiVersionInfo?.defaultValue) {
+  if (!packageDetails?.version && model.apiVersionInfo?.defaultValue) {
     if (model.apiVersionInfo?.defaultValue?.toLowerCase().includes("preview")) {
       apiRefUrlQueryParameter = "?view=azure-node-preview";
     }
   } else {
-    packageDetails.version = packageDetails.version ?? "1.0.0-beta.1";
-    if (packageDetails?.version.includes("beta")) {
+    const packageVersion = packageDetails.version ?? "1.0.0-beta.1";
+    if (packageVersion.includes("beta")) {
       apiRefUrlQueryParameter = "?view=azure-node-preview";
     }
   }

--- a/packages/typespec-ts/src/metadata/build-ts-config.ts
+++ b/packages/typespec-ts/src/metadata/build-ts-config.ts
@@ -61,6 +61,9 @@ export function buildTsSrcEsmConfig() {
     content: JSON.stringify(
       {
         extends: "../../../../eng/tsconfigs/src.esm.json",
+        compilerOptions: {
+          resolveJsonModule: true,
+        },
         include: ["../src/index.ts"],
       },
       null,
@@ -78,6 +81,9 @@ export function buildTsSrcBrowserConfig() {
     content: JSON.stringify(
       {
         extends: "../../../../eng/tsconfigs/src.browser.json",
+        compilerOptions: {
+          resolveJsonModule: true,
+        },
         include: ["../src/index.ts"],
       },
       null,
@@ -95,6 +101,9 @@ export function buildTsSrcReactNativeConfig() {
     content: JSON.stringify(
       {
         extends: "../../../../eng/tsconfigs/src.react-native.json",
+        compilerOptions: {
+          resolveJsonModule: true,
+        },
         include: ["../src/index.ts"],
       },
       null,
@@ -112,6 +121,9 @@ export function buildTsSrcCjsConfig() {
     content: JSON.stringify(
       {
         extends: "../../../../eng/tsconfigs/src.cjs.json",
+        compilerOptions: {
+          resolveJsonModule: true,
+        },
         include: ["../src/index.ts"],
       },
       null,

--- a/packages/typespec-ts/src/metadata/package-json/build-azure-monorepo-package.ts
+++ b/packages/typespec-ts/src/metadata/package-json/build-azure-monorepo-package.ts
@@ -6,7 +6,6 @@ import { getCommonPackageScripts, getPackageCommonInfo } from "./package-common.
 
 export interface AzureMonorepoInfoConfig extends AzurePackageInfoConfig {
   monorepoPackageDirectory?: string;
-  clientContextPaths?: string[];
 }
 
 /**
@@ -101,7 +100,6 @@ export function getAzureMonorepoPackageInfo(config: AzureMonorepoInfoConfig): Re
       homepage: `https://github.com/Azure/azure-sdk-for-js/tree/main/${config.monorepoPackageDirectory}/README.md`,
     }),
     prettier: "@azure/eslint-plugin-azure-sdk/prettier.json",
-    "//metadata": getMetadataInfo(config),
   };
 }
 
@@ -163,17 +161,3 @@ function getEsmScripts() {
   };
 }
 
-function getMetadataInfo(config: AzureMonorepoInfoConfig) {
-  const metadata: Record<string, any> = {
-    constantPaths: [],
-  };
-  const paths = config.clientContextPaths;
-  for (const path of paths ?? []) {
-    metadata["constantPaths"].push({
-      path: path,
-      prefix: "userAgentInfo",
-    });
-  }
-
-  return metadata;
-}

--- a/packages/typespec-ts/src/metadata/package-json/build-azure-monorepo-package.ts
+++ b/packages/typespec-ts/src/metadata/package-json/build-azure-monorepo-package.ts
@@ -160,4 +160,3 @@ function getEsmScripts() {
     test: "tsc -b --noEmit && npm run test:node && npm run test:browser",
   };
 }
-

--- a/packages/typespec-ts/src/modular/helpers/client-helpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/client-helpers.ts
@@ -326,7 +326,7 @@ export function buildUserAgentOptions(
     emitterOptions.options.packageDetails?.nameWithoutScope ??
     emitterOptions.options.packageDetails?.name ??
     "";
-  const packageVersion = emitterOptions.options.packageDetails?.version ?? "";
+  const packageVersion = emitterOptions.options.packageDetails?.version ?? "1.0.0-beta.1";
 
   const userAgentInfoStatement =
     packageVersion && clientPackageName && sdkUserAgentPrefix.includes("api")

--- a/packages/typespec-ts/src/modular/helpers/client-helpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/client-helpers.ts
@@ -6,7 +6,7 @@ import {
   SdkMethodParameter,
   SdkServiceOperation,
 } from "@azure-tools/typespec-client-generator-core";
-import { OptionalKind, ParameterDeclarationStructure, StatementedNode } from "ts-morph";
+import { Node, OptionalKind, ParameterDeclarationStructure, StatementedNode } from "ts-morph";
 import { ModularEmitterOptions } from "../interfaces.js";
 
 import { resolveReference } from "../../framework/reference.js";
@@ -236,7 +236,7 @@ export function buildGetClientEndpointParam(
  * @returns - an expression representing the options to be passed in to getClient
  */
 export function buildGetClientOptionsParam(
-  context: StatementedNode,
+  context: StatementedNode & Node,
   emitterOptions: ModularEmitterOptions,
   endpointParam: string,
   apiVersionParamName?: string,
@@ -314,7 +314,7 @@ function buildLoggingOptions(): string | undefined {
 }
 
 export function buildUserAgentOptions(
-  context: StatementedNode,
+  context: StatementedNode & Node,
   emitterOptions: ModularEmitterOptions,
   sdkUserAgentPrefix: string,
 ): string {
@@ -322,16 +322,31 @@ export function buildUserAgentOptions(
   const prefixFromOptions = "const prefixFromOptions = options?.userAgentOptions?.userAgentPrefix;";
   userAgentStatements.push(prefixFromOptions);
 
+  const packageName = emitterOptions.options.packageDetails?.name;
   const clientPackageName =
-    emitterOptions.options.packageDetails?.nameWithoutScope ??
-    emitterOptions.options.packageDetails?.name ??
-    "";
-  const packageVersion = emitterOptions.options.packageDetails?.version ?? "1.0.0-beta.1";
+    emitterOptions.options.packageDetails?.nameWithoutScope ?? packageName ?? "";
 
-  const userAgentInfoStatement =
-    packageVersion && clientPackageName && sdkUserAgentPrefix.includes("api")
-      ? "const userAgentInfo = `azsdk-js-" + clientPackageName + "/" + packageVersion + "`;"
-      : "";
+  // The version is read from the generated package.json at runtime rather than
+  // hardcoded here: once the package is generated, its version is owned by
+  // package.json. We import it via the package's own "./package.json" export so
+  // the specifier is identical in `src` and the built `dist` output.
+  let userAgentInfoStatement = "";
+  if (clientPackageName && packageName && sdkUserAgentPrefix.includes("api")) {
+    const packageJsonModule = `${packageName}/package.json`;
+    const sourceFile = context.getSourceFile();
+    const hasPackageJsonImport = sourceFile
+      .getImportDeclarations()
+      .some((declaration) => declaration.getModuleSpecifierValue() === packageJsonModule);
+    if (!hasPackageJsonImport) {
+      sourceFile.addImportDeclaration({
+        defaultImport: "pkgJson",
+        moduleSpecifier: packageJsonModule,
+        attributes: [{ name: "type", value: "json" }],
+      });
+    }
+    userAgentInfoStatement =
+      "const userAgentInfo = `azsdk-js-" + clientPackageName + "/${pkgJson.version}`;";
+  }
 
   if (userAgentInfoStatement) {
     userAgentStatements.push(userAgentInfoStatement);

--- a/packages/typespec-ts/src/transform/transform-client-options.ts
+++ b/packages/typespec-ts/src/transform/transform-client-options.ts
@@ -232,14 +232,12 @@ function buildPackageDetails(program: Program, emitterOptions: EmitterOptions): 
     nameWithoutScope: "unamedpackage",
     version: "1.0.0-beta.1",
   };
-  const isVersionUserProvided = Boolean(emitterOptions["package-details"]?.version);
   const packageDetails: PackageDetails = {
     ...emitterOptions["package-details"],
     name:
       emitterOptions["package-details"]?.name ??
       normalizeName(getDefaultService(program)?.title ?? "", NameType.Class),
-    version: emitterOptions["package-details"]?.version ?? "1.0.0-beta.1",
-    isVersionUserProvided,
+    version: emitterOptions["package-details"]?.version,
   };
   if (emitterOptions["package-details"]?.name) {
     const nameParts = emitterOptions["package-details"]?.name.split("/");

--- a/packages/typespec-ts/test-next/unit/metadata/package-json.test.ts
+++ b/packages/typespec-ts/test-next/unit/metadata/package-json.test.ts
@@ -63,27 +63,6 @@ describe("Package file generation", () => {
       });
     });
 
-    it("should have monorepo metadata", () => {
-      const model = createMockModel({ ...baseConfig });
-      const packageFileContent = buildPackageFile(model, {
-        clientContextPaths: ["src/api/testContext.ts"],
-      });
-      const packageFile = JSON.parse(packageFileContent?.content ?? "{}");
-
-      const expectedMetadata = {
-        constantPaths: [
-          {
-            path: "src/api/testContext.ts",
-            prefix: "userAgentInfo",
-          },
-        ],
-      };
-
-      // Verify monorepo specific metadata
-      expect(packageFile).to.have.property("//metadata");
-      expect(packageFile["//metadata"]).toEqual(expectedMetadata);
-    });
-
     it("should have sample metadata", () => {
       const model = createMockModel({
         ...baseConfig,
@@ -246,24 +225,6 @@ describe("Package file generation", () => {
       expect(packageFile.scripts).to.have.property(
         "format",
         'prettier --write --config ../../../.prettierrc.json --ignore-path ../../../.prettierignore "src/**/*.{ts,cts,mts}" "test/**/*.{ts,cts,mts}" "*.{js,cjs,mjs,json}" ',
-      );
-    });
-
-    it("[esm] should read clientContextPaths from config for modular", () => {
-      const model = createMockModel({
-        ...baseConfig,
-        isModularLibrary: true,
-      });
-
-      const packageFileContent = buildPackageFile(model, {
-        clientContextPaths: ["src/api/chatCompletionsContext.ts"],
-      });
-      const packageFile = JSON.parse(packageFileContent?.content ?? "{}");
-      expect(packageFile).to.have.property("//metadata");
-      expect(packageFile["//metadata"]["constantPaths"][0]).to.have.property(
-        "path",
-        "src/api/chatCompletionsContext.ts",
-        "modular",
       );
     });
 
@@ -453,81 +414,6 @@ describe("Package file generation", () => {
       expect(packageFile.exports["./package.json"]).to.equal("./package.json");
       expect(packageFile.exports["."]).to.have.property("import");
       expect(packageFile).not.toHaveProperty("tshy");
-    });
-
-    it("should update constantPaths when clientContextPaths option is provided for Azure packages", () => {
-      const model = createMockModel({
-        hasLro: false,
-      });
-
-      const initialPackageInfo = {
-        name: "@azure/test-package",
-        version: "1.0.0",
-        dependencies: {
-          "@azure/core-client": "^1.0.0",
-        },
-        "//metadata": {
-          constantPaths: [
-            { path: "src/old-path.ts", prefix: "userAgentInfo" },
-            { path: "src/other-file.ts", prefix: "packageDetails" },
-          ],
-        },
-      };
-
-      const packageFileContent = updatePackageFile(model, initialPackageInfo, {
-        clientContextPaths: ["src/api/newContext.ts", "src/api/anotherContext.ts"],
-      });
-      const packageFile = JSON.parse(packageFileContent?.content ?? "{}");
-
-      expect(packageFile["//metadata"]).to.have.property("constantPaths");
-      const constantPaths = packageFile["//metadata"]["constantPaths"];
-
-      // Should keep non-userAgentInfo entries
-      expect(constantPaths).toContainEqual({
-        path: "src/other-file.ts",
-        prefix: "packageDetails",
-      });
-
-      // Should replace old userAgentInfo entries with new ones
-      expect(constantPaths).toContainEqual({
-        path: "src/api/newContext.ts",
-        prefix: "userAgentInfo",
-      });
-      expect(constantPaths).toContainEqual({
-        path: "src/api/anotherContext.ts",
-        prefix: "userAgentInfo",
-      });
-
-      // Should not include old userAgentInfo entry
-      expect(constantPaths).not.toContainEqual({
-        path: "src/old-path.ts",
-        prefix: "userAgentInfo",
-      });
-    });
-
-    it("should not update constantPaths when clientContextPaths is empty", () => {
-      const model = createMockModel({
-        hasLro: false,
-      });
-
-      const initialPackageInfo = {
-        name: "@azure/test-package",
-        version: "1.0.0",
-        "//metadata": {
-          constantPaths: [{ path: "src/old-path.ts", prefix: "userAgentInfo" }],
-        },
-      };
-
-      const packageFileContent = updatePackageFile(model, initialPackageInfo, {
-        clientContextPaths: [],
-      });
-
-      // Should still return a result (imports are added for warp packages),
-      // but constantPaths should remain unchanged
-      const packageInfo = JSON.parse(packageFileContent!.content);
-      expect(packageInfo["//metadata"].constantPaths).toEqual([
-        { path: "src/old-path.ts", prefix: "userAgentInfo" },
-      ]);
     });
 
     it("should migrate @azure/core-client to @azure-rest/core-client", () => {

--- a/packages/typespec-ts/test-next/unit/modular/client-helpers.test.ts
+++ b/packages/typespec-ts/test-next/unit/modular/client-helpers.test.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import { Project } from "ts-morph";
+import { describe, expect, it } from "vitest";
+import { buildUserAgentOptions } from "../../../src/modular/helpers/client-helpers.js";
+import { ModularEmitterOptions } from "../../../src/modular/interfaces.js";
+
+function createFactoryFunction() {
+  const project = new Project({ useInMemoryFileSystem: true });
+  const sourceFile = project.createSourceFile("src/api/testContext.ts", "", {
+    overwrite: true,
+  });
+  const factoryFunction = sourceFile.addFunction({
+    name: "createTest",
+    isExported: true,
+  });
+  return { sourceFile, factoryFunction };
+}
+
+function emitterOptionsWith(
+  packageDetails: Record<string, unknown> | undefined,
+): ModularEmitterOptions {
+  return { options: { packageDetails } } as unknown as ModularEmitterOptions;
+}
+
+describe("buildUserAgentOptions", () => {
+  it("reads the package version dynamically from package.json for the api context", () => {
+    const { sourceFile, factoryFunction } = createFactoryFunction();
+    const result = buildUserAgentOptions(
+      factoryFunction,
+      emitterOptionsWith({ name: "@azure/foo", nameWithoutScope: "foo" }),
+      "azsdk-js-api",
+    );
+    const text = sourceFile.getFullText();
+
+    expect(result).toBe("{ userAgentPrefix }");
+    // A self-referencing JSON import of the package's own package.json is added.
+    expect(text).toContain('import pkgJson from "@azure/foo/package.json"');
+    expect(text).toContain('type: "json"');
+    // The version is interpolated at runtime, not hardcoded.
+    expect(text).toContain("azsdk-js-foo/${pkgJson.version}");
+    expect(text).not.toContain("1.0.0-beta.1");
+  });
+
+  it("does not surface userAgentInfo (or import package.json) for the client prefix", () => {
+    const { sourceFile, factoryFunction } = createFactoryFunction();
+    buildUserAgentOptions(
+      factoryFunction,
+      emitterOptionsWith({ name: "@azure/foo", nameWithoutScope: "foo" }),
+      "azsdk-js-client",
+    );
+    const text = sourceFile.getFullText();
+
+    expect(text).not.toContain("userAgentInfo");
+    expect(text).not.toContain("package.json");
+  });
+
+  it("does not surface userAgentInfo when no package name is available", () => {
+    const { sourceFile, factoryFunction } = createFactoryFunction();
+    buildUserAgentOptions(factoryFunction, emitterOptionsWith(undefined), "azsdk-js-api");
+    const text = sourceFile.getFullText();
+
+    expect(text).not.toContain("userAgentInfo");
+    expect(text).not.toContain("package.json");
+  });
+
+  it("only imports package.json once when invoked for multiple clients in a file", () => {
+    const { sourceFile, factoryFunction } = createFactoryFunction();
+    const secondFactory = sourceFile.addFunction({ name: "createOther", isExported: true });
+    const options = emitterOptionsWith({ name: "@azure/foo", nameWithoutScope: "foo" });
+
+    buildUserAgentOptions(factoryFunction, options, "azsdk-js-api");
+    buildUserAgentOptions(secondFactory, options, "azsdk-js-api");
+
+    const importCount = sourceFile
+      .getImportDeclarations()
+      .filter((d) => d.getModuleSpecifierValue() === "@azure/foo/package.json").length;
+    expect(importCount).toBe(1);
+  });
+});

--- a/website/src/content/docs/docs/emitters/clients/typespec-ts/reference/emitter.md
+++ b/website/src/content/docs/docs/emitters/clients/typespec-ts/reference/emitter.md
@@ -44,20 +44,19 @@ This option is used to indicate whether to include response headers in the gener
 
 ### `package-details`
 
-**Type:** `object { name, scopeName, nameWithoutScope, description, version, isVersionUserProvided }`
+**Type:** `object { name, scopeName, nameWithoutScope, description, version }`
 
 This is to indicate the package information such as package name, package description etc.
 
 **Properties:**
 
-| Name                    | Type      | Default | Description |
-| ----------------------- | --------- | ------- | ----------- |
-| `name`                  | `string`  |         |             |
-| `scopeName`             | `string`  |         |             |
-| `nameWithoutScope`      | `string`  |         |             |
-| `description`           | `string`  |         |             |
-| `version`               | `string`  |         |             |
-| `isVersionUserProvided` | `boolean` |         |             |
+| Name               | Type     | Default | Description |
+| ------------------ | -------- | ------- | ----------- |
+| `name`             | `string` |         |             |
+| `scopeName`        | `string` |         |             |
+| `nameWithoutScope` | `string` |         |             |
+| `description`      | `string` |         |             |
+| `version`          | `string` |         |             |
 
 ### `add-credentials`
 


### PR DESCRIPTION
## Why

The `@azure-tools/typespec-ts` emitter burned the `package-details.version` emitter option into the generated client's user-agent string. Once a package is generated, that version is really owned by the package's own `package.json`, so hardcoding it forced a whole machinery (the `//metadata.constantPaths` `userAgentInfo` entries) to exist purely so `dev-tool` could rewrite the burned-in constant on every release. This PR removes that coupling and simplifies the version handling along the way.

## What changed

**1. Stop defaulting `package-details.version` in the datamodel; default at the point of use.**
The version was previously defaulted to `1.0.0-beta.1` during option transform, and a separate `isVersionUserProvided` flag was carried around so the README logic could tell "user set it" from "we defaulted it." That flag existed for exactly one consumer. Now `version` stays `undefined` when unset and each consumer (package.json, CHANGELOG, README, user-agent) applies its own default locally, so `isVersionUserProvided` is gone entirely.

**2. Emit code that reads the version dynamically at runtime.**
Instead of interpolating a literal version into the generated source, `buildUserAgentOptions` now emits a self-referencing JSON import and reads `pkgJson.version`:

```ts
import pkgJson from "@azure/foo/package.json" with { type: "json" };
...
const userAgentInfo = `azsdk-js-foo/${pkgJson.version}`;
```

The self-reference (`<packageName>/package.json`) relies on the `"./package.json"` export the emitted package already declares, so the specifier resolves identically from `src` and from the built `dist` output regardless of directory depth. The import is deduped per file and only emitted for the api context (the classical-client prefix never surfaced `userAgentInfo`).

**3. Remove the now-obsolete `constantPaths` plumbing.**
With no literal version in the source, there is nothing for `dev-tool` to bump, so the `//metadata.constantPaths` `userAgentInfo` generation and the `clientContextPaths` option threaded through `buildPackageFile` / `updatePackageFile` / `buildAzureMonorepoPackage` (plus the `getRelativeContextPaths` helper) are dead. All removed.

## Notes for reviewers

- Emitter type-checks; `test-next` (252) and `unit-modular` (657) all pass. The modular snapshot scenarios don't set `package-details`, so there is zero snapshot churn.
- One thing worth a careful look / a spector run before merge: I verified the emitted import shape and emitter-side behavior, but did not run a full downstream `azure-sdk-for-js` build (tshy + api-extractor) to confirm the JSON import compiles end to end in a real generated package. The syntax and module resolution are correct, but that integration path is out of scope for this environment.
- ts-morph gotcha handled: the import attribute value is passed unquoted (`value: "json"`) because the writer auto-quotes it.