### PR TITLE
test(eng): adapt init-templates e2e to TemplateSource scaffold API

### DIFF
--- a/eng/feeds/test/init-templates.e2e.ts
+++ b/eng/feeds/test/init-templates.e2e.ts
@@ -9,18 +9,20 @@ import {
   makeScaffoldingConfig,
   scaffoldNewProject,
 } from "../node_modules/@typespec/compiler/dist/src/init/scaffold.js";
+import { UriTemplateSource } from "../node_modules/@typespec/compiler/dist/src/init/template-source/uri-template-source.js";
 const __dirname = import.meta.dirname;
 const root = resolve(__dirname, "../");
 const testTempRoot = resolve(root, "temp/scaffolded-template-tests");
 const snapshotFolder = resolve(root, "__snapshots__");
 
 export const templatesDir = resolvePath(root);
-const content = JSON.parse(
-  await readFile(resolvePath(templatesDir, "azure-scaffolding.json"), "utf-8"),
-);
+const scaffoldingIndexPath = resolvePath(templatesDir, "azure-scaffolding.json");
+const content = JSON.parse(await readFile(scaffoldingIndexPath, "utf-8"));
+
+/** Reads the template files referenced by the templates relative to the scaffolding index. */
+const templateSource = new UriTemplateSource(NodeHost, scaffoldingIndexPath);
 
 export const Templates = {
-  baseUri: templatesDir,
   templates: content as Record<string, InitTemplate>,
 };
 
@@ -86,7 +88,7 @@ describe("Init templates e2e tests", () => {
       makeScaffoldingConfig(template, {
         name,
         directory: targetFolder,
-        baseUri: Templates.baseUri,
+        source: templateSource,
         parameters,
       }),
     );


### PR DESCRIPTION
## Description

Adapts the `eng/feeds` init-templates e2e test to the compiler's new template-source scaffolding API.

The compiler's `ScaffoldingConfig.baseUri` (a path string) is being replaced by `source?: TemplateSource`, and `makeScaffoldingConfig` no longer accepts `baseUri`. This updates the test to build a `UriTemplateSource` from the azure scaffolding index and pass it as `source`.

## Dependency

> [!IMPORTANT]
> This depends on the compiler change in microsoft/typespec#11303 (`refactor(compiler): introduce TemplateSource abstraction for tsp init`). It cannot be merged until that lands in `core` **and** the `core` submodule here is bumped to include it. CI will stay red until then.

## Validation

Verified locally against the base-PR compiler build by scaffolding the real azure feeds (`azure-arm`, `azure-core`, `azure-core_stand_alone`) through the new `UriTemplateSource` + `makeScaffoldingConfig({ source })` + `scaffoldNewProject` path — all expected files (`main.tsp`, `tspconfig.yaml`, `package.json`, examples) are produced.