### PR TITLE
[typespec-go] probe: check whether Go CI already fails on main (DO NOT MERGE)

### DIFF
--- a/packages/typespec-go/.ci-status-probe.md
+++ b/packages/typespec-go/.ci-status-probe.md
@@ -1,0 +1,6 @@
+<!--
+Temporary draft-PR probe: verify whether Go CI (`ci-go.yml`) already fails on
+current `main` due to the go emitter not supporting the ARM scenario
+`postPagingLroWithBody` (azure-http-specs #4632). This file has no effect on
+build/generate/lint and will be removed.
+-->


### PR DESCRIPTION
**Draft / do-not-merge — diagnostic probe.**

Purpose: confirm that **Go CI already fails on `main`** independently of #4874's downstream-CI wiring.

The `Regenerate` step (`pnpm run tspcompile`) is expected to fail with:

```
lropaging.tsp - error @azure-tools/typespec-go/InternalError
Error: paged method PostPagingLroWithBody has no synthesized response type
```

Root cause: the `postPagingLroWithBody` ARM scenario was added to `packages/azure-http-specs/.../operation-templates/lropaging.tsp` in #4632 (specs-only). The go emitter (autorest.go) doesn't support it yet. On `main`, `ci-go.yml` only triggers on `packages/typespec-go/**`, so #4632 never ran it and the break stayed latent.

This PR adds one inert file under `packages/typespec-go/**` to trigger `ci-go.yml`. If the `Go / Mock API Tests` job fails at `Regenerate` with the error above, it proves the failure is a pre-existing emitter bug, not a defect in #4874.

Will be closed once CI status is confirmed.
