### PR TITLE
Enrich TCGC linter rule docs with impact, severity, message and suppression

### DIFF
--- a/packages/typespec-client-generator-core/src/rules/csharp-no-url-suffix.md
+++ b/packages/typespec-client-generator-core/src/rules/csharp-no-url-suffix.md
@@ -7,7 +7,7 @@ The rule checks the C#-resolved name (respecting `@clientName` overrides).
 - **Area:** SDK generation, **C# only**. Affects the generated property name in the C# SDK (applies to both data-plane and management-plane).
 - **Not affected:** Other language SDKs, the service definition, and the wire protocol are unchanged — the serialized name is untouched, only the C# client-surface name.
 
-#### ❌ Incorrect Example
+#### ❌ Incorrect Usage
 
 ```tsp
 model Foo {

--- a/packages/typespec-client-generator-core/src/rules/csharp-no-url-suffix.md
+++ b/packages/typespec-client-generator-core/src/rules/csharp-no-url-suffix.md
@@ -2,6 +2,27 @@ Properties ending with `Url` should use `Uri` suffix instead to follow .NET SDK 
 
 The rule checks the C#-resolved name (respecting `@clientName` overrides).
 
+## Impact
+
+- **Area:** SDK generation, **C# only**. Affects the generated property name in the C# SDK (applies to both data-plane and management-plane).
+- **Not affected:** Other language SDKs, the service definition, and the wire protocol are unchanged — the serialized name is untouched, only the C# client-surface name.
+
+## Severity
+
+`warning` — suppressible. This is a .NET naming-convention issue, not a correctness error: the C# SDK still generates, but the property name will not match .NET's preferred `Uri` spelling. Recommended to fix so the C# SDK reads idiomatically.
+
+## Diagnostic message
+
+```text
+Property 'imageUrl' ends with 'Url'. Use 'Uri' suffix instead (e.g. 'imageUri'). Use @clientName("imageUri", "csharp") to rename it for C#.
+```
+
+**What it means:** A property's C#-resolved name ends with `Url`, which the .NET guidelines spell as `Uri`.
+
+**Why it matters:** .NET SDKs consistently use the `Uri` suffix. A `Url`-suffixed property makes the generated C# SDK inconsistent with .NET conventions and other Azure C# SDKs.
+
+**Recommended fix:** Rename the property to end with `Uri`, or keep the TypeSpec name and rename it for C# only with `@clientName("<name>Uri", "csharp")`.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -25,4 +46,15 @@ Or using `@@clientName` in `client.tsp` to override just the C# name:
 ```tsp
 // client.tsp
 @@clientName(Foo.imageUrl, "imageUri", "csharp");
