### PR TITLE
perf: cache getHttpOperation results across linter rules

### DIFF
--- a/packages/typespec-azure-core/src/rules/byos.ts
+++ b/packages/typespec-azure-core/src/rules/byos.ts
@@ -1,11 +1,10 @@
 import {
   Operation,
   createRule,
-  ignoreDiagnostics,
   isTemplateInstance,
   paramMessage,
 } from "@typespec/compiler";
-import { getHttpOperation } from "@typespec/http";
+import { getCachedHttpOperation } from "./utils.js";
 
 const binaryContentTypes = new Set(["application/octet-stream", "multipart/form-data"]);
 export const byosRule = createRule({
@@ -23,7 +22,7 @@ export const byosRule = createRule({
           // Operation template instance are just referenced in `op is`. Main operation will be validated.
           return;
         }
-        const httpOperation = ignoreDiagnostics(getHttpOperation(context.program, operation));
+        const httpOperation = getCachedHttpOperation(context.program, operation);
         if (httpOperation.parameters.body !== undefined) {
           for (const contentType of httpOperation.parameters.body.contentTypes) {
             if (binaryContentTypes.has(contentType)) {

--- a/packages/typespec-azure-core/src/rules/no-error-status-codes.ts
+++ b/packages/typespec-azure-core/src/rules/no-error-status-codes.ts
@@ -1,6 +1,5 @@
-import { Operation, createRule, ignoreDiagnostics } from "@typespec/compiler";
-import { getHttpOperation } from "@typespec/http";
-import { isAzureSubNamespace, isExcludedCoreType } from "./utils.js";
+import { Operation, createRule } from "@typespec/compiler";
+import { getCachedHttpOperation, isAzureSubNamespace, isExcludedCoreType } from "./utils.js";
 
 export const noErrorStatusCodesRule = createRule({
   name: "no-error-status-codes",
@@ -17,7 +16,7 @@ export const noErrorStatusCodesRule = createRule({
         if (isExcludedCoreType(context.program, operation)) return;
         if (!isAzureSubNamespace(context.program, operation.namespace)) return;
 
-        const httpOperation = ignoreDiagnostics(getHttpOperation(context.program, operation));
+        const httpOperation = getCachedHttpOperation(context.program, operation);
         if (httpOperation.responses !== undefined) {
           for (const response of httpOperation.responses) {
             const statusCode = response.statusCodes;

--- a/packages/typespec-azure-core/src/rules/no-header-explode.ts
+++ b/packages/typespec-azure-core/src/rules/no-header-explode.ts
@@ -1,5 +1,5 @@
-import { createRule, ignoreDiagnostics, Operation } from "@typespec/compiler";
-import { getHttpOperation } from "@typespec/http";
+import { createRule, Operation } from "@typespec/compiler";
+import { getCachedHttpOperation } from "./utils.js";
 
 export const noHeaderExplodeRule = createRule({
   name: "no-header-explode",
@@ -12,8 +12,10 @@ export const noHeaderExplodeRule = createRule({
   create(context) {
     return {
       operation: (operation: Operation) => {
-        const httpOperation = ignoreDiagnostics(getHttpOperation(context.program, operation));
-        for (const prop of httpOperation.parameters.properties.filter((x) => x.kind === "header")) {
+        const httpOperation = getCachedHttpOperation(context.program, operation);
+        for (const prop of httpOperation.parameters.properties.filter(
+          (x) => x.kind === "header",
+        )) {
           if (prop.options.explode === true) {
             context.reportDiagnostic({
               target: prop.property,

--- a/packages/typespec-azure-core/src/rules/no-query-explode.ts
+++ b/packages/typespec-azure-core/src/rules/no-query-explode.ts
@@ -1,5 +1,5 @@
-import { createRule, ignoreDiagnostics, Operation } from "@typespec/compiler";
-import { getHttpOperation } from "@typespec/http";
+import { createRule, Operation } from "@typespec/compiler";
+import { getCachedHttpOperation } from "./utils.js";
 
 export const noQueryExplodeRule = createRule({
   name: "no-query-explode",
@@ -12,7 +12,7 @@ export const noQueryExplodeRule = createRule({
   create(context) {
     return {
       operation: (operation: Operation) => {
-        const httpOperation = ignoreDiagnostics(getHttpOperation(context.program, operation));
+        const httpOperation = getCachedHttpOperation(context.program, operation);
         for (const prop of httpOperation.parameters.properties.filter((x) => x.kind === "query")) {
           if (prop.options.explode === true) {
             context.reportDiagnostic({

--- a/packages/typespec-azure-core/src/rules/no-route-parameter-name-mismatch.ts
+++ b/packages/typespec-azure-core/src/rules/no-route-parameter-name-mismatch.ts
@@ -1,12 +1,11 @@
 import {
   createRule,
   getNamespaceFullName,
-  ignoreDiagnostics,
   Operation,
   paramMessage,
 } from "@typespec/compiler";
-import { getHttpOperation, HttpOperationPathParameter } from "@typespec/http";
-import { isExcludedCoreType, isTemplatedInterfaceOperation } from "./utils.js";
+import { HttpOperationPathParameter } from "@typespec/http";
+import { getCachedHttpOperation, isExcludedCoreType, isTemplatedInterfaceOperation } from "./utils.js";
 
 interface PathParamInfo {
   name: string;
@@ -48,7 +47,7 @@ export const noRouteParameterNameMismatchRule = createRule({
         if (isExcludedCoreType(context.program, operation)) return;
         if (isTemplatedInterfaceOperation(operation)) return;
 
-        const httpOp = ignoreDiagnostics(getHttpOperation(context.program, operation));
+        const httpOp = getCachedHttpOperation(context.program, operation);
 
         // Get path parameters
         const pathParams = httpOp.parameters.parameters.filter(

--- a/packages/typespec-azure-core/src/rules/response-schema-multi-status-code.ts
+++ b/packages/typespec-azure-core/src/rules/response-schema-multi-status-code.ts
@@ -2,11 +2,11 @@ import {
   Operation,
   Type,
   createRule,
-  ignoreDiagnostics,
   isErrorModel,
   paramMessage,
 } from "@typespec/compiler";
-import { Visibility, createMetadataInfo, getHttpOperation } from "@typespec/http";
+import { Visibility, createMetadataInfo } from "@typespec/http";
+import { getCachedHttpOperation } from "./utils.js";
 
 export const responseSchemaMultiStatusCodeRule = createRule({
   name: "response-schema-problem",
@@ -17,13 +17,16 @@ export const responseSchemaMultiStatusCodeRule = createRule({
     multipleSuccessSchemas: paramMessage`Operation '${"name"}' has multiple non-error response schemas. Did you forget to add '@error' to one of them?`,
   },
   create(context) {
+    // Create MetadataInfo once per lint run instead of per-operation.
+    // MetadataInfo uses internal lazy caching, so reuse across operations
+    // avoids recomputing effective payload types.
+    const metadataInfo = createMetadataInfo(context.program, {
+      canonicalVisibility: Visibility.Read,
+    });
     return {
       operation: (op: Operation) => {
-        const httpOp = ignoreDiagnostics(getHttpOperation(context.program, op));
+        const httpOp = getCachedHttpOperation(context.program, op);
         const responses = httpOp.responses.flatMap((x) => x.responses);
-        const metadataInfo = createMetadataInfo(context.program, {
-          canonicalVisibility: Visibility.Read,
-        });
 
         let firstResponse: Type | undefined = undefined;
         for (const resp of responses) {

--- a/packages/typespec-azure-core/src/rules/rpc-operation-request-body.ts
+++ b/packages/typespec-azure-core/src/rules/rpc-operation-request-body.ts
@@ -1,5 +1,6 @@
 import { Operation, createRule, paramMessage } from "@typespec/compiler";
-import { getHttpOperation, isBodyIgnore } from "@typespec/http";
+import { isBodyIgnore } from "@typespec/http";
+import { getCachedHttpOperation } from "./utils.js";
 
 export const rpcOperationRequestBodyRule = createRule({
   name: "rpc-operation-request-body",
@@ -23,7 +24,7 @@ export const rpcOperationRequestBodyRule = createRule({
             operation.namespace?.name === "Core" &&
             operation.namespace?.namespace?.name === "Azure"
           ) {
-            const httpOperation = getHttpOperation(context.program, originalOperation)[0];
+            const httpOperation = getCachedHttpOperation(context.program, originalOperation);
             const bodyParam = httpOperation.parameters.properties.find(
               (p) =>
                 p.kind === "body" ||

--- a/packages/typespec-azure-core/src/rules/use-standard-names.ts
+++ b/packages/typespec-azure-core/src/rules/use-standard-names.ts
@@ -1,11 +1,10 @@
 import {
   Operation,
   createRule,
-  ignoreDiagnostics,
   isList,
   isTemplateDeclarationOrInstance,
 } from "@typespec/compiler";
-import { getHttpOperation } from "@typespec/http";
+import { getCachedHttpOperation } from "./utils.js";
 import { isListOperation } from "@typespec/rest";
 
 export const useStandardNames = createRule({
@@ -28,7 +27,7 @@ export const useStandardNames = createRule({
     return {
       operation: (op: Operation) => {
         if (isTemplateDeclarationOrInstance(op)) return;
-        const httpOp = ignoreDiagnostics(getHttpOperation(context.program, op));
+        const httpOp = getCachedHttpOperation(context.program, op);
         const verb = httpOp.verb;
         const name = op.name;
         const statusCodes = httpOp.responses.map((x) => x.statusCodes.toString());

--- a/packages/typespec-azure-core/src/rules/utils.ts
+++ b/packages/typespec-azure-core/src/rules/utils.ts
@@ -213,3 +213,28 @@ export function isInDisallowedNamespace(
   }
   return false;
 }
+
+import { getHttpOperation as _getHttpOperation, HttpOperation } from "@typespec/http";
+import { Diagnostic, ignoreDiagnostics as _ignoreDiagnostics } from "@typespec/compiler";
+
+/**
+ * Module-level cache for `getHttpOperation` results.
+ * Uses a WeakMap keyed on Program so cache is automatically GC'd when the program is released.
+ * Rules that call `getHttpOperation` per-operation should use `getCachedHttpOperation` to avoid
+ * redundant recomputation across multiple rule invocations on the same operation.
+ */
+const httpOperationCacheByProgram = new WeakMap<Program, WeakMap<Operation, HttpOperation>>();
+
+export function getCachedHttpOperation(program: Program, operation: Operation): HttpOperation {
+  let programCache = httpOperationCacheByProgram.get(program);
+  if (programCache === undefined) {
+    programCache = new WeakMap();
+    httpOperationCacheByProgram.set(program, programCache);
+  }
+  let result = programCache.get(operation);
+  if (result === undefined) {
+    result = _ignoreDiagnostics(_getHttpOperation(program, operation));
+    programCache.set(operation, result);
+  }
+  return result;
+}


### PR DESCRIPTION
## Motivation

Feedback from the Shanghai team indicates that linter delays on large ARM spec conversions (e.g., Compute RP with 66 tsp files, 31,831 types) are long enough that engineers sometimes give up waiting for results. As we plan to add more rules, this will worsen.

## Approach

Profiling with `tsp compile --no-emit --stats` on Compute RP shows the linter accounts for ~580ms (42% of total compile time), with the top 5 rules consuming 62% of that:

| Rule | Time |
|------|------|
| response-schema-problem | 91ms |
| no-query-explode | 86ms |
| no-header-explode | 86ms |
| arm-no-path-casing-conflicts | 55ms |
| no-route-parameter-name-mismatch | 43ms |

The root cause: `getHttpOperation()` in `@typespec/http` creates a fresh empty `Map()` as its internal cache on every call (line 37 of operations.ts), so when ~8 rules each call it per-operation, the HTTP operation details (path resolution, parameters, responses, authentication) are recomputed from scratch each time.

This PR adds a module-level `WeakMap<Program, WeakMap<Operation, HttpOperation>>` cache in `packages/typespec-azure-core/src/rules/utils.ts`. The first rule to request an operation's HTTP details pays the computation cost; subsequent rules get the cached result.

Additionally, `createMetadataInfo()` in the response-schema-problem rule is hoisted to be created once per lint run instead of once per operation visit.

## Changes

- **`packages/typespec-azure-core/src/rules/utils.ts`**: Added `getCachedHttpOperation()` utility with program-scoped WeakMap cache
- **8 rule files updated** to use the cached version: no-query-explode, no-header-explode, response-schema-multi-status-code, no-route-parameter-name-mismatch, byos, no-error-status-codes, use-standard-names, rpc-operation-request-body

## Testing

All 26 existing rule tests pass. The cache is transparent to rule behavior -- it only avoids redundant recomputation.