### PR TITLE
Standardize TCGC and ARM linter rule docs: unify headings, de-duplicate description and id

### DIFF
--- a/packages/typespec-azure-resource-manager/src/rules/arm-agent-base-type-child-resources.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-agent-base-type-child-resources.md
@@ -1,4 +1,4 @@
-Resources decorated with `@azureBaseType` for the Agent base type must have both a Conversation and a Response child resource.
+Define both child resources so Agent SDKs expose the expected conversation and response surfaces together.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-agent-base-type-child-resources.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-agent-base-type-child-resources.md
@@ -6,7 +6,7 @@ Resources decorated with `@azureBaseType` for the Agent base type must have both
 
 Agent base types must correctly model their child resources; violations can misrepresent the resource for emitters and tooling.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armProviderNamespace
@@ -22,7 +22,7 @@ model MyAgent is TrackedResource<MyAgentProperties> {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @armProviderNamespace

--- a/packages/typespec-azure-resource-manager/src/rules/arm-agent-base-type-lifecycle-operations.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-agent-base-type-lifecycle-operations.md
@@ -6,7 +6,7 @@ Conversation and Response child resources of an Agent must define create, read, 
 
 Agent base types must correctly model their lifecycle operations; violations can misrepresent the resource for emitters and tooling.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armProviderNamespace
@@ -27,7 +27,7 @@ interface Conversations {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @armProviderNamespace

--- a/packages/typespec-azure-resource-manager/src/rules/arm-agent-base-type-lifecycle-operations.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-agent-base-type-lifecycle-operations.md
@@ -1,4 +1,4 @@
-Conversation and Response child resources of an Agent must define create, read, update, and delete lifecycle operations.
+Implement the full lifecycle on each required child resource so Agent clients can manage conversations and responses consistently.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-common-types-version.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-common-types-version.md
@@ -6,14 +6,14 @@ ARM services must specify the ARM common-types version using the `@armCommonType
 
 Indicates common-types are not being used, which normally surfaces as other violations too.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armProviderNamespace
 namespace Microsoft.Contoso;
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 Apply `@armCommonTypesVersion` on the namespace:
 
@@ -23,7 +23,7 @@ Apply `@armCommonTypesVersion` on the namespace:
 namespace Microsoft.Contoso;
 ```
 
-#### ✅ Correct (per version)
+## ✅ Correct (per version)
 
 Apply `@armCommonTypesVersion` on each version enum member:
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-common-types-version.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-common-types-version.md
@@ -1,4 +1,4 @@
-ARM services must specify the ARM common-types version using the `@armCommonTypesVersion` decorator. If the same common types version is used across all service versions, this decorator should be applied either on the service namespace or on each version enum member. If the common types version is updated in later versions, the decorator should appear on each version enum member.
+If the same common types version is used across all service versions, this decorator should be applied either on the service namespace or on each version enum member. If the common types version is updated in later versions, the decorator should appear on each version enum member.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-custom-resource-no-key.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-custom-resource-no-key.md
@@ -2,7 +2,7 @@
 @azure-tools/typespec-azure-resource-manager/arm-custom-resource-no-key
 ```
 
-Custom Azure resource models must define a key property using the `@key` decorator, especially if the custom resource will be used in operations. Without a key, operation paths may be duplicated.
+Without a key, operation paths may be duplicated.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-custom-resource-no-key.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-custom-resource-no-key.md
@@ -10,7 +10,7 @@ Custom Azure resource models must define a key property using the `@key` decorat
 
 Mainly a correctness issue: the resource's name property should be marked with `@key`.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @Azure.ResourceManager.Legacy.customAzureResource
@@ -19,7 +19,7 @@ model CustomResource {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @Azure.ResourceManager.Legacy.customAzureResource

--- a/packages/typespec-azure-resource-manager/src/rules/arm-custom-resource-no-key.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-custom-resource-no-key.md
@@ -1,7 +1,3 @@
-```text title=- Full name-
-@azure-tools/typespec-azure-resource-manager/arm-custom-resource-no-key
-```
-
 Without a key, operation paths may be duplicated.
 
 ## Impact

--- a/packages/typespec-azure-resource-manager/src/rules/arm-custom-resource-usage-discourage.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-custom-resource-usage-discourage.md
@@ -6,7 +6,7 @@ Avoid using the `@customAzureResource` decorator. It doesn't provide validation 
 
 The resource does not use the ARM common-types resource base types.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @Azure.ResourceManager.Legacy.customAzureResource
@@ -15,7 +15,7 @@ model Person {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 Use standard ARM resource types:
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-delete-operation-response-codes.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-delete-operation-response-codes.md
@@ -1,7 +1,3 @@
-## Synchronous
-
-````
-
 ## Impact
 
 - **Area:** API
@@ -16,7 +12,7 @@ This rule corresponds to the LintDiff rule [DeleteResponseCodes](https://github.
 
 Synchronous delete operations should use the `ArmResourceDeleteSync` template. They must have 200, 204, default and no other responses.
 
-#### ❌ Incorrect
+### ❌ Incorrect
 
 ```tsp
 @armResourceOperations
@@ -27,9 +23,9 @@ interface Employees {
     result: boolean;
   };
 }
-````
+```
 
-#### ✅ Correct
+### ✅ Correct
 
 ```tsp
 @armResourceOperations
@@ -42,7 +38,7 @@ interface Employees {
 
 Long-running (LRO) delete operations should use the `ArmResourceDeleteWithoutOkAsync` template. They must have 202, 204, default, and no other responses.
 
-#### ❌ Incorrect
+### ❌ Incorrect
 
 ```tsp
 @armResourceOperations
@@ -51,7 +47,7 @@ interface Employees {
 }
 ```
 
-#### ✅ Correct
+### ✅ Correct
 
 ```tsp
 @armResourceOperations

--- a/packages/typespec-azure-resource-manager/src/rules/arm-feature-file-usage-discourage.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-feature-file-usage-discourage.md
@@ -1,6 +1,6 @@
 Avoid using the `@featureFiles` decorator. Its usage should be limited to brownfield services migration and requires explicit approval.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armProviderNamespace
@@ -12,7 +12,7 @@ enum Features {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 Do not use the `@featureFiles` decorator unless you have explicit approval for brownfield migration:
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-no-path-casing-conflicts.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-no-path-casing-conflicts.md
@@ -1,8 +1,4 @@
-ARM operation paths must be unique case-insensitively. Two operations whose
-paths differ only by character casing (for example `/foos` and `/Foos`, or
-`/{scope}/...` and `/{Scope}/...`) violate this rule. Path parameter names
-are part of the comparison: paths whose parameter names differ (for example
-`/{resourceUri}/...` versus `/{scope}/...`) are treated as distinct.
+Two operations whose paths differ only by character casing (for example `/foos` and `/Foos`, or `/{scope}/...` and `/{Scope}/...`) violate this rule. Path parameter names are part of the comparison: paths whose parameter names differ (for example `/{resourceUri}/...` versus `/{scope}/...`) are treated as distinct.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-no-path-casing-conflicts.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-no-path-casing-conflicts.md
@@ -10,7 +10,7 @@ are part of the comparison: paths whose parameter names differ (for example
 
 Different-cased paths to the same resource can cause ARM manifest failures.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model Foo is ProxyResource<{}> {
@@ -30,7 +30,7 @@ model Bar is ProxyResource<{}> {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model Foo is ProxyResource<{}> {

--- a/packages/typespec-azure-resource-manager/src/rules/arm-no-record.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-no-record.md
@@ -14,7 +14,7 @@ ARM requires Resource provider teams to define types explicitly. This is to ensu
 
 This rule corresponds to the LintDiff rule [AvoidAdditionalProperties](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model Address {
@@ -24,7 +24,7 @@ model Address {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model Address {
@@ -36,13 +36,13 @@ model Address {
 }
 ```
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model Address is Record<string>;
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model Address {
@@ -54,13 +54,13 @@ model Address {
 }
 ```
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model Address extends Record<string> {}
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model Address {

--- a/packages/typespec-azure-resource-manager/src/rules/arm-no-record.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-no-record.md
@@ -1,7 +1,3 @@
-```text title=- Full name-
-@azure-tools/typespec-azure-resource-manager/arm-no-record
-```
-
 ARM requires Resource provider teams to define types explicitly. This is to ensure good customer experience in terms of the discoverability of concrete type definitions.
 
 ## Impact

--- a/packages/typespec-azure-resource-manager/src/rules/arm-post-operation-response-codes.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-post-operation-response-codes.md
@@ -1,7 +1,3 @@
-## Synchronous
-
-````
-
 ## Impact
 
 - **Area:** API
@@ -16,7 +12,7 @@ This rule corresponds to the LintDiff rule [PostResponseCodes](https://github.co
 
 Synchronous post operations should have one of the following combinations of responses - 200 and default, or 204 and default. They must have no other responses.
 
-#### ❌ Incorrect
+### ❌ Incorrect
 
 ```tsp
 @armResourceOperations
@@ -27,9 +23,9 @@ interface Employees {
     result: boolean;
   };
 }
-````
+```
 
-#### ✅ Correct
+### ✅ Correct
 
 ```tsp
 @armResourceOperations
@@ -42,7 +38,7 @@ interface Employees {
 
 Long-running (LRO) post operations should have 202 and default responses. The must also have a 200 response only if the final response is intended to have a schema. They must have no other responses. The 202 response must not have a response schema specified.
 
-#### ❌ Incorrect
+### ❌ Incorrect
 
 ```tsp
 @armResourceOperations
@@ -51,7 +47,7 @@ interface Employees {
 }
 ```
 
-#### ✅ Correct
+### ✅ Correct
 
 ```tsp
 @armResourceOperations

--- a/packages/typespec-azure-resource-manager/src/rules/arm-put-operation-response-codes.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-put-operation-response-codes.md
@@ -10,7 +10,7 @@ The PUT operation returns response codes that violate the RPC contract.
 
 This rule corresponds to the LintDiff rule [PutResponseCodes](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armResourceOperations
@@ -23,7 +23,7 @@ interface Employees {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @armResourceOperations

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-action-no-segment.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-action-no-segment.md
@@ -10,7 +10,7 @@ May indicate a resource action path that does not follow the standard segment la
 
 This rule corresponds to the LintDiff rule [PathForResourceAction](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md) (partial).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armResourceAction(MyResource)
@@ -19,7 +19,7 @@ This rule corresponds to the LintDiff rule [PathForResourceAction](https://githu
 op doAction(...ApiVersionParameter): void;
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @armResourceAction(MyResource)
@@ -27,7 +27,7 @@ op doAction(...ApiVersionParameter): void;
 op doAction(...ApiVersionParameter): void;
 ```
 
-#### ✅ Correct (with custom action name)
+## ✅ Correct (with custom action name)
 
 ```tsp
 @armResourceAction(MyResource)

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-action-no-segment.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-action-no-segment.md
@@ -1,4 +1,4 @@
-The `@armResourceAction` decorator should not be used together with `@segment`. If you need to rename the action, use `@action(...)` instead or omit the segment entirely.
+If you need to rename the action, use `@action(...)` instead or omit the segment entirely.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-duplicate-property.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-duplicate-property.md
@@ -10,7 +10,7 @@ Reusing an envelope property name inside the RP-specific property bag violates t
 
 This rule corresponds to the LintDiff rule [ArmResourcePropertiesBag](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r3019).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armProviderNamespace
@@ -27,7 +27,7 @@ model FooProperties {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @armProviderNamespace

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-duplicate-property.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-duplicate-property.md
@@ -1,4 +1,4 @@
-Warns when a property defined in the resource envelope is also defined in the resource-specific properties bag. Envelope properties should not be duplicated in the `properties` model.
+Envelope properties should not be duplicated in the `properties` model.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-interface-requires-decorator.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-interface-requires-decorator.md
@@ -1,12 +1,12 @@
 Each resource interface must have an `@armResourceOperations` decorator to associate the interface with its ARM resource type.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 interface FooResources extends TrackedResourceOperations<FooResource, FooProperties> {}
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @armResourceOperations(FooResource)

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-interface-requires-decorator.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-interface-requires-decorator.md
@@ -1,4 +1,4 @@
-Each resource interface must have an `@armResourceOperations` decorator to associate the interface with its ARM resource type.
+The decorator associates the interface with its ARM resource type so ARM operations can be validated against the correct resource.
 
 ## ❌ Incorrect
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-action-verb.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-action-verb.md
@@ -2,7 +2,7 @@
 @azure-tools/typespec-azure-resource-manager/arm-resource-invalid-action-verb
 ```
 
-For ARM http operations, the action verb must be `@post` or `@get`. Any other action verb is flagged as incorrect.
+Use `@post` or `@get` for actions; model other HTTP verbs as normal resource operations instead.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-action-verb.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-action-verb.md
@@ -1,7 +1,3 @@
-```text title=- Full name-
-@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-action-verb
-```
-
 Use `@post` or `@get` for actions; model other HTTP verbs as normal resource operations instead.
 
 ## Impact

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-action-verb.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-action-verb.md
@@ -14,7 +14,7 @@ A resource action that does not use POST or GET produces an improper HTTP API an
 
 This rule corresponds to the LintDiff rule [InvalidVerbUsed](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r2044).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @delete op getAction is ArmProviderActionAsync<
@@ -26,7 +26,7 @@ This rule corresponds to the LintDiff rule [InvalidVerbUsed](https://github.com/
 >;
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 op postAction is ArmProviderActionAsync<
@@ -38,7 +38,7 @@ op postAction is ArmProviderActionAsync<
 >;
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @get op getAction is ArmProviderActionSync<

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-envelope-property.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-envelope-property.md
@@ -10,7 +10,7 @@ Defining non-standard top-level envelope properties violates the RPC contract.
 
 This rule corresponds to the LintDiff rule [BodyTopLevelProperties](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r3006).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armProviderNamespace
@@ -22,7 +22,7 @@ model FooResource is TrackedResource<{}> {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @armProviderNamespace

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-version-format.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-invalid-version-format.md
@@ -10,7 +10,7 @@ The api-version does not follow the required format, violating the RPC contract.
 
 This rule corresponds to the LintDiff rule [ApiVersionPattern](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r3012).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @versioned(Versions)
@@ -22,7 +22,7 @@ enum Versions {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @versioned(Versions)

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-key-invalid-chars.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-key-invalid-chars.md
@@ -6,7 +6,7 @@ ARM resource key must contain only alphanumeric characters or dashes, starting w
 
 Invalid characters in a resource key produce invalid parameter names in SDKs.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model Employee is TrackedResource<EmployeeProperties> {
@@ -14,7 +14,7 @@ model Employee is TrackedResource<EmployeeProperties> {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model Employee is TrackedResource<EmployeeProperties> {

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-key-invalid-chars.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-key-invalid-chars.md
@@ -1,4 +1,4 @@
-ARM resource key must contain only alphanumeric characters or dashes, starting with a lowercase letter.
+Beyond alphanumeric characters, a resource key may also contain dashes, but it must start with a lowercase letter.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-name-pattern.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-name-pattern.md
@@ -10,7 +10,7 @@ The resource name lacks the required pattern restriction, violating the RPC cont
 
 This rule corresponds to the LintDiff rule [ResourceNameRestriction](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model Employee is ProxyResource<{}> {
@@ -21,7 +21,7 @@ model Employee is ProxyResource<{}> {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model Employee is ProxyResource<{}> {

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-name-pattern.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-name-pattern.md
@@ -1,4 +1,4 @@
-Resource names must specify a pattern string using `@pattern`, providing a regular expression that the name must match.
+Use a regular expression that accurately describes valid resource names so invalid names can be rejected before requests are sent.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-operation-response.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-operation-response.md
@@ -14,7 +14,7 @@ The resource operation returns a response schema that violates the RPC contract.
 
 This rule corresponds to the LintDiff rule [PutGetPatchResponseSchema](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r3007) (the TypeSpec rule also covers `list`).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armResourceOperations
@@ -26,7 +26,7 @@ interface FooResources {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @armResourceOperations

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-operation-response.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-operation-response.md
@@ -1,4 +1,4 @@
-PUT, GET, PATCH & LIST must return the same resource schema. Operations on a resource such as read, create, update, and list must all return the resource type itself (or a collection of the resource type for list operations).
+Operations on a resource such as read, create, update, and list must all return the resource type itself (or a collection of the resource type for list operations).
 
 :::note
 ARM RPC rule: [`RPC-008`](https://armwiki.azurewebsites.net/api_contracts/guidelines/rpc.html)

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-operation.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-operation.md
@@ -6,7 +6,7 @@ Validate that all ARM Resource operations are defined inside an interface, inclu
 
 Missing the resource decorators can leave operations unassociated with their resource - breaking the C# SDK and preventing resource-based reasoning, linting, and generation of resource-centric content (service generation, tests, portal).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 Operations must be inside an interface:
 
@@ -30,7 +30,7 @@ interface FooResources {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @armResourceOperations

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-patch.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-patch.md
@@ -1,4 +1,4 @@
-Validate ARM PATCH operations. The request body of a PATCH must be a model with a subset of the resource properties. The PATCH body must not contain properties that do not exist on the resource.
+The request body of a PATCH must be a model with a subset of the resource properties. The PATCH body must not contain properties that do not exist on the resource.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-patch.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-patch.md
@@ -10,7 +10,7 @@ Inconsistent PATCH properties violate the RPC contract.
 
 This rule corresponds to the LintDiff rule [ConsistentPatchProperties](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model FooResource is TrackedResource<FooProperties> {
@@ -24,7 +24,7 @@ model MyBadPatch {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model FooResource is TrackedResource<FooProperties> {

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-path-segment-invalid-chars.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-path-segment-invalid-chars.md
@@ -6,7 +6,7 @@ ARM resource path segments must contain only alphanumeric characters or dashes, 
 
 Invalid characters in a path segment produce an invalid ARM API and invalid parameter names.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model FooResource is TrackedResource<{}> {
@@ -14,7 +14,7 @@ model FooResource is TrackedResource<{}> {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model FooResource is TrackedResource<{}> {

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-provisioning-state.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-provisioning-state.md
@@ -1,7 +1,3 @@
-```text title=- Full name-
-@azure-tools/typespec-azure-resource-manager/arm-resource-provisioning-state
-```
-
 `ProvisioningState` property of ARM resource must be:
 
 - optional

--- a/packages/typespec-azure-resource-manager/src/rules/arm-resource-provisioning-state.md
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-resource-provisioning-state.md
@@ -18,7 +18,7 @@ A missing or invalid provisioning state violates the RPC and RPaaS contracts.
 
 This rule corresponds to the LintDiff rule [ProvisioningStateValidation](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md) (also ProvisioningStateSpecifiedForLROPut, ProvisioningStateSpecifiedForLROPatch, and RpaaS_ResourceProvisioningState).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model ResourceProperties {
@@ -26,7 +26,7 @@ model ResourceProperties {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model ResourceProperties {

--- a/packages/typespec-azure-resource-manager/src/rules/beyond-nesting-levels.md
+++ b/packages/typespec-azure-resource-manager/src/rules/beyond-nesting-levels.md
@@ -1,4 +1,4 @@
-Tracked Resources must use 3 or fewer levels of nesting. Deeply nested resources make the API harder to use and are discouraged by ARM guidelines.
+Deeply nested resources make the API harder to use and are discouraged by ARM guidelines.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/beyond-nesting-levels.md
+++ b/packages/typespec-azure-resource-manager/src/rules/beyond-nesting-levels.md
@@ -10,7 +10,7 @@ Nesting resources beyond three levels violates the RPC contract.
 
 This rule corresponds to the LintDiff rule [TrackedResourceBeyondThirdLevel](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armProviderNamespace
@@ -37,7 +37,7 @@ model D is TrackedResource<{}> {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @armProviderNamespace

--- a/packages/typespec-azure-resource-manager/src/rules/empty-updateable-properties.md
+++ b/packages/typespec-azure-resource-manager/src/rules/empty-updateable-properties.md
@@ -1,4 +1,4 @@
-Resources with update operations should have updateable properties. The RP-specific properties of the resource (as defined in the `properties` property) should have at least one updateable property. Properties are updateable if they do not have a `@visibility` decorator, or if they include `Lifecycle.Update` in the `@visibility` decorator arguments.
+The RP-specific properties of the resource (as defined in the `properties` property) should have at least one updateable property. Properties are updateable if they do not have a `@visibility` decorator, or if they include `Lifecycle.Update` in the `@visibility` decorator arguments.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/empty-updateable-properties.md
+++ b/packages/typespec-azure-resource-manager/src/rules/empty-updateable-properties.md
@@ -6,7 +6,7 @@ Resources with update operations should have updateable properties. The RP-speci
 
 Covered by the patch-specific rules; indicates the properties bag has no updateable properties.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 All properties are read-only:
 
@@ -17,7 +17,7 @@ model FooResourceProperties {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 At least one property without read-only visibility:
 

--- a/packages/typespec-azure-resource-manager/src/rules/improper-subscription-list-operation.md
+++ b/packages/typespec-azure-resource-manager/src/rules/improper-subscription-list-operation.md
@@ -6,7 +6,7 @@ Tenant and Extension resources should not define a list by subscription operatio
 
 Likely a modeling error - only subscription-based resources should have subscription list operations.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @tenantResource
@@ -20,7 +20,7 @@ interface FooResources {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @tenantResource

--- a/packages/typespec-azure-resource-manager/src/rules/improper-subscription-list-operation.md
+++ b/packages/typespec-azure-resource-manager/src/rules/improper-subscription-list-operation.md
@@ -1,4 +1,4 @@
-Tenant and Extension resources should not define a list by subscription operation. These resource types are not scoped to a subscription, so listing them by subscription is not appropriate.
+These resource types are not scoped to a subscription, so listing them by subscription is not appropriate.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/lro-location-header.md
+++ b/packages/typespec-azure-resource-manager/src/rules/lro-location-header.md
@@ -2,7 +2,7 @@
 @azure-tools/typespec-azure-resource-manager/lro-location-header
 ```
 
-Long-running (LRO) operations with 202 responses must have a "Location" response header.
+The header tells clients where to poll after a 202 response from a long-running operation.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/lro-location-header.md
+++ b/packages/typespec-azure-resource-manager/src/rules/lro-location-header.md
@@ -14,7 +14,7 @@ A long-running operation without the standard Location header violates the RPC c
 
 This rule corresponds to the LintDiff rule [LroLocationHeader](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armResourceOperations
@@ -23,7 +23,7 @@ interface Employees {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @armResourceOperations

--- a/packages/typespec-azure-resource-manager/src/rules/lro-location-header.md
+++ b/packages/typespec-azure-resource-manager/src/rules/lro-location-header.md
@@ -1,7 +1,3 @@
-```text title=- Full name-
-@azure-tools/typespec-azure-resource-manager/lro-location-header
-```
-
 The header tells clients where to poll after a 202 response from a long-running operation.
 
 ## Impact

--- a/packages/typespec-azure-resource-manager/src/rules/missing-operations-endpoint.md
+++ b/packages/typespec-azure-resource-manager/src/rules/missing-operations-endpoint.md
@@ -10,14 +10,14 @@ The service is missing the standard Operations endpoint required by the RPC cont
 
 This rule corresponds to the LintDiff rule [OperationsAPIImplementation](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r3023).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp title="main.tsp"
 @armProviderNamespace
 namespace MyService;
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp title="main.tsp"
 @armProviderNamespace

--- a/packages/typespec-azure-resource-manager/src/rules/missing-operations-endpoint.md
+++ b/packages/typespec-azure-resource-manager/src/rules/missing-operations-endpoint.md
@@ -1,4 +1,4 @@
-Check for missing Operations interface. All Azure Resource Manager services must expose the operations endpoint. Add the Operations interface to your service namespace.
+All Azure Resource Manager services must expose the operations endpoint. Add the Operations interface to your service namespace.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/missing-x-ms-identifiers.md
+++ b/packages/typespec-azure-resource-manager/src/rules/missing-x-ms-identifiers.md
@@ -2,7 +2,7 @@
 @azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers
 ```
 
-Array of models must explicity define which keys are used as identifiers using the `@identifiers` decorator.
+Identifiers let downstream OpenAPI and SDK tooling correlate items in array-valued model properties.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/missing-x-ms-identifiers.md
+++ b/packages/typespec-azure-resource-manager/src/rules/missing-x-ms-identifiers.md
@@ -1,7 +1,3 @@
-```text title=- Full name-
-@azure-tools/typespec-azure-resource-manager/missing-x-ms-identifiers
-```
-
 Identifiers let downstream OpenAPI and SDK tooling correlate items in array-valued model properties.
 
 ## Impact

--- a/packages/typespec-azure-resource-manager/src/rules/missing-x-ms-identifiers.md
+++ b/packages/typespec-azure-resource-manager/src/rules/missing-x-ms-identifiers.md
@@ -14,7 +14,7 @@ An old-pattern warning with no real runtime impact.
 
 This rule corresponds to the LintDiff rule [XmsIdentifierValidation](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r4041) (warning).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model Address {
@@ -27,7 +27,7 @@ model ResourceProperties {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model ResourceProperties {

--- a/packages/typespec-azure-resource-manager/src/rules/no-empty-model.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-empty-model.md
@@ -1,7 +1,3 @@
-```text title=- Full name-
-@azure-tools/typespec-azure-resource-manager/no-empty-model
-```
-
 Define a named model with explicit properties instead of a generic object shape so clients and OpenAPI consumers see a concrete schema.
 
 ## Impact

--- a/packages/typespec-azure-resource-manager/src/rules/no-empty-model.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-empty-model.md
@@ -2,7 +2,7 @@
 @azure-tools/typespec-azure-resource-manager/no-empty-model
 ```
 
-ARM Properties with type:object that don't reference a model definition are not allowed. ARM doesn't allow generic type definitions as this leads to bad customer experience.
+Define a named model with explicit properties instead of a generic object shape so clients and OpenAPI consumers see a concrete schema.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/no-empty-model.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-empty-model.md
@@ -14,7 +14,7 @@ A model that accepts any schema is difficult to use from both the API and genera
 
 This rule corresponds to the LintDiff rule [MissingTypeObject](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r4037).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model Information {
@@ -22,13 +22,13 @@ model Information {
 }
 ```
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model Empty {}
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model Information {
@@ -44,7 +44,7 @@ model Address {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model Information {

--- a/packages/typespec-azure-resource-manager/src/rules/no-override-props.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-override-props.md
@@ -1,4 +1,4 @@
-Warns when a model redefines a property that is already defined in one of its base models. Repeating inherited properties in a child model is an anti-pattern for Azure APIs and can cause problems with OpenAPI tooling and some language representations of the models.
+Repeating inherited properties in a child model is an anti-pattern for Azure APIs and can cause problems with OpenAPI tooling and some language representations of the models.
 
 Overriding an inherited property is allowed when:
 

--- a/packages/typespec-azure-resource-manager/src/rules/no-override-props.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-override-props.md
@@ -11,7 +11,7 @@ Overriding an inherited property is allowed when:
 
 Overridden properties can crash the breaking-change tool and are unsupported by most languages.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armProviderNamespace
@@ -34,7 +34,7 @@ model Child extends Base {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @armProviderNamespace
@@ -50,7 +50,7 @@ model Child extends Base {
 }
 ```
 
-#### ✅ Correct (compatible scalar override)
+## ✅ Correct (compatible scalar override)
 
 ```tsp
 @armProviderNamespace

--- a/packages/typespec-azure-resource-manager/src/rules/no-reserved-resource-property.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-reserved-resource-property.md
@@ -1,4 +1,4 @@
-Certain property names are reserved and must not be present in a resource's property bag (the model referenced by the `properties` property of an ARM resource). For example, `billingData` is reserved for platform billing integration and is being standardized through Common Types, so resource providers must not declare it.
+Reserved names are used by the ARM platform and common types; declaring them in RP-specific properties can conflict with standardized behavior.
 
 The property name is matched case-insensitively (`billingData`, `BillingData`, `billingdata`, etc.) and is disallowed regardless of its type (named model reference, inline model, or primitive). The set of reserved names is maintained by the rule.
 

--- a/packages/typespec-azure-resource-manager/src/rules/no-reserved-resource-property.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-reserved-resource-property.md
@@ -2,7 +2,7 @@ Certain property names are reserved and must not be present in a resource's prop
 
 The property name is matched case-insensitively (`billingData`, `BillingData`, `billingdata`, etc.) and is disallowed regardless of its type (named model reference, inline model, or primitive). The set of reserved names is maintained by the rule.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armProviderNamespace
@@ -20,7 +20,7 @@ model FooProperties {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @armProviderNamespace

--- a/packages/typespec-azure-resource-manager/src/rules/no-resource-delete-operation.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-resource-delete-operation.md
@@ -1,7 +1,3 @@
-```text title=- Full name-
-@azure-tools/typespec-azure-resource-manager/no-resource-delete-operation
-```
-
 Every ARM resource that provides a create operation must also provide a delete operation.
 
 ## Impact

--- a/packages/typespec-azure-resource-manager/src/rules/no-resource-delete-operation.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-resource-delete-operation.md
@@ -14,7 +14,7 @@ A tracked resource without a delete operation violates the RPC contract.
 
 This rule corresponds to the LintDiff rule [AllTrackedResourcesMustHaveDelete](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armResourceOperations
@@ -23,7 +23,7 @@ interface EmployeeOperations {
 }
 ```
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 @armResourceOperations
@@ -33,7 +33,7 @@ interface EmployeeOperations {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @armResourceOperations

--- a/packages/typespec-azure-resource-manager/src/rules/no-response-body.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-response-body.md
@@ -5,15 +5,15 @@
 
 ARM operation responses with status code 202 or 204 should not contain a response body. Operation responses with other success (2xx) status codes should contain a response body.
 
-### For 202 and 204 status codes (response body should be empty)
-
 ## Impact
 
 - **Area:** API
 
+## For 202 and 204 status codes (response body should be empty)
+
 A response - usually a 202 - carries a body that should be empty.
 
-#### ❌ Incorrect
+### ❌ Incorrect
 
 ```tsp
 op walk(): ArmNoContentResponse & {
@@ -34,7 +34,7 @@ op walk(): ArmNoContentResponse & {
 }
 ```
 
-#### ✅ Correct
+### ✅ Correct
 
 ```tsp
 op walk(): ArmAcceptedResponse;
@@ -50,9 +50,9 @@ op walk(): ArmAcceptedResponse;
 }
 ```
 
-### For other success (2xx) response status codes (response body should not be empty)
+## For other success (2xx) response status codes (response body should not be empty)
 
-#### ❌ Incorrect
+### ❌ Incorrect
 
 ```tsp
 op walk(): CreatedResponse;
@@ -68,7 +68,7 @@ op walk(): CreatedResponse;
 }
 ```
 
-#### ✅ Correct
+### ✅ Correct
 
 ```tsp
 op walk(): ArmCreatedResponse<{

--- a/packages/typespec-azure-resource-manager/src/rules/no-response-body.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-response-body.md
@@ -1,8 +1,3 @@
-```text title=- Full name-
-@azure-tools/typespec-azure-resource-manager/no-response-body
-
-```
-
 This keeps ARM response schemas aligned with how clients interpret long-running or empty success responses versus success responses that return resource data.
 
 ## Impact

--- a/packages/typespec-azure-resource-manager/src/rules/no-response-body.md
+++ b/packages/typespec-azure-resource-manager/src/rules/no-response-body.md
@@ -3,7 +3,7 @@
 
 ```
 
-ARM operation responses with status code 202 or 204 should not contain a response body. Operation responses with other success (2xx) status codes should contain a response body.
+This keeps ARM response schemas aligned with how clients interpret long-running or empty success responses versus success responses that return resource data.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/patch-envelope.md
+++ b/packages/typespec-azure-resource-manager/src/rules/patch-envelope.md
@@ -1,4 +1,4 @@
-Patch envelope properties should match the resource properties. If a resource defines envelope properties such as `identity`, `managedBy`, `plan`, `sku`, or `tags`, these properties must also be present in the PATCH request body so they can be updated.
+If a resource defines envelope properties such as `identity`, `managedBy`, `plan`, `sku`, or `tags`, these properties must also be present in the PATCH request body so they can be updated.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/patch-envelope.md
+++ b/packages/typespec-azure-resource-manager/src/rules/patch-envelope.md
@@ -6,7 +6,7 @@ Patch envelope properties should match the resource properties. If a resource de
 
 The PATCH operation is missing updateable envelope properties.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model FooResource is TrackedResource<FooProperties> {
@@ -29,7 +29,7 @@ interface FooResources {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model FooResource is TrackedResource<FooProperties> {

--- a/packages/typespec-azure-resource-manager/src/rules/resource-name.md
+++ b/packages/typespec-azure-resource-manager/src/rules/resource-name.md
@@ -6,7 +6,7 @@ Check the resource name. ARM resource model names must contain only alphanumeric
 
 Invalid characters in a resource name violate the RPC contract and produce invalid client parameter names, preventing SDK generation.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 Missing `@path` decorator on `name`:
 
@@ -18,7 +18,7 @@ model FooResource is TrackedResource<{}> {
 }
 ```
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 Underscore in model name:
 
@@ -28,7 +28,7 @@ model Foo_Resource is TrackedResource<{}> {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model FooResource is TrackedResource<{}> {

--- a/packages/typespec-azure-resource-manager/src/rules/resource-name.md
+++ b/packages/typespec-azure-resource-manager/src/rules/resource-name.md
@@ -1,4 +1,4 @@
-Check the resource name. ARM resource model names must contain only alphanumeric characters (starting with an uppercase letter), and the `name` property must be a read-only `@path` parameter.
+ARM resource model names must contain only alphanumeric characters (starting with an uppercase letter), and the `name` property must be a read-only `@path` parameter.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/retry-after.md
+++ b/packages/typespec-azure-resource-manager/src/rules/retry-after.md
@@ -6,7 +6,7 @@ Check if the `Retry-After` header appears in the response for long-running opera
 
 Long-running or throttled operations should expose a standard Retry-After header so clients can poll correctly.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 Custom long-running operation missing `Retry-After` header:
 
@@ -23,7 +23,7 @@ interface FooResources {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 Use ARM operation templates which include the `Retry-After` header automatically:
 

--- a/packages/typespec-azure-resource-manager/src/rules/retry-after.md
+++ b/packages/typespec-azure-resource-manager/src/rules/retry-after.md
@@ -1,4 +1,4 @@
-Check if the `Retry-After` header appears in the response for long-running operations. For long-running operations, the `Retry-After` header indicates how long the client should wait before polling the operation status. This header should be included in 201 or 202 responses.
+For long-running operations, the `Retry-After` header indicates how long the client should wait before polling the operation status. This header should be included in 201 or 202 responses.
 
 ## Impact
 

--- a/packages/typespec-azure-resource-manager/src/rules/secret-prop.md
+++ b/packages/typespec-azure-resource-manager/src/rules/secret-prop.md
@@ -18,7 +18,7 @@ Returning a secret in a response violates the RPC contract unless the property i
 
 This rule corresponds to the LintDiff rule [XMSSecretInResponse](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md).
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model Data {
@@ -27,7 +27,7 @@ model Data {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model Data {

--- a/packages/typespec-azure-resource-manager/src/rules/secret-prop.md
+++ b/packages/typespec-azure-resource-manager/src/rules/secret-prop.md
@@ -1,7 +1,3 @@
-```text title=- Full name-
-@azure-tools/typespec-azure-resource-manager/secret-prop
-```
-
 Marking these fields lets ARM and SDK tooling identify sensitive values and handle them according to security guidelines.
 
 :::note

--- a/packages/typespec-azure-resource-manager/src/rules/secret-prop.md
+++ b/packages/typespec-azure-resource-manager/src/rules/secret-prop.md
@@ -2,7 +2,7 @@
 @azure-tools/typespec-azure-resource-manager/secret-prop
 ```
 
-When defining the model returned in an ARM operation, any property that contains sensitive information (such as passwords, keys, tokens, credentials, or other secrets) must be marked with `@secret`. This ensures that secrets are properly identified and handled according to ARM security guidelines.
+Marking these fields lets ARM and SDK tooling identify sensitive values and handle them according to security guidelines.
 
 :::note
 ARM RPC rule: [`RPC-v1-13`](https://armwiki.azurewebsites.net/api_contracts/guidelines/rpc.html)

--- a/packages/typespec-azure-resource-manager/src/rules/unsupported-type.md
+++ b/packages/typespec-azure-resource-manager/src/rules/unsupported-type.md
@@ -1,5 +1,3 @@
-Check the ARM specification is not using types not supported in ARM.
-
 Primitive types currently unsupported in ARM:
 
 - int8

--- a/packages/typespec-azure-resource-manager/src/rules/unsupported-type.md
+++ b/packages/typespec-azure-resource-manager/src/rules/unsupported-type.md
@@ -15,7 +15,7 @@ Primitive types currently unsupported in ARM:
 
 The data type cannot be modeled in SDKs.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 ```tsp
 model ResourceProperties {
@@ -23,7 +23,7 @@ model ResourceProperties {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 model ResourceProperties {

--- a/packages/typespec-azure-resource-manager/src/rules/version-progression.md
+++ b/packages/typespec-azure-resource-manager/src/rules/version-progression.md
@@ -11,7 +11,7 @@ This rule complements [`arm-resource-invalid-version-format`](./arm-resource-inv
 
 Out-of-order versions, or versions with matching dates, make specs unmaintainable and cause SDK problems.
 
-#### ❌ Incorrect
+## ❌ Incorrect
 
 A preview and a stable version share the same date:
 
@@ -39,7 +39,7 @@ enum Versions {
 }
 ```
 
-#### ✅ Correct
+## ✅ Correct
 
 ```tsp
 @versioned(Versions)

--- a/packages/typespec-azure-resource-manager/src/rules/version-progression.md
+++ b/packages/typespec-azure-resource-manager/src/rules/version-progression.md
@@ -1,9 +1,4 @@
-ARM service api-versions must:
-
-1. Use a **unique date** — every entry's `YYYY-MM-DD` must differ from every other entry's date in the same `Versions` enum. A preview version and a stable version cannot share the same date (for example, `2026-04-28` and `2026-04-28-preview` together is not allowed).
-2. Be declared in **strictly increasing chronological order** from top to bottom.
-
-This rule complements [`arm-resource-invalid-version-format`](./arm-resource-invalid-version-format.md), which validates the format of each individual version string. `arm-version-progression` does not flag malformed version strings — those are reported by the format rule.
+Use this rule to catch ordering mistakes across otherwise well-formed service versions. It complements [`arm-resource-invalid-version-format`](./arm-resource-invalid-version-format.md), which validates the format of each individual version string; `arm-version-progression` does not flag malformed version strings because those are reported by the format rule.
 
 ## Impact
 

--- a/packages/typespec-client-generator-core/src/rules/csharp-no-url-suffix.md
+++ b/packages/typespec-client-generator-core/src/rules/csharp-no-url-suffix.md
@@ -7,7 +7,7 @@ The rule checks the C#-resolved name (respecting `@clientName` overrides).
 - **Area:** SDK generation, **C# only**. Affects the generated property name in the C# SDK (applies to both data-plane and management-plane).
 - **Not affected:** Other language SDKs, the service definition, and the wire protocol are unchanged — the serialized name is untouched, only the C# client-surface name.
 
-#### ❌ Incorrect Usage
+## ❌ Incorrect Usage
 
 ```tsp
 model Foo {
@@ -16,7 +16,7 @@ model Foo {
 }
 ```
 
-#### Diagnostic Message
+## Diagnostic Message
 
 For the model above, the linter reports each property whose C# name ends with `Url`:
 
@@ -24,7 +24,7 @@ For the model above, the linter reports each property whose C# name ends with `U
 Property 'imageUrl' ends with 'Url'. Use 'Uri' suffix instead (e.g. 'imageUri'). Use @clientName("imageUri", "csharp") to rename it for C#.
 ```
 
-#### ✅ How to Fix
+## ✅ How to Fix
 
 Rename the property to end with `Uri`:
 

--- a/packages/typespec-client-generator-core/src/rules/csharp-no-url-suffix.md
+++ b/packages/typespec-client-generator-core/src/rules/csharp-no-url-suffix.md
@@ -1,5 +1,3 @@
-Properties ending with `Url` should use `Uri` suffix instead to follow .NET SDK naming conventions.
-
 The rule checks the C#-resolved name (respecting `@clientName` overrides).
 
 ## Impact

--- a/packages/typespec-client-generator-core/src/rules/property-name-conflict.md
+++ b/packages/typespec-client-generator-core/src/rules/property-name-conflict.md
@@ -8,7 +8,7 @@ rename it for the affected language.
 - **Area:** SDK generation, primarily **C#**. A property whose name collides with its enclosing model's name produces code that does not compile in C# (applies to both data-plane and management-plane).
 - **Not affected:** The service definition and the wire protocol are unchanged; the collision only affects the generated client code.
 
-#### ❌ Incorrect Usage
+## ❌ Incorrect Usage
 
 ```tsp
 model Widget {
@@ -16,7 +16,7 @@ model Widget {
 }
 ```
 
-#### Diagnostic Message
+## Diagnostic Message
 
 For the model above, the linter reports that the property name is the same as its enclosing model name:
 
@@ -24,7 +24,7 @@ For the model above, the linter reports that the property name is the same as it
 Property 'widget' having the same name as its enclosing model will cause problems with C# code generation. Consider renaming the property directly or using the @clientName("newName", "csharp") decorator to rename the property for C#.
 ```
 
-#### ✅ How to Fix
+## ✅ How to Fix
 
 Rename the property:
 

--- a/packages/typespec-client-generator-core/src/rules/require-client-suffix.md
+++ b/packages/typespec-client-generator-core/src/rules/require-client-suffix.md
@@ -1,9 +1,6 @@
-Top-level client names should end with the `Client` suffix. This convention
-makes it clear that a namespace or interface represents a generated SDK
-client and provides a consistent experience across emitted languages.
+This convention makes it clear that a namespace or interface represents a generated SDK client and provides a consistent experience across emitted languages.
 
-If the underlying TypeSpec name does not end with `Client`, use the
-`@client` decorator to provide a client-friendly name.
+If the underlying TypeSpec name does not end with `Client`, use the `@client` decorator to provide a client-friendly name.
 
 ## Impact
 

--- a/packages/typespec-client-generator-core/src/rules/require-client-suffix.md
+++ b/packages/typespec-client-generator-core/src/rules/require-client-suffix.md
@@ -10,14 +10,14 @@ If the underlying TypeSpec name does not end with `Client`, use the
 - **Area:** SDK generation. Affects the name of the top-level client type in every emitted language SDK (both data-plane and management-plane).
 - **Not affected:** The service definition and the generated wire protocol are unchanged; this is a client-surface naming convention only.
 
-#### ❌ Incorrect Usage
+## ❌ Incorrect Usage
 
 ```tsp
 @client
 namespace MyService;
 ```
 
-#### Diagnostic Message
+## Diagnostic Message
 
 For the client above, the linter reports that the client name does not end with `Client`:
 
@@ -25,7 +25,7 @@ For the client above, the linter reports that the client name does not end with 
 Client name "MyService" must end with Client. Use @client({name: "...Client"})
 ```
 
-#### ✅ How to Fix
+## ✅ How to Fix
 
 Rename the namespace or interface so it ends with `Client`:
 


### PR DESCRIPTION
## Summary

Cleans up and standardizes the TypeSpec Client Generator Core (TCGC) and Azure Resource Manager (ARM) linter rule reference docs so the generated pages are consistent and free of duplicated content.

## Changes

### 1. Unify section heading levels to h2
The `Incorrect` / `Correct` (and, for TCGC, `Diagnostic Message` / `How to Fix`) example headings were `h4` while `Impact` / `Suppression` / `LintDiff Equivalent` were `h2`. All section headings are now `h2`.
- For multi-case rules (`arm-delete-operation-response-codes`, `arm-post-operation-response-codes`, `no-response-body`), the case heading stays `h2` (e.g. `## Synchronous` / `## Asynchronous`, `## For 202 and 204 ...`) and the `Incorrect` / `Correct` examples nest at `h3`.
- Fixed structural artifacts found while normalizing: a stray `## Synchronous` heading + empty code fence at the top of the two response-code docs, a mismatched 4-backtick fence, and a misplaced `## Impact` in `no-response-body`.

### 2. Make doc intros supplement (not repeat) the rule description
`tspd doc` renders each rule's `description` field at the top of the generated page, immediately before the doc body. The doc's opening paragraph restated it, so the description appeared twice. Reworded 31 rule doc intros to add supplementary context instead of duplicating the description (or removed the intro where it added nothing).

### 3. Remove duplicate rule id blocks
10 ARM rule docs contained a hand-written `Full name` code block repeating the rule id — which `tspd` already renders as the `Id` block. Removed those duplicates.

## Notes

- Docs only. Generated website pages are produced by `tspd doc` and are not tracked; regenerate with `pnpm --filter <package> regen-docs`.
- Verified against the generated pages: every rule page now has a single `Id` block, its description, and a non-duplicating intro; all section headings are `h2` (with `h3` nesting only inside multi-case rules).
- No changelog entry: markdown-only changes are excluded from Chronus.