+```
+
+## Suppression
+
+Suppress this rule only when the `Url` spelling is intentional for the C# SDK:
+
+```tsp
+#suppress "@azure-tools/typespec-client-generator-core/csharp-no-url-suffix" "intentional Url naming"
+model Foo {
+  imageUrl: string;
+}
 ```

--- a/packages/typespec-client-generator-core/src/rules/csharp-no-url-suffix.md
+++ b/packages/typespec-client-generator-core/src/rules/csharp-no-url-suffix.md
@@ -7,23 +7,7 @@ The rule checks the C#-resolved name (respecting `@clientName` overrides).
 - **Area:** SDK generation, **C# only**. Affects the generated property name in the C# SDK (applies to both data-plane and management-plane).
 - **Not affected:** Other language SDKs, the service definition, and the wire protocol are unchanged — the serialized name is untouched, only the C# client-surface name.
 
-## Severity
-
-`warning` — suppressible. This is a .NET naming-convention issue, not a correctness error: the C# SDK still generates, but the property name will not match .NET's preferred `Uri` spelling. Recommended to fix so the C# SDK reads idiomatically.
-
-## Diagnostic message
-
-```text
-Property 'imageUrl' ends with 'Url'. Use 'Uri' suffix instead (e.g. 'imageUri'). Use @clientName("imageUri", "csharp") to rename it for C#.
-```
-
-**What it means:** A property's C#-resolved name ends with `Url`, which the .NET guidelines spell as `Uri`.
-
-**Why it matters:** .NET SDKs consistently use the `Uri` suffix. A `Url`-suffixed property makes the generated C# SDK inconsistent with .NET conventions and other Azure C# SDKs.
-
-**Recommended fix:** Rename the property to end with `Uri`, or keep the TypeSpec name and rename it for C# only with `@clientName("<name>Uri", "csharp")`.
-
-#### ❌ Incorrect
+#### ❌ Incorrect Example
 
 ```tsp
 model Foo {
@@ -32,7 +16,17 @@ model Foo {
 }
 ```
 
-#### ✅ Correct
+#### Diagnostic Message
+
+For the model above, the linter reports each property whose C# name ends with `Url`:
+
+```text
+Property 'imageUrl' ends with 'Url'. Use 'Uri' suffix instead (e.g. 'imageUri'). Use @clientName("imageUri", "csharp") to rename it for C#.
+```
+
+#### ✅ How to Fix
+
+Rename the property to end with `Uri`:
 
 ```tsp
 model Foo {
@@ -41,7 +35,7 @@ model Foo {
 }
 ```
 
-Or using `@@clientName` in `client.tsp` to override just the C# name:
+Or use `@@clientName` in `client.tsp` to override just the C# name:
 
 ```tsp
 // client.tsp
@@ -50,7 +44,7 @@ Or using `@@clientName` in `client.tsp` to override just the C# name:
 
 ## Suppression
 
-Suppress this rule only when the `Url` spelling is intentional for the C# SDK:
+This rule is a `warning` and can be suppressed. Suppress it only when the `Url` spelling is intentional for the C# SDK:
 
 ```tsp
 #suppress "@azure-tools/typespec-client-generator-core/csharp-no-url-suffix" "intentional Url naming"

--- a/packages/typespec-client-generator-core/src/rules/property-name-conflict.md
+++ b/packages/typespec-client-generator-core/src/rules/property-name-conflict.md
@@ -3,6 +3,27 @@ some language emitters (notably C#), where the generated property would
 collide with the type name. Rename the property, or use `@clientName` to
 rename it for the affected language.
 
+## Impact
+
+- **Area:** SDK generation, primarily **C#**. A property whose name collides with its enclosing model's name produces code that does not compile in C# (applies to both data-plane and management-plane).
+- **Not affected:** The service definition and the wire protocol are unchanged; the collision only affects the generated client code.
+
+## Severity
+
+`warning` — suppressible. Although reported as a warning, it should be treated as a must-fix for the C# SDK: leaving the conflict in place produces C# code that fails to compile.
+
+## Diagnostic message
+
+```text
+Property 'widget' having the same name as its enclosing model will cause problems with C# code generation. Consider renaming the property directly or using the @clientName("newName", "csharp") decorator to rename the property for C#.
+```
+
+**What it means:** A property's C#-resolved name is the same (case-insensitively) as its enclosing model's C#-resolved name.
+
+**Why it matters:** In C#, a member cannot have the same name as its containing type, so the generated model does not compile. This blocks building the C# SDK.
+
+**Recommended fix:** Rename the property, or keep the TypeSpec name and rename it for C# only with `@clientName("<newName>", "csharp")`.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -24,6 +45,17 @@ model Widget {
 ```tsp
 model Widget {
   @clientName("widgetName", "csharp")
+  widget: string;
+}
+```
+
+## Suppression
+
+Because this conflict breaks C# generation, suppressing the rule is discouraged. Only suppress it if the affected model is never generated for C#:
+
+```tsp
+#suppress "@azure-tools/typespec-client-generator-core/property-name-conflict" "model not generated for C#"
+model Widget {
   widget: string;
 }
 ```

--- a/packages/typespec-client-generator-core/src/rules/property-name-conflict.md
+++ b/packages/typespec-client-generator-core/src/rules/property-name-conflict.md
@@ -8,23 +8,7 @@ rename it for the affected language.
 - **Area:** SDK generation, primarily **C#**. A property whose name collides with its enclosing model's name produces code that does not compile in C# (applies to both data-plane and management-plane).
 - **Not affected:** The service definition and the wire protocol are unchanged; the collision only affects the generated client code.
 
-## Severity
-
-`warning` — suppressible. Although reported as a warning, it should be treated as a must-fix for the C# SDK: leaving the conflict in place produces C# code that fails to compile.
-
-## Diagnostic message
-
-```text
-Property 'widget' having the same name as its enclosing model will cause problems with C# code generation. Consider renaming the property directly or using the @clientName("newName", "csharp") decorator to rename the property for C#.
-```
-
-**What it means:** A property's C#-resolved name is the same (case-insensitively) as its enclosing model's C#-resolved name.
-
-**Why it matters:** In C#, a member cannot have the same name as its containing type, so the generated model does not compile. This blocks building the C# SDK.
-
-**Recommended fix:** Rename the property, or keep the TypeSpec name and rename it for C# only with `@clientName("<newName>", "csharp")`.
-
-#### ❌ Incorrect
+#### ❌ Incorrect Example
 
 ```tsp
 model Widget {
@@ -32,7 +16,17 @@ model Widget {
 }
 ```
 
-#### ✅ Correct (rename the property)
+#### Diagnostic Message
+
+For the model above, the linter reports that the property name is the same as its enclosing model name:
+
+```text
+Property 'widget' having the same name as its enclosing model will cause problems with C# code generation. Consider renaming the property directly or using the @clientName("newName", "csharp") decorator to rename the property for C#.
+```
+
+#### ✅ How to Fix
+
+Rename the property:
 
 ```tsp
 model Widget {
@@ -40,7 +34,7 @@ model Widget {
 }
 ```
 
-#### ✅ Correct (rename only for C#)
+Or keep the TypeSpec name and rename it for C# only:
 
 ```tsp
 model Widget {
@@ -51,7 +45,7 @@ model Widget {
 
 ## Suppression
 
-Because this conflict breaks C# generation, suppressing the rule is discouraged. Only suppress it if the affected model is never generated for C#:
+Although reported as a `warning`, this conflict breaks C# code generation, so it should be treated as a must-fix. Suppress it only if the affected model is never generated for C#:
 
 ```tsp
 #suppress "@azure-tools/typespec-client-generator-core/property-name-conflict" "model not generated for C#"

--- a/packages/typespec-client-generator-core/src/rules/property-name-conflict.md
+++ b/packages/typespec-client-generator-core/src/rules/property-name-conflict.md
@@ -8,7 +8,7 @@ rename it for the affected language.
 - **Area:** SDK generation, primarily **C#**. A property whose name collides with its enclosing model's name produces code that does not compile in C# (applies to both data-plane and management-plane).
 - **Not affected:** The service definition and the wire protocol are unchanged; the collision only affects the generated client code.
 
-#### ❌ Incorrect Example
+#### ❌ Incorrect Usage
 
 ```tsp
 model Widget {

--- a/packages/typespec-client-generator-core/src/rules/property-name-conflict.md
+++ b/packages/typespec-client-generator-core/src/rules/property-name-conflict.md
@@ -45,11 +45,4 @@ model Widget {
 
 ## Suppression
 
-Although reported as a `warning`, this conflict breaks C# code generation, so it should be treated as a must-fix. Suppress it only if the affected model is never generated for C#:
-
-```tsp
-#suppress "@azure-tools/typespec-client-generator-core/property-name-conflict" "model not generated for C#"
-model Widget {
-  widget: string;
-}
-```
+This rule should not be suppressed. Although it is reported as a `warning`, the name conflict breaks C# code generation, so it must be fixed rather than suppressed.

--- a/packages/typespec-client-generator-core/src/rules/require-client-suffix.md
+++ b/packages/typespec-client-generator-core/src/rules/require-client-suffix.md
@@ -10,7 +10,7 @@ If the underlying TypeSpec name does not end with `Client`, use the
 - **Area:** SDK generation. Affects the name of the top-level client type in every emitted language SDK (both data-plane and management-plane).
 - **Not affected:** The service definition and the generated wire protocol are unchanged; this is a client-surface naming convention only.
 
-#### ❌ Incorrect Example
+#### ❌ Incorrect Usage
 
 ```tsp
 @client

--- a/packages/typespec-client-generator-core/src/rules/require-client-suffix.md
+++ b/packages/typespec-client-generator-core/src/rules/require-client-suffix.md
@@ -10,37 +10,31 @@ If the underlying TypeSpec name does not end with `Client`, use the
 - **Area:** SDK generation. Affects the name of the top-level client type in every emitted language SDK (both data-plane and management-plane).
 - **Not affected:** The service definition and the generated wire protocol are unchanged; this is a client-surface naming convention only.
 
-## Severity
-
-`warning` — suppressible. This is a naming-consistency convention rather than a correctness error: the SDK still generates, but the entry-point client will not follow the expected `...Client` naming. Recommended to fix so the SDK stays idiomatic and discoverable.
-
-## Diagnostic message
-
-```text
-Client name "MyService" must end with Client. Use @client({name: "...Client"})
-```
-
-**What it means:** A top-level client (a namespace or interface treated as a client) has a name that does not end with `Client`.
-
-**Why it matters:** Consumers rely on the `...Client` suffix to discover the entry point of an SDK. A non-standard name makes the generated SDK inconsistent with other Azure SDKs and harder to use.
-
-**Recommended fix:** Rename the namespace/interface so it ends with `Client`, or give it a client-friendly name with `@client({ name: "...Client" })`.
-
-#### ❌ Incorrect
+#### ❌ Incorrect Example
 
 ```tsp
 @client
 namespace MyService;
 ```
 
-#### ✅ Correct
+#### Diagnostic Message
+
+For the client above, the linter reports that the client name does not end with `Client`:
+
+```text
+Client name "MyService" must end with Client. Use @client({name: "...Client"})
+```
+
+#### ✅ How to Fix
+
+Rename the namespace or interface so it ends with `Client`:
 
 ```tsp
 @client
 namespace MyServiceClient;
 ```
 
-#### ✅ Correct (renamed via `@client`)
+Or give it a client-friendly name with `@client`:
 
 ```tsp
 @client({
@@ -51,7 +45,7 @@ namespace MyService;
 
 ## Suppression
 
-Suppress this rule only when a non-standard client name is intentional:
+This rule is a `warning` and can be suppressed. Suppress it only when the non-standard client name is intentional and you accept that the generated SDK entry point will not follow the `...Client` convention:
 
 ```tsp
 #suppress "@azure-tools/typespec-client-generator-core/require-client-suffix" "intentional non-standard client name"

--- a/packages/typespec-client-generator-core/src/rules/require-client-suffix.md
+++ b/packages/typespec-client-generator-core/src/rules/require-client-suffix.md
@@ -5,6 +5,27 @@ client and provides a consistent experience across emitted languages.
 If the underlying TypeSpec name does not end with `Client`, use the
 `@client` decorator to provide a client-friendly name.
 
+## Impact
+
+- **Area:** SDK generation. Affects the name of the top-level client type in every emitted language SDK (both data-plane and management-plane).
+- **Not affected:** The service definition and the generated wire protocol are unchanged; this is a client-surface naming convention only.
+
+## Severity
+
+`warning` — suppressible. This is a naming-consistency convention rather than a correctness error: the SDK still generates, but the entry-point client will not follow the expected `...Client` naming. Recommended to fix so the SDK stays idiomatic and discoverable.
+
+## Diagnostic message
+
+```text
+Client name "MyService" must end with Client. Use @client({name: "...Client"})
+```
+
+**What it means:** A top-level client (a namespace or interface treated as a client) has a name that does not end with `Client`.
+
+**Why it matters:** Consumers rely on the `...Client` suffix to discover the entry point of an SDK. A non-standard name makes the generated SDK inconsistent with other Azure SDKs and harder to use.
+
+**Recommended fix:** Rename the namespace/interface so it ends with `Client`, or give it a client-friendly name with `@client({ name: "...Client" })`.
+
 #### ❌ Incorrect
 
 ```tsp
@@ -25,5 +46,15 @@ namespace MyServiceClient;
 @client({
   name: "MyServiceClient",
 })
+namespace MyService;
+```
+
+## Suppression
+
+Suppress this rule only when a non-standard client name is intentional:
+
+```tsp
+#suppress "@azure-tools/typespec-client-generator-core/require-client-suffix" "intentional non-standard client name"
+@client
 namespace MyService;
 ```


### PR DESCRIPTION
## Summary

Enriches the reference docs for all TCGC (`@azure-tools/typespec-client-generator-core`) linter rules with structured guidance, so each rule page explains its impact, the error it produces, how to fix it, and when it may be suppressed.

The three rules covered: `require-client-suffix`, `property-name-conflict`, `csharp-no-url-suffix`.

## Doc structure

Each rule doc now follows this layout (keeping the original description):

- **Impact** — which SDK / language and plane (data-plane / management-plane) the rule affects, and what it does not affect.
- **❌ Incorrect Usage** — TypeSpec that triggers the rule.
- **Diagnostic Message** — the actual message text for that example, with a brief explanation.
- **✅ How to Fix** — the corrected TypeSpec (including `@clientName` / `@client` variants where relevant).
- **Suppression** — when it is appropriate to suppress the rule. All TCGC linter rules are `warning`, so the severity nuance lives here: `require-client-suffix` and `csharp-no-url-suffix` may be suppressed when the naming is intentional, while `property-name-conflict` should not be suppressed because the conflict breaks C# code generation and must be fixed.

## Notes

- Docs only (source markdown under `packages/typespec-client-generator-core/src/rules/*.md`). The generated website pages are produced by `tspd doc` and are not tracked.
- No changelog entry: markdown-only changes are excluded from Chronus.