### PR TITLE
fix(pipeline): authenticate pip to azure-sdk-for-python feed to fix install hang

### DIFF
--- a/eng/common/pipelines/templates/steps/pip-authenticate.yml
+++ b/eng/common/pipelines/templates/steps/pip-authenticate.yml
@@ -1,0 +1,12 @@
+parameters:
+  ArtifactFeeds: "public/azure-sdk-for-python"
+
+steps:
+  # Authenticate pip to the Azure Artifacts feed and set an authenticated
+  # PIP_INDEX_URL, since pypi.org is blocked by CFSClean network isolation and
+  # anonymous feed access is throttled.
+  - task: PipAuthenticate@1
+    displayName: "Pip Authenticate"
+    inputs:
+      artifactFeeds: ${{ parameters.ArtifactFeeds }}
+      onlyAddExtraIndex: false

--- a/eng/pipelines/templates/install.yml
+++ b/eng/pipelines/templates/install.yml
@@ -32,6 +32,8 @@ steps:
 
   - template: /eng/common/pipelines/templates/steps/maven-authenticate.yml
 
+  - template: /eng/common/pipelines/templates/steps/pip-authenticate.yml
+
   - task: Cache@2
     inputs:
       key: 'pnpm | "$(Agent.OS)" | pnpm-lock.yaml'

--- a/eng/pipelines/templates/variables/globals.yml
+++ b/eng/pipelines/templates/variables/globals.yml
@@ -1,8 +1,3 @@
 variables:
   # Disable CodeQL by default to prevent build timeouts
   Codeql.SkipTaskAutoInjection: true
-  # Route pip through the azure-sdk PyPI proxy feed so `pip install` (triggered
-  # by the typespec-python prepare lifecycle during `pnpm install`) can resolve
-  # packages in network-isolated CI agents where pypi.org is blocked by the
-  # CFSClean network isolation policy.
-  PIP_INDEX_URL: https://pkgs.dev.azure.com/azure-sdk/public/_packaging/azure-sdk-for-python/pypi/simple/


### PR DESCRIPTION
## Problem

The ADO **PR Tools** and **Publish** pipelines time out (1h cap) during the `typespec-python` `prepare` lifecycle that runs on `pnpm install`. The step hangs while pip downloads the Python dev-tools venv.

## Root cause

Since the CFSClean network-isolation lockdown, `pypi.org` is not reachable from CI agents (`Failed to establish a new connection: [Errno 1] Operation not permitted`). Package managers must go through the sanctioned Azure Artifacts feeds.

#5033 pointed pip at the azure-sdk PyPI proxy feed via `PIP_INDEX_URL`, but — unlike npm and maven, which are **authenticated** in `install.yml` (`create-authenticated-npmrc.yml` / `maven-authenticate.yml`) — pip was left **unauthenticated**. Anonymous Azure Artifacts access is heavily throttled, so the install starts, then stalls indefinitely until the job hits the 1h timeout.

## Fix

Add a `PipAuthenticate@1` step to the shared `eng/pipelines/templates/install.yml` (used by PR Tools, Publish, spector-coverage, and the release pipelines), mirroring the existing npm/maven authentication. The task authenticates to `public/azure-sdk-for-python` using the build identity and sets an authenticated `PIP_INDEX_URL`, so the `pip install` in `prepare` is no longer throttled.

The feed reference (`public/azure-sdk-for-python`) matches the canonical usage in `Azure/azure-sdk-for-java` (`eng/pipelines/templates/jobs/ci.yml`).

The now-redundant static `PIP_INDEX_URL` variable added by #5033 is removed — `PipAuthenticate@1` sets the (authenticated) value instead.
