### PR TITLE
Make TypeSpec Python setup opt-in

### DIFF
--- a/.chronus/changes/python-setup-opt-in-2026-07-22-14-00-00.md
+++ b/.chronus/changes/python-setup-opt-in-2026-07-22-14-00-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Allow installing the package without a local Python interpreter by making the Python development environment setup explicit.

--- a/.chronus/changes/remove-typespec-python-tsx-2026-07-22-14-25-00.md
+++ b/.chronus/changes/remove-typespec-python-tsx-2026-07-22-14-25-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Use Node.js native TypeScript execution for development scripts instead of installing `tsx`.

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -26,7 +26,7 @@ jobs:
         run: pnpm turbo run --filter "@azure-tools/typespec-python..." build
 
       - name: Prepare Python environment
-        run: pnpm run prepare
+        run: pnpm run setup:python
         working-directory: packages/typespec-python
 
       - name: Regenerate
@@ -75,7 +75,7 @@ jobs:
           pnpm --filter "@azure-tools/azure-http-specs" exec tsc -p ./tsconfig.build.json
 
       - name: Prepare Python environment
-        run: pnpm run prepare
+        run: pnpm run setup:python
         working-directory: packages/typespec-python
 
       - name: Download generated artifacts
@@ -105,7 +105,7 @@ jobs:
         run: pnpm install --filter "@azure-tools/typespec-python..."
 
       - name: Prepare Python environment
-        run: pnpm run prepare
+        run: pnpm run setup:python
         working-directory: packages/typespec-python
 
       - name: Download generated artifacts
@@ -135,7 +135,7 @@ jobs:
         run: pnpm install --filter "@azure-tools/typespec-python..."
 
       - name: Prepare Python environment
-        run: pnpm run prepare
+        run: pnpm run setup:python
         working-directory: packages/typespec-python
 
       - name: Download generated artifacts
@@ -173,7 +173,7 @@ jobs:
         run: pnpm install --filter "@azure-tools/typespec-python..."
 
       - name: Prepare Python environment
-        run: pnpm run prepare
+        run: pnpm run setup:python
         working-directory: packages/typespec-python
 
       - name: Download generated artifacts

--- a/.github/workflows/nightly-e2e.yml
+++ b/.github/workflows/nightly-e2e.yml
@@ -28,7 +28,8 @@ concurrency:
 # 2. Add an entry to the matrix below with:
 #    - name, lang, package-filter, working-directory
 #    - mise-install-args: tools to install via mise (e.g., "java maven")
-#    - run-prepare / run-regenerate: set to true if the package has those scripts
+#    - setup-script: package script for language-specific environment setup, or empty
+#    - run-regenerate: set to true if the package has that script
 # ============================================================================
 
 jobs:
@@ -44,7 +45,7 @@ jobs:
             package-filter: "@azure-tools/typespec-python"
             working-directory: packages/typespec-python
             mise-install-args: "python uv"
-            run-prepare: true
+            setup-script: "setup:python"
             run-regenerate: true
             # Core packages excluded from the pnpm workspace that must be
             # built from source and injected via overrides.
@@ -53,14 +54,14 @@ jobs:
             lang: ts
             package-filter: "@azure-tools/typespec-ts"
             working-directory: packages/typespec-ts
-            run-prepare: false
+            setup-script: ""
             run-regenerate: false
           - name: Java
             lang: java
             package-filter: "@azure-tools/typespec-java"
             working-directory: packages/typespec-java/emitter-tests
             mise-install-args: "java maven"
-            run-prepare: false
+            setup-script: ""
             run-regenerate: true
 
     env:
@@ -179,8 +180,8 @@ jobs:
       # --- Language-specific preparation ---
 
       - name: Prepare environment
-        if: matrix.run-prepare
-        run: pnpm run prepare
+        if: matrix.setup-script != ''
+        run: pnpm run ${{ matrix.setup-script }}
         working-directory: ${{ matrix.working-directory }}
 
       - name: Regenerate

--- a/eng/pipelines/jobs/spector-coverage.yml
+++ b/eng/pipelines/jobs/spector-coverage.yml
@@ -39,7 +39,7 @@ jobs:
       - script: pnpm run build
         displayName: Build (turbo cache restore)
 
-      - script: pnpm run prepare
+      - script: pnpm run setup:python
         displayName: "Prepare Python environment"
         workingDirectory: packages/typespec-python
 

