### PR TITLE
fix(azure-http-specs): declare LRO final result for postPagingLroWithBody

### DIFF
--- a/.chronus/changes/fix-lropaging-with-body-final-result-2026-07-21-15-50-00.md
+++ b/.chronus/changes/fix-lropaging-with-body-final-result-2026-07-21-15-50-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Fix the `postPagingLroWithBody` ARM scenario to declare the LRO final result (`ArmLroLocationHeader<FinalResult = ProductListResult>`) so the accepted response's `location` header points at the paged result type.

--- a/packages/azure-http-specs/specs/azure/resource-manager/operation-templates/lropaging.tsp
+++ b/packages/azure-http-specs/specs/azure/resource-manager/operation-templates/lropaging.tsp
@@ -184,7 +184,8 @@ interface LroPaging {
     Product,
     VnetProfile,
     | ArmResponse<ProductListResult>
-    | (ArmAcceptedLroResponse & {
+    | (ArmAcceptedLroResponse<LroHeaders = ArmLroLocationHeader<FinalResult = ProductListResult> &
+        Azure.Core.Foundations.RetryAfterHeader> & {
         @TypeSpec.Http.bodyRoot
         _: ProductListResult;
       }),


### PR DESCRIPTION
## Fix

The Go Mock API Tests **Regenerate** step was failing on `main` (e.g. [this run](https://github.com/Azure/typespec-azure/actions/runs/29806638201/job/88558874577)) with:

```
lropaging.tsp:183:3 - error @azure-tools/typespec-go/InternalError:
Error: paged method PostPagingLroWithBody has no synthesized response type
```

### Root cause

The `postPagingLroWithBody` ARM scenario (added in #4632) uses `ArmResourceActionAsyncBase` with a hand-written union response. Its `ArmAcceptedLroResponse` relied on the default `ArmLroLocationHeader`, where `FinalResult = void`. That produces `@finalLocation(void)`, so TCGC never synthesizes an `lroMetadata.finalResponse`, and the Go emitter crashes trying to read the paged final result — aborting regeneration of the entire `templatesgroup`.

### Change

Declare the LRO final result on the Accepted response, matching the documented ARM template pattern, while preserving the 202 body:

```tsp
| (ArmAcceptedLroResponse<
    LroHeaders = ArmLroLocationHeader<FinalResult = ProductListResult> &
      Azure.Core.Foundations.RetryAfterHeader
  > & {
    @TypeSpec.Http.bodyRoot
    _: ProductListResult;
  })
```

### Validation

- `tsp-spector validate-scenarios` passes.
- Go regenerate for `templatesgroup` succeeds; `go build ./...` and `go vet ./...` are clean.
- typespec-ts baseline (`operation-templates/src/index.d.ts`) is unchanged — `postPagingLroWithBody` still resolves to `PagedAsyncIterableIterator<Product>`. No Python baseline exists.
