### PR TITLE
fix(typespec-ts): add license header to emitted .mts/.mjs files

### DIFF
--- a/.chronus/changes/fix-mts-mjs-license-header-2026-07-23-11-08-30.md
+++ b/.chronus/changes/fix-mts-mjs-license-header-2026-07-23-11-08-30.md
@@ -1,0 +1,8 @@
+---
+# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Add the license header to emitted `.mts`/`.mjs` files (e.g. the browser and react-native static helper variants such as `get-binary-stream-response-browser.mts`), which were previously skipped because the source-code detection only matched `.ts`/`.js` extensions.

--- a/packages/typespec-ts/src/utils/emit-util.ts
+++ b/packages/typespec-ts/src/utils/emit-util.ts
@@ -36,7 +36,7 @@ async function emitFile(file: File, program: Program, emitterOutputDir?: string)
   const host: CompilerHost = program.host;
   const filePath = joinPaths(emitterOutputDir ?? "", file.path);
   const isJson = /\.json$/gi.test(filePath);
-  const isSourceCode = /\.(ts|js)$/gi.test(filePath);
+  const isSourceCode = /\.(m|c)?(ts|js)$/gi.test(filePath);
   const licenseHeader = `// Copyright (c) Microsoft Corporation.\n// Licensed under the MIT License.\n`;
   let prettierFileContent = file.content;
 


### PR DESCRIPTION
## Why

The browser and react-native static helper variants generated by the emitter (for example `get-binary-stream-response-browser.mts` and `get-binary-stream-response-react-native.mts`) were being emitted without the required license header. This shows up as generated `.mts`/`.mjs` files that are missing the `// Copyright (c) Microsoft Corporation.` / `// Licensed under the MIT License.` banner that every other generated source file gets.

## Root cause

In `packages/typespec-ts/src/utils/emitUtil.ts`, `emitFile` decides whether a file is source code (and therefore whether to prepend the license header and run Prettier) with:

```ts
const isSourceCode = /\.(ts|js)$/gi.test(filePath);
```

That regex only matches `.ts` and `.js`. Platform-specific variants are emitted with `.mts`/`.mjs` extensions, so they fell through the check: no header, and no formatting either.

## Fix

Broaden the detection to also cover module/CommonJS variants:

```ts
const isSourceCode = /\.(m|c)?(ts|js)$/gi.test(filePath);
```

Now `.mts`, `.mjs`, `.cts`, and `.cjs` are treated like `.ts`/`.js`, while non-source files such as `.json` and `.md` remain excluded. The Prettier `typescript` parser already handles `.mts` content, so those files are now formatted consistently as well.

## Notes for reviewers

- This affects all emitted `.mts`/`.mjs` output (the browser/react-native static helper variants), not just the binary-stream helpers, bringing them in line with the rest of the generated sources.
- I was unable to run the full build/tests locally because dependencies were not installed and `pnpm install` was blocked here by a registry signature-verification failure. The change is a self-contained regex edit; I verified the pattern matches the intended extensions and excludes `.json`/`.md`.
