### PR TITLE
Bump version for hotfix: typespec-java@0.45.9

### DIFF
--- a/.chronus/changes/typespec-java-fix-xml-serializer-bytes-2026-07-22-13-11-0.md
+++ b/.chronus/changes/typespec-java-fix-xml-serializer-bytes-2026-07-22-13-11-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Fix XML serialization to only apply for `azure-v1` data-plane clients, and to skip the XML `ObjectSerializer` for raw `byte[]`/`BinaryData` payloads that are not structured XML models. This avoids emitting a reference to a non-generated `XmlSerializerProviders` helper (which caused a build break) for operations that return raw XML bytes.

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-java
 
+## 0.45.9
+
+### Bug Fixes
+
+- [#5012](https://github.com/Azure/typespec-azure/pull/5012) Fix XML serialization to only apply for `azure-v1` data-plane clients, and to skip the XML `ObjectSerializer` for raw `byte[]`/`BinaryData` payloads that are not structured XML models. This avoids emitting a reference to a non-generated `XmlSerializerProviders` helper (which caused a build break) for operations that return raw XML bytes.
+
+
 ## 0.45.8
 
 ### Features

--- a/packages/typespec-java/emitter-tests/package.json
+++ b/packages/typespec-java/emitter-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java-tests",
-  "version": "0.45.8",
+  "version": "0.45.9",
   "type": "module",
   "scripts": {
     "format": "npm run -s prettier -- --write",
@@ -17,7 +17,7 @@
     "@typespec/spector": "0.1.0-alpha.26",
     "@typespec/http-specs": "0.1.0-alpha.39",
     "@azure-tools/azure-http-specs": "0.1.0-alpha.43",
-    "@azure-tools/typespec-java": "file:../azure-tools-typespec-java-0.45.8.tgz"
+    "@azure-tools/typespec-java": "file:../azure-tools-typespec-java-0.45.9.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": "^1.13.0",

--- a/packages/typespec-java/package.json
+++ b/packages/typespec-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.45.8",
+  "version": "0.45.9",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
Hotfix version bump for `@azure-tools/typespec-java` 0.45.8 -> 0.45.9.

Publishes the fix from #5012 (XML serializer gated to azure-v1 data-plane + skip raw byte[]/BinaryData payloads).

- Consumes the `fix` change file (patch bump)
- `packages/typespec-java/package.json`: 0.45.8 -> 0.45.9
- `packages/typespec-java/emitter-tests/package.json`: version + .tgz dep bumped to 0.45.9
- `core` submodule unchanged

Squash merge to trigger the NPM publish pipeline.