### PR TITLE
fix(arm): constrain BaseTypeInfo.baseType to a BaseType extensible enum

### DIFF
--- a/.chronus/changes/agent-base-type-constrained-basetype-enum-2026-7-14-0-0-0.md
+++ b/.chronus/changes/agent-base-type-constrained-basetype-enum-2026-7-14-0-0-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Constrain the `baseType` field of the experimental `BaseTypeInfo` to a new `BaseType` extensible enum (a union of `Agent` and `Relationship` with a `string` variant) instead of a free-form `string`, following the Azure `no-enum` / `no-closed-literal-union` conventions.

--- a/packages/samples/test/output/azure/resource-manager/resource-types/agent/@azure-tools/typespec-autorest/2024-06-01/openapi.json
+++ b/packages/samples/test/output/azure/resource-manager/resource-types/agent/@azure-tools/typespec-autorest/2024-06-01/openapi.json
@@ -2168,13 +2168,37 @@
       },
       "readOnly": true
     },
+    "Azure.ResourceManager.BaseTypes.BaseType": {
+      "type": "string",
+      "description": "The set of Azure base types a resource may declare conformance to via the\n`@azureBaseType` decorator. Modeled as an extensible (open) enum so additional\nbase types can be introduced without a breaking change.",
+      "enum": [
+        "Agent",
+        "Relationship"
+      ],
+      "x-ms-enum": {
+        "name": "BaseType",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Agent",
+            "value": "Agent",
+            "description": "The Agent base type."
+          },
+          {
+            "name": "Relationship",
+            "value": "Relationship",
+            "description": "The Relationship base type."
+          }
+        ]
+      }
+    },
     "Azure.ResourceManager.BaseTypes.BaseTypeInfo": {
       "type": "object",
       "description": "An ARM-managed base type descriptor identifying the schema contract a resource conforms to.\nUsed as a parameter to the `@azureBaseType` decorator to indicate which\nbase types a resource conforms to.",
       "properties": {
         "baseType": {
-          "type": "string",
-          "description": "The base type identifier (for example, \"Agent\")."
+          "$ref": "#/definitions/Azure.ResourceManager.BaseTypes.BaseType",
+          "description": "The base type identifier."
         },
         "version": {
           "type": "string",

--- a/packages/typespec-azure-resource-manager/README.md
+++ b/packages/typespec-azure-resource-manager/README.md
@@ -704,7 +704,7 @@ model ContosoApplianceProperties is AgentPropertiesAppliance<ContosoApplianceDef
 
 // The @azureBaseType decorator marks the resource as conforming to the Agent base type.
 // (The Agent template applies this automatically, but it can also be applied directly.)
-@azureBaseType(#{ baseType: "Agent", version: "2024-06-01" })
+@azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
 model ContosoApplianceAgent is TrackedResource<ContosoApplianceProperties> {
   ...ResourceNameParameter<ContosoApplianceAgent>;
 }

--- a/packages/typespec-azure-resource-manager/generated-defs/Azure.ResourceManager.BaseTypes.ts
+++ b/packages/typespec-azure-resource-manager/generated-defs/Azure.ResourceManager.BaseTypes.ts
@@ -1,7 +1,7 @@
 import type { DecoratorContext, DecoratorValidatorCallbacks, Model } from "@typespec/compiler";
 
 export interface BaseTypeInfo {
-  readonly baseType: string;
+  readonly baseType: "Agent" | "Relationship" | string;
   readonly version: string;
 }
 
@@ -24,7 +24,7 @@ export interface BaseTypeInfo {
  *
  * // The @azureBaseType decorator marks the resource as conforming to the Agent base type.
  * // (The Agent template applies this automatically, but it can also be applied directly.)
- * @azureBaseType(#{ baseType: "Agent", version: "2024-06-01" })
+ * @azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
  * model ContosoApplianceAgent is TrackedResource<ContosoApplianceProperties> {
  *   ...ResourceNameParameter<ContosoApplianceAgent>;
  * }

--- a/packages/typespec-azure-resource-manager/lib/base-types/agent.tsp
+++ b/packages/typespec-azure-resource-manager/lib/base-types/agent.tsp
@@ -399,7 +399,7 @@ model ResponseInstructionsProperty {
  * Applies the Agent base type decorator automatically.
  * @template Properties RP-specific properties for the agent (must extend AgentProperties)
  */
-@azureBaseType(#{ baseType: "Agent", version: "2024-06-01" })
+@azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
 model Agent<Properties extends AgentProperties> is TrackedResource<Properties>;
 
 /**

--- a/packages/typespec-azure-resource-manager/lib/base-types/base-types.tsp
+++ b/packages/typespec-azure-resource-manager/lib/base-types/base-types.tsp
@@ -3,13 +3,28 @@ using Reflection;
 namespace Azure.ResourceManager.BaseTypes;
 
 /**
+ * The set of Azure base types a resource may declare conformance to via the
+ * `@azureBaseType` decorator. Modeled as an extensible (open) enum so additional
+ * base types can be introduced without a breaking change.
+ */
+union BaseType {
+  /** The Agent base type. */
+  Agent: "Agent",
+
+  /** The Relationship base type. */
+  Relationship: "Relationship",
+
+  string,
+}
+
+/**
  * An ARM-managed base type descriptor identifying the schema contract a resource conforms to.
  * Used as a parameter to the `@azureBaseType` decorator to indicate which
  * base types a resource conforms to.
  */
 model BaseTypeInfo {
-  /** The base type identifier (for example, "Agent"). */
-  baseType: string;
+  /** The base type identifier. */
+  baseType: BaseType;
 
   /** The schema version of the base type. */
   version: string;
@@ -36,7 +51,7 @@ model BaseTypeInfo {
  *
  * // The @azureBaseType decorator marks the resource as conforming to the Agent base type.
  * // (The Agent template applies this automatically, but it can also be applied directly.)
- * @azureBaseType(#{ baseType: "Agent", version: "2024-06-01" })
+ * @azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
  * model ContosoApplianceAgent is TrackedResource<ContosoApplianceProperties> {
  *   ...ResourceNameParameter<ContosoApplianceAgent>;
  * }

--- a/packages/typespec-azure-resource-manager/test/basetypes-experimental.test.ts
+++ b/packages/typespec-azure-resource-manager/test/basetypes-experimental.test.ts
@@ -13,7 +13,7 @@ describe("basetypes-experimental diagnostic", () => {
         description: string;
       }
 
-      @azureBaseType(#{ baseType: "Agent", version: "2024-06-01" })
+      @azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
       model MyAgent is TrackedResource<MyAgentProperties> {
         @key("myAgentName") @segment("myAgents") name: string;
       }

--- a/packages/typespec-azure-resource-manager/test/rules/arm-agent-base-type-child-resources.test.ts
+++ b/packages/typespec-azure-resource-manager/test/rules/arm-agent-base-type-child-resources.test.ts
@@ -34,7 +34,7 @@ describe("arm-agent-base-type-child-resources", () => {
         }
 
         #suppress "@azure-tools/typespec-azure-resource-manager/basetypes-experimental" "test"
-        @azureBaseType(#{ baseType: "Agent", version: "2024-06-01" })
+        @azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
         model MyAgent is TrackedResource<MyAgentProperties> {
           @key("myAgentName") @segment("myAgents") name: string;
         }
@@ -72,7 +72,7 @@ describe("arm-agent-base-type-child-resources", () => {
         }
 
         #suppress "@azure-tools/typespec-azure-resource-manager/basetypes-experimental" "test"
-        @azureBaseType(#{ baseType: "Agent", version: "2024-06-01" })
+        @azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
         model MyAgent is TrackedResource<MyAgentProperties> {
           @key("myAgentName") @segment("myAgents") name: string;
         }
@@ -106,7 +106,7 @@ describe("arm-agent-base-type-child-resources", () => {
         }
 
         #suppress "@azure-tools/typespec-azure-resource-manager/basetypes-experimental" "test"
-        @azureBaseType(#{ baseType: "Agent", version: "2024-06-01" })
+        @azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
         model MyAgent is TrackedResource<MyAgentProperties> {
           @key("myAgentName") @segment("myAgents") name: string;
         }
@@ -140,7 +140,7 @@ describe("arm-agent-base-type-child-resources", () => {
         }
 
         #suppress "@azure-tools/typespec-azure-resource-manager/basetypes-experimental" "test"
-        @azureBaseType(#{ baseType: "Agent", version: "2024-06-01" })
+        @azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
         model MyAgent is TrackedResource<MyAgentProperties> {
           @key("myAgentName") @segment("myAgents") name: string;
         }
@@ -165,7 +165,7 @@ describe("arm-agent-base-type-child-resources", () => {
         }
 
         #suppress "@azure-tools/typespec-azure-resource-manager/basetypes-experimental" "test"
-        @azureBaseType(#{ baseType: "SomethingElse", version: "2024-06-01" })
+        @azureBaseType(#{ baseType: BaseType.Relationship, version: "2024-06-01" })
         model MyResource is TrackedResource<MyProperties> {
           @key("myResourceName") @segment("myResources") name: string;
         }

--- a/website/src/content/docs/docs/libraries/azure-resource-manager/reference/data-types.md
+++ b/website/src/content/docs/docs/libraries/azure-resource-manager/reference/data-types.md
@@ -1560,10 +1560,27 @@ model Azure.ResourceManager.BaseTypes.BaseTypeInfo
 
 #### Properties
 
-| Name     | Type     | Description                                      |
-| -------- | -------- | ------------------------------------------------ |
-| baseType | `string` | The base type identifier (for example, "Agent"). |
-| version  | `string` | The schema version of the base type.             |
+| Name     | Type                                                                   | Description                          |
+| -------- | ---------------------------------------------------------------------- | ------------------------------------ |
+| baseType | [`BaseType`](./data-types.md#Azure.ResourceManager.BaseTypes.BaseType) | The base type identifier.            |
+| version  | `string`                                                               | The schema version of the base type. |
+
+### `BaseType` {#Azure.ResourceManager.BaseTypes.BaseType}
+
+The set of Azure base types a resource may declare conformance to via the
+`@azureBaseType` decorator. Modeled as an extensible (open) enum so additional
+base types can be introduced without a breaking change.
+
+```typespec
+union Azure.ResourceManager.BaseTypes.BaseType
+```
+
+#### Variants
+
+| Name         | Type             | Description                 |
+| ------------ | ---------------- | --------------------------- |
+| Agent        | `"Agent"`        | The Agent base type.        |
+| Relationship | `"Relationship"` | The Relationship base type. |
 
 ## Azure.ResourceManager.BaseTypes.Agents
 

--- a/website/src/content/docs/docs/libraries/azure-resource-manager/reference/decorators.md
+++ b/website/src/content/docs/docs/libraries/azure-resource-manager/reference/decorators.md
@@ -609,7 +609,7 @@ model ContosoApplianceProperties is AgentPropertiesAppliance<ContosoApplianceDef
 
 // The @azureBaseType decorator marks the resource as conforming to the Agent base type.
 // (The Agent template applies this automatically, but it can also be applied directly.)
-@azureBaseType(#{ baseType: "Agent", version: "2024-06-01" })
+@azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
 model ContosoApplianceAgent is TrackedResource<ContosoApplianceProperties> {
   ...ResourceNameParameter<ContosoApplianceAgent>;
 }

--- a/website/src/content/docs/docs/libraries/azure-resource-manager/rules/arm-agent-base-type-child-resources.md
+++ b/website/src/content/docs/docs/libraries/azure-resource-manager/rules/arm-agent-base-type-child-resources.md
@@ -18,7 +18,7 @@ model MyAgentProperties is Azure.ResourceManager.BaseTypes.Agents.AgentPropertie
   ...DefaultProvisioningStateProperty;
 }
 
-@azureBaseType(#{ baseType: "Agent", version: "2024-06-01" })
+@azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
 model MyAgent is TrackedResource<MyAgentProperties> {
   ...ResourceNameParameter<MyAgent>;
 }


### PR DESCRIPTION
## Summary

Constrains the experimental `BaseTypeInfo.baseType` field to a well-defined set of allowed base types instead of a free-form `string`.

### Changes
- Add a **`BaseType` extensible enum** modeled as a union (`Agent`, `Relationship`, `string`), following the Azure `no-enum` and `no-closed-literal-union` conventions (mirrors the existing `ResponseStatus` union in `agent.tsp`).
- Change `BaseTypeInfo.baseType` from `string` → `BaseType`.
- Update all `@azureBaseType` **call sites** to reference the union variants (e.g. `@azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })`), including the `Agent` template, the decorator's doc example, the rule/experimental tests, and the hand-written rule doc.

### Notes
- Union variant values marshal to their underlying string, so the `@azureBaseType` decorator implementation and the agent linter rules (which compare `baseType === "Agent"`) required **no changes**.
- The generated OpenAPI now emits `BaseType` as an extensible `x-ms-enum` (`modelAsString: true`) with `Agent` / `Relationship` values.

### Generated artifacts
- Regenerated extern signatures (`generated-defs`), reference docs (`data-types.md`, `decorators.md`, `README.md`), and the sample OpenAPI snapshot.
- Added a Chronus changeset (`fix`).

### Validation
- ARM build passes: `gen-extern-signature` + `tsc` + `lint-typespec-library` (with `--warn-as-error`).
- All 13 agent base-type / experimental unit tests pass.
- All 69 ARM samples regenerate and pass.
- Prettier clean.
