### PR TITLE
Minor release: @azure-tools/typespec-go@0.15.0

### DIFF
--- a/.chronus/changes/upgrade-typespec-go-dependency-2026-07-17-15-55-00.md
+++ b/.chronus/changes/upgrade-typespec-go-dependency-2026-07-17-15-55-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-go"
+---
+
+Upgrade dependency for `@azure-tools/typespec-go` package.

--- a/.chronus/changes/upgrade-typespec-go-dependency-2026-07-17-15-55-00.md
+++ b/.chronus/changes/upgrade-typespec-go-dependency-2026-07-17-15-55-00.md
@@ -1,7 +1,0 @@
----
-changeKind: feature
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Upgrade dependency for `@azure-tools/typespec-go` package.

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 0.15.0
+
+### Features
+
+- [ce2380e](https://github.com/Azure/typespec-azure/commit/ce2380eaf2cb67dba69e2b5c9fa920eb0fdec71a) Upgrade dependency for `@azure-tools/typespec-go` package.
+
+
 ## 0.14.3 (2026-07-08)
 
 ### Bugs Fixed

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-go",
-  "version": "0.14.3",
+  "version": "0.15.0",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Go SDKs",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
Isolated minor release for @azure-tools/typespec-go (0.14.3 -> 0.15.0).

## Change
- Adds a changeset: upgrade dependency for the typespec-go package.
- Bumps ONLY @azure-tools/typespec-go; the other 12 pending change files on main are left untouched for the next regular release.

## Files
- packages/typespec-go/package.json (version 0.15.0)
- packages/typespec-go/CHANGELOG.md

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>