### PR TITLE
Bump version for hotfix: typespec-java@0.45.8

### DIFF
--- a/.chronus/changes/typespec-java-dpg-xml-2026-07-21-14-26-0.md
+++ b/.chronus/changes/typespec-java-dpg-xml-2026-07-21-14-26-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Support XML serialization for models: generate XmlSerializer helper classes and use the XML ObjectSerializer overload of toObject/fromObject in convenience methods for XML request/response bodies.

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.45.8
 
-### Bug Fixes
+### Features
 
 - [#4987](https://github.com/Azure/typespec-azure/pull/4987) Support XML serialization for models: generate XmlSerializer helper classes and use the XML ObjectSerializer overload of toObject/fromObject in convenience methods for XML request/response bodies.
 

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-java
 
+## 0.45.8
+
+### Bug Fixes
+
+- [#4987](https://github.com/Azure/typespec-azure/pull/4987) Support XML serialization for models: generate XmlSerializer helper classes and use the XML ObjectSerializer overload of toObject/fromObject in convenience methods for XML request/response bodies.
+
+
 ## 0.45.7
 
 Compatible with compiler 1.14.0.

--- a/packages/typespec-java/emitter-tests/Setup.ps1
+++ b/packages/typespec-java/emitter-tests/Setup.ps1
@@ -34,7 +34,7 @@ if (Test-Path package-lock.json) {
 # typespec-tests references typespec-java via a local file path.
 # npm ci will fail when the hash of the package is different from the one in package-lock.json.
 # To avoid this, we remove package-lock.json and run npm install instead.
-npm install
+npm install --registry=https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-js/npm/registry/
 
 # delete output
 if (Test-Path tsp-output) {

--- a/packages/typespec-java/emitter-tests/package.json
+++ b/packages/typespec-java/emitter-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java-tests",
-  "version": "0.45.7",
+  "version": "0.45.8",
   "type": "module",
   "scripts": {
     "format": "npm run -s prettier -- --write",
@@ -17,7 +17,7 @@
     "@typespec/spector": "0.1.0-alpha.26",
     "@typespec/http-specs": "0.1.0-alpha.39",
     "@azure-tools/azure-http-specs": "0.1.0-alpha.43",
-    "@azure-tools/typespec-java": "file:../azure-tools-typespec-java-0.45.7.tgz"
+    "@azure-tools/typespec-java": "file:../azure-tools-typespec-java-0.45.8.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": "^1.13.0",

--- a/packages/typespec-java/emitter-tests/pom.xml
+++ b/packages/typespec-java/emitter-tests/pom.xml
@@ -35,6 +35,11 @@
       <version>1.2.1</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.dataformat</groupId>
+      <artifactId>jackson-dataformat-xml</artifactId>
+      <version>2.18.7</version>
+    </dependency>
+    <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-identity</artifactId>
       <version>1.18.2</version>

--- a/packages/typespec-java/package.json
+++ b/packages/typespec-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.45.7",
+  "version": "0.45.8",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
Hotfix (patch) release of `@azure-tools/typespec-java` **0.45.7 -> 0.45.8** from `release/july-2026`.

Includes the XML serialization sync fix (#4987).

Version bump via `pnpm chronus version --ignore-policies`:
- `packages/typespec-java/package.json` -> 0.45.8
- `packages/typespec-java/CHANGELOG.md` (Bug Fixes)
- removed the consumed `.chronus/changes` entry
- `packages/typespec-java/emitter-tests/package.json` -> 0.45.8 (version + `@azure-tools/typespec-java` .tgz dependency)

Core submodule unchanged. Backmerge to `main` to follow after publish.