### PR TITLE
Fix Agent base type contract version to 2026-04-01

### DIFF
--- a/.chronus/changes/fix-agent-base-type-contract-version-2026-7-20-17-9-0.md
+++ b/.chronus/changes/fix-agent-base-type-contract-version-2026-7-20-17-9-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Fix the Agent base type contract version in the `@azureBaseType` decorator on the `Agent` resource template, correcting a typo where it was set to `2024-06-01` instead of `2026-04-01`.

--- a/packages/typespec-azure-resource-manager/README.md
+++ b/packages/typespec-azure-resource-manager/README.md
@@ -704,7 +704,7 @@ model ContosoApplianceProperties is AgentPropertiesAppliance<ContosoApplianceDef
 
 // The @azureBaseType decorator marks the resource as conforming to the Agent base type.
 // (The Agent template applies this automatically, but it can also be applied directly.)
-@azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
+@azureBaseType(#{ baseType: BaseType.Agent, version: "2026-04-01" })
 model ContosoApplianceAgent is TrackedResource<ContosoApplianceProperties> {
   ...ResourceNameParameter<ContosoApplianceAgent>;
 }

--- a/packages/typespec-azure-resource-manager/generated-defs/Azure.ResourceManager.BaseTypes.ts
+++ b/packages/typespec-azure-resource-manager/generated-defs/Azure.ResourceManager.BaseTypes.ts
@@ -24,7 +24,7 @@ export interface BaseTypeInfo {
  *
  * // The @azureBaseType decorator marks the resource as conforming to the Agent base type.
  * // (The Agent template applies this automatically, but it can also be applied directly.)
- * @azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
+ * @azureBaseType(#{ baseType: BaseType.Agent, version: "2026-04-01" })
  * model ContosoApplianceAgent is TrackedResource<ContosoApplianceProperties> {
  *   ...ResourceNameParameter<ContosoApplianceAgent>;
  * }

--- a/packages/typespec-azure-resource-manager/lib/base-types/agent.tsp
+++ b/packages/typespec-azure-resource-manager/lib/base-types/agent.tsp
@@ -399,7 +399,7 @@ model ResponseInstructionsProperty {
  * Applies the Agent base type decorator automatically.
  * @template Properties RP-specific properties for the agent (must extend AgentProperties)
  */
-@azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
+@azureBaseType(#{ baseType: BaseType.Agent, version: "2026-04-01" })
 model Agent<Properties extends AgentProperties> is TrackedResource<Properties>;
 
 /**

--- a/packages/typespec-azure-resource-manager/lib/base-types/base-types.tsp
+++ b/packages/typespec-azure-resource-manager/lib/base-types/base-types.tsp
@@ -51,7 +51,7 @@ model BaseTypeInfo {
  *
  * // The @azureBaseType decorator marks the resource as conforming to the Agent base type.
  * // (The Agent template applies this automatically, but it can also be applied directly.)
- * @azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
+ * @azureBaseType(#{ baseType: BaseType.Agent, version: "2026-04-01" })
  * model ContosoApplianceAgent is TrackedResource<ContosoApplianceProperties> {
  *   ...ResourceNameParameter<ContosoApplianceAgent>;
  * }

--- a/website/src/content/docs/docs/libraries/azure-resource-manager/reference/decorators.md
+++ b/website/src/content/docs/docs/libraries/azure-resource-manager/reference/decorators.md
@@ -609,7 +609,7 @@ model ContosoApplianceProperties is AgentPropertiesAppliance<ContosoApplianceDef
 
 // The @azureBaseType decorator marks the resource as conforming to the Agent base type.
 // (The Agent template applies this automatically, but it can also be applied directly.)
-@azureBaseType(#{ baseType: BaseType.Agent, version: "2024-06-01" })
+@azureBaseType(#{ baseType: BaseType.Agent, version: "2026-04-01" })
 model ContosoApplianceAgent is TrackedResource<ContosoApplianceProperties> {
   ...ResourceNameParameter<ContosoApplianceAgent>;
 }


### PR DESCRIPTION
Corrects a typo in the `@azureBaseType` decorator in `agent.tsp`. The `version` field was mistakenly set to `2024-06-01` instead of the correct `2026-04-01` for `BaseType.Agent`.