### PR TITLE
docs: use chronus version --only for single-package hotfix bumps

### DIFF
--- a/.github/skills/hotfix-release/SKILL.md
+++ b/.github/skills/hotfix-release/SKILL.md
@@ -54,11 +54,13 @@ Before starting, confirm the following with the user:
    git submodule update --init
    ```
 
-### 3. Run the version bump command with `--ignore-policies` (required for hotfix releases since the release branch is not `main`):
+### 3. Run the version bump command with `--ignore-policies` (required for hotfix releases since the release branch is not `main`) and `--only` to scope it to the hotfixed package(s):
 
 ```bash
-pnpm chronus version --ignore-policies
+pnpm chronus version --ignore-policies --only <package-name> [--only <package-name> ...]
 ```
+
+> ⚠️ Always pass `--only <package-name>` for each package being hotfixed. The `release/*` branch often carries unrelated pending change files (e.g. tcgc, benchmark, playground, website). Without `--only`, `chronus version` consumes ALL of them and bumps unrelated packages. `--only` bumps just the target package(s) and consumes only their change files, so you don't need to know or manually remove the other pending change files.
 
 3. **IMPORTANT:** If the `core` submodule pointer was changed by the version bump, reset it — the submodule should NOT change in a hotfix:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -385,7 +385,7 @@ Depending on the package where the fix needs to go do this on the `Microsoft/typ
 ### 2. Release the hot fix
 
 1. Make a new branch in this format `publish/hotfix/<hotfix-name>` against the `release/xyz` branch
-1. Run `pnpm chronus version --ignore-policies` to bump the versions, commit push, make PR, wait for CI and squash merge.
+1. Run `pnpm chronus version --ignore-policies --only <package-name>` to bump the version(s) of only the package(s) being hotfixed, commit push, make PR, wait for CI and squash merge. Using `--only` ensures unrelated pending change files on the `release/xyz` branch are not consumed and unrelated packages are not bumped.
 1. The package should then get published
 
 ### 3. Backmerge


### PR DESCRIPTION
Documents passing  + '--only <package-name>' +  to  + 'pnpm chronus version' +  during a hotfix release.

## Why
On a  + 'elease/*' +  branch there are often unrelated pending change files (tcgc, benchmark, playground, website). Running  + 'pnpm chronus version --ignore-policies' +  without  + '--only' +  consumes ALL of them and bumps unrelated packages. Passing  + '--only <package-name>' +  bumps just the target package(s) and consumes only their change files — so you don't need to know or manually remove the other pending change files.

## Changes
-  + 'CONTRIBUTING.md' +  — hotfix release step now uses  + '--only <package-name>' + .
-  + '.github/skills/hotfix-release/SKILL.md' +  — version bump step updated with  + '--only' +  and a warning.

Doc-only change ( + '.md' +  files are excluded from chronus change detection, so no changeset needed).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: cd6f2e08-d6d3-42ae-affd-bc71e98086f7