### PR TITLE
Bump version for hotfix: typespec-go@0.16.0

### DIFF
--- a/.chronus/changes/add-typespec-go-emitter-diff-2026-07-22-11-11-00.md
+++ b/.chronus/changes/add-typespec-go-emitter-diff-2026-07-22-11-11-00.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Add `diff-regen-code` script wiring typespec-go into the language-agnostic `emitter-diff` tool to diff all generated test output (`test/http-specs`, `test/azure-http-specs`, and `test/local`) between emitter versions.

--- a/.chronus/changes/cleanup-npm-usage-2026-07-20-13-49-00.md
+++ b/.chronus/changes/cleanup-npm-usage-2026-07-20-13-49-00.md
@@ -6,7 +6,6 @@ packages:
   - "@azure-tools/typespec-azure-portal-core"
   - "@azure-tools/typespec-azure-resource-manager"
   - "@azure-tools/typespec-client-generator-core"
-  - "@azure-tools/typespec-go"
   - "@azure-tools/typespec-java"
   - "@azure-tools/typespec-ts"
 ---

--- a/.chronus/changes/fix-typespec-go-spector-coverage-path-2026-07-23-23-37-00.md
+++ b/.chronus/changes/fix-typespec-go-spector-coverage-path-2026-07-23-23-37-00.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Write the typespec-go spector coverage report to the shared `@azure-tools/azure-http-specs/spec-coverage.json` location so the CI coverage upload uses the same convention as other emitters.

--- a/.chronus/changes/fix-typespec-go-unpopulate-errorlint-2026-7-21-5-30-0.md
+++ b/.chronus/changes/fix-typespec-go-unpopulate-errorlint-2026-7-21-5-30-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Emit the `unpopulate` and `unpopulateTime` serde helpers using the `%s` verb with `err.Error()` instead of the non-wrapping `%v` verb, keeping the generated code `errorlint`-clean (follow-up to the earlier `unmarshalling type %T` fix).

--- a/.chronus/changes/go-module-identity-2026-6-22-17-4-52.md
+++ b/.chronus/changes/go-module-identity-2026-6-22-17-4-52.md
@@ -1,7 +1,0 @@
----
-changeKind: feature
-packages:
-  - "@azure-tools/typespec-go"
----
-
-During SDK generation, if a go.mod file exists, its module identity is used as the source of truth, including any major version suffix. This alleviates the need to update tspconfig.yaml whenever a new major version is required.

--- a/.chronus/changes/typespec-go-move-into-typespec-azure-2026-06-11-14-30-00.md
+++ b/.chronus/changes/typespec-go-move-into-typespec-azure-2026-06-11-14-30-00.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Move `@azure-tools/typespec-go` from `Azure/autorest.go` into `Azure/typespec-azure`. The previously-private workspace packages `@azure-tools/codegen.go`, `@azure-tools/codemodel.go`, and `@azure-tools/naming.go` are now inlined into `src/codegen`, `src/codemodel`, and `src/naming` respectively. No behavior changes for emitter consumers.

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Release History
 
+## 0.16.0
+
+### Features
+
+- [#5032](https://github.com/Azure/typespec-azure/pull/5032) During SDK generation, if a go.mod file exists, its module identity is used as the source of truth, including any major version suffix. This alleviates the need to update tspconfig.yaml whenever a new major version is required.
+
+### Bug Fixes
+
+- [#4985](https://github.com/Azure/typespec-azure/pull/4985) Emit the `unpopulate` and `unpopulateTime` serde helpers using the `%s` verb with `err.Error()` instead of the non-wrapping `%v` verb, keeping the generated code `errorlint`-clean (follow-up to the earlier `unmarshalling type %T` fix).
+
+
 ## 0.15.0
 
 ### Features

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-go",
-  "version": "0.15.0",
+  "version": "0.16.0",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Go SDKs",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
Version bump for typespec-go hotfix release from `main`.

Bumps `@azure-tools/typespec-go` 0.15.0 -> 0.16.0 (minor).

### Features
- [#5032](https://github.com/Azure/typespec-azure/pull/5032) go.mod module identity used as source of truth during SDK generation.

### Bug Fixes
- [#4985](https://github.com/Azure/typespec-azure/pull/4985) Emit `unpopulate`/`unpopulateTime` serde helpers with `%s` + `err.Error()` to stay `errorlint`-clean.

Plus internal-only changes (no changelog entries). Generated via `pnpm chronus version --only @azure-tools/typespec-go`; core submodule unchanged.