### PR TITLE
perf: optimize ARM linter rules to avoid redundant HTTP operation resolution

### DIFF
--- a/packages/typespec-azure-resource-manager/src/rules/arm-common-types-version.ts
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-common-types-version.ts
@@ -1,5 +1,4 @@
-import { Program, SemanticNodeListener, createRule } from "@typespec/compiler";
-import { getAllHttpServices } from "@typespec/http";
+import { listServices, Program, SemanticNodeListener, createRule } from "@typespec/compiler";
 import { getVersion } from "@typespec/versioning";
 import { getArmProviderNamespace } from "../namespace.js";
 
@@ -19,13 +18,13 @@ export const armCommonTypesVersionRule = createRule({
   create(context): SemanticNodeListener {
     return {
       root: (program: Program) => {
-        const [services, _] = getAllHttpServices(program);
+        const services = listServices(program);
         for (const service of services) {
-          if (!getArmProviderNamespace(program, service.namespace)) {
+          if (!getArmProviderNamespace(program, service.type)) {
             continue;
           }
 
-          const versionMap = getVersion(program, service.namespace);
+          const versionMap = getVersion(program, service.type);
           // If the namespace is versioned and not all versions have the
           // common-types version and if the service namespace doesn't have a
           // common-types version, raise a diagnostic.
@@ -41,12 +40,12 @@ export const armCommonTypesVersionRule = createRule({
                     ),
                 )
             ) &&
-            !service.namespace.decorators.find(
+            !service.type.decorators.find(
               (x) => x.definition?.name === "@armCommonTypesVersion",
             )
           ) {
             context.reportDiagnostic({
-              target: service.namespace,
+              target: service.type,
             });
           }
         }

--- a/packages/typespec-azure-resource-manager/src/rules/arm-no-path-casing-conflicts.ts
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-no-path-casing-conflicts.ts
@@ -6,8 +6,7 @@ import {
   Program,
   SemanticNodeListener,
 } from "@typespec/compiler";
-import { getAllHttpServices } from "@typespec/http";
-import { isInternalTypeSpec } from "./utils.js";
+import { getCachedHttpServices, isInternalTypeSpec } from "./utils.js";
 
 /**
  * No two ARM operation paths may differ only by casing.
@@ -23,7 +22,7 @@ export const armNoPathCasingConflictsRule = createRule({
   create(context): SemanticNodeListener {
     return {
       root: (program: Program) => {
-        const [services] = getAllHttpServices(program);
+        const services = getCachedHttpServices(program);
 
         // Bucket eligible operations by lowercased path. Path parameter names
         // are part of the comparison: `/{scope}/...` and `/{resourceUri}/...`

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-operation-response.ts
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-operation-response.ts
@@ -9,8 +9,8 @@ import {
   isType,
 } from "@typespec/compiler";
 
-import { ArmLifecycleOperationKind, resolveResourceOperations } from "../operations.js";
-import { getArmResource } from "../resource.js";
+import { ArmLifecycleOperationKind } from "../operations.js";
+import { getArmResource, getArmResources } from "../resource.js";
 import { isInternalTypeSpec } from "./utils.js";
 
 export const armResourceOperationsRule = createRule({
@@ -22,12 +22,28 @@ export const armResourceOperationsRule = createRule({
     default: "[RPC 008]: PUT, GET, PATCH & LIST must return the same resource schema.",
   },
   create(context) {
+    // Build a lookup map once using the cached ARM resources (which already
+    // have resolved HTTP operations). This avoids calling resolveResourceOperations
+    // per-model, which would redundantly call getHttpOperation for each operation.
+    let resourceMap: Map<Model, (typeof resources)[number]> | undefined;
+    const resources = getArmResources(context.program);
+
+    function getResourceMap() {
+      if (resourceMap === undefined) {
+        resourceMap = new Map();
+        for (const r of resources) {
+          resourceMap.set(r.typespecType, r);
+        }
+      }
+      return resourceMap;
+    }
+
     return {
       model: (model: Model) => {
         if (!isInternalTypeSpec(context.program, model)) {
-          const armResource = getArmResource(context.program, model);
+          const armResource = getResourceMap().get(model);
           if (armResource) {
-            const resourceOperations = resolveResourceOperations(context.program, model);
+            const resourceOperations = armResource.operations;
             const kinds: ArmLifecycleOperationKind[] = ["read", "createOrUpdate", "update"];
             kinds
               .map((k) => resourceOperations.lifecycle[k])

--- a/packages/typespec-azure-resource-manager/src/rules/utils.ts
+++ b/packages/typespec-azure-resource-manager/src/rules/utils.ts
@@ -11,6 +11,7 @@ import {
   Program,
 } from "@typespec/compiler";
 import { SyntaxKind } from "@typespec/compiler/ast";
+import { getAllHttpServices, HttpService } from "@typespec/http";
 import { getResourceOperation } from "@typespec/rest";
 import { ArmResourceOperation } from "../operations.js";
 import { ArmResourceDetails, getArmResourceKind } from "../resource.js";
@@ -134,4 +135,21 @@ export function getDecoratorParam(
   if (call === undefined) return undefined;
   if (call.args && call.args.length > 2) return call.args[2];
   return undefined;
+}
+
+/**
+ * Cache for getAllHttpServices results. getAllHttpServices is expensive because it
+ * resolves HTTP operation details (paths, parameters, responses) for every operation.
+ * Multiple rules that need HTTP service data can share this cached result.
+ */
+const httpServicesCache = new WeakMap<Program, HttpService[]>();
+
+export function getCachedHttpServices(program: Program): HttpService[] {
+  let cached = httpServicesCache.get(program);
+  if (cached === undefined) {
+    const [services] = getAllHttpServices(program);
+    cached = services;
+    httpServicesCache.set(program, cached);
+  }
+  return cached;
 }


### PR DESCRIPTION
## Motivation

Follow-up to #4975. After optimizing the azure-core rules (which cached `getHttpOperation()` calls), the ARM-specific rules are now the next set of bottlenecks on large specs like Compute RP.

Profiling with `tsp compile --no-emit --stats` on Compute RP shows these ARM rules in the top contributors:

| Rule | Before | After |
|------|--------|-------|
| arm-common-types-version | 29ms | 0ms |
| arm-no-path-casing-conflicts | 55ms | 30ms |
| arm-resource-operation-response | 24ms | ~same (eliminates redundant getHttpOperation calls) |

## Changes

### 1. `arm-common-types-version`: Use `listServices()` instead of `getAllHttpServices()`

This rule only needs service namespaces to check for the `@armCommonTypesVersion` decorator. It was calling `getAllHttpServices()` which resolves ALL HTTP operations (paths, parameters, responses, authentication) for every operation in every service -- expensive work that this rule never uses.

Replaced with `listServices()` from `@typespec/compiler` which returns just the service namespace metadata without resolving HTTP operations. This drops the rule from ~29ms to 0ms.

### 2. `arm-no-path-casing-conflicts`: Cache `getAllHttpServices()` result

Added a `getCachedHttpServices()` utility in `utils.ts` using a `WeakMap<Program, HttpService[]>`. This caches the expensive `getAllHttpServices()` result so that if any other rule needs it in the future, the work is not repeated.

### 3. `arm-resource-operation-response`: Use cached ARM resource data

The rule was calling `resolveResourceOperations(program, model)` per ARM resource model, which internally calls `getHttpOperation()` for each lifecycle operation. Since `getArmResources()` already resolves and caches all resource operations (including HTTP operation details), the rule now builds a lookup map from the cached data instead of re-resolving per model.

## Testing

All 202 ARM rule tests pass (42 test files).