### PR TITLE
[TS] Document api-version, examples-dir, namespace emitter options; remove unused should-use-pnpm-dep

### DIFF
--- a/.chronus/changes/remove-should-use-pnpm-dep-option-2026-7-13-15-30-0.md
+++ b/.chronus/changes/remove-should-use-pnpm-dep-option-2026-7-13-15-30-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+[TS] Remove the unused internal `should-use-pnpm-dep` emitter option and document the `api-version`, `examples-dir`, and `namespace` options.

--- a/packages/typespec-ts/README.md
+++ b/packages/typespec-ts/README.md
@@ -42,6 +42,29 @@ options:
 Defines the emitter output directory. Defaults to `{output-dir}/@azure-tools/typespec-ts`
 See [Configuring output directory for more info](https://typespec.io/docs/handbook/configuration/configuration/#configuring-output-directory)
 
+### `api-version`
+
+**Type:** `string | object`
+
+Use this flag if you would like to generate the sdk only for a specific version. Default value is the latest version. Also accepts values `latest` and `all`. For multi-service packages, provide a map from each service namespace's full name to its desired version; services not listed default to their latest version.
+
+**Options:**
+
+- `string`
+- `object`
+
+### `examples-dir`
+
+**Type:** `string`
+
+Specifies the directory where the emitter will look for example files. If the flag isn't set, the emitter defaults to using an `examples` directory located at the project root.
+
+### `namespace`
+
+**Type:** `string`
+
+Specifies the namespace you want to override for namespaces set in the spec. With this config, all namespace for the spec types will default to it.
+
 ### `include-headers-in-response`
 
 **Type:** `boolean`
@@ -198,12 +221,6 @@ typespec-title-map:
   AnomalyDetectorClient: AnomalyDetectorRest
   AnomalyDetectorClient2: AnomalyDetectorRest2
 ```
-
-### `should-use-pnpm-dep`
-
-**Type:** `boolean`
-
-Internal option for test.
 
 ### `ignore-nullable-on-optional`
 

--- a/packages/typespec-ts/src/lib.ts
+++ b/packages/typespec-ts/src/lib.ts
@@ -7,6 +7,21 @@ import { PackageDetails } from "./interfaces.js";
 
 export interface EmitterOptions {
   /**
+   * Use this flag if you would like to generate the sdk only for a specific version.
+   * Also accepts values `latest` and `all`, or a map from service namespace full name to version for multi-service packages.
+   */
+  "api-version"?: string | Record<string, string>;
+  /**
+   * Specifies the directory where the emitter will look for example files.
+   * Defaults to an `examples` directory located at the project root.
+   */
+  "examples-dir"?: string;
+  /**
+   * Specifies the namespace you want to override for namespaces set in the spec.
+   * With this config, all namespace for the spec types will default to it.
+   */
+  namespace?: string;
+  /**
    * Indicates whether to include response headers in the generated response type for modular operations.
    * When set to true, modular operation responses with model or void bodies will have their headers
    * represented as properties on the response type. Other SDK styles and response shapes are not
@@ -50,8 +65,6 @@ export interface EmitterOptions {
   "ignore-property-name-normalize"?: boolean;
   "typespec-title-map"?: Record<string, string>;
   "ignore-enum-member-name-normalize"?: boolean;
-  //TODO should remove this after finish the release tool test
-  "should-use-pnpm-dep"?: boolean;
   "ignore-nullable-on-optional"?: boolean;
   /**
    * When set to true (default for Azure services), non-model return types (arrays, scalars, enums,
@@ -84,6 +97,31 @@ export const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
   type: "object",
   additionalProperties: true,
   properties: {
+    "api-version": {
+      oneOf: [
+        { type: "string", nullable: true },
+        {
+          type: "object",
+          additionalProperties: { type: "string" },
+          required: [],
+          nullable: true,
+        },
+      ],
+      description:
+        "Use this flag if you would like to generate the sdk only for a specific version. Default value is the latest version. Also accepts values `latest` and `all`. For multi-service packages, provide a map from each service namespace's full name to its desired version; services not listed default to their latest version.",
+    } as any,
+    "examples-dir": {
+      type: "string",
+      nullable: true,
+      description:
+        "Specifies the directory where the emitter will look for example files. If the flag isn't set, the emitter defaults to using an `examples` directory located at the project root.",
+    },
+    namespace: {
+      type: "string",
+      nullable: true,
+      description:
+        "Specifies the namespace you want to override for namespaces set in the spec. With this config, all namespace for the spec types will default to it.",
+    },
     "include-headers-in-response": {
       type: "boolean",
       nullable: true,
@@ -244,11 +282,6 @@ export const EmitterOptionsSchema: JSONSchemaType<EmitterOptions> = {
         "  AnomalyDetectorClient2: AnomalyDetectorRest2",
         "```",
       ].join("\n"),
