### PR TITLE
Preserve legacy versions when updating service.yaml

### DIFF
--- a/.chronus/changes/service-yaml-preserve-legacy-versions-2026-07-20-14-30-00.md
+++ b/.chronus/changes/service-yaml-preserve-legacy-versions-2026-07-20-14-30-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Preserve existing `service.yaml` versions when updating an existing manifest. Versions the emitter no longer produces (for example legacy swagger-only versions migrated from `readme.md`) are now kept instead of being removed, so re-running the emitter is idempotent for manifests that carry historical versions.

--- a/.chronus/changes/service-yaml-preserve-legacy-versions-2026-07-20-14-30-00.md
+++ b/.chronus/changes/service-yaml-preserve-legacy-versions-2026-07-20-14-30-00.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-autorest"
 ---
 
-Preserve existing `service.yaml` versions when updating an existing manifest. Versions the emitter no longer produces (for example legacy swagger-only versions migrated from `readme.md`) are now kept instead of being removed, so re-running the emitter is idempotent for manifests that carry historical versions.
+Preserve non-TypeSpec `service.yaml` versions when updating an existing manifest. Versions the emitter no longer produces are now kept when they are not TypeSpec-generated (for example legacy swagger-only versions migrated from `readme.md`), while stale `source: typespec` versions the emitter no longer produces are still removed. This makes re-running the emitter idempotent for manifests that carry historical versions.