--- a/packages/typespec-python/CONTRIBUTING.md
+++ b/packages/typespec-python/CONTRIBUTING.md
@@ -15,6 +15,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 ## Local development
 
 A repository-wide `pnpm install` does not require Python. Python is only required when developing or testing this package.
+The development scripts require Node.js 22.18 or newer so they can execute TypeScript files directly.
 Install the versions pinned in the repository's `mise.toml` with `mise install python uv`, or provide Python 3.9 or newer
 with either `uv` or `pip`. Then create the development virtual environment from the repository root:
 

--- a/packages/typespec-python/CONTRIBUTING.md
+++ b/packages/typespec-python/CONTRIBUTING.md
@@ -12,6 +12,16 @@ This project has adopted the [Microsoft Open Source Code of Conduct](https://ope
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or
 contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
+## Local development
+
+A repository-wide `pnpm install` does not require Python. Python is only required when developing or testing this package.
+Install the versions pinned in the repository's `mise.toml` with `mise install python uv`, or provide Python 3.9 or newer
+with either `uv` or `pip`. Then create the development virtual environment from the repository root:
+
+```bash
+pnpm --dir packages/typespec-python run setup:python
+```
+
 ## Before making a Pull request
 
 Make sure to run the following commands:

--- a/packages/typespec-python/eng/scripts/ci/format.ts
+++ b/packages/typespec-python/eng/scripts/ci/format.ts
@@ -16,7 +16,9 @@ function getVenvPython(): string {
   } else if (fs.existsSync(join(venvPath, "Scripts"))) {
     return join(venvPath, "Scripts", "python.exe");
   }
-  throw new Error("Virtual environment not found. Run 'pnpm run install' first.");
+  throw new Error(
+    "Virtual environment not found. Run 'pnpm run setup:python' from packages/typespec-python first.",
+  );
 }
 
 const argv = parseArgs({
@@ -31,7 +33,7 @@ const argv = parseArgs({
 
 if (argv.values.help) {
   console.log(`
-${pc.bold("Usage:")} tsx format.ts [options]
+${pc.bold("Usage:")} node format.ts [options]
 
 ${pc.bold("Description:")}
   Format code using Prettier (TypeScript) and Black (Python).
@@ -51,13 +53,13 @@ ${pc.bold("Options:")}
 
 ${pc.bold("Examples:")}
   ${pc.dim("# Format all code (default)")}
-  tsx format.ts
+  node format.ts
 
   ${pc.dim("# Format only TypeScript")}
-  tsx format.ts --typescript
+  node format.ts --typescript
 
   ${pc.dim("# Check formatting without making changes")}
-  tsx format.ts --check
+  node format.ts --check
 `);
   process.exit(0);
 }

--- a/packages/typespec-python/eng/scripts/ci/lint.ts
+++ b/packages/typespec-python/eng/scripts/ci/lint.ts
@@ -11,7 +11,7 @@ const argv = parseArgs({
 
 if (argv.values.help) {
   console.log(`
-${pc.bold("Usage:")} tsx lint.ts [options]
+${pc.bold("Usage:")} node lint.ts [options]
 
 ${pc.bold("Description:")}
   Run extra linting checks beyond what tox provides.

--- a/packages/typespec-python/eng/scripts/ci/regenerate.ts
+++ b/packages/typespec-python/eng/scripts/ci/regenerate.ts
@@ -23,10 +23,10 @@ import {
   getSubdirectories,
   prepareBaselineOfGeneratedCode,
   preprocess,
-  RegenerateContext,
-  RegenerateFlags,
   runParallel,
-} from "./regenerate-common.js";
+  type RegenerateContext,
+  type RegenerateFlags,
+} from "./regenerate-common.ts";
 
 const argv = parseArgs({
   args: process.argv.slice(2),
@@ -44,7 +44,7 @@ const argv = parseArgs({
 
 if (argv.values.help) {
   console.log(`
-${pc.bold("Usage:")} tsx regenerate.ts [options]
+${pc.bold("Usage:")} node regenerate.ts [options]
 
 ${pc.bold("Description:")}
   Regenerates Python SDK code from TypeSpec definitions using in-process
@@ -73,16 +73,16 @@ ${pc.bold("Options:")}
 
 ${pc.bold("Examples:")}
   ${pc.dim("# Regenerate all packages for both flavors")}
-  tsx regenerate.ts
+  node regenerate.ts
 
   ${pc.dim("# Regenerate only Azure packages")}
-  tsx regenerate.ts --flavor azure
+  node regenerate.ts --flavor azure
 
   ${pc.dim("# Regenerate a specific package by name")}
-  tsx regenerate.ts --flavor azure --name authentication-api-key
+  node regenerate.ts --flavor azure --name authentication-api-key
 
   ${pc.dim("# Regenerate with more parallelism")}
-  tsx regenerate.ts --jobs 50
+  node regenerate.ts --jobs 50
 `);
   process.exit(0);
 }

--- a/packages/typespec-python/eng/scripts/ci/run-tests.ts
+++ b/packages/typespec-python/eng/scripts/ci/run-tests.ts
@@ -1,5 +1,5 @@
 /* eslint-disable no-console */
-import { ChildProcess, spawn } from "child_process";
+import { spawn, type ChildProcess } from "child_process";
 import fs from "fs";
 import { cpus } from "os";
 import { dirname, join } from "path";

--- a/packages/typespec-python/eng/scripts/ci/run-tests.ts
+++ b/packages/typespec-python/eng/scripts/ci/run-tests.ts
@@ -64,7 +64,9 @@ function getVenvPython(): string {
   } else if (fs.existsSync(join(venvPath, "Scripts"))) {
     return join(venvPath, "Scripts", "python.exe");
   }
-  throw new Error("Virtual environment not found. Run 'pnpm run install' first.");
+  throw new Error(
+    "Virtual environment not found. Run 'pnpm run setup:python' from packages/typespec-python first.",
+  );
 }
 
 interface ToxResult {

--- a/packages/typespec-python/eng/scripts/setup/run-python3.ts
+++ b/packages/typespec-python/eng/scripts/setup/run-python3.ts
@@ -4,10 +4,10 @@
 // path resolution algorithm as AutoRest so that the behavior
 // is fully consistent (and also supports AUTOREST_PYTHON_EXE).
 //
-// Invoke it like so: "tsx run-python3.ts script.py"
+// Invoke it like so: "node run-python3.ts script.py"
 
 import cp from "child_process";
-import { patchPythonPath } from "./system-requirements.js";
+import { patchPythonPath } from "./system-requirements.ts";
 
 async function runPython3(...args: string[]) {
   const command = await patchPythonPath(["python", ...args], {

--- a/packages/typespec-python/eng/scripts/setup/system-requirements.ts
+++ b/packages/typespec-python/eng/scripts/setup/system-requirements.ts
@@ -1,4 +1,4 @@
-import { ChildProcess, spawn, SpawnOptions } from "child_process";
+import { spawn, type ChildProcess, type SpawnOptions } from "child_process";
 import { coerce, satisfies } from "semver";
 
 /*

--- a/packages/typespec-python/eng/scripts/sync.ts
+++ b/packages/typespec-python/eng/scripts/sync.ts
@@ -15,8 +15,8 @@
  * nothing.
  *
  * Usage:
- *   tsx eng/scripts/sync.ts          # write mode: overwrite local files
- *   tsx eng/scripts/sync.ts --check  # check mode: exit non-zero on drift (CI)
+ *   node eng/scripts/sync.ts          # write mode: overwrite local files
+ *   node eng/scripts/sync.ts --check  # check mode: exit non-zero on drift (CI)
  */
 import fs from "fs";
 import { dirname, join, relative, sep } from "path";
@@ -145,7 +145,7 @@ const argv = parseArgs({
 
 if (argv.values.help) {
   console.log(`
-${pc.bold("Usage:")} tsx eng/scripts/sync.ts [options]
+${pc.bold("Usage:")} node eng/scripts/sync.ts [options]
 
 ${pc.bold("Description:")}
   Copy the files (and recursive directories) listed in INCLUDES from
@@ -400,7 +400,7 @@ function main(): void {
     console.error(
       pc.red(
         `\nSynced files have drifted from core/packages/http-client-python.\n` +
-          `Run 'pnpm sync' (or 'tsx eng/scripts/sync.ts') and commit the result.`,
+          `Run 'pnpm sync' (or 'node eng/scripts/sync.ts') and commit the result.`,
       ),
     );
     process.exit(1);

--- a/packages/typespec-python/package.json
+++ b/packages/typespec-python/package.json
@@ -31,15 +31,15 @@
   "scripts": {
     "clean": "rimraf ./dist ./temp ./venv ./node_modules",
     "build": "tsc -p .",
-    "setup:python": "tsx ./eng/scripts/setup/run-python3.ts ./eng/scripts/setup/install.py && tsx ./eng/scripts/setup/run-python3.ts ./eng/scripts/setup/prepare.py",
+    "setup:python": "node ./eng/scripts/setup/run-python3.ts ./eng/scripts/setup/install.py && node ./eng/scripts/setup/run-python3.ts ./eng/scripts/setup/prepare.py",
     "watch": "tsc -p . --watch",
-    "lint:extra": "tsx ./eng/scripts/ci/lint.ts",
-    "format:extra": "tsx ./eng/scripts/ci/format.ts --python",
-    "format:extra:check": "tsx ./eng/scripts/ci/format.ts --python --check",
-    "regenerate": "tsx ./eng/scripts/ci/regenerate.ts",
-    "sync": "tsx ./eng/scripts/sync.ts",
-    "sync:check": "tsx ./eng/scripts/sync.ts --check",
-    "test:python:e2e": "tsx ./eng/scripts/ci/run-tests.ts",
+    "lint:extra": "node ./eng/scripts/ci/lint.ts",
+    "format:extra": "node ./eng/scripts/ci/format.ts --python",
+    "format:extra:check": "node ./eng/scripts/ci/format.ts --python --check",
+    "regenerate": "node ./eng/scripts/ci/regenerate.ts",
+    "sync": "node ./eng/scripts/sync.ts",
+    "sync:check": "node ./eng/scripts/sync.ts --check",
+    "test:python:e2e": "node ./eng/scripts/ci/run-tests.ts",
     "regen-docs": "pnpm run build && tspd doc . --enable-experimental --output-dir ../../website/src/content/docs/docs/emitters/clients/typespec-python/reference --skip-js"
   },
   "files": [
@@ -65,8 +65,7 @@
   },
   "dependencies": {
     "@typespec/http-client-python": "catalog:",
-    "semver": "catalog:",
-    "tsx": "catalog:"
+    "semver": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/azure-http-specs": "workspace:^",

--- a/packages/typespec-python/package.json
+++ b/packages/typespec-python/package.json
@@ -31,9 +31,8 @@
   "scripts": {
     "clean": "rimraf ./dist ./temp ./venv ./node_modules",
     "build": "tsc -p .",
+    "setup:python": "tsx ./eng/scripts/setup/run-python3.ts ./eng/scripts/setup/install.py && tsx ./eng/scripts/setup/run-python3.ts ./eng/scripts/setup/prepare.py",
     "watch": "tsc -p . --watch",
-    "install": "tsx ./eng/scripts/setup/run-python3.ts ./eng/scripts/setup/install.py",
-    "prepare": "tsx ./eng/scripts/setup/run-python3.ts ./eng/scripts/setup/prepare.py",
     "lint:extra": "tsx ./eng/scripts/ci/lint.ts",
     "format:extra": "tsx ./eng/scripts/ci/format.ts --python",
     "format:extra:check": "tsx ./eng/scripts/ci/format.ts --python --check",

--- a/packages/typespec-python/tsconfig.json
+++ b/packages/typespec-python/tsconfig.json
@@ -1,8 +1,10 @@
 {
   "extends": "../../core/tsconfig.base.json",
   "compilerOptions": {
+    "erasableSyntaxOnly": true,
     "outDir": "dist",
     "rootDir": ".",
+    "rewriteRelativeImportExtensions": true,
     "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"
   },
   "include": ["src/**/*.ts", "eng/**/*.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3919,9 +3919,6 @@ importers:
       semver:
         specifier: 'catalog:'
         version: 7.8.5
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.1
     devDependencies:
       '@azure-tools/azure-http-specs':
         specifier: workspace:^


### PR DESCRIPTION
## Summary

- remove the Python `install` and `prepare` lifecycle hooks and add an explicit `setup:python` command
- update Python-specific CI, nightly, and release workflows to prepare the environment explicitly
- run development TypeScript scripts directly with Node, remove the `tsx` dependency, and enforce erasable syntax

## Validation

- `pnpm format`
- `pnpm lint`
- full workspace install with Python resolution forced to an invalid path
- TypeSpec Python build, explicit Python setup, lint, and formatting checks
- native execution of each converted TypeScript entry point on Node 22

Closes #5024