### PR TITLE
Enable allowImportingTsExtensions for core/eng typecheck

### DIFF
--- a/tsconfig.eng.json
+++ b/tsconfig.eng.json
@@ -4,5 +4,5 @@
     "allowJs": true
   },
   "include": ["./eng", "./core/eng"],
-  "exclude": ["./core/eng/vitest.config.ts", "./eng/scripts/doc-updater"]
+  "exclude": ["./core/eng/vitest.config.ts", "./core/eng/emitter-diff", "./eng/scripts/doc-updater"]
 }

--- a/tsconfig.eng.json
+++ b/tsconfig.eng.json
@@ -1,8 +1,9 @@
 {
   "extends": "./core/tsconfig.base.json",
   "compilerOptions": {
-    "allowJs": true
+    "allowJs": true,
+    "allowImportingTsExtensions": true
   },
   "include": ["./eng", "./core/eng"],
-  "exclude": ["./core/eng/vitest.config.ts", "./core/eng/emitter-diff", "./eng/scripts/doc-updater"]
+  "exclude": ["./core/eng/vitest.config.ts", "./eng/scripts/doc-updater"]
 }


### PR DESCRIPTION
The core PR microsoft/typespec#11122 adds the `eng/emitter-diff` tool, whose source uses Node-native `.ts`-extension imports (it runs under `node --experimental-strip-types`). This repo's `check:eng` typechecks `./core/eng` (which now includes `emitter-diff`) and was failing with **TS5097** (`An import path can only end with a '.ts' extension when 'allowImportingTsExtensions' is enabled`).

**Fix:** enable `allowImportingTsExtensions: true` in `tsconfig.eng.json` — mirroring what core's own `tsconfig.eng.json` does. `check:eng` already runs with `--noEmit`, which this flag requires. Nothing is excluded; `emitter-diff` stays fully typechecked.

Companion to microsoft/typespec#11122.