### PR TITLE
fix(eng): trigger all emitter CI on any pnpm-workspace.yaml change

### DIFF
--- a/eng/scripts/detect-affected.config.json
+++ b/eng/scripts/detect-affected.config.json
@@ -1,5 +1,6 @@
 {
   "submodulePath": "core",
+  "catalogPath": "pnpm-workspace.yaml",
   "ignore": ["**/test/**", "**/tests/**", "**/*.test.ts", "**/*.md"],
   "sharedExtra": [".github/actions/setup/**"],
   "targets": {

--- a/eng/scripts/detect-affected.config.json
+++ b/eng/scripts/detect-affected.config.json
@@ -1,8 +1,7 @@
 {
   "submodulePath": "core",
-  "catalogPath": "pnpm-workspace.yaml",
   "ignore": ["**/test/**", "**/tests/**", "**/*.test.ts", "**/*.md"],
-  "sharedExtra": [".github/actions/setup/**"],
+  "sharedExtra": [".github/actions/setup/**", "pnpm-workspace.yaml"],
   "targets": {
     "python": {
       "package": "@azure-tools/typespec-python",

--- a/eng/scripts/detect-affected.test.ts
+++ b/eng/scripts/detect-affected.test.ts
@@ -1,5 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { CONFIG, computeAffected, matchesAny } from "./detect-affected.ts";
+import {
+  CONFIG,
+  catalogEntryKey,
+  catalogOfSpecifier,
+  computeAffected,
+  diffCatalogs,
+  matchesAny,
+  packagesUsingCatalogEntries,
+  parseCatalogs,
+} from "./detect-affected.ts";
 
 const NONE = new Set<string>();
 
@@ -31,6 +40,10 @@ describe("CONFIG (loaded from detect-affected.config.json)", () => {
     for (const [name, target] of Object.entries(CONFIG.targets)) {
       expect(target.package, `target "${name}" must set a package`).toBeTruthy();
     }
+  });
+
+  it("declares the root catalog file", () => {
+    expect(CONFIG.catalogPath).toBeTruthy();
   });
 });
 
@@ -98,5 +111,170 @@ describe("computeAffected", () => {
 
   it("unrelated root file change triggers nothing", () => {
     expect(computeAffected(NONE, ["README.md", "package.json"], CONFIG)).toEqual(NONE_AFFECTED);
+  });
+});
+
+// A `pnpm-workspace.yaml` shaped like the real one: quoted and bare keys, quoted
+// and bare values, comments, a named catalog, and non-catalog top-level blocks.
+const WORKSPACE_YAML = `packages:
+  - packages/*
+  - "!core/packages/http-client-python/**"
+
+verifyDepsBeforeRun: false
+
+overrides:
+  "cross-spawn@>=7.0.0 <7.0.5": "^7.0.5"
+
+catalog:
+  "@typespec/http-client-python": ">=0.35.0 <1.0.0"
+  # Pinned to 2.9.14: keep the comment out of the catalog
+  turbo: "2.9.14"
+  yaml: ^2.8.3
+
+catalogs:
+  legacy:
+    react: ^17.0.0
+
+allowBuilds:
+  "@scarf/scarf": false
+`;
+
+describe("parseCatalogs", () => {
+  it("reads the default catalog, ignoring comments and quoting", () => {
+    const def = parseCatalogs(WORKSPACE_YAML).get("default");
+    expect(Object.fromEntries(def!)).toEqual({
+      "@typespec/http-client-python": ">=0.35.0 <1.0.0",
+      turbo: "2.9.14",
+      yaml: "^2.8.3",
+    });
+  });
+
+  it("reads named catalogs", () => {
+    expect(Object.fromEntries(parseCatalogs(WORKSPACE_YAML).get("legacy")!)).toEqual({
+      react: "^17.0.0",
+    });
+  });
+
+  it("ignores non-catalog blocks", () => {
+    const catalogs = parseCatalogs(WORKSPACE_YAML);
+    expect([...catalogs.keys()].sort()).toEqual(["default", "legacy"]);
+    for (const entries of catalogs.values()) {
+      expect(entries.has("cross-spawn@>=7.0.0 <7.0.5")).toBe(false);
+      expect(entries.has("@scarf/scarf")).toBe(false);
+    }
+  });
+});
+
+describe("diffCatalogs", () => {
+  const bump = (from: string, to: string) => WORKSPACE_YAML.replace(from, to);
+
+  it("reports an edited version", () => {
+    const head = bump('">=0.35.0 <1.0.0"', '">=0.35.1 <1.0.0"');
+    expect([...diffCatalogs(WORKSPACE_YAML, head)]).toEqual([
+      catalogEntryKey("default", "@typespec/http-client-python"),
+    ]);
+  });
+
+  it("reports an added entry", () => {
+    const head = bump("  yaml: ^2.8.3\n", "  yaml: ^2.8.3\n  semver: ^7.7.4\n");
+    expect([...diffCatalogs(WORKSPACE_YAML, head)]).toEqual([catalogEntryKey("default", "semver")]);
+  });
+
+  it("reports a removed entry", () => {
+    const head = bump("  yaml: ^2.8.3\n", "");
+    expect([...diffCatalogs(WORKSPACE_YAML, head)]).toEqual([catalogEntryKey("default", "yaml")]);
+  });
+
+  it("reports changes in named catalogs", () => {
+    const head = bump("react: ^17.0.0", "react: ^17.0.2");
+    expect([...diffCatalogs(WORKSPACE_YAML, head)]).toEqual([catalogEntryKey("legacy", "react")]);
+  });
+
+  it("reports nothing when only non-catalog blocks change", () => {
+    const head = bump("verifyDepsBeforeRun: false", "verifyDepsBeforeRun: true");
+    expect(diffCatalogs(WORKSPACE_YAML, head).size).toBe(0);
+  });
+
+  it("reports nothing when the file is untouched", () => {
+    expect(diffCatalogs(WORKSPACE_YAML, WORKSPACE_YAML).size).toBe(0);
+  });
+
+  it("treats every entry as changed when the base file did not exist", () => {
+    expect(diffCatalogs(undefined, WORKSPACE_YAML).size).toBe(4);
+  });
+});
+
+describe("catalogOfSpecifier", () => {
+  it("maps `catalog:` and `catalog:default` to the default catalog", () => {
+    expect(catalogOfSpecifier("catalog:")).toBe("default");
+    expect(catalogOfSpecifier("catalog:default")).toBe("default");
+  });
+
+  it("maps `catalog:<name>` to that catalog", () => {
+    expect(catalogOfSpecifier("catalog:legacy")).toBe("legacy");
+  });
+
+  it("returns undefined for non-catalog specifiers", () => {
+    expect(catalogOfSpecifier("^1.0.0")).toBeUndefined();
+    expect(catalogOfSpecifier("workspace:~")).toBeUndefined();
+  });
+});
+
+describe("packagesUsingCatalogEntries", () => {
+  const manifests = [
+    { name: "emitter", dependencies: { "@typespec/http-client-python": "catalog:" } },
+    { name: "pinned", dependencies: { "@typespec/http-client-python": "0.35.0" } },
+    { name: "dev-only", devDependencies: { turbo: "catalog:" } },
+    { name: "named", peerDependencies: { react: "catalog:legacy" } },
+    { name: "unrelated", dependencies: { yaml: "catalog:" } },
+  ];
+
+  it("finds consumers across every dependency group", () => {
+    const changed = new Set([
+      catalogEntryKey("default", "@typespec/http-client-python"),
+      catalogEntryKey("default", "turbo"),
+      catalogEntryKey("legacy", "react"),
+    ]);
+    expect([...packagesUsingCatalogEntries(manifests, changed)].sort()).toEqual([
+      "dev-only",
+      "emitter",
+      "named",
+    ]);
+  });
+
+  it("ignores packages that pin the dependency instead of using the catalog", () => {
+    const changed = new Set([catalogEntryKey("default", "@typespec/http-client-python")]);
+    expect([...packagesUsingCatalogEntries(manifests, changed)]).toEqual(["emitter"]);
+  });
+
+  it("does not match the same dependency in a different catalog", () => {
+    const changed = new Set([catalogEntryKey("legacy", "turbo")]);
+    expect(packagesUsingCatalogEntries(manifests, changed).size).toBe(0);
+  });
+
+  it("returns nothing when no catalog entry changed", () => {
+    expect(packagesUsingCatalogEntries(manifests, new Set()).size).toBe(0);
+  });
+});
+
+// Regression test for Azure/typespec-azure#5010: a PR that only bumps the
+// `@typespec/http-client-python` catalog entry (plus the lockfile) must still
+// trigger the Python target, even though pnpm reports no affected package.
+describe("catalog bump end to end (issue #5010)", () => {
+  it("triggers only the target that consumes the changed catalog entry", () => {
+    const head = WORKSPACE_YAML.replace('">=0.35.0 <1.0.0"', '">=0.36.0 <1.0.0"');
+    const changed = diffCatalogs(WORKSPACE_YAML, head);
+    const consumers = packagesUsingCatalogEntries(
+      [
+        {
+          name: CONFIG.targets.python.package,
+          dependencies: { "@typespec/http-client-python": "catalog:" },
+        },
+        { name: CONFIG.targets.java.package, dependencies: { yaml: "catalog:" } },
+      ],
+      changed,
+    );
+    const affected = computeAffected(consumers, [CONFIG.catalogPath, "pnpm-lock.yaml"], CONFIG);
+    expect(affected).toEqual(only("python"));
   });
 });

--- a/eng/scripts/detect-affected.test.ts
+++ b/eng/scripts/detect-affected.test.ts
@@ -1,15 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { Manifest } from "./detect-affected.ts";
-import {
-  CONFIG,
-  catalogEntryKey,
-  catalogOfSpecifier,
-  computeAffected,
-  diffCatalogs,
-  matchesAny,
-  packagesUsingCatalogEntries,
-  parseCatalogs,
-} from "./detect-affected.ts";
+import { CONFIG, computeAffected, matchesAny } from "./detect-affected.ts";
 
 const NONE = new Set<string>();
 
@@ -41,10 +31,6 @@ describe("CONFIG (loaded from detect-affected.config.json)", () => {
     for (const [name, target] of Object.entries(CONFIG.targets)) {
       expect(target.package, `target "${name}" must set a package`).toBeTruthy();
     }
-  });
-
-  it("declares the root catalog file", () => {
-    expect(CONFIG.catalogPath).toBeTruthy();
   });
 });
 
@@ -110,172 +96,16 @@ describe("computeAffected", () => {
     expect(computeAffected(NONE, ["core"], CONFIG)).toEqual(ALL_AFFECTED);
   });
 
+  // Azure/typespec-azure#5010: catalog upstreams such as
+  // `@typespec/http-client-python` are not workspace packages, so pnpm reports no
+  // affected package when one is bumped. The file itself must trigger everything.
+  it("pnpm-workspace.yaml change triggers all targets", () => {
+    expect(computeAffected(NONE, ["pnpm-workspace.yaml", "pnpm-lock.yaml"], CONFIG)).toEqual(
+      ALL_AFFECTED,
+    );
+  });
+
   it("unrelated root file change triggers nothing", () => {
     expect(computeAffected(NONE, ["README.md", "package.json"], CONFIG)).toEqual(NONE_AFFECTED);
-  });
-});
-
-// A `pnpm-workspace.yaml` shaped like the real one: quoted and bare keys, quoted
-// and bare values, comments, a named catalog, and non-catalog top-level blocks.
-const WORKSPACE_YAML = `packages:
-  - packages/*
-  - "!core/packages/http-client-python/**"
-
-verifyDepsBeforeRun: false
-
-overrides:
-  "cross-spawn@>=7.0.0 <7.0.5": "^7.0.5"
-
-catalog:
-  "@typespec/http-client-python": ">=0.35.0 <1.0.0"
-  # Pinned to 2.9.14: keep the comment out of the catalog
-  turbo: "2.9.14"
-  yaml: ^2.8.3
-
-catalogs:
-  legacy:
-    react: ^17.0.0
-
-allowBuilds:
-  "@scarf/scarf": false
-`;
-
-describe("parseCatalogs", () => {
-  it("reads the default catalog, ignoring comments and quoting", () => {
-    const def = parseCatalogs(WORKSPACE_YAML).get("default");
-    expect(Object.fromEntries(def!)).toEqual({
-      "@typespec/http-client-python": ">=0.35.0 <1.0.0",
-      turbo: "2.9.14",
-      yaml: "^2.8.3",
-    });
-  });
-
-  it("reads named catalogs", () => {
-    expect(Object.fromEntries(parseCatalogs(WORKSPACE_YAML).get("legacy")!)).toEqual({
-      react: "^17.0.0",
-    });
-  });
-
-  it("ignores non-catalog blocks", () => {
-    const catalogs = parseCatalogs(WORKSPACE_YAML);
-    expect([...catalogs.keys()].sort()).toEqual(["default", "legacy"]);
-    for (const entries of catalogs.values()) {
-      expect(entries.has("cross-spawn@>=7.0.0 <7.0.5")).toBe(false);
-      expect(entries.has("@scarf/scarf")).toBe(false);
-    }
-  });
-});
-
-describe("diffCatalogs", () => {
-  const bump = (from: string, to: string) => WORKSPACE_YAML.replace(from, to);
-
-  it("reports an edited version", () => {
-    const head = bump('">=0.35.0 <1.0.0"', '">=0.35.1 <1.0.0"');
-    expect([...diffCatalogs(WORKSPACE_YAML, head)]).toEqual([
-      catalogEntryKey("default", "@typespec/http-client-python"),
-    ]);
-  });
-
-  it("reports an added entry", () => {
-    const head = bump("  yaml: ^2.8.3\n", "  yaml: ^2.8.3\n  semver: ^7.7.4\n");
-    expect([...diffCatalogs(WORKSPACE_YAML, head)]).toEqual([catalogEntryKey("default", "semver")]);
-  });
-
-  it("reports a removed entry", () => {
-    const head = bump("  yaml: ^2.8.3\n", "");
-    expect([...diffCatalogs(WORKSPACE_YAML, head)]).toEqual([catalogEntryKey("default", "yaml")]);
-  });
-
-  it("reports changes in named catalogs", () => {
-    const head = bump("react: ^17.0.0", "react: ^17.0.2");
-    expect([...diffCatalogs(WORKSPACE_YAML, head)]).toEqual([catalogEntryKey("legacy", "react")]);
-  });
-
-  it("reports nothing when only non-catalog blocks change", () => {
-    const head = bump("verifyDepsBeforeRun: false", "verifyDepsBeforeRun: true");
-    expect(diffCatalogs(WORKSPACE_YAML, head).size).toBe(0);
-  });
-
-  it("reports nothing when the file is untouched", () => {
-    expect(diffCatalogs(WORKSPACE_YAML, WORKSPACE_YAML).size).toBe(0);
-  });
-
-  it("treats every entry as changed when the base file did not exist", () => {
-    expect(diffCatalogs(undefined, WORKSPACE_YAML).size).toBe(4);
-  });
-});
-
-describe("catalogOfSpecifier", () => {
-  it("maps `catalog:` and `catalog:default` to the default catalog", () => {
-    expect(catalogOfSpecifier("catalog:")).toBe("default");
-    expect(catalogOfSpecifier("catalog:default")).toBe("default");
-  });
-
-  it("maps `catalog:<name>` to that catalog", () => {
-    expect(catalogOfSpecifier("catalog:legacy")).toBe("legacy");
-  });
-
-  it("returns undefined for non-catalog specifiers", () => {
-    expect(catalogOfSpecifier("^1.0.0")).toBeUndefined();
-    expect(catalogOfSpecifier("workspace:~")).toBeUndefined();
-  });
-});
-
-describe("packagesUsingCatalogEntries", () => {
-  const manifests: Manifest[] = [
-    { name: "emitter", dependencies: { "@typespec/http-client-python": "catalog:" } },
-    { name: "pinned", dependencies: { "@typespec/http-client-python": "0.35.0" } },
-    { name: "dev-only", devDependencies: { turbo: "catalog:" } },
-    { name: "named", peerDependencies: { react: "catalog:legacy" } },
-    { name: "unrelated", dependencies: { yaml: "catalog:" } },
-  ];
-
-  it("finds consumers across every dependency group", () => {
-    const changed = new Set([
-      catalogEntryKey("default", "@typespec/http-client-python"),
-      catalogEntryKey("default", "turbo"),
-      catalogEntryKey("legacy", "react"),
-    ]);
-    expect([...packagesUsingCatalogEntries(manifests, changed)].sort()).toEqual([
-      "dev-only",
-      "emitter",
-      "named",
-    ]);
-  });
-
-  it("ignores packages that pin the dependency instead of using the catalog", () => {
-    const changed = new Set([catalogEntryKey("default", "@typespec/http-client-python")]);
-    expect([...packagesUsingCatalogEntries(manifests, changed)]).toEqual(["emitter"]);
-  });
-
-  it("does not match the same dependency in a different catalog", () => {
-    const changed = new Set([catalogEntryKey("legacy", "turbo")]);
-    expect(packagesUsingCatalogEntries(manifests, changed).size).toBe(0);
-  });
-
-  it("returns nothing when no catalog entry changed", () => {
-    expect(packagesUsingCatalogEntries(manifests, new Set()).size).toBe(0);
-  });
-});
-
-// Regression test for Azure/typespec-azure#5010: a PR that only bumps the
-// `@typespec/http-client-python` catalog entry (plus the lockfile) must still
-// trigger the Python target, even though pnpm reports no affected package.
-describe("catalog bump end to end (issue #5010)", () => {
-  it("triggers only the target that consumes the changed catalog entry", () => {
-    const head = WORKSPACE_YAML.replace('">=0.35.0 <1.0.0"', '">=0.36.0 <1.0.0"');
-    const changed = diffCatalogs(WORKSPACE_YAML, head);
-    const consumers = packagesUsingCatalogEntries(
-      [
-        {
-          name: CONFIG.targets.python.package,
-          dependencies: { "@typespec/http-client-python": "catalog:" },
-        },
-        { name: CONFIG.targets.java.package, dependencies: { yaml: "catalog:" } },
-      ],
-      changed,
-    );
-    const affected = computeAffected(consumers, [CONFIG.catalogPath, "pnpm-lock.yaml"], CONFIG);
-    expect(affected).toEqual(only("python"));
   });
 });