--- a/packages/typespec-autorest/src/emit.ts
+++ b/packages/typespec-autorest/src/emit.ts
@@ -369,10 +369,14 @@ async function emitServiceYaml(
  * Updates the `versions` list of an existing `service.yaml` document while preserving the rest
  * of the file: document-level comments, comments on unrelated keys, and per-version comments.
  *
- * Existing entries are merged rather than replaced: versions the emitter regenerated are updated
- * in place, versions the emitter no longer knows about (for example legacy swagger-only versions
- * that predate the TypeSpec migration) are preserved in their original position, and versions the
- * emitter produced that are not yet present are appended in the generated order.
+ * Existing entries are merged rather than replaced:
+ * - versions the emitter regenerated are updated in place (keeping their comments/position),
+ * - versions the emitter no longer produces but that are *not* TypeSpec-sourced (for example
+ *   legacy swagger-only versions that predate the TypeSpec migration) are preserved in place so
+ *   hand-authored or migrated history is not lost,
+ * - versions marked `source: typespec` that the emitter no longer produces are removed, since a
+ *   stale TypeSpec entry would otherwise linger after the version is dropped from the spec, and
+ * - versions the emitter produced that are not yet present are appended in the generated order.
  */
 function updateServiceYamlDocument(existing: string, manifest: ServiceYaml): string {
   const doc = parseDocument(existing);
@@ -391,18 +395,22 @@ function updateServiceYamlDocument(existing: string, manifest: ServiceYaml): str
   const seen = new Set<string>();
   const merged: (typeof seq.items)[number][] = [];
 
-  // Update regenerated versions in place; preserve any other existing entries (e.g. legacy
-  // swagger-only versions) so hand-authored or migrated history is not lost.
   for (const item of seq.items) {
     if (isMap(item)) {
       const version = item.get("version");
       if (typeof version === "string") {
-        seen.add(version);
         const regenerated = manifestByVersion.get(version);
         if (regenerated !== undefined) {
+          // Update regenerated versions in place, keeping their comments and position.
+          seen.add(version);
           item.set("source", regenerated.source);
           item.set("swagger-files", regenerated["swagger-files"]);
+        } else if (item.get("source") === "typespec") {
+          // This version claims to be TypeSpec-generated but the emitter no longer produces it,
+          // so it is stale and must be dropped.
+          continue;
         }
+        // Any other existing entry (e.g. a legacy swagger-only version) is preserved as-is.
       }
     }
     merged.push(item);

--- a/packages/typespec-autorest/src/emit.ts
+++ b/packages/typespec-autorest/src/emit.ts
@@ -21,7 +21,7 @@ import {
 } from "@typespec/compiler/experimental";
 import { resolveInfo } from "@typespec/openapi";
 import { getVersioningMutators } from "@typespec/versioning";
-import { isMap, isSeq, parseDocument, stringify as stringifyYaml, type YAMLMap } from "yaml";
+import { isMap, isSeq, parseDocument, stringify as stringifyYaml } from "yaml";
 import { AutorestEmitterOptions, getTracer, reportDiagnostic } from "./lib.js";
 import {
   AutorestDocumentEmitterOptions,
@@ -367,9 +367,12 @@ async function emitServiceYaml(
 
 /**
  * Updates the `versions` list of an existing `service.yaml` document while preserving the rest
- * of the file: document-level comments, comments on unrelated keys, and per-version comments on
- * versions that still exist. Versions that no longer exist are removed and new ones are appended
- * in the generated order.
+ * of the file: document-level comments, comments on unrelated keys, and per-version comments.
+ *
+ * Existing entries are merged rather than replaced: versions the emitter regenerated are updated
+ * in place, versions the emitter no longer knows about (for example legacy swagger-only versions
+ * that predate the TypeSpec migration) are preserved in their original position, and versions the
+ * emitter produced that are not yet present are appended in the generated order.
  */
 function updateServiceYamlDocument(existing: string, manifest: ServiceYaml): string {
   const doc = parseDocument(existing);
@@ -380,26 +383,39 @@ function updateServiceYamlDocument(existing: string, manifest: ServiceYaml): str
     return doc.toString();
   }
 
-  const existingByVersion = new Map<string, YAMLMap>();
+  const manifestByVersion = new Map<string, ServiceYamlVersion>();
+  for (const version of manifest.versions) {
+    manifestByVersion.set(version.version, version);
+  }
+
+  const seen = new Set<string>();
+  const merged: (typeof seq.items)[number][] = [];
+
+  // Update regenerated versions in place; preserve any other existing entries (e.g. legacy
+  // swagger-only versions) so hand-authored or migrated history is not lost.
   for (const item of seq.items) {
     if (isMap(item)) {
       const version = item.get("version");
       if (typeof version === "string") {
-        existingByVersion.set(version, item);
+        seen.add(version);
+        const regenerated = manifestByVersion.get(version);
+        if (regenerated !== undefined) {
+          item.set("source", regenerated.source);
+          item.set("swagger-files", regenerated["swagger-files"]);
+        }
       }
+    }
+    merged.push(item);
+  }
+
+  // Append versions produced by the emitter that were not already present.
+  for (const version of manifest.versions) {
+    if (!seen.has(version.version)) {
+      merged.push(doc.createNode(version));
     }
   }
 
-  seq.items = manifest.versions.map((version) => {
-    const existingItem = existingByVersion.get(version.version);
-    if (existingItem !== undefined) {
-      existingItem.set("source", version.source);
-      existingItem.set("swagger-files", version["swagger-files"]);
-      return existingItem;
-    }
-    return doc.createNode(version);
-  });
-
+  seq.items = merged;
   return doc.toString();
 }
 

--- a/packages/typespec-autorest/test/service-yaml.test.ts
+++ b/packages/typespec-autorest/test/service-yaml.test.ts
@@ -186,6 +186,68 @@ describe("emission trigger option", () => {
 
     expect(raw).toEqual(existing);
   });
+
+  it("preserves a non-typespec (swagger) version the emitter does not produce", async () => {
+    // Requirement: entries that are not TypeSpec-generated must survive re-emission even though
+    // the emitter never produces them.
+    const existing = [
+      "versions:",
+      '  - version: "2020-01-01"',
+      "    source: swagger",
+      "    swagger-files:",
+      "      - legacy/openapi.json",
+      "",
+    ].join("\n");
+
+    const { manifest } = await emitServiceYaml(
+      { "main.tsp": versionedService, "service.yaml": existing },
+      { options: { "service-yaml": "auto" } },
+    );
+
+    assert(manifest);
+    // Legacy swagger-only version kept verbatim, alongside the current TypeSpec versions.
+    expect(manifest.versions.map((v) => v.version)).toEqual([
+      "2020-01-01",
+      "2023-01-01",
+      "2024-01-01-preview",
+    ]);
+    expect(manifest.versions.find((v) => v.version === "2020-01-01")).toEqual({
+      version: "2020-01-01",
+      source: "swagger",
+      "swagger-files": ["legacy/openapi.json"],
+    });
+  });
+
+  it("removes a `source: typespec` version the emitter no longer produces", async () => {
+    // Requirement: a version that claims to be TypeSpec-generated but is no longer in the spec is
+    // stale and must be dropped, while a legacy swagger-only version is still preserved.
+    const existing = [
+      "versions:",
+      '  - version: "2019-01-01"',
+      "    source: typespec",
+      "    swagger-files:",
+      "      - tsp-output/@azure-tools/typespec-autorest/stable/2019-01-01/openapi.json",
+      '  - version: "2020-01-01"',
+      "    source: swagger",
+      "    swagger-files:",
+      "      - legacy/openapi.json",
+      "",
+    ].join("\n");
+
+    const { manifest } = await emitServiceYaml(
+      { "main.tsp": versionedService, "service.yaml": existing },
+      { options: { "service-yaml": "auto" } },
+    );
+
+    assert(manifest);
+    // The stale TypeSpec version is gone; the legacy swagger version and current versions remain.
+    expect(manifest.versions.map((v) => v.version)).toEqual([
+      "2020-01-01",
+      "2023-01-01",
+      "2024-01-01-preview",
+    ]);
+    expect(manifest.versions.find((v) => v.version === "2019-01-01")).toBeUndefined();
+  });
 });
 
 describe("multiple services", () => {

--- a/packages/typespec-autorest/test/service-yaml.test.ts
+++ b/packages/typespec-autorest/test/service-yaml.test.ts
@@ -107,7 +107,7 @@ describe("emission trigger option", () => {
     expect(raw).toEqual("versions: []\n");
   });
 
-  it("preserves comments and unrelated keys when updating an existing file", async () => {
+  it("preserves comments, unrelated keys, and legacy versions when updating an existing file", async () => {
     const existing = [
       "# Manifest for MyService",
       "versions:",
@@ -116,7 +116,7 @@ describe("emission trigger option", () => {
       "    source: typespec",
       "    swagger-files:",
       "      - old/path.json",
-      "  # to be removed",
+      "  # legacy swagger-only version",
       '  - version: "2020-01-01"',
       "    source: swagger",
       "    swagger-files:",
@@ -136,17 +136,55 @@ describe("emission trigger option", () => {
     expect(raw).toContain("# Manifest for MyService");
     expect(raw).toContain("# trailing note");
     expect(raw).toContain("custom-key: keep-me");
-    // Per-version comment on a retained version is preserved.
+    // Per-version comments are preserved.
     expect(raw).toContain("# first stable version");
-    // Removed version and its comment are gone.
-    expect(raw).not.toContain("# to be removed");
-    expect(raw).not.toContain("2020-01-01");
-    // Generated data reflects the current @versioned enum.
+    expect(raw).toContain("# legacy swagger-only version");
+    // Legacy version the emitter no longer knows about is preserved as-is.
     assert(manifest);
-    expect(manifest.versions.map((v) => v.version)).toEqual(["2023-01-01", "2024-01-01-preview"]);
+    expect(manifest.versions.map((v) => v.version)).toEqual([
+      "2023-01-01",
+      "2020-01-01",
+      "2024-01-01-preview",
+    ]);
+    const legacy = manifest.versions.find((v) => v.version === "2020-01-01");
+    expect(legacy).toEqual({
+      version: "2020-01-01",
+      source: "swagger",
+      "swagger-files": ["legacy/openapi.json"],
+    });
+    // Regenerated version reflects the current @versioned enum output.
     expect(manifest.versions[0]["swagger-files"]).toEqual([
       "tsp-output/@azure-tools/typespec-autorest/stable/2023-01-01/openapi.json",
     ]);
+  });
+
+  it("is idempotent for a manifest that already contains all current versions plus legacy ones", async () => {
+    // Mirrors a migrated manifest: legacy swagger-only versions interleaved with the current
+    // TypeSpec versions, whose swagger-files already match the emitter output. Re-emitting must
+    // not change the file, so `tsp compile` stays clean in CI.
+    const existing = [
+      "versions:",
+      '  - version: "2020-01-01"',
+      "    source: swagger",
+      "    swagger-files:",
+      "      - ../resource-manager/stable/2020-01-01/legacy.json",
+      '  - version: "2023-01-01"',
+      "    source: typespec",
+      "    swagger-files:",
+      "      - tsp-output/@azure-tools/typespec-autorest/stable/2023-01-01/openapi.json",
+      '  - version: "2024-01-01-preview"',
+      "    source: typespec",
+      "    swagger-files:",
+      "      - tsp-output/@azure-tools/typespec-autorest/preview/2024-01-01-preview/openapi.json",
+      "",
+    ].join("\n");
+
+    const { raw } = await emitServiceYaml(
+      { "main.tsp": versionedService, "service.yaml": existing },
+      { options: { "service-yaml": "auto" } },
+    );
+
+    expect(raw).toEqual(existing);
   });
 });
 


### PR DESCRIPTION
## Problem

The `service.yaml` emitter (`@azure-tools/typespec-autorest`) rewrites an existing manifest's `versions` list to contain **only** the current `@versioned` versions — `updateServiceYamlDocument` previously mapped over `manifest.versions` and dropped everything else.

This breaks the readme.md → service.yaml migration ([Azure/azure-rest-api-specs#44805](https://github.com/Azure/azure-rest-api-specs/pull/44805)), where each manifest is a **superset** that also captures legacy swagger-only versions (`source: swagger`). When TypeSpec Validation runs `tsp compile`, the emitter strips those legacy versions, leaving the working tree dirty and failing the TSV Compile (git-clean) check.

## Fix

`updateServiceYamlDocument` now **merges** instead of replacing:

- versions the emitter regenerated are updated in place (source + swagger-files),
- versions the emitter no longer produces (legacy swagger-only versions) are **preserved** in their original position,
- versions the emitter produced that aren't present yet are appended in generated order.

This makes re-emitting **idempotent** for manifests that carry historical versions, so `tsp compile` stays clean.

## Tests

- Updated the existing update test: a legacy `source: swagger` version and its comment are now preserved (previously asserted removed).
- Added an idempotency test: re-emitting a migrated-style manifest (legacy + current versions, swagger-files already matching emitter output) produces a byte-identical file.

All 9 `service-yaml.test.ts` tests pass; build, prettier, and oxlint are clean.