### PR TITLE
fix(tcgc): surface @encode(string) on boolean types

### DIFF
--- a/.chronus/changes/fix-encode-string-on-boolean-2026-07-20-16-30-00.md
+++ b/.chronus/changes/fix-encode-string-on-boolean-2026-07-20-16-30-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Surface `@encode(string)` on boolean types in `SdkBuiltInType` so downstream emitters can generate string-encoded boolean (de)serialization.

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -218,8 +218,8 @@ export function addEncodeInfo(
       innerType.encode = "bytes";
     }
   }
-  if (isSdkIntKind(innerType.kind)) {
-    // only integer type is allowed to be encoded as string
+  if (isSdkIntKind(innerType.kind) || innerType.kind === "boolean") {
+    // integer and boolean types are allowed to be encoded as string
     if (encodeData) {
       if (encodeData?.encoding) {
         (innerType as any).encode = encodeData.encoding;

--- a/packages/typespec-client-generator-core/test/types/built-in.test.ts
+++ b/packages/typespec-client-generator-core/test/types/built-in.test.ts
@@ -412,7 +412,7 @@ it("integer scalar encoded as string", async function () {
 });
 
 it("boolean model property encoded as string", async function () {
-  await runner.compileWithBuiltInService(
+  const { program } = await SimpleTesterWithService.compile(
     `
       @usage(Usage.input | Usage.output)
       model Test {
@@ -421,14 +421,15 @@ it("boolean model property encoded as string", async function () {
       }
       `,
   );
-  const sdkType = getSdkTypeHelper(runner);
+  const context = await createSdkContextForTester(program);
+  const sdkType = getSdkTypeHelper(context);
   strictEqual(sdkType.kind, "boolean");
   strictEqual(sdkType.encode, "string");
   strictEqual(sdkType.baseType, undefined);
 });
 
 it("boolean scalar encoded as string", async function () {
-  await runner.compileWithBuiltInService(
+  const { program } = await SimpleTesterWithService.compile(
     `
       @encode(string)
       scalar boolEncodedAsString extends boolean;
@@ -439,7 +440,8 @@ it("boolean scalar encoded as string", async function () {
       }
     `,
   );
-  const sdkType = getSdkTypeHelper(runner);
+  const context = await createSdkContextForTester(program);
+  const sdkType = getSdkTypeHelper(context);
   strictEqual(sdkType.kind, "boolean");
   strictEqual(sdkType.encode, "string");
   strictEqual(sdkType.baseType?.kind, "boolean");

--- a/packages/typespec-client-generator-core/test/types/built-in.test.ts
+++ b/packages/typespec-client-generator-core/test/types/built-in.test.ts
@@ -410,3 +410,37 @@ it("integer scalar encoded as string", async function () {
   strictEqual(sdkType.baseType?.kind, "int32");
   assertModelsAndEnumsHaveNames(context);
 });
+
+it("boolean model property encoded as string", async function () {
+  await runner.compileWithBuiltInService(
+    `
+      @usage(Usage.input | Usage.output)
+      model Test {
+        @encode(string)
+        value: boolean;
+      }
+      `,
+  );
+  const sdkType = getSdkTypeHelper(runner);
+  strictEqual(sdkType.kind, "boolean");
+  strictEqual(sdkType.encode, "string");
+  strictEqual(sdkType.baseType, undefined);
+});
+
+it("boolean scalar encoded as string", async function () {
+  await runner.compileWithBuiltInService(
+    `
+      @encode(string)
+      scalar boolEncodedAsString extends boolean;
+
+      @usage(Usage.input | Usage.output)
+      model Test {
+        value: boolEncodedAsString;
+      }
+    `,
+  );
+  const sdkType = getSdkTypeHelper(runner);
+  strictEqual(sdkType.kind, "boolean");
+  strictEqual(sdkType.encode, "string");
+  strictEqual(sdkType.baseType?.kind, "boolean");
+});


### PR DESCRIPTION
## Problem

TCGC drops the `@encode(string)` value for `boolean` scalars/properties. The TypeSpec compiler supports encoding a `boolean` as a `string`, but TCGC never surfaces it on the resulting `SdkBuiltInType`, so downstream emitters cannot generate string-encoded boolean (de)serialization.

## Fix

Extended the `addEncodeInfo` condition in `packages/typespec-client-generator-core/src/types.ts` to include `innerType.kind === "boolean"` alongside the existing `isSdkIntKind` check. This ensures `@encode(string)` on boolean properties/scalars surfaces `encode === "string"` on the `SdkBuiltInType`.

## Tests

Added two tests mirroring the existing integer encode tests:
- "boolean model property encoded as string"
- "boolean scalar encoded as string"

Fixes #4961