--- a/eng/scripts/detect-affected.test.ts
+++ b/eng/scripts/detect-affected.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Manifest } from "./detect-affected.ts";
 import {
   CONFIG,
   catalogEntryKey,
@@ -221,7 +222,7 @@ describe("catalogOfSpecifier", () => {
 });
 
 describe("packagesUsingCatalogEntries", () => {
-  const manifests = [
+  const manifests: Manifest[] = [
     { name: "emitter", dependencies: { "@typespec/http-client-python": "catalog:" } },
     { name: "pinned", dependencies: { "@typespec/http-client-python": "0.35.0" } },
     { name: "dev-only", devDependencies: { turbo: "catalog:" } },

--- a/eng/scripts/detect-affected.test.ts
+++ b/eng/scripts/detect-affected.test.ts
@@ -98,7 +98,8 @@ describe("computeAffected", () => {
 
   // Azure/typespec-azure#5010: catalog upstreams such as
   // `@typespec/http-client-python` are not workspace packages, so pnpm reports no
-  // affected package when one is bumped. The file itself must trigger everything.
+  // affected package when one is bumped. The root workspace file must trigger
+  // every target on its own.
   it("pnpm-workspace.yaml change triggers all targets", () => {
     expect(computeAffected(NONE, ["pnpm-workspace.yaml", "pnpm-lock.yaml"], CONFIG)).toEqual(
       ALL_AFFECTED,

--- a/eng/scripts/detect-affected.ts
+++ b/eng/scripts/detect-affected.ts
@@ -203,7 +203,7 @@ export function catalogOfSpecifier(specifier: string): string | undefined {
   return specifier.slice("catalog:".length).trim() || DEFAULT_CATALOG;
 }
 
-interface Manifest {
+export interface Manifest {
   name?: string;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;

--- a/eng/scripts/detect-affected.ts
+++ b/eng/scripts/detect-affected.ts
@@ -1,6 +1,5 @@
 import { execFileSync } from "node:child_process";
 import { appendFileSync, readFileSync } from "node:fs";
-import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // -----------------------------------------------------------------------------
@@ -21,11 +20,14 @@ import { pathToFileURL } from "node:url";
 //
 // TO ADD A NEW UPSTREAM LIBRARY (e.g. a new typespec-azure-* package that an
 // emitter depends on): nothing to do — the workspace graph picks it up
-// automatically as soon as the emitter declares the dependency. The same is true
-// for third-party upstreams consumed through the pnpm *catalog* (e.g.
-// `@typespec/http-client-python`): those live in the root `pnpm-workspace.yaml`,
-// which pnpm's own change detection attributes to the root package only, so they
-// are handled separately by `getCatalogAffectedPackages` below.
+// automatically as soon as the emitter declares the dependency.
+//
+// Third-party upstreams consumed through the pnpm catalog (e.g.
+// `@typespec/http-client-python`) are not workspace packages, so the graph
+// cannot see them: bumping one only edits the root `pnpm-workspace.yaml`, which
+// pnpm attributes to the root package alone. That file is therefore listed in
+// `sharedExtra` and any change to it triggers every target
+// (Azure/typespec-azure#5010).
 // -----------------------------------------------------------------------------
 
 interface Target {
@@ -38,8 +40,6 @@ interface Target {
 interface Config {
   /** Git path that changes when the git-submodule pointer moves (triggers all targets). */
   submodulePath: string;
-  /** Root pnpm workspace file holding the dependency `catalog:` (see `getCatalogAffectedPackages`). */
-  catalogPath: string;
   /** Globs whose sole change should NOT trigger anything; passed to pnpm via `--changed-files-ignore-pattern`. */
   ignore: string[];
   /** Paths that trigger every target (shared CI infrastructure). */
@@ -81,168 +81,6 @@ export function matchesAny(file: string, patterns: string[]): boolean {
 }
 
 /**
- * ---------------------------------------------------------------------------
- * Catalog support
- * ---------------------------------------------------------------------------
- * Third-party upstreams such as `@typespec/http-client-python` are NOT workspace
- * packages (they are excluded in `pnpm-workspace.yaml` and installed from npm).
- * Packages depend on them through the pnpm catalog:
- *
- *   pnpm-workspace.yaml:  catalog: { "@typespec/http-client-python": ">=0.35.0 <1.0.0" }
- *   package.json:         "@typespec/http-client-python": "catalog:"
- *
- * Bumping such a dependency therefore only edits root-level files, and
- * `pnpm --filter "...[base]"` attributes that change to the root package alone —
- * no emitter is reported as affected (Azure/typespec-azure#5010). The helpers
- * below recover the missing edge: diff the catalog, find the packages that
- * consume the changed entries, then let pnpm expand their dependents.
- *
- * Only `catalog:`/`catalogs:` are considered. Other `pnpm-workspace.yaml` keys
- * (`overrides`, `packages`, `allowBuilds`, ...) deliberately trigger nothing.
- */
-
-/** Catalog name used by the unnamed (default) `catalog:` block. */
-const DEFAULT_CATALOG = "default";
-
-/** Stable key for one catalog entry, so entries can live in a single Set. */
-export function catalogEntryKey(catalog: string, dependency: string): string {
-  return `${catalog}\u0000${dependency}`;
-}
-
-/**
- * Extract the `catalog:` / `catalogs:` blocks from `pnpm-workspace.yaml`.
- *
- * Hand-rolled rather than using a YAML library on purpose: the detect-affected
- * job runs before any `pnpm install`, so no third-party module is available. The
- * supported subset is exactly what pnpm allows here — flat `key: value` maps,
- * optionally quoted, nested one extra level under `catalogs:`.
- *
- * @returns catalog name (`"default"` for the unnamed block) -> dependency -> version range.
- */
-export function parseCatalogs(text: string): Map<string, Map<string, string>> {
-  const catalogs = new Map<string, Map<string, string>>();
-  let topKey: string | undefined;
-  let namedCatalog: string | undefined;
-
-  const entryOf = (catalog: string) => {
-    let map = catalogs.get(catalog);
-    if (!map) catalogs.set(catalog, (map = new Map()));
-    return map;
-  };
-
-  for (const line of text.split("\n")) {
-    if (!line.trim() || line.trim().startsWith("#")) continue;
-    const indent = line.length - line.trimStart().length;
-    const parsed = parseMappingLine(line);
-
-    if (indent === 0) {
-      topKey = parsed?.key;
-      namedCatalog = undefined;
-      continue;
-    }
-    if (!parsed) continue; // sequence item (`- foo`) or anything else we don't model
-
-    if (topKey === "catalog" && indent === 2) {
-      entryOf(DEFAULT_CATALOG).set(parsed.key, parsed.value);
-    } else if (topKey === "catalogs") {
-      if (indent === 2 && parsed.value === "") {
-        namedCatalog = parsed.key;
-      } else if (indent === 4 && namedCatalog !== undefined) {
-        entryOf(namedCatalog).set(parsed.key, parsed.value);
-      }
-    }
-  }
-  return catalogs;
-}
-
-/** Parse a single `key: value` YAML line; returns undefined for non-mapping lines. */
-function parseMappingLine(line: string): { key: string; value: string } | undefined {
-  const match = /^\s*(?:"([^"]*)"|'([^']*)'|([^\s:#][^:]*?))\s*:(?:\s+(.*))?$/.exec(line);
-  if (!match) return undefined;
-  const key = match[1] ?? match[2] ?? match[3];
-  return { key, value: unquote(match[4] ?? "") };
-}
-
-function unquote(value: string): string {
-  const trimmed = value.trim();
-  const quoted = /^"([^"]*)"$|^'([^']*)'$/.exec(trimmed);
-  return quoted ? (quoted[1] ?? quoted[2]) : trimmed;
-}
-
-/**
- * Catalog entries whose version changed between two `pnpm-workspace.yaml`
- * revisions. Additions, removals and edits all count; an entry that only moved
- * does not.
- *
- * @param baseText Base revision content, or undefined when the file did not exist.
- */
-export function diffCatalogs(baseText: string | undefined, headText: string): Set<string> {
-  const base = baseText === undefined ? new Map() : parseCatalogs(baseText);
-  const head = parseCatalogs(headText);
-  const changed = new Set<string>();
-
-  for (const [catalog, entries] of head) {
-    const before = base.get(catalog);
-    for (const [dependency, version] of entries) {
-      if (before?.get(dependency) !== version) changed.add(catalogEntryKey(catalog, dependency));
-    }
-  }
-  for (const [catalog, entries] of base) {
-    const after = head.get(catalog);
-    for (const dependency of entries.keys()) {
-      if (!after?.has(dependency)) changed.add(catalogEntryKey(catalog, dependency));
-    }
-  }
-  return changed;
-}
-
-/** Catalog referenced by a package.json specifier, or undefined if it is not a catalog reference. */
-export function catalogOfSpecifier(specifier: string): string | undefined {
-  if (typeof specifier !== "string" || !specifier.startsWith("catalog:")) return undefined;
-  // `catalog:` and `catalog:default` both mean the unnamed catalog.
-  return specifier.slice("catalog:".length).trim() || DEFAULT_CATALOG;
-}
-
-export interface Manifest {
-  name?: string;
-  dependencies?: Record<string, string>;
-  devDependencies?: Record<string, string>;
-  peerDependencies?: Record<string, string>;
-  optionalDependencies?: Record<string, string>;
-}
-
-/**
- * Workspace packages that directly consume at least one of the changed catalog
- * entries. Dependents are added later by pnpm, from the real graph.
- */
-export function packagesUsingCatalogEntries(
-  manifests: Manifest[],
-  changedEntries: Set<string>,
-): Set<string> {
-  const consumers = new Set<string>();
-  if (changedEntries.size === 0) return consumers;
-
-  for (const manifest of manifests) {
-    if (!manifest.name) continue;
-    const groups = [
-      manifest.dependencies,
-      manifest.devDependencies,
-      manifest.peerDependencies,
-      manifest.optionalDependencies,
-    ];
-    for (const group of groups) {
-      for (const [dependency, specifier] of Object.entries(group ?? {})) {
-        const catalog = catalogOfSpecifier(specifier);
-        if (catalog !== undefined && changedEntries.has(catalogEntryKey(catalog, dependency))) {
-          consumers.add(manifest.name);
-        }
-      }
-    }
-  }
-  return consumers;
-}
-
-/**
  * Decide which targets are affected. Pure: all git/pnpm I/O happens in the caller.
  *
  * A target fires on any of three signals: its package is in the pnpm-derived
@@ -251,8 +89,7 @@ export function packagesUsingCatalogEntries(
  * targets), or a non-package `extra` CI-infra path.
  *
  * @param affectedPackages Target package OR any graph-dependent of a meaningfully
- *   changed package (from `pnpm --filter "...[base]"`), plus consumers of changed
- *   catalog entries and their dependents (from `getCatalogAffectedPackages`).
+ *   changed package (from `pnpm --filter "...[base]"`).
  * @param changedFiles Full changed-file list, used only for the two non-graph
  *   signals (`core` submodule + `extra` paths).
  */
@@ -296,69 +133,10 @@ function getAffectedPackages(base: string, ignore: string[]): Set<string> {
   const args = ["--filter", `...[${base}]`];
   for (const glob of ignore) args.push("--changed-files-ignore-pattern", glob);
   args.push("list", "--depth", "-1", "--json");
-  return new Set(listPackageNames(args));
-}
-
-function listPackageNames(args: string[]): string[] {
   const out = runPnpm(args).trim();
-  if (!out) return [];
+  if (!out) return new Set();
   const parsed = JSON.parse(out) as Array<{ name?: string }>;
-  return parsed.map((p) => p.name).filter((n): n is string => Boolean(n));
-}
-
-/** Content of `path` at `rev`, or undefined when it does not exist there. */
-function getFileAtRev(rev: string, path: string): string | undefined {
-  try {
-    return execFileSync("git", ["show", `${rev}:${path}`], {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "ignore"],
-    });
-  } catch {
-    return undefined;
-  }
-}
-
-/** Every workspace package.json, read from the checked-out working tree. */
-function readWorkspaceManifests(): Manifest[] {
-  const out = runPnpm(["list", "-r", "--depth", "-1", "--json"]).trim();
-  if (!out) return [];
-  const projects = JSON.parse(out) as Array<{ path?: string }>;
-  const manifests: Manifest[] = [];
-  for (const project of projects) {
-    if (!project.path) continue;
-    try {
-      manifests.push(JSON.parse(readFileSync(join(project.path, "package.json"), "utf8")));
-    } catch {
-      // A project without a readable manifest cannot consume a catalog entry.
-    }
-  }
-  return manifests;
-}
-
-/** Expand a set of packages to include all of their workspace dependents. */
-function expandDependents(packages: Set<string>): Set<string> {
-  if (packages.size === 0) return packages;
-  const args: string[] = [];
-  for (const name of packages) args.push("--filter", `...${name}`);
-  args.push("list", "--depth", "-1", "--json");
-  return new Set([...packages, ...listPackageNames(args)]);
-}
-
-/**
- * Packages affected by a change to the root catalog: the direct consumers of the
- * changed catalog entries plus all of their dependents. Empty unless
- * `config.catalogPath` is among the changed files.
- */
-function getCatalogAffectedPackages(
-  base: string,
-  head: string,
-  changedFiles: string[],
-): Set<string> {
-  if (!changedFiles.includes(CONFIG.catalogPath)) return new Set();
-  const headText = getFileAtRev(head, CONFIG.catalogPath);
-  if (headText === undefined) return new Set(); // catalog deleted: no consumer can resolve
-  const changedEntries = diffCatalogs(getFileAtRev(base, CONFIG.catalogPath), headText);
-  return expandDependents(packagesUsingCatalogEntries(readWorkspaceManifests(), changedEntries));
+  return new Set(parsed.map((p) => p.name).filter((n): n is string => Boolean(n)));
 }
 
 // CLI entry: run only when executed directly (not when imported by tests).
@@ -372,10 +150,7 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   }
 
   const changedFiles = getChangedFiles(base, head);
-  const affectedPackages = new Set([
-    ...getAffectedPackages(base, CONFIG.ignore),
-    ...getCatalogAffectedPackages(base, head, changedFiles),
-  ]);
+  const affectedPackages = getAffectedPackages(base, CONFIG.ignore);
   const affected = computeAffected(affectedPackages, changedFiles, CONFIG);
 
   console.log(`Base: ${base}`);

--- a/eng/scripts/detect-affected.ts
+++ b/eng/scripts/detect-affected.ts
@@ -1,5 +1,6 @@
 import { execFileSync } from "node:child_process";
 import { appendFileSync, readFileSync } from "node:fs";
+import { join } from "node:path";
 import { pathToFileURL } from "node:url";
 
 // -----------------------------------------------------------------------------
@@ -20,7 +21,11 @@ import { pathToFileURL } from "node:url";
 //
 // TO ADD A NEW UPSTREAM LIBRARY (e.g. a new typespec-azure-* package that an
 // emitter depends on): nothing to do — the workspace graph picks it up
-// automatically as soon as the emitter declares the dependency.
+// automatically as soon as the emitter declares the dependency. The same is true
+// for third-party upstreams consumed through the pnpm *catalog* (e.g.
+// `@typespec/http-client-python`): those live in the root `pnpm-workspace.yaml`,
+// which pnpm's own change detection attributes to the root package only, so they
+// are handled separately by `getCatalogAffectedPackages` below.
 // -----------------------------------------------------------------------------
 
 interface Target {
@@ -33,6 +38,8 @@ interface Target {
 interface Config {
   /** Git path that changes when the git-submodule pointer moves (triggers all targets). */
   submodulePath: string;
+  /** Root pnpm workspace file holding the dependency `catalog:` (see `getCatalogAffectedPackages`). */
+  catalogPath: string;
   /** Globs whose sole change should NOT trigger anything; passed to pnpm via `--changed-files-ignore-pattern`. */
   ignore: string[];
   /** Paths that trigger every target (shared CI infrastructure). */
@@ -74,6 +81,168 @@ export function matchesAny(file: string, patterns: string[]): boolean {
 }
 
 /**
+ * ---------------------------------------------------------------------------
+ * Catalog support
+ * ---------------------------------------------------------------------------
+ * Third-party upstreams such as `@typespec/http-client-python` are NOT workspace
+ * packages (they are excluded in `pnpm-workspace.yaml` and installed from npm).
+ * Packages depend on them through the pnpm catalog:
+ *
+ *   pnpm-workspace.yaml:  catalog: { "@typespec/http-client-python": ">=0.35.0 <1.0.0" }
+ *   package.json:         "@typespec/http-client-python": "catalog:"
+ *
+ * Bumping such a dependency therefore only edits root-level files, and
+ * `pnpm --filter "...[base]"` attributes that change to the root package alone —
+ * no emitter is reported as affected (Azure/typespec-azure#5010). The helpers
+ * below recover the missing edge: diff the catalog, find the packages that
+ * consume the changed entries, then let pnpm expand their dependents.
+ *
+ * Only `catalog:`/`catalogs:` are considered. Other `pnpm-workspace.yaml` keys
+ * (`overrides`, `packages`, `allowBuilds`, ...) deliberately trigger nothing.
+ */
+
+/** Catalog name used by the unnamed (default) `catalog:` block. */
+const DEFAULT_CATALOG = "default";
+
+/** Stable key for one catalog entry, so entries can live in a single Set. */
+export function catalogEntryKey(catalog: string, dependency: string): string {
+  return `${catalog}\u0000${dependency}`;
+}
+
+/**
+ * Extract the `catalog:` / `catalogs:` blocks from `pnpm-workspace.yaml`.
+ *
+ * Hand-rolled rather than using a YAML library on purpose: the detect-affected
+ * job runs before any `pnpm install`, so no third-party module is available. The
+ * supported subset is exactly what pnpm allows here — flat `key: value` maps,
+ * optionally quoted, nested one extra level under `catalogs:`.
+ *
+ * @returns catalog name (`"default"` for the unnamed block) -> dependency -> version range.
+ */
+export function parseCatalogs(text: string): Map<string, Map<string, string>> {
+  const catalogs = new Map<string, Map<string, string>>();
+  let topKey: string | undefined;
+  let namedCatalog: string | undefined;
+
+  const entryOf = (catalog: string) => {
+    let map = catalogs.get(catalog);
+    if (!map) catalogs.set(catalog, (map = new Map()));
+    return map;
+  };
+
+  for (const line of text.split("\n")) {
+    if (!line.trim() || line.trim().startsWith("#")) continue;
+    const indent = line.length - line.trimStart().length;
+    const parsed = parseMappingLine(line);
+
+    if (indent === 0) {
+      topKey = parsed?.key;
+      namedCatalog = undefined;
+      continue;
+    }
+    if (!parsed) continue; // sequence item (`- foo`) or anything else we don't model
+
+    if (topKey === "catalog" && indent === 2) {
+      entryOf(DEFAULT_CATALOG).set(parsed.key, parsed.value);
+    } else if (topKey === "catalogs") {
+      if (indent === 2 && parsed.value === "") {
+        namedCatalog = parsed.key;
+      } else if (indent === 4 && namedCatalog !== undefined) {
+        entryOf(namedCatalog).set(parsed.key, parsed.value);
+      }
+    }
+  }
+  return catalogs;
+}
+
+/** Parse a single `key: value` YAML line; returns undefined for non-mapping lines. */
+function parseMappingLine(line: string): { key: string; value: string } | undefined {
+  const match = /^\s*(?:"([^"]*)"|'([^']*)'|([^\s:#][^:]*?))\s*:(?:\s+(.*))?$/.exec(line);
+  if (!match) return undefined;
+  const key = match[1] ?? match[2] ?? match[3];
+  return { key, value: unquote(match[4] ?? "") };
+}
+
+function unquote(value: string): string {
+  const trimmed = value.trim();
+  const quoted = /^"([^"]*)"$|^'([^']*)'$/.exec(trimmed);
+  return quoted ? (quoted[1] ?? quoted[2]) : trimmed;
+}
+
+/**
+ * Catalog entries whose version changed between two `pnpm-workspace.yaml`
+ * revisions. Additions, removals and edits all count; an entry that only moved
+ * does not.
+ *
+ * @param baseText Base revision content, or undefined when the file did not exist.
+ */
+export function diffCatalogs(baseText: string | undefined, headText: string): Set<string> {
+  const base = baseText === undefined ? new Map() : parseCatalogs(baseText);
+  const head = parseCatalogs(headText);
+  const changed = new Set<string>();
+
+  for (const [catalog, entries] of head) {
+    const before = base.get(catalog);
+    for (const [dependency, version] of entries) {
+      if (before?.get(dependency) !== version) changed.add(catalogEntryKey(catalog, dependency));
+    }
+  }
+  for (const [catalog, entries] of base) {
+    const after = head.get(catalog);
+    for (const dependency of entries.keys()) {
+      if (!after?.has(dependency)) changed.add(catalogEntryKey(catalog, dependency));
+    }
+  }
+  return changed;
+}
+
+/** Catalog referenced by a package.json specifier, or undefined if it is not a catalog reference. */
+export function catalogOfSpecifier(specifier: string): string | undefined {
+  if (typeof specifier !== "string" || !specifier.startsWith("catalog:")) return undefined;
+  // `catalog:` and `catalog:default` both mean the unnamed catalog.
+  return specifier.slice("catalog:".length).trim() || DEFAULT_CATALOG;
+}
+
+interface Manifest {
+  name?: string;
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  peerDependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+}
+
+/**
+ * Workspace packages that directly consume at least one of the changed catalog
+ * entries. Dependents are added later by pnpm, from the real graph.
+ */
+export function packagesUsingCatalogEntries(
+  manifests: Manifest[],
+  changedEntries: Set<string>,
+): Set<string> {
+  const consumers = new Set<string>();
+  if (changedEntries.size === 0) return consumers;
+
+  for (const manifest of manifests) {
+    if (!manifest.name) continue;
+    const groups = [
+      manifest.dependencies,
+      manifest.devDependencies,
+      manifest.peerDependencies,
+      manifest.optionalDependencies,
+    ];
+    for (const group of groups) {
+      for (const [dependency, specifier] of Object.entries(group ?? {})) {
+        const catalog = catalogOfSpecifier(specifier);
+        if (catalog !== undefined && changedEntries.has(catalogEntryKey(catalog, dependency))) {
+          consumers.add(manifest.name);
+        }
+      }
+    }
+  }
+  return consumers;
+}
+
+/**
  * Decide which targets are affected. Pure: all git/pnpm I/O happens in the caller.
  *
  * A target fires on any of three signals: its package is in the pnpm-derived
@@ -82,7 +251,8 @@ export function matchesAny(file: string, patterns: string[]): boolean {
  * targets), or a non-package `extra` CI-infra path.
  *
  * @param affectedPackages Target package OR any graph-dependent of a meaningfully
- *   changed package (from `pnpm --filter "...[base]"`).
+ *   changed package (from `pnpm --filter "...[base]"`), plus consumers of changed
+ *   catalog entries and their dependents (from `getCatalogAffectedPackages`).
  * @param changedFiles Full changed-file list, used only for the two non-graph
  *   signals (`core` submodule + `extra` paths).
  */
@@ -126,10 +296,69 @@ function getAffectedPackages(base: string, ignore: string[]): Set<string> {
   const args = ["--filter", `...[${base}]`];
   for (const glob of ignore) args.push("--changed-files-ignore-pattern", glob);
   args.push("list", "--depth", "-1", "--json");
+  return new Set(listPackageNames(args));
+}
+
+function listPackageNames(args: string[]): string[] {
   const out = runPnpm(args).trim();
-  if (!out) return new Set();
+  if (!out) return [];
   const parsed = JSON.parse(out) as Array<{ name?: string }>;
-  return new Set(parsed.map((p) => p.name).filter((n): n is string => Boolean(n)));
+  return parsed.map((p) => p.name).filter((n): n is string => Boolean(n));
+}
+
+/** Content of `path` at `rev`, or undefined when it does not exist there. */
+function getFileAtRev(rev: string, path: string): string | undefined {
+  try {
+    return execFileSync("git", ["show", `${rev}:${path}`], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+  } catch {
+    return undefined;
+  }
+}
+
+/** Every workspace package.json, read from the checked-out working tree. */
+function readWorkspaceManifests(): Manifest[] {
+  const out = runPnpm(["list", "-r", "--depth", "-1", "--json"]).trim();
+  if (!out) return [];
+  const projects = JSON.parse(out) as Array<{ path?: string }>;
+  const manifests: Manifest[] = [];
+  for (const project of projects) {
+    if (!project.path) continue;
+    try {
+      manifests.push(JSON.parse(readFileSync(join(project.path, "package.json"), "utf8")));
+    } catch {
+      // A project without a readable manifest cannot consume a catalog entry.
+    }
+  }
+  return manifests;
+}
+
+/** Expand a set of packages to include all of their workspace dependents. */
+function expandDependents(packages: Set<string>): Set<string> {
+  if (packages.size === 0) return packages;
+  const args: string[] = [];
+  for (const name of packages) args.push("--filter", `...${name}`);
+  args.push("list", "--depth", "-1", "--json");
+  return new Set([...packages, ...listPackageNames(args)]);
+}
+
+/**
+ * Packages affected by a change to the root catalog: the direct consumers of the
+ * changed catalog entries plus all of their dependents. Empty unless
+ * `config.catalogPath` is among the changed files.
+ */
+function getCatalogAffectedPackages(
+  base: string,
+  head: string,
+  changedFiles: string[],
+): Set<string> {
+  if (!changedFiles.includes(CONFIG.catalogPath)) return new Set();
+  const headText = getFileAtRev(head, CONFIG.catalogPath);
+  if (headText === undefined) return new Set(); // catalog deleted: no consumer can resolve
+  const changedEntries = diffCatalogs(getFileAtRev(base, CONFIG.catalogPath), headText);
+  return expandDependents(packagesUsingCatalogEntries(readWorkspaceManifests(), changedEntries));
 }
 
 // CLI entry: run only when executed directly (not when imported by tests).
@@ -143,7 +372,10 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
   }
 
   const changedFiles = getChangedFiles(base, head);
-  const affectedPackages = getAffectedPackages(base, CONFIG.ignore);
+  const affectedPackages = new Set([
+    ...getAffectedPackages(base, CONFIG.ignore),
+    ...getCatalogAffectedPackages(base, head, changedFiles),
+  ]);
   const affected = computeAffected(affectedPackages, changedFiles, CONFIG);
 
   console.log(`Base: ${base}`);

--- a/eng/scripts/detect-affected.ts
+++ b/eng/scripts/detect-affected.ts
@@ -22,12 +22,14 @@ import { pathToFileURL } from "node:url";
 // emitter depends on): nothing to do — the workspace graph picks it up
 // automatically as soon as the emitter declares the dependency.
 //
-// Third-party upstreams consumed through the pnpm catalog (e.g.
-// `@typespec/http-client-python`) are not workspace packages, so the graph
-// cannot see them: bumping one only edits the root `pnpm-workspace.yaml`, which
-// pnpm attributes to the root package alone. That file is therefore listed in
-// `sharedExtra` and any change to it triggers every target
-// (Azure/typespec-azure#5010).
+// EXCEPTION — upstreams consumed from npm via the pnpm catalog (e.g.
+// `@typespec/http-client-python`): these are not workspace packages, so the
+// graph cannot see them. Bumping one edits only the root `pnpm-workspace.yaml`,
+// which pnpm attributes to the root package alone, leaving every emitter
+// unaffected (Azure/typespec-azure#5010). `pnpm-workspace.yaml` is therefore in
+// `sharedExtra`: any change to it triggers all targets. It changes rarely and
+// always affects dependency resolution repo-wide, so this is deliberately blunt
+// rather than trying to work out which catalog entry moved.
 // -----------------------------------------------------------------------------
 
 interface Target {
@@ -42,7 +44,7 @@ interface Config {
   submodulePath: string;
   /** Globs whose sole change should NOT trigger anything; passed to pnpm via `--changed-files-ignore-pattern`. */
   ignore: string[];
-  /** Paths that trigger every target (shared CI infrastructure). */
+  /** Paths that trigger every target (shared CI infra + the root pnpm workspace file). */
   sharedExtra: string[];
   targets: Record<string, Target>;
 }
@@ -86,7 +88,8 @@ export function matchesAny(file: string, patterns: string[]): boolean {
  * A target fires on any of three signals: its package is in the pnpm-derived
  * affected set, OR one of the two things the graph cannot see changed — the
  * `core` submodule pointer (which every emitter depends on, so it triggers all
- * targets), or a non-package `extra` CI-infra path.
+ * targets), or an `extra` path outside any package (CI infra, and the root
+ * `pnpm-workspace.yaml` — see the header comment).
  *
  * @param affectedPackages Target package OR any graph-dependent of a meaningfully
  *   changed package (from `pnpm --filter "...[base]"`).


### PR DESCRIPTION
Fixes #5010.

## Problem

`@typespec/http-client-python` is not a workspace package — it is consumed from npm through the pnpm **catalog**, so bumping it only edits the root `pnpm-workspace.yaml`.

pnpm attributes root-file changes to the **root package only**, so `pnpm --filter "...[base]"` reports no affected emitter and `detect-affected` returns `python: false`. That is why #5009 ran no Python CI.

## Fix

Add `pnpm-workspace.yaml` to `sharedExtra`, so any change to it triggers every emitter target — the same treatment the `core` submodule pointer already gets.

The file changes rarely and always affects dependency resolution repo-wide, so this is deliberately blunt rather than trying to work out which catalog entry moved.

## Verification

Simulated the #5009 diff locally with `BASE_SHA=origin/main`:

```
Affected targets: {"python":true,"java":true,"typescript":true,"go":true}
```

Plus a unit test in `eng/scripts/detect-affected.test.ts`.
