### PR TITLE
Bump version for hotfix: typespec-java@0.45.7

### DIFF
--- a/.chronus/changes/typespec-java-fix-per-client-serviceversion-2026-07-17-14-32-0.md
+++ b/.chronus/changes/typespec-java-fix-per-client-serviceversion-2026-07-17-14-32-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Fix per-client `ServiceVersion` regression after migrating from js-yaml and lodash.

--- a/.chronus/changes/typespec-java-remove-liftr-openai-deps-2026-07-17-14-29-0.md
+++ b/.chronus/changes/typespec-java-remove-liftr-openai-deps-2026-07-17-14-29-0.md
@@ -1,7 +1,0 @@
----
-changeKind: dependencies
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Remove `@azure-tools/typespec-liftr-base` and `@azure-tools/openai-typespec` from the peer and dev dependencies.

--- a/.chronus/changes/typespec-java-support-client-api-versions-2026-07-17-17-22-0.md
+++ b/.chronus/changes/typespec-java-support-client-api-versions-2026-07-17-17-22-0.md
@@ -1,7 +1,0 @@
----
-changeKind: feature
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Support `clientApiVersions`.

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 ## 0.45.7
 
+### Features
+
+- [#4916](https://github.com/Azure/typespec-azure/pull/4916) Support `clientApiVersions`.
+
 ### Bug Fixes
 
 - [#4916](https://github.com/Azure/typespec-azure/pull/4916) Fix per-client `ServiceVersion` regression after migrating from js-yaml and lodash.
-- [#4916](https://github.com/Azure/typespec-azure/pull/4916) Support `clientApiVersions`.
 
 
 ## 0.45.6 (2026-07-15)

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Change Log - @azure-tools/typespec-java
 
+## 0.45.7
+
+### Bug Fixes
+
+- [#4916](https://github.com/Azure/typespec-azure/pull/4916) Fix per-client `ServiceVersion` regression after migrating from js-yaml and lodash.
+- [#4916](https://github.com/Azure/typespec-azure/pull/4916) Support `clientApiVersions`.
+
+
 ## 0.45.6 (2026-07-15)
 
 Compatible with compiler 1.14.0.

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.45.7
 
+Compatible with compiler 1.14.0.
+
 ### Features
 
 - [#4916](https://github.com/Azure/typespec-azure/pull/4916) Support `clientApiVersions`.

--- a/packages/typespec-java/emitter-tests/package.json
+++ b/packages/typespec-java/emitter-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java-tests",
-  "version": "0.1.0",
+  "version": "0.45.7",
   "type": "module",
   "scripts": {
     "format": "npm run -s prettier -- --write",
@@ -17,7 +17,7 @@
     "@typespec/spector": "0.1.0-alpha.26",
     "@typespec/http-specs": "0.1.0-alpha.39",
     "@azure-tools/azure-http-specs": "0.1.0-alpha.43",
-    "@azure-tools/typespec-java": "file:../azure-tools-typespec-java-0.45.6.tgz"
+    "@azure-tools/typespec-java": "file:../azure-tools-typespec-java-0.45.7.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": "^1.13.0",

--- a/packages/typespec-java/package.json
+++ b/packages/typespec-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.45.6",
+  "version": "0.45.7",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
Hotfix (patch) release for `@azure-tools/typespec-java` **0.45.6 -> 0.45.7** from the `release/july-2026` branch.

## Changes included

- Fix per-client `ServiceVersion` regression after migrating from js-yaml and lodash.
- Remove `@azure-tools/typespec-liftr-base` and `@azure-tools/openai-typespec` from peer and dev dependencies.
- Support `clientApiVersions`.

## Notes

- Version bump generated via `pnpm chronus version --ignore-policies`.
- The `clientApiVersions` changeset was authored as `feature` but is released here under a **patch** bump (consistent with prior hotfix precedent, e.g. #4670); all entries appear under **Bug Fixes** in the changelog.
- `core` submodule pointer unchanged.
- Only `@azure-tools/typespec-java` is bumped; unrelated pending changesets are untouched.

Targets `release/july-2026` (not `main`). Backmerge to `main` to follow after merge.