### PR TITLE
Migrate PR change comment from Azure pipeline to GitHub Actions

### DIFF
--- a/.github/workflows/commenter.yml
+++ b/.github/workflows/commenter.yml
@@ -1,0 +1,43 @@
+name: Make Change Comment
+
+on:
+  workflow_run:
+    workflows: ["Consistency"]
+    types:
+      - completed
+
+permissions:
+  pull-requests: write
+
+jobs:
+  # DO NOT BUILD ANYTHING FROM A PR HERE https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  commenter:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.actor != 'dependabot[bot]' &&
+      !startsWith(github.head_ref, 'publish/')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          submodules: recursive
+      - name: Prepare artifact directory
+        run: mkdir -p "${{ runner.temp }}/comment-artifact"
+      - uses: actions/download-artifact@v8
+        with:
+          name: comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path: ${{ runner.temp }}/comment-artifact
+      - name: Display structure of downloaded files
+        run: ls -R
+
+      - uses: ./.github/actions/setup
+
+      - run: pnpm install
+        name: Install dependencies
+
+      - run: pnpm chronus-github-pr-commenter --comment-file "${{ runner.temp }}/comment-artifact/comment.json"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        name: Create/update comment

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -33,6 +33,21 @@ jobs:
       - run: pnpm install
         name: Install dependencies
 
+      - name: Create PR comment
+        run: pnpm chronus-github get-pr-comment --out ./comment-out/comment.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        if: |
+          !startsWith(github.head_ref, 'publish/')
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: comment
+          path: comment-out/
+          retention-days: 1 # Only needed by the commenter workflow, so no need to waste storage
+        if: |
+          !startsWith(github.head_ref, 'publish/')
+
       - run: npx chronus verify --since ${{ github.event.pull_request.base.ref }}
         name: Check changelog
         if: |

--- a/eng/pipelines/pr-tools.yml
+++ b/eng/pipelines/pr-tools.yml
@@ -68,19 +68,3 @@ extends:
                 displayName: Check already commented
                 env:
                   GH_TOKEN: $(GH_TOKEN)
-          - job: change_comment
-            displayName: Describe changes on PR
-            condition: and(succeeded(), eq(startsWith(variables['System.PullRequest.SourceBranch'], 'publish/'), false))
-            pool:
-              name: $(LINUXPOOL)
-              image: $(LINUXVMIMAGE)
-              os: linux
-            steps:
-              - checkout: self
-
-              - template: /eng/common/pipelines/templates/steps/login-to-github.yml
-
-              - script: npx -p @chronus/github-pr-commenter@0.5.0 chronus-github-pr-commenter
-                displayName: Make comment about changes
-                env:
-                  GITHUB_TOKEN: $(GH_TOKEN)

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@chronus/chronus": "catalog:",
     "@chronus/github": "catalog:",
+    "@chronus/github-pr-commenter": "catalog:",
     "@pnpm/workspace.find-packages": "catalog:",
     "@types/node": "catalog:",
     "@vitest/coverage-v8": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,6 +582,9 @@ importers:
       '@chronus/github':
         specifier: 'catalog:'
         version: 1.0.6
+      '@chronus/github-pr-commenter':
+        specifier: 'catalog:'
+        version: 1.0.6
       '@pnpm/workspace.find-packages':
         specifier: 'catalog:'
         version: 1000.0.65(@pnpm/logger@1001.0.1)(@pnpm/worker@1000.6.11(@pnpm/logger@1001.0.1)(@types/node@26.1.1))(typanion@3.14.0)


### PR DESCRIPTION
## Problem

The `change_comment` Azure pipeline job (`eng/pipelines/pr-tools.yml`) ran:

```
npx -p @chronus/github-pr-commenter@0.5.0 chronus-github-pr-commenter
```

This fetches the package from the **public npm registry at runtime**, which fails under network isolation:

```
npm error code EPERM
npm error FetchError: request to https://registry.npmjs.org/@chronus%2fgithub-pr-commenter failed
```

## Fix

Migrate the PR change-comment to GitHub Actions, mirroring the `core` submodule's two-step, [pwn-request-safe](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/) pattern:

- **`.github/workflows/consistency.yml`** (`check-changes` job): generate the changelog comment (`chronus-github get-pr-comment`) and upload it as a `comment` artifact.
- **`.github/workflows/commenter.yml`** (new): a `workflow_run`-triggered privileged workflow that downloads the artifact and posts/updates the PR comment. It does not build any PR code.
- **`package.json` / `pnpm-lock.yaml`**: add `@chronus/github-pr-commenter` (catalog `^1.0.6`) to root `devDependencies` so the CLI resolves via the authenticated `pnpm install` instead of a public `npx` fetch.
- **`eng/pipelines/pr-tools.yml`**: remove the now-obsolete `change_comment` job.

## Notes

- `workflow_run` workflows only become active once `commenter.yml` is on the default branch.
- No changelog entry: root `package.json` is `private` and only CI/eng files changed.
