### PR TITLE
[specs] release azure-http-specs 0.1.0-alpha.43 for 0.70.0

### DIFF
--- a/packages/azure-http-specs/CHANGELOG.md
+++ b/packages/azure-http-specs/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @azure-tools/azure-http-specs
 
+## 0.1.0-alpha.43
+
+### Bump dependencies
+
+- Republish aligned with the TypeSpec `1.14.0` / TypeSpec Azure `0.70.0` release. Peer dependencies now resolve to `@azure-tools/typespec-azure-core@^0.70.0`, `@typespec/compiler@^1.14.0`, `@typespec/http@^1.14.0`, `@typespec/rest@^0.84.0`, `@typespec/versioning@^0.84.0`, and `@typespec/xml@^0.84.0`, so downstream emitters (e.g. `@typespec/http-client-python`) can install against the `0.70.0` line.
+
 ## 0.1.0-alpha.42
 
 ### Features

--- a/packages/azure-http-specs/package.json
+++ b/packages/azure-http-specs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/azure-http-specs",
-  "version": "0.1.0-alpha.42",
+  "version": "0.1.0-alpha.43",
   "description": "Azure Spec scenarios and mock apis",
   "main": "dist/index.js",
   "type": "module",


### PR DESCRIPTION
## Why

PR #4896 ("Prepare publish for 0.70.0") bumped `@azure-tools/typespec-azure-core` to `0.70.0` but did **not** bump `@azure-tools/azure-http-specs`, so it remains at `0.1.0-alpha.42` whose published peer is `@azure-tools/typespec-azure-core@^0.69.0`.

As a result, the `@typespec/http-client-python` release PR (microsoft/typespec#11252) fails `npm ci` with an `ERESOLVE` peer conflict:

```
Found: @azure-tools/typespec-azure-core@0.70.0
peer @azure-tools/typespec-azure-core@"^0.69.0" from @azure-tools/azure-http-specs@0.1.0-alpha.42
```

No published `azure-http-specs` (public npm or the azure-sdk-for-js feed) currently accepts stable `0.70.0`.

## What

Bump `@azure-tools/azure-http-specs` to `0.1.0-alpha.43` and republish. Its `workspace:^` peer ranges resolve against `main` (now on `0.70.0` / `1.14.0`), so the republished package carries `@azure-tools/typespec-azure-core@^0.70.0` and the `1.14.0` core peers.

Draft for maintainer review of the release/publish process.
