### PR TITLE
[tcgc] Cherry-pick: add events to sse information (#4882)

### DIFF
--- a/.chronus/changes/tcgc-addStreamEvents-2026-6-13-17-8-25.md
+++ b/.chronus/changes/tcgc-addStreamEvents-2026-6-13-17-8-25.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+add `sseMetadata` with per-event information for server-sent event (SSE) streams

--- a/packages/typespec-client-generator-core/src/http.ts
+++ b/packages/typespec-client-generator-core/src/http.ts
@@ -11,6 +11,8 @@ import {
   isErrorModel,
 } from "@typespec/compiler";
 import { $ } from "@typespec/compiler/typekit";
+import { isEvents } from "@typespec/events";
+import { unsafe_getEventDefinitions as getEventDefinitions } from "@typespec/events/experimental";
 import {
   HttpOperation,
   HttpOperationHeaderParameter,
@@ -31,6 +33,7 @@ import {
   isQueryParam,
 } from "@typespec/http";
 import { StreamMetadata, getStreamMetadata } from "@typespec/http/experimental";
+import { isTerminalEvent } from "@typespec/sse";
 import { camelCase } from "change-case";
 import { getResponseAsBool, isInScope, shouldOmitSlashFromEmptyRoute } from "./decorators.js";
 import {
@@ -49,6 +52,8 @@ import {
   SdkPathParameter,
   SdkQueryParameter,
   SdkServiceResponseHeader,
+  SdkSseEventMetadata,
+  SdkSseMetadata,
   SdkStreamMetadata,
   SdkType,
   SerializationOptions,
@@ -130,6 +135,37 @@ function buildSdkStreamMetadata(
     streamType,
     contentTypes: [...tspStreamMetadata.contentTypes],
   });
+}
+
+/**
+ * Build server-sent event (SSE) metadata for a stream. Returns `undefined` for
+ * non-event streams (e.g. JSONL), whose streamed type is not an `@events` union.
+ *
+ * Kept separate from {@link buildSdkStreamMetadata} because SSE, streaming, and events
+ * are modeled by distinct TypeSpec libraries.
+ */
+function buildSdkSseMetadata(
+  context: TCGCContext,
+  streamType: Type,
+  operation: Operation,
+): [SdkSseMetadata | undefined, readonly Diagnostic[]] {
+  const diagnostics = createDiagnosticCollector();
+  if (streamType.kind !== "Union" || !isEvents(context.program, streamType)) {
+    return diagnostics.wrap(undefined);
+  }
+  const eventDefinitions = diagnostics.pipe(getEventDefinitions(context.program, streamType));
+  const events: SdkSseEventMetadata[] = eventDefinitions.map((event) => ({
+    eventType: event.eventType,
+    isTerminalEvent: isTerminalEvent(context.program, event.root),
+    isEventEnvelope: event.isEventEnvelope,
+    type: diagnostics.pipe(getClientTypeWithDiagnostics(context, event.type, operation)),
+    contentType: event.contentType,
+    payloadType: diagnostics.pipe(
+      getClientTypeWithDiagnostics(context, event.payloadType, operation),
+    ),
+    payloadContentType: event.payloadContentType,
+  }));
+  return diagnostics.wrap({ events });
 }
 
 export function getSdkHttpOperation(
@@ -347,6 +383,9 @@ function getSdkHttpParameters(
         );
         retval.bodyParam.streamMetadata = diagnostics.pipe(
           buildSdkStreamMetadata(context, requestStreamMeta, httpOperation.operation),
+        );
+        retval.bodyParam.sseMetadata = diagnostics.pipe(
+          buildSdkSseMetadata(context, requestStreamMeta.streamType, httpOperation.operation),
         );
         // eslint-disable-next-line @typescript-eslint/no-deprecated
         retval.bodyParam.correspondingMethodParams.map((p) => (p.type = retval.bodyParam!.type));
@@ -662,6 +701,7 @@ function getSdkHttpResponseAndExceptions(
     let type: SdkType | undefined;
     let contentTypes: string[] = [];
     let streamMetadata: SdkStreamMetadata | undefined;
+    let sseMetadata: SdkSseMetadata | undefined;
     let lastBodyProperty: ModelProperty | undefined;
     let lastDefaultContentType: string | undefined;
 
@@ -707,6 +747,9 @@ function getSdkHttpResponseAndExceptions(
           type = diagnostics.pipe(getStreamAsBytes(context, innerResponse.body.type));
           streamMetadata = diagnostics.pipe(
             buildSdkStreamMetadata(context, responseStreamMeta, httpOperation.operation),
+          );
+          sseMetadata = diagnostics.pipe(
+            buildSdkSseMetadata(context, responseStreamMeta.streamType, httpOperation.operation),
           );
         }
       }
@@ -756,6 +799,7 @@ function getSdkHttpResponseAndExceptions(
       ),
       description: response.description,
       streamMetadata,
+      sseMetadata,
       serializationOptions: buildSerializationOptionsFromContentTypes(contentTypes),
     };
 

--- a/packages/typespec-client-generator-core/src/interfaces.ts
+++ b/packages/typespec-client-generator-core/src/interfaces.ts
@@ -894,6 +894,56 @@ export interface SdkStreamMetadata {
 }
 
 /**
+ * Metadata about a server-sent event (SSE, `text/event-stream`) body or response.
+ *
+ * Kept separate from {@link SdkStreamMetadata} because SSE, streaming, and events are
+ * modeled by distinct TypeSpec libraries (`@typespec/sse`, `@typespec/http`, and
+ * `@typespec/events`). Present alongside `streamMetadata` when the body/response is an
+ * SSE stream; absent for non-event streams such as JSONL.
+ */
+export interface SdkSseMetadata {
+  /**
+   * Per-event metadata, one entry per variant of the streamed `@events` union.
+   */
+  events: SdkSseEventMetadata[];
+}
+
+/**
+ * Metadata about a single server-sent event within an SSE (`text/event-stream`) stream.
+ *
+ * Derived from the `@typespec/events` event definitions of the streamed union,
+ * plus the `@typespec/sse` `@terminalEvent` marker. Gives emitters the information
+ * they need to (de)serialize each event without re-deriving it from raw TypeSpec:
+ * the wire `event:` name, whether the event terminates the stream, and the
+ * payload type/content type.
+ */
+export interface SdkSseEventMetadata {
+  /**
+   * The SSE `event:` field name, taken from the named union variant. Undefined for
+   * unnamed variants, which are `message` events with no `event:` field.
+   */
+  eventType?: string;
+  /**
+   * Whether the presence of this event terminates the stream and the client should
+   * disconnect (from `@terminalEvent`).
+   */
+  isTerminalEvent: boolean;
+  /**
+   * Whether `type` describes an event envelope wrapping a separate `@data` payload.
+   * When `false`, `type` and `payloadType` (and their content types) are the same.
+   */
+  isEventEnvelope: boolean;
+  /** The event type. Represents the event envelope when `isEventEnvelope` is `true`. */
+  type: SdkType;
+  /** The content type of the event (the envelope when `isEventEnvelope` is `true`). */
+  contentType?: string;
+  /** The type of the event payload. Matches `type` when `isEventEnvelope` is `false`. */
+  payloadType: SdkType;
+  /** The content type of the event payload. Matches `contentType` when `isEventEnvelope` is `false`. */
+  payloadContentType?: string;
+}
+
+/**
  * Http body parameter.
  */
 export interface SdkBodyParameter extends SdkModelPropertyTypeBase {
@@ -915,6 +965,8 @@ export interface SdkBodyParameter extends SdkModelPropertyTypeBase {
   methodParameterSegments: (SdkMethodParameter | SdkModelPropertyType)[][];
   /** Stream metadata, present when the body is a streaming type (e.g. JsonlStream, SSEStream). */
   streamMetadata?: SdkStreamMetadata;
+  /** SSE metadata, present when the body is a server-sent event stream (SSEStream). */
+  sseMetadata?: SdkSseMetadata;
   /** Options to show how to serialize the body. */
   serializationOptions: SerializationOptions;
 }
@@ -950,6 +1002,8 @@ export interface SdkMethodResponse {
   optional?: boolean;
   /** Stream metadata, present when the response is a streaming type (e.g. JsonlStream, SSEStream). */
   streamMetadata?: SdkStreamMetadata;
+  /** SSE metadata, present when the response is a server-sent event stream (SSEStream). */
+  sseMetadata?: SdkSseMetadata;
 }
 
 export interface SdkServiceResponse {
@@ -967,6 +1021,8 @@ interface SdkHttpResponseBase extends SdkServiceResponse {
   description?: string;
   /** Stream metadata, present when the response is a streaming type (e.g. JsonlStream, SSEStream). */
   streamMetadata?: SdkStreamMetadata;
+  /** SSE metadata, present when the response is a server-sent event stream (SSEStream). */
+  sseMetadata?: SdkSseMetadata;
   /** Options to show how to deserialize the response body. */
   serializationOptions: SerializationOptions;
 }

--- a/packages/typespec-client-generator-core/src/methods.ts
+++ b/packages/typespec-client-generator-core/src/methods.ts
@@ -56,6 +56,7 @@ import {
   SdkPropertyMap,
   SdkServiceMethod,
   SdkServiceOperation,
+  SdkSseMetadata,
   SdkStreamMetadata,
   SdkTerminationStatus,
   SdkType,
@@ -668,9 +669,11 @@ function getSdkMethodResponse(
 
   // Propagate stream metadata from HTTP responses to method response
   let streamMetadata: SdkStreamMetadata | undefined;
+  let sseMetadata: SdkSseMetadata | undefined;
   for (const response of responses) {
     if (response.streamMetadata) {
       streamMetadata = response.streamMetadata;
+      sseMetadata = response.sseMetadata;
       break;
     }
   }
@@ -680,6 +683,7 @@ function getSdkMethodResponse(
     type,
     ...(optional !== undefined && { optional }),
     ...(streamMetadata && { streamMetadata }),
+    ...(sseMetadata && { sseMetadata }),
   };
 }
 

--- a/packages/typespec-client-generator-core/src/types.ts
+++ b/packages/typespec-client-generator-core/src/types.ts
@@ -12,6 +12,7 @@ import {
   Namespace,
   NumericLiteral,
   Operation,
+  Program,
   Scalar,
   StringLiteral,
   Tuple,
@@ -21,6 +22,7 @@ import {
   getDiscriminator,
   getEncode,
   getLifecycleVisibilityEnum,
+  getMediaTypeHint,
   getSummary,
   getVisibilityForClass,
   ignoreDiagnostics,
@@ -30,6 +32,8 @@ import {
   isTemplateDeclaration,
   resolveEncodedName,
 } from "@typespec/compiler";
+import { isEvents } from "@typespec/events";
+import { unsafe_getEventDefinitions as getEventDefinitions } from "@typespec/events/experimental";
 import {
   Authentication,
   HttpOperationFileBody,
@@ -1537,6 +1541,66 @@ interface PropagationOptions {
   isOverride?: boolean;
 }
 
+/**
+ * Infers the default content type for an event type, mirroring the HTTP lib behavior:
+ * - Models → "application/json"
+ * - Scalars → "text/plain"
+ * - Literals/constants → undefined (no serialization needed)
+ */
+function inferEventContentType(program: Program, type: Type): string | undefined {
+  // Use @mediaTypeHint if explicitly set on the type, otherwise fall back to kind-based default
+  const hint = getMediaTypeHint(program, type);
+  if (hint) return hint;
+  if (type.kind === "Model") return "application/json";
+  if (type.kind === "Scalar") return "text/plain";
+  return undefined;
+}
+
+/**
+ * Propagates `UsageFlags.Json` and serialization options to individual SSE event `type` and
+ * `payloadType` based on their per-event content type. When no explicit content type is set,
+ * infers a default using the same logic as the HTTP lib (model → application/json,
+ * scalar → text/plain).
+ */
+function propagateSseEventUsage(
+  context: TCGCContext,
+  streamType: Type,
+  operation: Operation,
+  diagnostics: ReturnType<typeof createDiagnosticCollector>,
+): void {
+  if (streamType.kind !== "Union" || !isEvents(context.program, streamType)) {
+    return;
+  }
+  const eventDefinitions = diagnostics.pipe(getEventDefinitions(context.program, streamType));
+  for (const event of eventDefinitions) {
+    const effectiveContentType =
+      event.contentType ?? inferEventContentType(context.program, event.type);
+    const effectivePayloadContentType =
+      event.payloadContentType ?? inferEventContentType(context.program, event.payloadType);
+
+    if (effectiveContentType) {
+      const sdkType = diagnostics.pipe(
+        getClientTypeWithDiagnostics(context, event.type, operation),
+      );
+      if (isMediaTypeJson(effectiveContentType)) {
+        diagnostics.pipe(updateUsageOrAccess(context, UsageFlags.Json, sdkType));
+      }
+      diagnostics.pipe(updateSerializationOptions(context, sdkType, [effectiveContentType]));
+    }
+    if (effectivePayloadContentType) {
+      const sdkPayloadType = diagnostics.pipe(
+        getClientTypeWithDiagnostics(context, event.payloadType, operation),
+      );
+      if (isMediaTypeJson(effectivePayloadContentType)) {
+        diagnostics.pipe(updateUsageOrAccess(context, UsageFlags.Json, sdkPayloadType));
+      }
+      diagnostics.pipe(
+        updateSerializationOptions(context, sdkPayloadType, [effectivePayloadContentType]),
+      );
+    }
+  }
+}
+
 export function updateUsageOrAccess(
   context: TCGCContext,
   value: UsageFlags | AccessFlags,
@@ -1822,6 +1886,8 @@ function updateTypesFromOperation(
       }
       const access = getAccessOverride(context, operation) ?? "public";
       diagnostics.pipe(updateUsageOrAccess(context, access, sdkStreamType));
+      // Propagate Json usage to individual SSE event types based on per-event content type
+      propagateSseEventUsage(context, requestStreamMeta.streamType, operation, diagnostics);
     }
 
     // Push "Parameter" context for operation parameters
@@ -1953,6 +2019,8 @@ function updateTypesFromOperation(
           }
           const access = getAccessOverride(context, operation) ?? "public";
           diagnostics.pipe(updateUsageOrAccess(context, access, sdkStreamType));
+          // Propagate Json usage to individual SSE event types based on per-event content type
+          propagateSseEventUsage(context, responseStreamMeta.streamType, operation, diagnostics);
         }
       }
     }

--- a/packages/typespec-client-generator-core/test/methods/sse.test.ts
+++ b/packages/typespec-client-generator-core/test/methods/sse.test.ts
@@ -1,0 +1,613 @@
+import { deepStrictEqual, ok, strictEqual } from "assert";
+import { describe, it } from "vitest";
+import { UsageFlags } from "../../src/interfaces.js";
+import { createSdkContextForTester, StreamsTesterWithBuiltInService } from "../tester.js";
+import { getServiceMethodOfClient } from "../utils.js";
+
+describe("sse request", () => {
+  it("sse request with heterogeneous events", async () => {
+    const { program } = await StreamsTesterWithBuiltInService.compile(
+      `
+        model UserConnect {
+          username: string;
+          time: string;
+        }
+
+        model UserMessage {
+          username: string;
+          time: string;
+          text: string;
+        }
+
+        model UserDisconnect {
+          username: string;
+          time: string;
+        }
+
+        @Events.events
+        union ChannelEvents {
+          userconnect: UserConnect,
+          usermessage: UserMessage,
+          userdisconnect: UserDisconnect,
+
+          @Events.contentType("text/plain")
+          @terminalEvent
+          "[unsubscribe]",
+        }
+
+        op subscribeToChannel(stream: SSEStream<ChannelEvents>): void;
+      `,
+    );
+    const context = await createSdkContextForTester(program);
+    const sdkPackage = context.sdkPackage;
+    const method = getServiceMethodOfClient(sdkPackage);
+    strictEqual(method.parameters[0].type.kind, "model");
+    strictEqual(method.parameters[0].type.properties[1].type.kind, "bytes");
+    strictEqual(method.parameters[0].type.properties[1].type.encode, "bytes");
+    deepStrictEqual(method.operation.bodyParam?.type, method.parameters[0].type.properties[1].type);
+
+    // stream metadata on body param - SSE streams have union streamType
+    const bodyMeta = method.operation.bodyParam?.streamMetadata;
+    ok(bodyMeta);
+    strictEqual(bodyMeta.bodyType.kind, "string");
+    strictEqual(bodyMeta.originalType.kind, "model");
+    strictEqual(bodyMeta.originalType.name, "SSEStreamChannelEvents");
+    strictEqual(bodyMeta.streamType.kind, "union");
+    strictEqual(bodyMeta.streamType.name, "ChannelEvents");
+    deepStrictEqual(bodyMeta.contentTypes, ["text/event-stream"]);
+
+    // streamType union has Input usage (no Json since SSE uses text/event-stream)
+    strictEqual(bodyMeta.streamType.usage, UsageFlags.Input);
+
+    // SSE event metadata lives on a separate sseMetadata, not on streamMetadata.
+    const sseMeta = method.operation.bodyParam?.sseMetadata;
+    ok(sseMeta);
+    strictEqual(sseMeta.events.length, 4);
+
+    const userconnect = sseMeta.events[0];
+    strictEqual(userconnect.eventType, "userconnect");
+    strictEqual(userconnect.isTerminalEvent, false);
+    strictEqual(userconnect.isEventEnvelope, false);
+    strictEqual(userconnect.type.kind, "model");
+    strictEqual(userconnect.type.name, "UserConnect");
+    strictEqual(userconnect.payloadType, userconnect.type);
+    // No @Events.contentType decorator => contentType is undefined
+    strictEqual(userconnect.contentType, undefined);
+
+    strictEqual(sseMeta.events[1].eventType, "usermessage");
+    strictEqual(sseMeta.events[2].eventType, "userdisconnect");
+
+    // Terminal event: the type is a constant representing the literal value "[unsubscribe]"
+    const unsubscribe = sseMeta.events[3];
+    strictEqual(unsubscribe.eventType, undefined);
+    strictEqual(unsubscribe.isTerminalEvent, true);
+    strictEqual(unsubscribe.contentType, "text/plain");
+    strictEqual(unsubscribe.type.kind, "constant");
+    strictEqual(unsubscribe.type.value, "[unsubscribe]");
+  });
+});
+
+describe("sse response", () => {
+  it("sse response with heterogeneous events and terminal event", async () => {
+    const { program } = await StreamsTesterWithBuiltInService.compile(
+      `
+        model UserConnect {
+          username: string;
+          time: string;
+        }
+
+        model UserMessage {
+          username: string;
+          time: string;
+          text: string;
+        }
+
+        model UserDisconnect {
+          username: string;
+          time: string;
+        }
+
+        @Events.events
+        union ChannelEvents {
+          userconnect: UserConnect,
+          usermessage: UserMessage,
+          userdisconnect: UserDisconnect,
+
+          @Events.contentType("text/plain")
+          @terminalEvent
+          "[unsubscribe]",
+        }
+
+        op subscribeToChannel(): SSEStream<ChannelEvents>;
+      `,
+    );
+    const context = await createSdkContextForTester(program);
+    const sdkPackage = context.sdkPackage;
+    const method = getServiceMethodOfClient(sdkPackage);
+    strictEqual(method.response.type?.kind, "bytes");
+    strictEqual(method.response.type?.encode, "bytes");
+    strictEqual(method.operation.responses.length, 1);
+    strictEqual(method.operation.responses[0].type?.kind, "bytes");
+    strictEqual(method.operation.responses[0].type?.encode, "bytes");
+
+    // stream metadata on HTTP response - SSE streams have union streamType
+    const responseMeta = method.operation.responses[0].streamMetadata;
+    ok(responseMeta);
+    strictEqual(responseMeta.bodyType.kind, "string");
+    strictEqual(responseMeta.originalType.kind, "model");
+    strictEqual(responseMeta.originalType.name, "SSEStreamChannelEvents");
+    strictEqual(responseMeta.streamType.kind, "union");
+    strictEqual(responseMeta.streamType.name, "ChannelEvents");
+    deepStrictEqual(responseMeta.contentTypes, ["text/event-stream"]);
+
+    // stream metadata propagated to method response
+    const methodMeta = method.response.streamMetadata;
+    ok(methodMeta);
+    strictEqual(methodMeta.streamType.kind, "union");
+    strictEqual(methodMeta.streamType.name, "ChannelEvents");
+    deepStrictEqual(methodMeta.contentTypes, ["text/event-stream"]);
+
+    // streamType union has Output usage (no Json since SSE uses text/event-stream)
+    strictEqual(responseMeta.streamType.usage, UsageFlags.Output);
+
+    // Event variant models have Output + Json usage (model type => inferred application/json)
+    const responseSse = method.operation.responses[0].sseMetadata;
+    ok(responseSse);
+    strictEqual(responseSse.events.length, 4);
+    strictEqual(responseSse.events[0].eventType, "userconnect");
+    strictEqual(responseSse.events[0].type.kind, "model");
+    strictEqual(responseSse.events[0].type.name, "UserConnect");
+    // No @Events.contentType set => contentType is undefined, but model type => inferred Json
+    strictEqual(responseSse.events[0].contentType, undefined);
+    strictEqual((responseSse.events[0].type as any).usage, UsageFlags.Output | UsageFlags.Json);
+    ok((responseSse.events[0].type as any).serializationOptions.json);
+
+    // Terminal event has constant type with the literal value
+    const terminal = responseSse.events[3];
+    strictEqual(terminal.eventType, undefined);
+    strictEqual(terminal.isTerminalEvent, true);
+    strictEqual(terminal.contentType, "text/plain");
+    strictEqual(terminal.type.kind, "constant");
+    strictEqual(terminal.type.value, "[unsubscribe]");
+
+    const methodSse = method.response.sseMetadata;
+    ok(methodSse);
+    strictEqual(methodSse.events.length, 4);
+    strictEqual(methodSse.events[3].isTerminalEvent, true);
+  });
+});
+
+// These mirror the SSE scenarios added to the http-specs spector suite
+// (streaming/sse): a basic unnamed `message` stream, a named-events stream with a
+// terminal event, and a POST whose response is an SSE stream.
+describe("sse scenarios (mirroring spector streaming/sse)", () => {
+  it("basic: unnamed message events", async () => {
+    const { program } = await StreamsTesterWithBuiltInService.compile(
+      `
+        model Info {
+          desc: string;
+        }
+
+        @Events.events
+        union BasicEvents {
+          @Events.contentType("application/json")
+          Info,
+        }
+
+        op receive(): SSEStream<BasicEvents>;
+      `,
+    );
+    const context = await createSdkContextForTester(program);
+    const method = getServiceMethodOfClient(context.sdkPackage);
+
+    const responseMeta = method.operation.responses[0].streamMetadata;
+    ok(responseMeta);
+    deepStrictEqual(responseMeta.contentTypes, ["text/event-stream"]);
+
+    const responseSse = method.operation.responses[0].sseMetadata;
+    ok(responseSse);
+    strictEqual(responseSse.events.length, 1);
+
+    const event = responseSse.events[0];
+    strictEqual(event.eventType, undefined); // unnamed variant => `message` event
+    strictEqual(event.isTerminalEvent, false);
+    strictEqual(event.isEventEnvelope, false);
+    strictEqual(event.type.kind, "model");
+    strictEqual(event.type.name, "Info");
+    strictEqual(event.payloadType, event.type);
+    strictEqual(event.contentType, "application/json");
+
+    // Event model gets Json usage because its contentType is application/json
+    strictEqual((event.type as any).usage, UsageFlags.Output | UsageFlags.Json);
+  });
+
+  it("named events with a terminal event", async () => {
+    const { program } = await StreamsTesterWithBuiltInService.compile(
+      `
+        model ResponseCreated {
+          id: string;
+        }
+
+        model ResponseDelta {
+          delta: string;
+        }
+
+        @Events.events
+        union ResponseEvents {
+          @Events.contentType("application/json")
+          responseCreated: ResponseCreated,
+
+          @Events.contentType("application/json")
+          responseDelta: ResponseDelta,
+
+          @Events.contentType("text/plain")
+          @terminalEvent
+          "[DONE]",
+        }
+
+        op receive(): SSEStream<ResponseEvents>;
+      `,
+    );
+    const context = await createSdkContextForTester(program);
+    const method = getServiceMethodOfClient(context.sdkPackage);
+
+    const responseSse = method.operation.responses[0].sseMetadata;
+    ok(responseSse);
+    strictEqual(responseSse.events.length, 3);
+
+    strictEqual(responseSse.events[0].eventType, "responseCreated");
+    strictEqual(responseSse.events[0].type.kind, "model");
+    strictEqual(responseSse.events[0].type.name, "ResponseCreated");
+    strictEqual(responseSse.events[0].isTerminalEvent, false);
+    // JSON event models get Json usage
+    strictEqual((responseSse.events[0].type as any).usage, UsageFlags.Output | UsageFlags.Json);
+
+    strictEqual(responseSse.events[1].eventType, "responseDelta");
+    strictEqual((responseSse.events[1].type as any).usage, UsageFlags.Output | UsageFlags.Json);
+
+    // Terminal event: type is a constant with the "[DONE]" value
+    const terminal = responseSse.events[2];
+    strictEqual(terminal.eventType, undefined);
+    strictEqual(terminal.isTerminalEvent, true);
+    strictEqual(terminal.contentType, "text/plain");
+    strictEqual(terminal.type.kind, "constant");
+    strictEqual(terminal.type.value, "[DONE]");
+  });
+
+  it("POST with a request body and an SSE-streamed response", async () => {
+    const { program } = await StreamsTesterWithBuiltInService.compile(
+      `
+        model RetrievalRequest {
+          query: string;
+        }
+
+        model PartialResult {
+          text: string;
+        }
+
+        model FinalResult {
+          references: string[];
+        }
+
+        @Events.events
+        union RetrievalEvents {
+          @Events.contentType("application/json")
+          partialResult: PartialResult,
+
+          @Events.contentType("application/json")
+          finalResult: FinalResult,
+
+          @Events.contentType("text/plain")
+          @terminalEvent
+          "[DONE]",
+        }
+
+        @post
+        op stream(@body request: RetrievalRequest): SSEStream<RetrievalEvents>;
+      `,
+    );
+    const context = await createSdkContextForTester(program);
+    const method = getServiceMethodOfClient(context.sdkPackage);
+
+    // The request body is a plain model, not a stream.
+    strictEqual(method.operation.bodyParam?.type.kind, "model");
+    strictEqual(method.operation.bodyParam?.type.name, "RetrievalRequest");
+    strictEqual(method.operation.bodyParam?.streamMetadata, undefined);
+    strictEqual(method.operation.bodyParam?.sseMetadata, undefined);
+
+    // The response is the SSE stream, with per-event metadata.
+    const responseMeta = method.operation.responses[0].streamMetadata;
+    ok(responseMeta);
+    deepStrictEqual(responseMeta.contentTypes, ["text/event-stream"]);
+
+    const responseSse = method.operation.responses[0].sseMetadata;
+    ok(responseSse);
+    strictEqual(responseSse.events.length, 3);
+    strictEqual(responseSse.events[0].eventType, "partialResult");
+    strictEqual(responseSse.events[1].eventType, "finalResult");
+    strictEqual(responseSse.events[2].isTerminalEvent, true);
+    // Terminal constant is accessible via type
+    strictEqual(responseSse.events[2].type.kind, "constant");
+    strictEqual(responseSse.events[2].type.value, "[DONE]");
+
+    // Request model has Input + Json usage
+    strictEqual(method.operation.bodyParam?.type.usage, UsageFlags.Input | UsageFlags.Json);
+    // Response event models have Output + Json usage
+    strictEqual((responseSse.events[0].type as any).usage, UsageFlags.Output | UsageFlags.Json);
+    strictEqual((responseSse.events[1].type as any).usage, UsageFlags.Output | UsageFlags.Json);
+  });
+});
+
+describe("sse event envelope", () => {
+  it("event with @data payload uses envelope and payload types", async () => {
+    const { program } = await StreamsTesterWithBuiltInService.compile(
+      `
+        model ChatMessage {
+          role: string;
+          content: string;
+        }
+
+        @Events.events
+        union ChatEvents {
+          @Events.contentType("application/json")
+          message: { done: false, @Events.data message: ChatMessage },
+
+          @Events.contentType("text/plain")
+          @terminalEvent
+          done: { done: true },
+        }
+
+        op chat(): SSEStream<ChatEvents>;
+      `,
+    );
+    const context = await createSdkContextForTester(program);
+    const method = getServiceMethodOfClient(context.sdkPackage);
+
+    const responseSse = method.operation.responses[0].sseMetadata;
+    ok(responseSse);
+    strictEqual(responseSse.events.length, 2);
+
+    const messageEvent = responseSse.events[0];
+    strictEqual(messageEvent.eventType, "message");
+    strictEqual(messageEvent.isTerminalEvent, false);
+    strictEqual(messageEvent.isEventEnvelope, true);
+    // The type is the envelope model
+    strictEqual(messageEvent.type.kind, "model");
+    // The payloadType is the @data-decorated property's type
+    strictEqual(messageEvent.payloadType.kind, "model");
+    strictEqual(messageEvent.payloadType.name, "ChatMessage");
+    // Envelope content type is JSON
+    strictEqual(messageEvent.contentType, "application/json");
+
+    const doneEvent = responseSse.events[1];
+    strictEqual(doneEvent.eventType, "done");
+    strictEqual(doneEvent.isTerminalEvent, true);
+    strictEqual(doneEvent.isEventEnvelope, false);
+  });
+});
+
+describe("sse usage and access propagation", () => {
+  it("propagates Json usage to event models with application/json content type", async () => {
+    const { program } = await StreamsTesterWithBuiltInService.compile(
+      `
+        model EventA {
+          value: string;
+        }
+
+        model EventB {
+          count: int32;
+        }
+
+        @Events.events
+        union MyEvents {
+          @Events.contentType("application/json")
+          eventA: EventA,
+
+          @Events.contentType("application/json")
+          eventB: EventB,
+        }
+
+        op subscribe(): SSEStream<MyEvents>;
+      `,
+    );
+    const context = await createSdkContextForTester(program);
+    const sdkPackage = context.sdkPackage;
+    const method = getServiceMethodOfClient(sdkPackage);
+
+    const responseSse = method.operation.responses[0].sseMetadata;
+    ok(responseSse);
+
+    // Both event types get Output + Json usage
+    strictEqual((responseSse.events[0].type as any).usage, UsageFlags.Output | UsageFlags.Json);
+    strictEqual((responseSse.events[1].type as any).usage, UsageFlags.Output | UsageFlags.Json);
+
+    // Serialization options are set on event models
+    ok((responseSse.events[0].type as any).serializationOptions.json);
+    ok((responseSse.events[1].type as any).serializationOptions.json);
+
+    // They also appear in sdkPackage.models
+    ok(sdkPackage.models.find((m) => m.name === "EventA"));
+    ok(sdkPackage.models.find((m) => m.name === "EventB"));
+  });
+
+  it("does not propagate Json usage when event has non-json content type", async () => {
+    const { program } = await StreamsTesterWithBuiltInService.compile(
+      `
+        model TextEvent {
+          text: string;
+        }
+
+        @Events.events
+        union TextEvents {
+          @Events.contentType("text/plain")
+          textEvent: TextEvent,
+        }
+
+        op subscribe(): SSEStream<TextEvents>;
+      `,
+    );
+    const context = await createSdkContextForTester(program);
+    const method = getServiceMethodOfClient(context.sdkPackage);
+
+    const responseSse = method.operation.responses[0].sseMetadata;
+    ok(responseSse);
+
+    // text/plain content type => no Json usage, only Output
+    strictEqual((responseSse.events[0].type as any).usage, UsageFlags.Output);
+  });
+
+  it("infers application/json for model events with no explicit content type", async () => {
+    const { program } = await StreamsTesterWithBuiltInService.compile(
+      `
+        model SimpleEvent {
+          data: string;
+        }
+
+        @Events.events
+        union SimpleEvents {
+          simpleEvent: SimpleEvent,
+        }
+
+        op subscribe(): SSEStream<SimpleEvents>;
+      `,
+    );
+    const context = await createSdkContextForTester(program);
+    const method = getServiceMethodOfClient(context.sdkPackage);
+
+    const responseSse = method.operation.responses[0].sseMetadata;
+    ok(responseSse);
+
+    // No explicit contentType, but model type => inferred application/json => Json usage + serialization
+    strictEqual((responseSse.events[0].type as any).usage, UsageFlags.Output | UsageFlags.Json);
+    ok((responseSse.events[0].type as any).serializationOptions.json);
+  });
+
+  it("propagates Json usage to @data payload type in envelope events", async () => {
+    const { program } = await StreamsTesterWithBuiltInService.compile(
+      `
+        model Payload {
+          value: string;
+        }
+
+        @Events.events
+        union EnvelopeEvents {
+          @Events.contentType("application/json")
+          wrapped: { done: false, @Events.data payload: Payload },
+        }
+
+        op subscribe(): SSEStream<EnvelopeEvents>;
+      `,
+    );
+    const context = await createSdkContextForTester(program);
+    const method = getServiceMethodOfClient(context.sdkPackage);
+
+    const responseSse = method.operation.responses[0].sseMetadata;
+    ok(responseSse);
+
+    const event = responseSse.events[0];
+    strictEqual(event.isEventEnvelope, true);
+    // Both the envelope type and the payload type get Json usage
+    strictEqual((event.type as any).usage, UsageFlags.Output | UsageFlags.Json);
+    strictEqual((event.payloadType as any).usage, UsageFlags.Output | UsageFlags.Json);
+    // Serialization options set on both envelope and payload types
+    ok((event.type as any).serializationOptions.json);
+    ok((event.payloadType as any).serializationOptions.json);
+  });
+
+  it("propagates access to event models", async () => {
+    const { program } = await StreamsTesterWithBuiltInService.compile(
+      `
+        model PublicEvent {
+          message: string;
+        }
+
+        @Events.events
+        union PublicEvents {
+          @Events.contentType("application/json")
+          publicEvent: PublicEvent,
+        }
+
+        op subscribe(): SSEStream<PublicEvents>;
+      `,
+    );
+    const context = await createSdkContextForTester(program);
+    const sdkPackage = context.sdkPackage;
+
+    // Event model gets public access
+    const publicEventModel = sdkPackage.models.find((m) => m.name === "PublicEvent");
+    ok(publicEventModel);
+    strictEqual(publicEventModel.access, "public");
+  });
+
+  it("propagates Input + Json usage for SSE request with json content type events", async () => {
+    const { program } = await StreamsTesterWithBuiltInService.compile(
+      `
+        model InputEvent {
+          data: string;
+        }
+
+        @Events.events
+        union InputEvents {
+          @Events.contentType("application/json")
+          inputEvent: InputEvent,
+        }
+
+        op send(stream: SSEStream<InputEvents>): void;
+      `,
+    );
+    const context = await createSdkContextForTester(program);
+    const method = getServiceMethodOfClient(context.sdkPackage);
+
+    const sseMeta = method.operation.bodyParam?.sseMetadata;
+    ok(sseMeta);
+
+    // Input event model gets Input + Json usage
+    strictEqual((sseMeta.events[0].type as any).usage, UsageFlags.Input | UsageFlags.Json);
+  });
+});
+
+describe("sse with HttpStream", () => {
+  it("HttpStream with text/event-stream content type and @events union", async () => {
+    const { program } = await StreamsTesterWithBuiltInService.compile(
+      `
+        model Notification {
+          id: string;
+          message: string;
+        }
+
+        @Events.events
+        union NotificationEvents {
+          @Events.contentType("application/json")
+          notification: Notification,
+
+          @Events.contentType("text/plain")
+          @terminalEvent
+          "[END]",
+        }
+
+        op subscribe(): HttpStream<NotificationEvents, "text/event-stream">;
+      `,
+    );
+    const context = await createSdkContextForTester(program);
+    const method = getServiceMethodOfClient(context.sdkPackage);
+
+    const responseMeta = method.operation.responses[0].streamMetadata;
+    ok(responseMeta);
+    deepStrictEqual(responseMeta.contentTypes, ["text/event-stream"]);
+    strictEqual(responseMeta.streamType.kind, "union");
+    strictEqual(responseMeta.streamType.name, "NotificationEvents");
+
+    const responseSse = method.operation.responses[0].sseMetadata;
+    ok(responseSse);
+    strictEqual(responseSse.events.length, 2);
+    strictEqual(responseSse.events[0].eventType, "notification");
+    strictEqual(responseSse.events[0].type.name, "Notification");
+    strictEqual(responseSse.events[1].isTerminalEvent, true);
+    // Terminal constant accessible
+    strictEqual(responseSse.events[1].type.kind, "constant");
+    strictEqual(responseSse.events[1].type.value, "[END]");
+
+    // Notification model gets Output + Json usage
+    strictEqual((responseSse.events[0].type as any).usage, UsageFlags.Output | UsageFlags.Json);
+  });
+});

--- a/packages/typespec-client-generator-core/test/methods/streams.test.ts
+++ b/packages/typespec-client-generator-core/test/methods/streams.test.ts
@@ -1,51 +1,8 @@
-import { resolvePath } from "@typespec/compiler";
-import { createTester } from "@typespec/compiler/testing";
 import { deepStrictEqual, ok, strictEqual } from "assert";
 import { describe, it } from "vitest";
 import { UsageFlags } from "../../src/interfaces.js";
-import { createSdkContextForTester } from "../tester.js";
+import { createSdkContextForTester, StreamsTesterWithBuiltInService } from "../tester.js";
 import { getServiceMethodOfClient } from "../utils.js";
-
-const StreamsTester = createTester(resolvePath(import.meta.dirname, "../.."), {
-  libraries: [
-    "@typespec/http",
-    "@typespec/rest",
-    "@typespec/versioning",
-    "@typespec/streams",
-    "@typespec/sse",
-    "@typespec/events",
-    "@azure-tools/typespec-client-generator-core",
-  ],
-})
-  .import(
-    "@typespec/http",
-    "@typespec/rest",
-    "@typespec/versioning",
-    "@typespec/http/streams",
-    "@typespec/streams",
-    "@typespec/sse",
-    "@typespec/events",
-    "@azure-tools/typespec-client-generator-core",
-  )
-  .using(
-    "Http",
-    "Rest",
-    "Versioning",
-    "TypeSpec.Http.Streams",
-    "TypeSpec.Streams",
-    "TypeSpec.SSE",
-    "TypeSpec.Events",
-    "Azure.ClientGenerator.Core",
-  );
-
-const StreamsTesterWithBuiltInService = StreamsTester.wrap(
-  (x) => `
-@service
-namespace TestService;
-
-${x}
-`,
-);
 
 describe("stream request", () => {
   it("http stream request", async () => {
@@ -107,6 +64,9 @@ describe("stream request", () => {
     strictEqual(bodyMeta.streamType.kind, "model");
     strictEqual(bodyMeta.streamType.name, "Thing");
     deepStrictEqual(bodyMeta.contentTypes, ["application/jsonl"]);
+
+    // JSONL is not an event stream, so no SSE metadata.
+    strictEqual(method.operation.bodyParam?.sseMetadata, undefined);
 
     // streamType has Input + Json usage and appears in sdkPackage.models
     strictEqual(bodyMeta.streamType.usage, UsageFlags.Input | UsageFlags.Json);
@@ -180,61 +140,6 @@ describe("stream request", () => {
     // streamType has Input + Json usage and appears in sdkPackage.models
     strictEqual(bodyMeta.streamType.usage, UsageFlags.Input | UsageFlags.Json);
     ok(sdkPackage.models.find((m) => m.name === "Thing"));
-  });
-
-  it("sse request", async () => {
-    const { program } = await StreamsTesterWithBuiltInService.compile(
-      `
-        model UserConnect {
-          username: string;
-          time: string;
-        }
-
-        model UserMessage {
-          username: string;
-          time: string;
-          text: string;
-        }
-
-        model UserDisconnect {
-          username: string;
-          time: string;
-        }
-
-        @Events.events
-        union ChannelEvents {
-          userconnect: UserConnect,
-          usermessage: UserMessage,
-          userdisconnect: UserDisconnect,
-
-          @Events.contentType("text/plain")
-          @terminalEvent
-          "[unsubscribe]",
-        }
-
-        op subscribeToChannel(stream: SSEStream<ChannelEvents>): void;
-      `,
-    );
-    const context = await createSdkContextForTester(program);
-    const sdkPackage = context.sdkPackage;
-    const method = getServiceMethodOfClient(sdkPackage);
-    strictEqual(method.parameters[0].type.kind, "model");
-    strictEqual(method.parameters[0].type.properties[1].type.kind, "bytes");
-    strictEqual(method.parameters[0].type.properties[1].type.encode, "bytes");
-    deepStrictEqual(method.operation.bodyParam?.type, method.parameters[0].type.properties[1].type);
-
-    // stream metadata on body param - SSE streams have union streamType
-    const bodyMeta = method.operation.bodyParam?.streamMetadata;
-    ok(bodyMeta);
-    strictEqual(bodyMeta.bodyType.kind, "string");
-    strictEqual(bodyMeta.originalType.kind, "model");
-    strictEqual(bodyMeta.originalType.name, "SSEStreamChannelEvents");
-    strictEqual(bodyMeta.streamType.kind, "union");
-    strictEqual(bodyMeta.streamType.name, "ChannelEvents");
-    deepStrictEqual(bodyMeta.contentTypes, ["text/event-stream"]);
-
-    // streamType union has Input usage (no Json since SSE uses text/event-stream)
-    strictEqual(bodyMeta.streamType.usage, UsageFlags.Input);
   });
 });
 
@@ -400,68 +305,5 @@ describe("stream response", () => {
     // streamType has Output + Json usage and appears in sdkPackage.models
     strictEqual(responseMeta.streamType.usage, UsageFlags.Output | UsageFlags.Json);
     ok(sdkPackage.models.find((m) => m.name === "Thing"));
-  });
-
-  it("sse response", async () => {
-    const { program } = await StreamsTesterWithBuiltInService.compile(
-      `
-        model UserConnect {
-          username: string;
-          time: string;
-        }
-
-        model UserMessage {
-          username: string;
-          time: string;
-          text: string;
-        }
-
-        model UserDisconnect {
-          username: string;
-          time: string;
-        }
-
-        @Events.events
-        union ChannelEvents {
-          userconnect: UserConnect,
-          usermessage: UserMessage,
-          userdisconnect: UserDisconnect,
-
-          @Events.contentType("text/plain")
-          @terminalEvent
-          "[unsubscribe]",
-        }
-
-        op subscribeToChannel(): SSEStream<ChannelEvents>;
-      `,
-    );
-    const context = await createSdkContextForTester(program);
-    const sdkPackage = context.sdkPackage;
-    const method = getServiceMethodOfClient(sdkPackage);
-    strictEqual(method.response.type?.kind, "bytes");
-    strictEqual(method.response.type?.encode, "bytes");
-    strictEqual(method.operation.responses.length, 1);
-    strictEqual(method.operation.responses[0].type?.kind, "bytes");
-    strictEqual(method.operation.responses[0].type?.encode, "bytes");
-
-    // stream metadata on HTTP response - SSE streams have union streamType
-    const responseMeta = method.operation.responses[0].streamMetadata;
-    ok(responseMeta);
-    strictEqual(responseMeta.bodyType.kind, "string");
-    strictEqual(responseMeta.originalType.kind, "model");
-    strictEqual(responseMeta.originalType.name, "SSEStreamChannelEvents");
-    strictEqual(responseMeta.streamType.kind, "union");
-    strictEqual(responseMeta.streamType.name, "ChannelEvents");
-    deepStrictEqual(responseMeta.contentTypes, ["text/event-stream"]);
-
-    // stream metadata propagated to method response
-    const methodMeta = method.response.streamMetadata;
-    ok(methodMeta);
-    strictEqual(methodMeta.streamType.kind, "union");
-    strictEqual(methodMeta.streamType.name, "ChannelEvents");
-    deepStrictEqual(methodMeta.contentTypes, ["text/event-stream"]);
-
-    // streamType union has Output usage (no Json since SSE uses text/event-stream)
-    strictEqual(responseMeta.streamType.usage, UsageFlags.Output);
   });
 });

--- a/packages/typespec-client-generator-core/test/tester.ts
+++ b/packages/typespec-client-generator-core/test/tester.ts
@@ -271,3 +271,49 @@ export function createSdkContextForTester(
     createSdkContextOption,
   );
 }
+/**
+ * Tester for streaming and SSE tests (loads @typespec/streams, @typespec/sse, @typespec/events).
+ */
+export const StreamsTester = createTester(resolvePath(import.meta.dirname, ".."), {
+  libraries: [
+    "@typespec/http",
+    "@typespec/rest",
+    "@typespec/versioning",
+    "@typespec/streams",
+    "@typespec/sse",
+    "@typespec/events",
+    "@azure-tools/typespec-client-generator-core",
+  ],
+})
+  .import(
+    "@typespec/http",
+    "@typespec/rest",
+    "@typespec/versioning",
+    "@typespec/http/streams",
+    "@typespec/streams",
+    "@typespec/sse",
+    "@typespec/events",
+    "@azure-tools/typespec-client-generator-core",
+  )
+  .using(
+    "Http",
+    "Rest",
+    "Versioning",
+    "TypeSpec.Http.Streams",
+    "TypeSpec.Streams",
+    "TypeSpec.SSE",
+    "TypeSpec.Events",
+    "Azure.ClientGenerator.Core",
+  );
+
+/**
+ * Streams/SSE tester with a built-in simple service namespace.
+ */
+export const StreamsTesterWithBuiltInService = StreamsTester.wrap(
+  (x) => `
+@service
+namespace TestService;
+
+${x}
+`,
+);


### PR DESCRIPTION
Cherry-pick of commit 383366f5 from `main` into `release/july-2026`.

Original PR: #4882

Adds SSE event metadata (`SdkSseMetadata`, `SdkSseEventMetadata`) to TCGC types, giving emitters per-event information (event type, terminal event flag, payload type/content type) for SSE streams without re-deriving from raw TypeSpec.

**Files changed (8):**
- `src/http.ts` — `buildSdkSseMetadata()` + wiring to body/response
- `src/interfaces.ts` — `SdkSseMetadata` / `SdkSseEventMetadata` types
- `src/methods.ts` — propagate `sseMetadata` to method response
- `src/types.ts` — `propagateSseEventUsage()` for Json usage flags
- `test/methods/sse.test.ts` — new SSE-specific tests
- `test/methods/streams.test.ts` — moved SSE tests out
- `test/tester.ts` — `StreamsTester` helper
- `.chronus/changes/tcgc-addStreamEvents-*` — changelog entry