### PR TITLE
fix(pipeline): restore publish pipeline + enable Go module proxy for spector coverage

### DIFF
--- a/eng/common/pipelines/templates/steps/maven-authenticate.yml
+++ b/eng/common/pipelines/templates/steps/maven-authenticate.yml
@@ -1,0 +1,17 @@
+parameters:
+  SourceDirectory: $(Build.SourcesDirectory)
+
+steps:
+  # Copy mirror settings to default Maven location so all requests go through CFS
+  - pwsh: |
+      $m2Dir = if ($env:USERPROFILE) { "$env:USERPROFILE\.m2" } else { "$HOME/.m2" }
+      New-Item -ItemType Directory -Force -Path $m2Dir | Out-Null
+      Copy-Item -Path "${{ parameters.SourceDirectory }}/eng/settings.xml" -Destination "$m2Dir/settings.xml"
+    displayName: "Setup Maven mirror settings"
+
+  # Authenticate with Azure Artifacts feeds
+  # MavenAuthenticate adds <server> entries to ~/.m2/settings.xml matching mirror id 'azure-sdk-for-java'
+  - task: MavenAuthenticate@0
+    displayName: "Maven Authenticate"
+    inputs:
+      artifactsFeeds: "azure-sdk-for-java"

--- a/eng/pipelines/templates/1es-redirect.yml
+++ b/eng/pipelines/templates/1es-redirect.yml
@@ -26,6 +26,14 @@ extends:
   ${{ else }}:
     template: v1/1ES.Unofficial.PipelineTemplate.yml@1ESPipelineTemplates
   parameters:
+    # Route 'go' CLI traffic through the centralized internal Go module proxy so
+    # `go` invocations during emitter code generation (e.g. typespec-go
+    # tspcompile) can resolve public modules in network-isolated CI agents.
+    # See https://aka.ms/goproxy_for_how_to_onboard
+    featureFlags:
+      golang:
+        internalModuleProxy:
+          enabled: true
     settings:
       skipBuildTagsForGitHubPullRequests: true
       networkIsolationPolicy: Permissive, CFSClean

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,3 +1,8 @@
 variables:
   # Disable CodeQL by default to prevent build timeouts
   Codeql.SkipTaskAutoInjection: true
+  # Route pip through the azure-sdk PyPI proxy feed so `pip install` (triggered
+  # by the typespec-python prepare lifecycle during `pnpm install`) can resolve
+  # packages in network-isolated CI agents where pypi.org is blocked by the
+  # CFSClean network isolation policy.
+  PIP_INDEX_URL: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/


### PR DESCRIPTION
## Problem

The `typespec-azure - Publish` ADO pipeline (`azure-sdk/internal` def **1793**, yaml `/eng/pipelines/publish.yml`) has been failing on every merge to `main`, which is why the spector coverage dashboard is frozen (e.g. Go stuck at `0.14.0`). There are two independent root causes:

### 1. Pipeline fails at YAML compile time
PR #4921 added a reference to `/eng/common/pipelines/templates/steps/maven-authenticate.yml` in `eng/pipelines/templates/install.yml`, but never added the template file. This makes the whole pipeline fail to compile — **no stages run at all**, including the Spector Coverage upload:

```
error: The 'stages' parameter is not a valid StageList.
error: /eng/pipelines/templates/install.yml: Could not find
       /eng/common/pipelines/templates/steps/maven-authenticate.yml
```

### 2. Spector Coverage (Go) fails to download modules
Even before #4921, the `Spector Coverage (Go)` job failed at `Regenerate Go test code` (`pnpm run tspcompile`). After Aug 2025 network isolation, `go` can no longer pull public modules (e.g. `azcore`) directly in isolated CI agents:

```
go: downloading github.com/Azure/azure-sdk-for-go/sdk/azcore v1.22.0
dial tcp: lookup After_August_2025_new_golang_builds_must_pull_public_modules_
from_the_internal_public_module_proxy... : no such host
```

Since this step runs before (and gates) the upload, Go coverage was never uploaded.

## Fix

1. **Restore `maven-authenticate.yml`** in `eng/common/pipelines/templates/steps/` from azure-sdk-tools upstream (matches #4921 intent; its runtime dep `eng/settings.xml` already exists on main).
2. **Enable the 1ES `golang.internalModuleProxy` feature flag** in `eng/pipelines/templates/1es-redirect.yml` so `go` traffic routes through the centralized internal Go module proxy. See https://aka.ms/goproxy_for_how_to_onboard (same approach as `Azure/azure-functions-core-tools`).

## Validation
- [x] Confirm the pipeline compiles and the `Spector Coverage` stage runs.
- [x] Confirm `Spector Coverage (Go)` passes `tspcompile` and uploads coverage.
