### PR TITLE
Add commit rules and branch/PR workflow to copilot-instructions.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,11 +11,23 @@ This document serves as an index to task-specific instructions for GitHub Copilo
 - Use `pnpm -r --filter "<pkgName>..." build` to build to a specific package `<pkgName>`
 - Use `pnpm format` to format all files
 
+## Commit Rules
+
+- Always run `pnpm format && pnpm lint` before committing.
+- Always describe changes (see "Describing changes" section below).
+- Do not commit the file `core` or `pnpm-lock.yaml` unless your change specifically requires updating them (e.g., the nightly bot updates the `core` submodule dependency). If these appear in your staged changes unintentionally, unstage them before committing.
+
 ## Describing changes
 
 - Repo use `@chronus/chronus` for changelogs
 - Use `pnpm change add` to add a change description for the touched packages
 - Types of changes are described in `.chronus/config.yaml`
+
+## Branch and PR Workflow
+
+- When creating worktrees or branches for new work, base them off the main Azure fork's `main` branch (Azure/typespec-azure). Depending on the user's local git remote setup, this may be called `upstream` or `origin`.
+- When creating worktrees (which clone the repo), always clone recursively with `--recurse-submodules` and run `git submodule update --init` if the `core/` submodule is missing or not at the correct commit. See [CONTRIBUTING.md - Cloning recursively](https://github.com/Azure/typespec-azure/blob/main/CONTRIBUTING.md#cloning-recursively) for details.
+- When pushing changes and creating pull requests, push to your personal fork and open PRs against the main Azure fork's `main` branch.
 
 ## Available Task Instructions
 


### PR DESCRIPTION
Copilot currently has no guidance on commit hygiene or the fork-based PR workflow used by contributors to this repo. This adds two new sections to the existing `.github/copilot-instructions.md` so that Copilot sessions automatically follow the same conventions human contributors use.

**Changes:**

- **Commit Rules** -- always run `pnpm format` before committing; avoid committing `core/` or `pnpm-lock.yaml` unless absolutely necessary.
- **Branch and PR Workflow** -- base new work off the main Azure fork's `main` branch; push to the contributor's personal fork; open PRs against `Azure/typespec-azure` main.

The existing Install/Build, Describing changes, and Available Task Instructions sections are unchanged.