### PR TITLE
[python] update pylintrc to disable no-cross-package-private-import

### DIFF
--- a/.chronus/changes/updatepylintrc-2026-6-20-11-16-52.md
+++ b/.chronus/changes/updatepylintrc-2026-6-20-11-16-52.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Disable no-cross-package-private-import pylint check

--- a/packages/typespec-python/eng/scripts/ci/config/pylintrc
+++ b/packages/typespec-python/eng/scripts/ci/config/pylintrc
@@ -1,52 +1,82 @@
 [MASTER]
 py-version=3.10
-ignore-patterns=test_*,conftest,setup
+ignore-patterns=test\_\*,conftest,setup
 reports=no
 
 # PYLINT DIRECTORY BLACKLIST.
-ignore=_generated,samples,examples,test,tests,doc,.tox,generated_samples
+
+ignore=\_generated,samples,examples,test,tests,doc,.tox,generated_samples
 
 [MESSAGES CONTROL]
 
 # Add enable for useless disables
+
 enable=useless-suppression
 
 # For all codes, run 'pylint --list-msgs' or go to 'https://pylint.readthedocs.io/en/latest/reference_guide/features.html'
+
 # locally-disabled: Warning locally suppressed using disable-msg
+
 # cyclic-import: because of https://github.com/PyCQA/pylint/issues/850
+
 # too-many-arguments: Due to the nature of the CLI many commands have large arguments set which reflect in large arguments set in corresponding methods.
+
 # too-many-lines: Due to code generation many files end up with too many lines.
+
+# no-cross-package-private-import: The guideline checker does not resolve relative
+
+# imports (it ignores the import level), so legitimate same-package relative imports
+
+# like `from ...operations._operations import ...` in generated async code are
+
+# misreported as cross-package private imports.
+
 # Let's black deal with bad-continuation
-disable=missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,consider-using-f-string,super-with-arguments,redefined-builtin,import-outside-toplevel,client-suffix-needed,unnecessary-dunder-call,unnecessary-ellipsis,disallowed-name,consider-using-max-builtin,unknown-option-value,file-needs-copyright-header,too-many-positional-arguments
+
+disable=missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,consider-using-f-string,super-with-arguments,redefined-builtin,import-outside-toplevel,client-suffix-needed,unnecessary-dunder-call,unnecessary-ellipsis,disallowed-name,consider-using-max-builtin,unknown-option-value,file-needs-copyright-header,too-many-positional-arguments,no-cross-package-private-import
 
 [FORMAT]
 max-line-length=120
 
 [VARIABLES]
-# Tells whether we should check for unused import in __init__ files.
+
+# Tells whether we should check for unused import in **init** files.
+
 init-import=yes
 
 [DESIGN]
+
 # Maximum number of locals for function / method body
+
 max-locals=25
+
 # Maximum number of branch for function / method body
+
 max-branches=20
+
 # Maximum number of instance attributes for class
+
 max-attributes=10
+
 # Maximum number of ancestors
+
 max-parents=15
 
 [SIMILARITIES]
 min-similarity-lines=10
 
 [BASIC]
+
 # Naming hints based on PEP 8 (https://www.python.org/dev/peps/pep-0008/#naming-conventions).
+
 # Consider these guidelines and not hard rules. Read PEP 8 for more details.
 
 # The invalid-name checker must be **enabled** for these hints to be used.
+
 include-naming-hint=yes
 
 # keep short; underscores are discouraged
+
 module-naming-style=snake_case
 const-naming-style=UPPER_CASE
 class-naming-style=PascalCase

--- a/packages/typespec-python/eng/scripts/ci/config/pylintrc
+++ b/packages/typespec-python/eng/scripts/ci/config/pylintrc
@@ -1,82 +1,56 @@
 [MASTER]
 py-version=3.10
-ignore-patterns=test\_\*,conftest,setup
+ignore-patterns=test_*,conftest,setup
 reports=no
 
 # PYLINT DIRECTORY BLACKLIST.
-
-ignore=\_generated,samples,examples,test,tests,doc,.tox,generated_samples
+ignore=_generated,samples,examples,test,tests,doc,.tox,generated_samples
 
 [MESSAGES CONTROL]
 
 # Add enable for useless disables
-
 enable=useless-suppression
 
 # For all codes, run 'pylint --list-msgs' or go to 'https://pylint.readthedocs.io/en/latest/reference_guide/features.html'
-
 # locally-disabled: Warning locally suppressed using disable-msg
-
 # cyclic-import: because of https://github.com/PyCQA/pylint/issues/850
-
 # too-many-arguments: Due to the nature of the CLI many commands have large arguments set which reflect in large arguments set in corresponding methods.
-
 # too-many-lines: Due to code generation many files end up with too many lines.
-
 # no-cross-package-private-import: The guideline checker does not resolve relative
-
 # imports (it ignores the import level), so legitimate same-package relative imports
-
 # like `from ...operations._operations import ...` in generated async code are
-
 # misreported as cross-package private imports.
-
 # Let's black deal with bad-continuation
-
 disable=missing-docstring,locally-disabled,fixme,cyclic-import,too-many-arguments,invalid-name,duplicate-code,too-few-public-methods,consider-using-f-string,super-with-arguments,redefined-builtin,import-outside-toplevel,client-suffix-needed,unnecessary-dunder-call,unnecessary-ellipsis,disallowed-name,consider-using-max-builtin,unknown-option-value,file-needs-copyright-header,too-many-positional-arguments,no-cross-package-private-import
 
 [FORMAT]
 max-line-length=120
 
 [VARIABLES]
-
-# Tells whether we should check for unused import in **init** files.
-
+# Tells whether we should check for unused import in __init__ files.
 init-import=yes
 
 [DESIGN]
-
 # Maximum number of locals for function / method body
-
 max-locals=25
-
 # Maximum number of branch for function / method body
-
 max-branches=20
-
 # Maximum number of instance attributes for class
-
 max-attributes=10
-
 # Maximum number of ancestors
-
 max-parents=15
 
 [SIMILARITIES]
 min-similarity-lines=10
 
 [BASIC]
-
 # Naming hints based on PEP 8 (https://www.python.org/dev/peps/pep-0008/#naming-conventions).
-
 # Consider these guidelines and not hard rules. Read PEP 8 for more details.
 
 # The invalid-name checker must be **enabled** for these hints to be used.
-
 include-naming-hint=yes
 
 # keep short; underscores are discouraged
-
 module-naming-style=snake_case
 const-naming-style=UPPER_CASE
 class-naming-style=PascalCase


### PR DESCRIPTION
disable no-cross-package-private-import for false positives, mirrors pylintrc in `typespec` repo to resolve errors seen here https://github.com/microsoft/typespec/actions/runs/29559758738/job/87821055874?pr=11289 for https://github.com/microsoft/typespec/pull/11289

e.g.
```
ERROR:root:/home/runner/work/typespec/typespec/packages/typespec-python/tests/generated/azure/azure-client-generator-core-usage/specs exited with linting error 16
************* Module client.naming.typeddict.aio.operations._operations
generated/azure/client-naming-typeddict/client/naming/typeddict/aio/operations/_operations.py:32: [C4776(no-cross-package-private-import), ] Do not import private APIs from other packages. Private modules (prefixed with '_') are internal implementation details and may change without notice. Use the public API instead.
```