### PR TITLE
docs: tell Copilot how to use mise for repo tooling

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,10 +2,21 @@
 
 This document serves as an index to task-specific instructions for GitHub Copilot. Each task has its own detailed instructions file in the `.github/prompts` directory.
 
+## Development Environment (mise)
+
+This repo pins its development tools with [mise](https://mise.jdx.dev) via `mise.toml` and `mise.lock`: Node.js, pnpm, Python, uv, Go, Java, and Maven.
+
+- Check for mise first (`mise --version`). If it is installed, prefer the mise-managed tools over whatever happens to be on `PATH` — a globally installed `node`/`pnpm`/`python` is often the wrong version or misconfigured.
+- A fresh clone or git worktree is untrusted, so mise refuses to load its config. If you see `Config files in ... are not trusted`, run `mise trust` from the repo root, then continue.
+- Run `mise install` from the repo root to install the pinned versions. It is a fast no-op (`mise all tools are installed`) when everything is already present, so it is safe to run before other setup.
+- Non-interactive shells (including the ones agents run commands in) usually do not have mise activated, so the pinned tools are not on `PATH`. Prefix commands with `mise exec --` (for example `mise exec -- pnpm install`, `mise exec -- pnpm build`, `mise exec -- python --version`). Without it, commands can fail with confusing errors such as `The packageManager dependency "pnpm@..." in pnpm-lock.yaml must use a registry package path`.
+- Use `mise ls --current` to confirm which tool versions are active for this repo.
+- If mise is not installed, fall back to the tools on `PATH`, but match the versions in `mise.toml` and the `packageManager` field in `package.json`.
+
 ## Install and Build
 
 - Packages are located in the `packages` folder
-- Use `pnpm` as the package manager
+- Use `pnpm` as the package manager (prefix with `mise exec --` when mise is installed but not activated in the shell)
 - Use `pnpm install` to install dependencies
 - Use `pnpm build` to build every package
 - Use `pnpm -r --filter "<pkgName>..." build` to build to a specific package `<pkgName>`
@@ -27,6 +38,7 @@ This document serves as an index to task-specific instructions for GitHub Copilo
 
 - When creating worktrees or branches for new work, base them off the main Azure fork's `main` branch (Azure/typespec-azure). Depending on the user's local git remote setup, this may be called `upstream` or `origin`.
 - When creating worktrees (which clone the repo), always clone recursively with `--recurse-submodules` and run `git submodule update --init` if the `core/` submodule is missing or not at the correct commit. See [CONTRIBUTING.md - Cloning recursively](https://github.com/Azure/typespec-azure/blob/main/CONTRIBUTING.md#cloning-recursively) for details.
+- A new clone or worktree also needs `mise trust` (and `mise install` if tools are missing) before `pnpm` and other tools will work — see [Development Environment (mise)](#development-environment-mise).
 - When pushing changes and creating pull requests, push to your personal fork and open PRs against the main Azure fork's `main` branch.
 
 ## Available Task Instructions


### PR DESCRIPTION
New Copilot sessions in this repo routinely stall on environment setup: a fresh clone or git worktree is untrusted by mise, so `mise.toml` never loads, and the `pnpm`/`python` that happen to be on `PATH` are either the wrong version or fail outright. Agents then either give up or start hand-installing tools instead of running the two commands that fix it.

This adds a "Development Environment (mise)" section to `.github/copilot-instructions.md` describing the actual recovery path:

- Check for mise before falling back to whatever is on `PATH`.
- Run `mise trust` when you see `Config files in ... are not trusted` (this is the default state of every new worktree).
- Run `mise install` from the repo root; it is a fast no-op when tools are already present, so it is safe to run first.
- Prefix commands with `mise exec --`, because non-interactive agent shells do not have mise activated.

It also cross-references this from the worktree bullet under "Branch and PR Workflow" (right next to the existing submodule note, since both bite at the same moment) and adds a short reminder on the `pnpm` bullet under "Install and Build".

Every claim was verified in a fresh worktree rather than written from memory. `mise ls --current` did fail as untrusted; plain `pnpm --version` failed with `The packageManager dependency "pnpm@11.10.0" in pnpm-lock.yaml must use a registry package path`, while `mise exec -- pnpm --version` printed `11.10.0`. That exact error string is quoted in the instructions so an agent hitting it can pattern-match to the fix.

Note on validation: `pnpm format` could not be run here because the repo's prettier config loads `core/packages/prettier-plugin-typespec/dist/index.js`, which requires a full install and build. The file was instead checked with standalone prettier using the repo's `printWidth`/`tabWidth`/`endOfLine` settings, and it is already conformant. Markdown-only change, no package touched, so no chronus change file.