### PR TITLE
Bump version for hotfix: typespec-java@0.45.6

### DIFF
--- a/.chronus/changes/remove-js-yaml-lodash-typespec-java-2026-7-10-0-0-0.md
+++ b/.chronus/changes/remove-js-yaml-lodash-typespec-java-2026-7-10-0-0-0.md
@@ -1,7 +1,0 @@
----
-changeKind: dependencies
-packages:
-  - "@azure-tools/typespec-java"
----
-
-[Java] Remove unused `js-yaml` and `lodash` dependencies.

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log - @azure-tools/typespec-java
 
+## 0.45.6 (2026-07-15)
+
+Compatible with compiler 1.14.0.
+
+- Replaced `js-yaml` with `yaml`, and `lodash` with builtin.
+
 ## 0.45.4 (2026-06-18)
 
 Compatible with compiler 1.13.0.

--- a/packages/typespec-java/package.json
+++ b/packages/typespec-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.45.4",
+  "version": "0.45.6",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
Prepares the hotfix release for `@azure-tools/typespec-java@0.45.6`.

### Changes
- Bump `@azure-tools/typespec-java` version `0.45.4` -> `0.45.6`
- Add `CHANGELOG.md` entry for `0.45.6`
- Remove consumed chronus change file

### Notes
- `0.45.6` (not `0.45.5`) because `0.45.5` was already published on npm from the pre-migration repo.
- Target branch: `release/july-2026` (hotfix, not `main`).