-    },
-    "should-use-pnpm-dep": {
-      type: "boolean",
-      nullable: true,
-      description: "Internal option for test.",
     },
     "ignore-nullable-on-optional": {
       type: "boolean",

--- a/website/src/content/docs/docs/emitters/clients/typespec-ts/reference/emitter.md
+++ b/website/src/content/docs/docs/emitters/clients/typespec-ts/reference/emitter.md
@@ -36,6 +36,29 @@ options:
 Defines the emitter output directory. Defaults to `{output-dir}/@azure-tools/typespec-ts`
 See [Configuring output directory for more info](https://typespec.io/docs/handbook/configuration/configuration/#configuring-output-directory)
 
+### `api-version`
+
+**Type:** `string | object`
+
+Use this flag if you would like to generate the sdk only for a specific version. Default value is the latest version. Also accepts values `latest` and `all`. For multi-service packages, provide a map from each service namespace's full name to its desired version; services not listed default to their latest version.
+
+**Options:**
+
+- `string`
+- `object`
+
+### `examples-dir`
+
+**Type:** `string`
+
+Specifies the directory where the emitter will look for example files. If the flag isn't set, the emitter defaults to using an `examples` directory located at the project root.
+
+### `namespace`
+
+**Type:** `string`
+
+Specifies the namespace you want to override for namespaces set in the spec. With this config, all namespace for the spec types will default to it.
+
 ### `include-headers-in-response`
 
 **Type:** `boolean`
@@ -192,12 +215,6 @@ typespec-title-map:
   AnomalyDetectorClient: AnomalyDetectorRest
   AnomalyDetectorClient2: AnomalyDetectorRest2
 ```
-
-### `should-use-pnpm-dep`
-
-**Type:** `boolean`
-
-Internal option for test.
 
 ### `ignore-nullable-on-optional`
 


### PR DESCRIPTION
Addresses part of #4077 (document all supported emitter CLI options).

## What
- Document three TCGC-forwarded emitter options that were supported by `typespec-ts` but undocumented:
  - `api-version` – generate the SDK for a specific version (or `latest`/`all`, or a per-service map)
  - `examples-dir` – directory the emitter looks in for example files
  - `namespace` – override namespace for spec types
- Remove the unused internal `should-use-pnpm-dep` option (it was declared in the schema/interface but never read anywhere, and was flagged with a `// TODO should remove` comment).

## Why
These options are forwarded via `context.options` into TCGC's `createSdkContext` (`api-version` → `apiVersion`, `examples-dir` → `examplesDir`, `namespace` → `namespaceFlag`) and affect generation, but were missing from the emitter options schema, so they never showed up in the generated reference docs. `api-version` in particular was only documented for Python (per the issue).

## Changes
- `packages/typespec-ts/src/lib.ts` – add the three options to `EmitterOptions` + `EmitterOptionsSchema`; remove `should-use-pnpm-dep`.
- `packages/typespec-ts/README.md` – matching doc updates.
- `website/.../typespec-ts/reference/emitter.md` – regenerated via `npm run regen-docs`.
- Changeset (`internal`).

Note: options with `additionalProperties: true` already worked at runtime; this change makes them discoverable in docs and adds validation/typing.