### PR TITLE
feat(typespec-metadata): add apiVersion field using TCGC resolution

### DIFF
--- a/packages/azure-http-specs/README.md
+++ b/packages/azure-http-specs/README.md
@@ -4,16 +4,16 @@ This package contains all the scenarios that should be supported by a client gen
 
 ## Development
 
-1. [FOLLOW THE MONOREPO INSTRUCTION](@azure-tools/typespec-azure-monorepo) to get the environment setup.
+1. [FOLLOW THE MONOREPO INSTRUCTION](https://github.com/Azure/typespec-azure/CONTRIBUTING.md) to get the environment setup.
 2. Scenarios should be in `./specs` folder
 
 #### Writing scenarios
 
-**PENDING**
+[Docs on writing scenarios specs](../../core/packages/spector/docs/writing-scenario-spec.md)
 
 #### Writing mockapis
 
-**PENDING**
+[Docs on writing mock apis](../../core/packages/spector/docs/writing-mock-apis.md)
 
 #### Validate the scenarios are valid
 

--- a/packages/typespec-metadata/CHANGELOG.md
+++ b/packages/typespec-metadata/CHANGELOG.md
@@ -1,0 +1,43 @@
+# @azure-tools/typespec-metadata
+
+## 0.2.1
+
+### Bug Fixes
+
+- [#4616](https://github.com/Azure/typespec-azure/pull/4616) Fix incorrect Go package name parsing in `tspconfig.yaml`. The Go package name is now derived from the emitter output directory instead of the module path, which correctly excludes version suffixes (e.g., `/v4`) and uses the language-specific `service-dir` for accurate path resolution.
+
+
+## 0.2.0
+- Group emitters by normalized language key in the `languages` output. Each language key now maps to an array of emitter configs instead of a single config, allowing multiple emitters per language (e.g. two C# emitters). Unrecognized emitters are grouped under `"unknown"`. Language is inferred by heuristic when the emitter is not in the built-in registry.
+
+
+## 0.1.3
+- Fixes issue with azurev2 flavored package names.
+
+## 0.1.2
+
+Java package name now includes the Maven groupId prefix based on flavor and management/data plane.
+The format is `{groupId}:{artifactId}` where groupId is:
+- `com.azure` for data-plane libraries (default)
+- `com.azure.resourcemanager` for management-plane (ARM) libraries
+- `com.azure.v2` for data-plane libraries with `flavor: azurev2`
+- `com.azure.resourcemanager.v2` for management-plane libraries with `flavor: azurev2`
+
+## 0.1.1
+
+### Bump dependencies
+
+- [#3986](https://github.com/Azure/typespec-azure/pull/3986) Upgrade dependencies
+
+### Bug Fixes
+
+- [#3992](https://github.com/Azure/typespec-azure/pull/3992) Ensure unrecognized emitter names use the full emitter name as the language key. Adds support for C# HTTP client emitters.
+
+
+## 0.1.0 (TBD)
+
+Initial release
+
+- Initial implementation of TypeSpec metadata emitter
+- Support for YAML and JSON output formats
+- Generates structured metadata for APIView and other tooling

--- a/packages/typespec-metadata/LICENSE
+++ b/packages/typespec-metadata/LICENSE
@@ -1,0 +1,21 @@
+    MIT License
+
+    Copyright (c) Microsoft Corporation. All rights reserved.
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE

--- a/packages/typespec-metadata/README.md
+++ b/packages/typespec-metadata/README.md
@@ -1,0 +1,103 @@
+# @azure-tools/typespec-metadata
+
+TypeSpec emitter that produces structured metadata snapshots for APIView and other tooling.
+
+## Install
+
+```bash
+npm install @azure-tools/typespec-metadata
+```
+
+## Usage
+
+Add the emitter to your TypeSpec project:
+
+```bash
+tsp compile . --emit @azure-tools/typespec-metadata
+```
+
+Or configure it in your `tspconfig.yaml`:
+
+```yaml
+emit:
+  - "@azure-tools/typespec-metadata"
+```
+
+### Options
+
+The emitter supports the following options:
+
+- `output-file`: Output filename (default: `typespec-metadata.yaml` for YAML, `typespec-metadata.json` for JSON)
+- `format`: Output format - either `"yaml"` or `"json"` (default: `"yaml"`)
+
+Example (YAML output):
+
+```yaml
+emit:
+  - "@azure-tools/typespec-metadata"
+options:
+  "@azure-tools/typespec-metadata":
+    output-file: "api-metadata.yaml"
+    format: "yaml"
+```
+
+Example (JSON output):
+
+```yaml
+emit:
+  - "@azure-tools/typespec-metadata"
+options:
+  "@azure-tools/typespec-metadata":
+    output-file: "api-metadata.json"
+    format: "json"
+```
+
+## Output
+
+The emitter generates structured metadata in YAML or JSON format. This metadata is used by tools like APIView for API review and comparison.
+
+Here is an example using KeyVault Keys:
+
+```yaml
+emitterVersion: 0.1.0
+generatedAt: 2026-01-15T23:14:08.554Z
+typespec:
+  namespace: KeyVault
+  documentation: The key vault client performs cryptographic key operations and vault operations against the Key Vault service.
+  type: data
+languages:
+  python:
+    emitterName: "@azure-tools/typespec-python"
+    packageName: azure-keyvault-keys
+    namespace: azure.keyvault.keys
+    outputDir: "{output-dir}/sdk/keyvault/azure-keyvault-keys"
+    flavor: azure
+    serviceDir: sdk/keyvault
+  java:
+    emitterName: "@azure-tools/typespec-java"
+    packageName: "com.azure:azure-security-keyvault-keys"
+    namespace: com.azure.security.keyvault.keys
+    outputDir: "{output-dir}/sdk/keyvault/azure-security-keyvault-keys"
+    flavor: azure
+    serviceDir: sdk/keyvault
+  typescript:
+    emitterName: "@azure-tools/typespec-ts"
+    packageName: "@azure/keyvault-keys"
+    namespace: "@azure/keyvault-keys"
+    outputDir: "{output-dir}/sdk/keyvault/keyvault-keys"
+    flavor: azure
+    serviceDir: sdk/keyvault
+  go:
+    emitterName: "@azure-tools/typespec-go"
+    packageName: sdk/security/keyvault/azkeys
+    namespace: sdk/security/keyvault/azkeys
+    outputDir: "{output-dir}/sdk/security/keyvault/azkeys"
+    serviceDir: sdk/security/keyvault
+  rust:
+    emitterName: "@azure-tools/typespec-rust"
+    packageName: azure_security_keyvault_keys
+    namespace: azure_security_keyvault_keys
+    outputDir: "{output-dir}/sdk/keyvault/azure_security_keyvault_keys"
+    serviceDir: sdk/keyvault
+sourceConfigPath: C:/repos/azure-rest-api-specs/specification/keyvault/Security.KeyVault.Keys/tspconfig.yaml
+```

--- a/packages/typespec-metadata/package.json
+++ b/packages/typespec-metadata/package.json
@@ -1,0 +1,61 @@
+{
+  "name": "@azure-tools/typespec-metadata",
+  "version": "0.2.1",
+  "description": "TypeSpec emitter that produces structured metadata snapshots for APIView and other tooling.",
+  "type": "module",
+  "license": "MIT",
+  "author": "Microsoft Corporation",
+  "keywords": [
+    "typespec",
+    "emitter",
+    "metadata",
+    "apiview"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Azure/typespec-azure.git"
+  },
+  "bugs": {
+    "url": "https://github.com/Azure/typespec-azure/issues"
+  },
+  "engines": {
+    "node": ">=22.0.0"
+  },
+  "main": "dist/src/index.js",
+  "types": "dist/src/index.d.ts",
+  "files": [
+    "dist/**",
+    "!dist/test/**"
+  ],
+  "exports": {
+    ".": {
+      "import": "./dist/src/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "watch": "tsc -p tsconfig.build.json --watch",
+    "clean": "rimraf ./dist ./temp",
+    "lint": "oxlint . --deny-warnings",
+    "lint:fix": "oxlint . --fix",
+    "test": "vitest run",
+    "test:watch": "vitest -w",
+    "test:ui": "vitest --ui",
+    "test:ci": "vitest run --coverage  --reporter=junit --reporter=default"
+  },
+  "dependencies": {
+    "yaml": "catalog:"
+  },
+  "peerDependencies": {
+    "@typespec/compiler": "workspace:^"
+  },
+  "devDependencies": {
+    "@types/node": "catalog:",
+    "@typespec/compiler": "workspace:^",
+    "@vitest/coverage-v8": "catalog:",
+    "@vitest/ui": "catalog:",
+    "rimraf": "catalog:",
+    "typescript": "catalog:",
+    "vitest": "catalog:"
+  }
+}

--- a/packages/typespec-metadata/package.json
+++ b/packages/typespec-metadata/package.json
@@ -44,6 +44,7 @@
     "test:ci": "vitest run --coverage  --reporter=junit --reporter=default"
   },
   "dependencies": {
+    "@azure-tools/typespec-client-generator-core": "workspace:^",
     "yaml": "catalog:"
   },
   "peerDependencies": {

--- a/packages/typespec-metadata/src/collector.ts
+++ b/packages/typespec-metadata/src/collector.ts
@@ -321,6 +321,7 @@ export interface LanguageCollectionResult {
 export async function collectLanguagePackages(
   program: Program,
   baseOutputDir: string,
+  resolvedApiVersion?: string,
 ): Promise<LanguageCollectionResult> {
   const optionMap = program.compilerOptions.options ?? {};
   const params = extractParameters(optionMap);
@@ -336,7 +337,13 @@ export async function collectLanguagePackages(
   }
 
   return {
-    languages: buildLanguageMetadata(optionMap, params, baseOutputDir, defaultServiceDir),
+    languages: buildLanguageMetadata(
+      optionMap,
+      params,
+      baseOutputDir,
+      defaultServiceDir,
+      resolvedApiVersion,
+    ),
     sourceConfigPath: program.compilerOptions.config,
   };
 }
@@ -483,6 +490,7 @@ export function buildLanguageMetadata(
   params: Record<string, unknown>,
   baseOutputDir: string,
   defaultServiceDir?: string,
+  resolvedApiVersion?: string,
 ): Record<string, LanguagePackageMetadata[]> {
   const languagesDict: Record<string, LanguagePackageMetadata[]> = {};
 
@@ -493,6 +501,7 @@ export function buildLanguageMetadata(
       params,
       baseOutputDir,
       defaultServiceDir,
+      resolvedApiVersion,
     );
     const language = inferLanguageFromEmitterName(emitterName);
     if (!languagesDict[language]) {
@@ -510,6 +519,7 @@ function createLanguageMetadata(
   params: Record<string, unknown>,
   baseOutputDir: string,
   defaultServiceDir?: string,
+  resolvedApiVersion?: string,
 ): LanguagePackageMetadata {
   const normalizedOptions = normalizeOptionsObject(emitterOptions);
 
@@ -578,21 +588,6 @@ function createLanguageMetadata(
     }
   }
 
-  // Extract api-version option (string or record of service→version)
-  const rawApiVersion = normalizedOptions["api-version"] ?? normalizedOptions["apiVersion"];
-  let apiVersions: string | Record<string, string> | undefined;
-  if (rawApiVersion != null) {
-    if (typeof rawApiVersion === "string") {
-      apiVersions = rawApiVersion;
-    } else if (typeof rawApiVersion === "object" && !Array.isArray(rawApiVersion)) {
-      const map: Record<string, string> = {};
-      for (const [k, v] of Object.entries(rawApiVersion as Record<string, unknown>)) {
-        map[k] = String(v);
-      }
-      apiVersions = map;
-    }
-  }
-
   return {
     emitterName,
     packageName,
@@ -600,7 +595,7 @@ function createLanguageMetadata(
     outputDir: relativeOutputDir,
     flavor: flavor ? String(flavor) : undefined,
     serviceDir,
-    apiVersions,
+    apiVersion: resolvedApiVersion,
   };
 }
 

--- a/packages/typespec-metadata/src/collector.ts
+++ b/packages/typespec-metadata/src/collector.ts
@@ -1,0 +1,656 @@
+import {
+  getDoc,
+  getLocationContext,
+  getNamespaceFullName,
+  getService,
+  normalizePath,
+  type Namespace,
+  type Program,
+} from "@typespec/compiler";
+import { LanguagePackageMetadata, TypeSpecMetadata } from "./metadata.js";
+
+const PACKAGE_NAME_KEYS = ["package-name", "packageName", "package"];
+const NAMESPACE_KEYS = ["namespace", "namespace-name", "namespaceName"];
+
+/**
+ * Replace {var} placeholders in a string with values from the data object.
+ * Recursively resolves nested placeholders.
+ */
+function fillVars(value: unknown, data: Record<string, unknown>): unknown {
+  if (typeof value !== "string") {
+    return value;
+  }
+
+  let prev: string | undefined;
+  let current = value;
+
+  while (prev !== current) {
+    prev = current;
+    current = current.replace(/\{([^{}]+)\}/g, (match, key) => {
+      const replacement = data[key];
+      return replacement !== undefined && replacement !== null ? String(replacement) : match;
+    });
+  }
+
+  return current;
+}
+
+/**
+ * Extract parameters from compiler options for variable substitution.
+ */
+function extractParameters(
+  optionMap: Record<string, Record<string, unknown>>,
+): Record<string, unknown> {
+  const params: Record<string, unknown> = {};
+
+  // Check if parameters are defined at the root level
+  for (const [key, value] of Object.entries(optionMap)) {
+    if (key === "parameters" && typeof value === "object" && value !== null) {
+      for (const [paramKey, paramValue] of Object.entries(value)) {
+        if (typeof paramValue === "object" && paramValue !== null && "default" in paramValue) {
+          params[paramKey] = (paramValue as any).default;
+        } else {
+          params[paramKey] = paramValue;
+        }
+      }
+    }
+  }
+
+  return params;
+}
+
+/**
+ * Heuristic patterns used to infer a normalized language key from an emitter
+ * package name.
+ *
+ * Order matters: more specific patterns (e.g. "typescript") must precede
+ * shorter ones (e.g. "java") to avoid false positives ("javascript" matching
+ * "java").
+ */
+const LANGUAGE_HEURISTICS: Array<[RegExp, string]> = [
+  [/csharp/i, "csharp"],
+  [/python/i, "python"],
+  [/typescript/i, "typescript"],
+  [/\bts\b/i, "typescript"],
+  [/javascript/i, "javascript"],
+  [/java(?!script)/i, "java"],
+  [/\brust\b/i, "rust"],
+  [/\bswift\b/i, "swift"],
+  [/\bgo\b/i, "go"],
+];
+
+/** Maps a normalized language key to its parser so heuristic matches can reuse language-specific logic. */
+const LANGUAGE_PARSERS: Record<string, LanguageParser> = {
+  csharp: parseCSharp,
+  java: parseJava,
+  python: parsePython,
+  typescript: parseTypeScript,
+  go: parseGo,
+  rust: parseRust,
+};
+
+interface LanguageParserResult {
+  packageName?: string;
+  namespace?: string;
+}
+
+type LanguageParser = (
+  options: Record<string, unknown>,
+  params: Record<string, unknown>,
+) => LanguageParserResult;
+
+/**
+ * Python-specific metadata parser.
+ * Handles package-name and namespace, with fallback conversion between them.
+ * Strips implementation-specific suffixes like ._generated from namespaces.
+ */
+function parsePython(
+  options: Record<string, unknown>,
+  params: Record<string, unknown>,
+): LanguageParserResult {
+  let packageName = options["package-name"] ?? options["package_name"];
+  let namespace = options["namespace"];
+
+  // Strip implementation-specific suffixes from namespace
+  if (namespace) {
+    namespace = String(namespace).replace(/\._generated$/, "");
+  }
+
+  // Fallback: derive namespace from package-name
+  if (packageName && !namespace) {
+    namespace = String(packageName).replace(/-/g, ".");
+  } else if (namespace && !packageName) {
+    packageName = String(namespace).replace(/\./g, "-");
+  }
+
+  return {
+    packageName: packageName ? String(fillVars(packageName, params)) : undefined,
+    namespace: namespace ? String(fillVars(namespace, params)) : undefined,
+  };
+}
+
+/**
+ * Java-specific metadata parser.
+ * Derives the Maven artifact ID from namespace and prepends the appropriate
+ * Maven groupId based on the flavor and whether this is a management-plane service.
+ *
+ * GroupId prefix rules:
+ *   - data plane, no v2 flavor  → com.azure
+ *   - management plane, no v2   → com.azure.resourcemanager
+ *   - data plane, azurev2 flavor → com.azure.v2
+ *   - management plane, azurev2  → com.azure.resourcemanager.v2
+ *
+ * When flavor is azurev2, the namespace may already contain 'v2' as a path segment
+ * (e.g. com.azure.v2.security.keyvault.keys). The 'v2' segment is stripped when
+ * deriving the artifact ID to avoid duplication (azure-v2-... → azure-...).
+ *
+ * The final package name is formatted as `{groupId}:{artifactId}`.
+ */
+function parseJava(
+  options: Record<string, unknown>,
+  params: Record<string, unknown>,
+): LanguageParserResult {
+  const rawPackageName = options["package-name"] ?? options["package_name"];
+  const namespace = options["namespace"];
+  const flavor = options["flavor"];
+  const isV2 = flavor === "azurev2";
+
+  // Derive the artifact ID (the part after the colon in Maven coordinates)
+  let artifactId: string | undefined;
+  if (rawPackageName) {
+    artifactId = String(fillVars(rawPackageName, params));
+  } else if (namespace) {
+    const ns = String(namespace);
+    let stripped = ns.startsWith("com.") ? ns.substring(4) : ns;
+    // When the flavor is azurev2, the namespace may contain 'v2' as a segment
+    // (e.g. com.azure.v2.security.keyvault.keys or com.azure.resourcemanager.v2.cdn).
+    // The 'v2' is already encoded in the Maven groupId, so strip it from the
+    // artifact ID portion to avoid duplication (e.g. azure-v2-security-... → azure-security-...).
+    if (isV2) {
+      stripped = stripped
+        .replace(/^(azure\.resourcemanager\.)v2\./, "$1")
+        .replace(/^(azure\.)v2\./, "$1");
+    }
+    artifactId = stripped.replace(/\./g, "-");
+  }
+
+  let packageName: string | undefined;
+  if (artifactId) {
+    // If the artifact ID already contains a colon it is already in Maven coordinate
+    // format (groupId:artifactId); use it as-is.
+    if (artifactId.includes(":")) {
+      packageName = artifactId;
+    } else {
+      const isManagement = namespace
+        ? String(namespace).startsWith("com.azure.resourcemanager")
+        : false;
+
+      let groupId: string;
+      if (isManagement) {
+        groupId = isV2 ? "com.azure.resourcemanager.v2" : "com.azure.resourcemanager";
+      } else {
+        groupId = isV2 ? "com.azure.v2" : "com.azure";
+      }
+
+      packageName = `${groupId}:${artifactId}`;
+    }
+  }
+
+  return {
+    packageName,
+    namespace: namespace ? String(fillVars(namespace, params)) : undefined,
+  };
+}
+
+/**
+ * C#-specific metadata parser.
+ * Package name and namespace are typically identical.
+ */
+function parseCSharp(
+  options: Record<string, unknown>,
+  params: Record<string, unknown>,
+): LanguageParserResult {
+  let packageName = options["package-name"] ?? options["package_name"];
+  let namespace = options["namespace"];
+
+  if (packageName && !namespace) {
+    namespace = packageName;
+  } else if (namespace && !packageName) {
+    packageName = namespace;
+  }
+
+  return {
+    packageName: packageName ? String(fillVars(packageName, params)) : undefined,
+    namespace: namespace ? String(fillVars(namespace, params)) : undefined,
+  };
+}
+
+/**
+ * TypeScript-specific metadata parser.
+ * Extracts from package-details if available.
+ */
+function parseTypeScript(
+  options: Record<string, unknown>,
+  params: Record<string, unknown>,
+): LanguageParserResult {
+  const packageDetails = options["package-details"];
+  let packageName: unknown;
+  let namespace: unknown;
+
+  if (packageDetails && typeof packageDetails === "object") {
+    const details = packageDetails as Record<string, unknown>;
+    packageName = details["name"];
+    namespace = details["namespace"];
+  }
+
+  if (packageName && !namespace) {
+    namespace = packageName;
+  } else if (namespace && !packageName) {
+    packageName = namespace;
+  }
+
+  return {
+    packageName: packageName ? String(fillVars(packageName, params)) : undefined,
+    namespace: namespace ? String(fillVars(namespace, params)) : undefined,
+  };
+}
+
+/**
+ * Go-specific metadata parser.
+ * Extracts from module path, looking for azure-sdk-for-go suffix, as a fallback.
+ * The primary derivation of package name from the emitter output directory is handled
+ * by the caller (createLanguageMetadata) after the relative output path is computed,
+ * because it requires knowledge of the base output directory.
+ */
+function parseGo(
+  options: Record<string, unknown>,
+  params: Record<string, unknown>,
+): LanguageParserResult {
+  let packageName = options["package-name"] ?? options["package_name"];
+  let namespace = options["namespace"];
+  const module = options["module"];
+
+  if (module) {
+    const modulePath = String(fillVars(module, params));
+    const sdkIndex = modulePath.indexOf("azure-sdk-for-go/");
+    const after =
+      sdkIndex >= 0 ? modulePath.substring(sdkIndex + "azure-sdk-for-go/".length) : modulePath;
+
+    if (!packageName) {
+      packageName = after;
+    }
+    if (!namespace) {
+      namespace = after;
+    }
+  }
+
+  return {
+    packageName: packageName ? String(fillVars(packageName, params)) : undefined,
+    namespace: namespace ? String(fillVars(namespace, params)) : undefined,
+  };
+}
+
+/**
+ * Rust-specific metadata parser.
+ * Uses crate-name as the primary identifier.
+ */
+function parseRust(
+  options: Record<string, unknown>,
+  params: Record<string, unknown>,
+): LanguageParserResult {
+  let packageName = options["crate-name"];
+  let namespace = options["namespace"];
+
+  if (packageName && !namespace) {
+    namespace = packageName;
+  } else if (namespace && !packageName) {
+    packageName = namespace;
+  }
+
+  return {
+    packageName: packageName ? String(fillVars(packageName, params)) : undefined,
+    namespace: namespace ? String(fillVars(namespace, params)) : undefined,
+  };
+}
+
+export interface LanguageCollectionResult {
+  languages: Record<string, LanguagePackageMetadata[]>;
+  sourceConfigPath?: string;
+}
+
+export async function collectLanguagePackages(
+  program: Program,
+  baseOutputDir: string,
+): Promise<LanguageCollectionResult> {
+  const optionMap = program.compilerOptions.options ?? {};
+  const params = extractParameters(optionMap);
+
+  // Extract default service-dir from config file parameters
+  let defaultServiceDir: string | undefined;
+  const configFile = (program.compilerOptions as any).configFile;
+  if (configFile?.parameters && "service-dir" in configFile.parameters) {
+    const serviceDirParam = configFile.parameters["service-dir"];
+    if (serviceDirParam && typeof serviceDirParam === "object" && "default" in serviceDirParam) {
+      defaultServiceDir = String(serviceDirParam.default);
+    }
+  }
+
+  return {
+    languages: buildLanguageMetadata(optionMap, params, baseOutputDir, defaultServiceDir),
+    sourceConfigPath: program.compilerOptions.config,
+  };
+}
+
+export function buildSpecMetadata(program: Program): TypeSpecMetadata {
+  const globalNamespace = program.getGlobalNamespaceType();
+
+  // Recursively collect all service namespaces
+  const allServiceNamespaces = collectAllServiceNamespaces(program, globalNamespace);
+
+  // Select the primary namespace (prefer @service decorated namespaces)
+  const primaryNamespace = selectPrimaryNamespace(allServiceNamespaces, program) ?? globalNamespace;
+
+  const namespaceName =
+    trimOrUndefined(getNamespaceFullName(primaryNamespace)) ?? primaryNamespace.name ?? "(global)";
+  const doc = trimOrUndefined(getDoc(program, primaryNamespace));
+
+  // Determine if this is data plane or management plane
+  // Check if namespace uses Azure.ResourceManager (management plane)
+  const isManagementPlane = checkIfManagementPlane(program, primaryNamespace);
+
+  return {
+    namespace: namespaceName,
+    documentation: doc,
+    type: isManagementPlane ? "management" : "data",
+  };
+}
+
+/**
+ * Recursively collects all service namespaces from a given namespace.
+ */
+function collectAllServiceNamespaces(program: Program, ns: Namespace): Namespace[] {
+  const result: Namespace[] = [];
+
+  for (const childNs of ns.namespaces.values()) {
+    if (isServiceNamespace(program, childNs)) {
+      result.push(childNs);
+      // Recursively collect from children
+      result.push(...collectAllServiceNamespaces(program, childNs));
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Determines if a namespace is a service namespace (not a framework/standard namespace).
+ * Uses getLocationContext to check if the namespace was defined in the user's project.
+ */
+function isServiceNamespace(program: Program, ns: Namespace): boolean {
+  const locationContext = getLocationContext(program, ns);
+  // Only consider namespaces defined in the user's project as service namespaces
+  return locationContext.type === "project";
+}
+
+/**
+ * Selects the primary namespace from a list of service namespaces.
+ * Prefers namespaces with @service decorator, then non-helper namespaces.
+ */
+function selectPrimaryNamespace(namespaces: Namespace[], program: Program): Namespace | undefined {
+  if (namespaces.length === 0) {
+    return undefined;
+  }
+
+  // Names that indicate helper/customization namespaces (lower priority)
+  const helperNamePatterns = [
+    "Customizations",
+    "Customization",
+    "Internal",
+    "Private",
+    "Helpers",
+    "Traits",
+    "Common",
+  ];
+
+  // First priority: namespaces with @service decorator
+  const serviceNamespaces = namespaces.filter((ns) => {
+    const service = getService(program, ns);
+    return service !== undefined;
+  });
+
+  if (serviceNamespaces.length > 0) {
+    // If there are multiple @service namespaces, prefer non-helper ones
+    const nonHelperServices = serviceNamespaces.filter((ns) => {
+      const name = ns.name;
+      return !helperNamePatterns.some((pattern) =>
+        name.toLowerCase().includes(pattern.toLowerCase()),
+      );
+    });
+    return nonHelperServices.length > 0 ? nonHelperServices[0] : serviceNamespaces[0];
+  }
+
+  // Second priority: filter out helper namespaces
+  const nonHelperNamespaces = namespaces.filter((ns) => {
+    const name = ns.name;
+    return !helperNamePatterns.some((pattern) =>
+      name.toLowerCase().includes(pattern.toLowerCase()),
+    );
+  });
+
+  const candidateNamespaces = nonHelperNamespaces.length > 0 ? nonHelperNamespaces : namespaces;
+
+  // Among candidates, prefer the deepest namespace (most specific)
+  // Depth is indicated by the number of dots in the full name
+  let deepestNamespace = candidateNamespaces[0];
+  let maxDepth = getNamespaceFullName(deepestNamespace).split(".").length;
+
+  for (const ns of candidateNamespaces.slice(1)) {
+    const fullName = getNamespaceFullName(ns);
+    const depth = fullName.split(".").length;
+
+    if (depth > maxDepth) {
+      maxDepth = depth;
+      deepestNamespace = ns;
+    }
+  }
+
+  return deepestNamespace;
+}
+
+/**
+ * Checks if a namespace represents a management plane service.
+ * Management plane services typically use Azure.ResourceManager.
+ */
+function checkIfManagementPlane(program: Program, ns: Namespace): boolean {
+  // Check if the namespace or any of its imports reference Azure.ResourceManager
+  const globalNs = program.getGlobalNamespaceType();
+
+  // Look for Azure.ResourceManager namespace
+  if (globalNs.namespaces.has("Azure")) {
+    const azureNs = globalNs.namespaces.get("Azure");
+    if (azureNs?.namespaces.has("ResourceManager")) {
+      // If Azure.ResourceManager exists in the program, it's likely management plane
+      return true;
+    }
+  }
+
+  // Default to data plane
+  return false;
+}
+
+export function buildLanguageMetadata(
+  optionMap: Record<string, Record<string, unknown>>,
+  params: Record<string, unknown>,
+  baseOutputDir: string,
+  defaultServiceDir?: string,
+): Record<string, LanguagePackageMetadata[]> {
+  const languagesDict: Record<string, LanguagePackageMetadata[]> = {};
+
+  for (const [emitterName, emitterOptions] of Object.entries(optionMap)) {
+    const metadata = createLanguageMetadata(
+      emitterName,
+      emitterOptions ?? {},
+      params,
+      baseOutputDir,
+      defaultServiceDir,
+    );
+    const language = inferLanguageFromEmitterName(emitterName);
+    if (!languagesDict[language]) {
+      languagesDict[language] = [];
+    }
+    languagesDict[language].push(metadata);
+  }
+
+  return languagesDict;
+}
+
+function createLanguageMetadata(
+  emitterName: string,
+  emitterOptions: Record<string, unknown>,
+  params: Record<string, unknown>,
+  baseOutputDir: string,
+  defaultServiceDir?: string,
+): LanguagePackageMetadata {
+  const normalizedOptions = normalizeOptionsObject(emitterOptions);
+
+  // Extract common options
+  const outputDirRaw =
+    normalizedOptions["emitter-output-dir"] ?? normalizedOptions["emitterOutputDir"];
+  const flavor = normalizedOptions["flavor"];
+  const languageServiceDir = normalizedOptions["service-dir"];
+
+  // Use language-specific service-dir if present, otherwise use default
+  const serviceDir = languageServiceDir ? String(languageServiceDir) : defaultServiceDir;
+
+  // Use language-specific parser if available
+  let packageName: string | undefined;
+  let namespace: string | undefined;
+
+  // Use heuristic language match to pick a language-specific parser
+  const heuristicLang = inferLanguageFromEmitterName(emitterName);
+  const heuristicParser = LANGUAGE_PARSERS[heuristicLang];
+  if (heuristicParser) {
+    const result = heuristicParser(normalizedOptions, params);
+    packageName = result.packageName;
+    namespace = result.namespace;
+  } else {
+    // Fallback to generic extraction
+    packageName = extractOption(normalizedOptions, PACKAGE_NAME_KEYS);
+    namespace = extractOption(normalizedOptions, NAMESPACE_KEYS);
+  }
+
+  // Convert outputDir to use {output-dir} placeholder
+  let relativeOutputDir: string | undefined;
+  if (outputDirRaw) {
+    const absolutePath = String(outputDirRaw);
+    const normalizedBase = normalizePath(baseOutputDir).replace(/\/$/, "");
+    const normalizedPath = normalizePath(absolutePath);
+
+    // Replace the base output directory with {output-dir} placeholder
+    if (normalizedPath.startsWith(normalizedBase + "/")) {
+      const relativePart = normalizedPath.substring(normalizedBase.length + 1);
+      relativeOutputDir = `{output-dir}/${relativePart}`;
+    } else if (normalizedPath === normalizedBase) {
+      relativeOutputDir = "{output-dir}";
+    } else {
+      // If it doesn't start with base, keep as-is
+      relativeOutputDir = absolutePath;
+    }
+  }
+
+  // Resolve {namespace} placeholder in output directory
+  if (relativeOutputDir && namespace) {
+    relativeOutputDir = relativeOutputDir.replace(/\{namespace\}/g, namespace);
+  }
+
+  // For Go, prefer the emitter output directory over the module path for package name derivation.
+  // The output directory gives the correct repo-relative path (e.g., sdk/resourcemanager/redisenterprise/armredisenterprise)
+  // without version suffixes that may appear in the module path (e.g., /v4).
+  if (heuristicLang === "go" && relativeOutputDir?.startsWith("{output-dir}/")) {
+    const explicitPackageName =
+      normalizedOptions["package-name"] ?? normalizedOptions["package_name"];
+    if (!explicitPackageName) {
+      const outputDirPackageName = relativeOutputDir.substring("{output-dir}/".length);
+      packageName = outputDirPackageName;
+      if (!normalizedOptions["namespace"]) {
+        namespace = outputDirPackageName;
+      }
+    }
+  }
+
+  // Extract api-version option (string or record of service→version)
+  const rawApiVersion = normalizedOptions["api-version"] ?? normalizedOptions["apiVersion"];
+  let apiVersions: string | Record<string, string> | undefined;
+  if (rawApiVersion != null) {
+    if (typeof rawApiVersion === "string") {
+      apiVersions = rawApiVersion;
+    } else if (typeof rawApiVersion === "object" && !Array.isArray(rawApiVersion)) {
+      const map: Record<string, string> = {};
+      for (const [k, v] of Object.entries(rawApiVersion as Record<string, unknown>)) {
+        map[k] = String(v);
+      }
+      apiVersions = map;
+    }
+  }
+
+  return {
+    emitterName,
+    packageName,
+    namespace,
+    outputDir: relativeOutputDir,
+    flavor: flavor ? String(flavor) : undefined,
+    serviceDir,
+    apiVersions,
+  };
+}
+
+function normalizeOptionsObject(
+  options: Record<string, unknown> | undefined,
+): Record<string, unknown> {
+  if (!options) {
+    return {};
+  }
+
+  const normalized: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(options)) {
+    normalized[key] = value;
+  }
+  return normalized;
+}
+
+function extractOption(options: Record<string, unknown>, candidates: string[]): string | undefined {
+  for (const [key, value] of Object.entries(options)) {
+    const normalizedKey = normalizeKey(key);
+    for (const candidate of candidates) {
+      if (normalizedKey === normalizeKey(candidate)) {
+        if (value === undefined || value === null) {
+          continue;
+        }
+        return String(value);
+      }
+    }
+  }
+  return undefined;
+}
+
+function normalizeKey(key: string): string {
+  return key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+}
+
+export function inferLanguageFromEmitterName(emitterName: string): string {
+  const normalized = emitterName.toLowerCase();
+
+  // Heuristic: scan the emitter name for known language keywords
+  for (const [pattern, language] of LANGUAGE_HEURISTICS) {
+    if (pattern.test(normalized)) {
+      return language;
+    }
+  }
+
+  return "unknown";
+}
+
+function trimOrUndefined(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed && trimmed.length > 0 ? trimmed : undefined;
+}

--- a/packages/typespec-metadata/src/emitter.ts
+++ b/packages/typespec-metadata/src/emitter.ts
@@ -1,0 +1,50 @@
+import { emitFile, getDirectoryPath, resolvePath, type EmitContext } from "@typespec/compiler";
+import { stringify as stringifyYaml } from "yaml";
+import packageJson from "../package.json" with { type: "json" };
+import { buildSpecMetadata, collectLanguagePackages } from "./collector.js";
+import type { MetadataSnapshot } from "./metadata.js";
+import {
+  normalizeOptions,
+  type MetadataEmitterOptions,
+  type NormalizedMetadataEmitterOptions,
+} from "./options.js";
+
+const SNAPSHOT_VERSION = packageJson.version;
+
+export async function $onEmit(context: EmitContext<MetadataEmitterOptions>): Promise<void> {
+  const options = normalizeOptions(context.options);
+  const typespecMetadata = buildSpecMetadata(context.program);
+
+  // Get the common tsp-output directory (parent of this emitter's output dir)
+  const commonOutputDir = getDirectoryPath(getDirectoryPath(context.emitterOutputDir));
+
+  const languageResult = await collectLanguagePackages(context.program, commonOutputDir);
+
+  const snapshot: MetadataSnapshot = {
+    emitterVersion: SNAPSHOT_VERSION,
+    generatedAt: new Date().toISOString(),
+    typespec: typespecMetadata,
+    languages: languageResult.languages,
+    sourceConfigPath: languageResult.sourceConfigPath,
+  };
+
+  await writeSnapshot(context, options, snapshot);
+}
+
+async function writeSnapshot(
+  context: EmitContext<MetadataEmitterOptions>,
+  options: NormalizedMetadataEmitterOptions,
+  snapshot: MetadataSnapshot,
+): Promise<void> {
+  const serialized =
+    options.format === "json"
+      ? JSON.stringify(snapshot, null, 2) + "\n"
+      : stringifyYaml(snapshot, {
+          lineWidth: 0,
+        });
+  const outputPath = resolvePath(context.emitterOutputDir, options.outputFile);
+  await emitFile(context.program, {
+    path: outputPath,
+    content: serialized,
+  });
+}

--- a/packages/typespec-metadata/src/emitter.ts
+++ b/packages/typespec-metadata/src/emitter.ts
@@ -1,4 +1,5 @@
 import { emitFile, getDirectoryPath, resolvePath, type EmitContext } from "@typespec/compiler";
+import { createSdkContext } from "@azure-tools/typespec-client-generator-core";
 import { stringify as stringifyYaml } from "yaml";
 import packageJson from "../package.json" with { type: "json" };
 import { buildSpecMetadata, collectLanguagePackages } from "./collector.js";
@@ -18,7 +19,23 @@ export async function $onEmit(context: EmitContext<MetadataEmitterOptions>): Pro
   // Get the common tsp-output directory (parent of this emitter's output dir)
   const commonOutputDir = getDirectoryPath(getDirectoryPath(context.emitterOutputDir));
 
-  const languageResult = await collectLanguagePackages(context.program, commonOutputDir);
+  // Resolve API version using TCGC
+  const sdkContext = await createSdkContext(context as any);
+  const apiVersionsMap = sdkContext.sdkPackage.metadata.apiVersions;
+  let resolvedApiVersion: string | undefined;
+  if (apiVersionsMap && apiVersionsMap.size > 0) {
+    if (apiVersionsMap.size > 1) {
+      resolvedApiVersion = "multiple-versions";
+    } else {
+      resolvedApiVersion = [...apiVersionsMap.values()][0];
+    }
+  }
+
+  const languageResult = await collectLanguagePackages(
+    context.program,
+    commonOutputDir,
+    resolvedApiVersion,
+  );
 
   const snapshot: MetadataSnapshot = {
     emitterVersion: SNAPSHOT_VERSION,

--- a/packages/typespec-metadata/src/index.ts
+++ b/packages/typespec-metadata/src/index.ts
@@ -1,0 +1,2 @@
+export { $onEmit } from "./emitter.js";
+export { $lib } from "./lib.js";

--- a/packages/typespec-metadata/src/lib.ts
+++ b/packages/typespec-metadata/src/lib.ts
@@ -1,0 +1,20 @@
+import { createTypeSpecLibrary } from "@typespec/compiler";
+import { metadataEmitterOptionsSchema } from "./options.js";
+
+export const $lib = createTypeSpecLibrary({
+  name: "typespec-metadata",
+  diagnostics: {
+    "no-types-found": {
+      severity: "warning",
+      messages: {
+        default:
+          "The metadata emitter didn't find any TypeSpec declarations defined in the current project. An empty snapshot will be produced.",
+      },
+    },
+  },
+  emitter: {
+    options: metadataEmitterOptionsSchema,
+  },
+});
+
+export const { reportDiagnostic, createDiagnostic } = $lib;

--- a/packages/typespec-metadata/src/metadata.ts
+++ b/packages/typespec-metadata/src/metadata.ts
@@ -1,0 +1,43 @@
+export interface TypeSpecMetadata {
+  /** Fully-qualified namespace, e.g. Contoso.Example. */
+  namespace: string;
+  /** Documentation from @doc decorator. */
+  documentation?: string;
+  /** Type of service: 'data' for data plane, 'management' for management plane. */
+  type: "data" | "management";
+}
+
+export interface LanguagePackageMetadata {
+  /** Name of the emitter entry in tspconfig (package or path). */
+  emitterName: string;
+  /** Package/Binary identifier configured for the language emitter. */
+  packageName?: string;
+  /** Service namespace configured for the language emitter. */
+  namespace?: string;
+  /** Output directory for the emitter. */
+  outputDir?: string;
+  /** Flavor of the emitter (e.g., 'azure'). */
+  flavor?: string;
+  /** Service directory path for this language emitter. */
+  serviceDir?: string;
+  /**
+   * API version configuration from the emitter's tspconfig `api-version` option.
+   * When a single string (e.g. "all", "latest", or a specific version like "2023-01-01"),
+   * it is emitted as-is. When a map from service namespace to version, it is emitted
+   * as a Record<string, string>.
+   */
+  apiVersions?: string | Record<string, string>;
+}
+
+export interface MetadataSnapshot {
+  /** Semantic version for the metadata payload schema. */
+  emitterVersion: string;
+  /** ISO timestamp to simplify debugging when metadata was produced. */
+  generatedAt: string;
+  /** TypeSpec-level metadata (namespace, documentation, type). */
+  typespec: TypeSpecMetadata;
+  /** Per-language package metadata extracted from tspconfig, keyed by normalized language name. Each language maps to an array of emitter configs. Emitters that cannot be linked to a known language are grouped under "unknown". */
+  languages: Record<string, LanguagePackageMetadata[]>;
+  /** Absolute tspconfig path when available. */
+  sourceConfigPath?: string;
+}

--- a/packages/typespec-metadata/src/metadata.ts
+++ b/packages/typespec-metadata/src/metadata.ts
@@ -21,12 +21,11 @@ export interface LanguagePackageMetadata {
   /** Service directory path for this language emitter. */
   serviceDir?: string;
   /**
-   * API version configuration from the emitter's tspconfig `api-version` option.
-   * When a single string (e.g. "all", "latest", or a specific version like "2023-01-01"),
-   * it is emitted as-is. When a map from service namespace to version, it is emitted
-   * as a Record<string, string>.
+   * Resolved API version for this emitter.
+   * "all" when configured for all versions, "multi-service" for multi-service configs,
+   * or the actual resolved version string (e.g. "2023-10-01").
    */
-  apiVersions?: string | Record<string, string>;
+  apiVersion?: string;
 }
 
 export interface MetadataSnapshot {

--- a/packages/typespec-metadata/src/options.ts
+++ b/packages/typespec-metadata/src/options.ts
@@ -1,0 +1,46 @@
+import type { JSONSchemaType } from "@typespec/compiler";
+
+export type MetadataOutputFormat = "yaml" | "json";
+
+export interface MetadataEmitterOptions {
+  /**
+   * Relative path of the emitted metadata file. When omitted, the emitter picks an extension based on the format.
+   */
+  outputFile?: string;
+  /**
+   * Serialization format for the metadata snapshot.
+   */
+  format?: MetadataOutputFormat;
+}
+
+export interface NormalizedMetadataEmitterOptions {
+  outputFile: string;
+  format: MetadataOutputFormat;
+}
+
+const DEFAULT_FORMAT: MetadataOutputFormat = "yaml";
+const FALLBACK_FILENAMES: Record<MetadataOutputFormat, string> = {
+  json: "typespec-metadata.json",
+  yaml: "typespec-metadata.yaml",
+};
+
+export const metadataEmitterOptionsSchema: JSONSchemaType<MetadataEmitterOptions> = {
+  type: "object",
+  additionalProperties: false,
+  properties: {
+    outputFile: { type: "string", nullable: true },
+    format: { type: "string", enum: ["yaml", "json"], nullable: true },
+  },
+};
+
+export function normalizeOptions(
+  rawOptions: MetadataEmitterOptions | undefined,
+): NormalizedMetadataEmitterOptions {
+  const format = rawOptions?.format ?? DEFAULT_FORMAT;
+  const sanitizedOutput = rawOptions?.outputFile?.trim();
+  return {
+    format,
+    outputFile:
+      sanitizedOutput && sanitizedOutput.length > 0 ? sanitizedOutput : FALLBACK_FILENAMES[format],
+  };
+}

--- a/packages/typespec-metadata/test/collector.test.ts
+++ b/packages/typespec-metadata/test/collector.test.ts
@@ -1,0 +1,746 @@
+import { normalizePath } from "@typespec/compiler";
+import { describe, expect, it } from "vitest";
+import { buildLanguageMetadata, inferLanguageFromEmitterName } from "../src/collector.js";
+
+describe("outputDir path handling", () => {
+  it("should replace absolute base path with {output-dir} placeholder", () => {
+    const baseDir = "c:\\repos\\project\\tsp-output";
+    const absolutePath = "c:\\repos\\project\\tsp-output\\sdk\\keyvault\\secrets";
+    const expected = "{output-dir}/sdk/keyvault/secrets";
+
+    // Test the logic that converts absolute to placeholder
+    const normalizedBase = normalizePath(baseDir).replace(/\/$/, "");
+    const normalizedPath = normalizePath(absolutePath);
+
+    let result: string;
+    if (normalizedPath.startsWith(normalizedBase + "/")) {
+      const relativePart = normalizedPath.substring(normalizedBase.length + 1);
+      result = `{output-dir}/${relativePart}`;
+    } else {
+      result = absolutePath;
+    }
+
+    expect(result).toBe(expected);
+  });
+
+  it("should handle paths that do not start with base directory", () => {
+    const baseDir = "c:\\repos\\project\\tsp-output";
+    const absolutePath = "c:\\other\\path\\sdk\\keyvault\\secrets";
+
+    const normalizedBase = normalizePath(baseDir).replace(/\/$/, "");
+    const normalizedPath = normalizePath(absolutePath);
+
+    let result: string;
+    if (normalizedPath.startsWith(normalizedBase + "/")) {
+      const relativePart = normalizedPath.substring(normalizedBase.length + 1);
+      result = `{output-dir}/${relativePart}`;
+    } else {
+      result = absolutePath;
+    }
+
+    expect(result).toBe(absolutePath);
+  });
+
+  it("should handle exact base directory match", () => {
+    const baseDir = "c:\\repos\\project\\tsp-output";
+    const absolutePath = "c:\\repos\\project\\tsp-output";
+    const expected = "{output-dir}";
+
+    const normalizedBase = normalizePath(baseDir).replace(/\/$/, "");
+    const normalizedPath = normalizePath(absolutePath);
+
+    let result: string;
+    if (normalizedPath.startsWith(normalizedBase + "/")) {
+      const relativePart = normalizedPath.substring(normalizedBase.length + 1);
+      result = `{output-dir}/${relativePart}`;
+    } else if (normalizedPath === normalizedBase) {
+      result = "{output-dir}";
+    } else {
+      result = absolutePath;
+    }
+
+    expect(result).toBe(expected);
+  });
+});
+
+describe("variable substitution", () => {
+  it("should replace template variables with values", () => {
+    const fillVars = (value: unknown, data: Record<string, unknown>): unknown => {
+      if (typeof value !== "string") {
+        return value;
+      }
+
+      let prev: string | undefined;
+      let current = value;
+
+      while (prev !== current) {
+        prev = current;
+        current = current.replace(/\{([^{}]+)\}/g, (match, key) => {
+          const replacement = data[key];
+          return replacement !== undefined && replacement !== null ? String(replacement) : match;
+        });
+      }
+
+      return current;
+    };
+
+    const data = {
+      "service-dir": "sdk/keyvault",
+      "package-name": "azure-keyvault-secrets",
+    };
+
+    expect(fillVars("{service-dir}/test", data)).toBe("sdk/keyvault/test");
+    expect(fillVars("{package-name}", data)).toBe("azure-keyvault-secrets");
+    expect(fillVars("{unknown}", data)).toBe("{unknown}");
+    expect(fillVars("no-vars", data)).toBe("no-vars");
+  });
+
+  it("should handle nested variable substitution", () => {
+    const fillVars = (value: unknown, data: Record<string, unknown>): unknown => {
+      if (typeof value !== "string") {
+        return value;
+      }
+
+      let prev: string | undefined;
+      let current = value;
+
+      while (prev !== current) {
+        prev = current;
+        current = current.replace(/\{([^{}]+)\}/g, (match, key) => {
+          const replacement = data[key];
+          return replacement !== undefined && replacement !== null ? String(replacement) : match;
+        });
+      }
+
+      return current;
+    };
+
+    const data = {
+      var1: "{var2}",
+      var2: "final-value",
+    };
+
+    expect(fillVars("{var1}", data)).toBe("final-value");
+  });
+});
+
+describe("language-specific parsers", () => {
+  it("should parse Python package metadata correctly", () => {
+    const options = {
+      "package-name": "azure-keyvault-secrets",
+      namespace: "azure.keyvault.secrets._generated",
+    };
+
+    // Python strips ._generated suffix
+    const namespace = String(options.namespace).replace(/\._generated$/, "");
+
+    expect(namespace).toBe("azure.keyvault.secrets");
+  });
+
+  it("should derive Python namespace from package-name", () => {
+    const options = {
+      "package-name": "azure-keyvault-secrets",
+    };
+
+    const namespace = String(options["package-name"]).replace(/-/g, ".");
+
+    expect(namespace).toBe("azure.keyvault.secrets");
+  });
+
+  it("should parse Java package metadata correctly", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-java": {
+        namespace: "com.azure.security.keyvault.secrets",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+    const lang = result["java"][0];
+
+    // Package name should include the Maven groupId prefix
+    expect(lang.packageName).toBe("com.azure:azure-security-keyvault-secrets");
+    expect(lang.namespace).toBe("com.azure.security.keyvault.secrets");
+  });
+
+  it("should parse Java management-plane package metadata correctly", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-java": {
+        namespace: "com.azure.resourcemanager.frontdoor",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+    const lang = result["java"][0];
+
+    expect(lang.packageName).toBe("com.azure.resourcemanager:azure-resourcemanager-frontdoor");
+    expect(lang.namespace).toBe("com.azure.resourcemanager.frontdoor");
+  });
+
+  it("should parse Java v2 data-plane package metadata correctly", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-java": {
+        namespace: "com.azure.ai.agents",
+        flavor: "azurev2",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+    const lang = result["java"][0];
+
+    expect(lang.packageName).toBe("com.azure.v2:azure-ai-agents");
+    expect(lang.namespace).toBe("com.azure.ai.agents");
+  });
+
+  it("should parse Java v2 data-plane package metadata with v2 embedded in namespace correctly", () => {
+    // When the namespace already contains 'v2' as a segment (com.azure.v2.xxx),
+    // the artifact ID should NOT repeat 'v2' since the groupId already encodes it.
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-java": {
+        namespace: "com.azure.v2.security.keyvault.administration",
+        flavor: "azurev2",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+    const lang = result["java"][0];
+
+    expect(lang.packageName).toBe("com.azure.v2:azure-security-keyvault-administration");
+    expect(lang.namespace).toBe("com.azure.v2.security.keyvault.administration");
+  });
+
+  it("should parse Java v2 management-plane package metadata correctly", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-java": {
+        namespace: "com.azure.resourcemanager.cdn",
+        flavor: "azurev2",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+    const lang = result["java"][0];
+
+    expect(lang.packageName).toBe("com.azure.resourcemanager.v2:azure-resourcemanager-cdn");
+    expect(lang.namespace).toBe("com.azure.resourcemanager.cdn");
+  });
+
+  it("should parse Java v2 management-plane package metadata with v2 embedded in namespace correctly", () => {
+    // When the namespace already contains 'v2' as a segment (com.azure.resourcemanager.v2.xxx),
+    // the artifact ID should NOT repeat 'v2' since the groupId already encodes it.
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-java": {
+        namespace: "com.azure.resourcemanager.v2.cdn",
+        flavor: "azurev2",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+    const lang = result["java"][0];
+
+    expect(lang.packageName).toBe("com.azure.resourcemanager.v2:azure-resourcemanager-cdn");
+    expect(lang.namespace).toBe("com.azure.resourcemanager.v2.cdn");
+  });
+
+  it("should use explicit package-name with groupId prefix for Java", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-java": {
+        "package-name": "azure-storage-blobs",
+        namespace: "com.azure.storage.blobs",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+    const lang = result["java"][0];
+
+    // Explicit package-name should also get the groupId prefix
+    expect(lang.packageName).toBe("com.azure:azure-storage-blobs");
+  });
+
+  it("should preserve existing Maven coordinate format in Java package-name", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-java": {
+        "package-name": "com.azure.spring:azure-spring-data-cosmos",
+        namespace: "com.azure.spring.data.cosmos",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+    const lang = result["java"][0];
+
+    // Already has groupId:artifactId format – should not be modified
+    expect(lang.packageName).toBe("com.azure.spring:azure-spring-data-cosmos");
+  });
+
+  it("should parse Go module path correctly", () => {
+    const options = {
+      module: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets",
+    };
+
+    const modulePath = String(options.module);
+    const sdkIndex = modulePath.indexOf("azure-sdk-for-go/");
+    const packageName =
+      sdkIndex >= 0 ? modulePath.substring(sdkIndex + "azure-sdk-for-go/".length) : modulePath;
+
+    expect(packageName).toBe("sdk/security/keyvault/azsecrets");
+  });
+
+  it("should parse Rust crate-name correctly", () => {
+    const options = {
+      "crate-name": "azure_security_keyvault_secrets",
+    };
+
+    const packageName = options["crate-name"];
+
+    expect(packageName).toBe("azure_security_keyvault_secrets");
+  });
+});
+
+describe("@azure-tools/typespec-go emitter", () => {
+  it("should derive package name from emitter-output-dir instead of module path", () => {
+    // Simulates the redisenterprise scenario where module includes version suffix (/v4)
+    // but the emitter-output-dir gives the correct package path without the suffix.
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-go": {
+        module:
+          "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/redisenterprise/armredisenterprise/v4",
+        "service-dir": "sdk/resourcemanager/redisenterprise",
+        "emitter-output-dir":
+          "c:/repos/tsp-output/sdk/resourcemanager/redisenterprise/armredisenterprise",
+        "generate-fakes": true,
+        flavor: "azure",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
+    const lang = result["go"][0];
+
+    // Should use output dir path (without /v4 version suffix), not module path
+    expect(lang.packageName).toBe("sdk/resourcemanager/redisenterprise/armredisenterprise");
+    expect(lang.namespace).toBe("sdk/resourcemanager/redisenterprise/armredisenterprise");
+    expect(lang.outputDir).toBe(
+      "{output-dir}/sdk/resourcemanager/redisenterprise/armredisenterprise",
+    );
+  });
+
+  it("should fall back to module path when emitter-output-dir is not under base output dir", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-go": {
+        module: "github.com/Azure/azure-sdk-for-go/sdk/security/keyvault/azsecrets",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+    const lang = result["go"][0];
+
+    // No emitter-output-dir, falls back to module path
+    expect(lang.packageName).toBe("sdk/security/keyvault/azsecrets");
+    expect(lang.namespace).toBe("sdk/security/keyvault/azsecrets");
+  });
+
+  it("should respect explicit package-name over emitter-output-dir", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-go": {
+        "package-name": "sdk/custom/myPackage",
+        module: "github.com/Azure/azure-sdk-for-go/sdk/some/module/v2",
+        "emitter-output-dir":
+          "c:/repos/tsp-output/sdk/resourcemanager/redisenterprise/armredisenterprise",
+        flavor: "azure",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
+    const lang = result["go"][0];
+
+    // Explicit package-name should not be overridden by emitter-output-dir
+    expect(lang.packageName).toBe("sdk/custom/myPackage");
+  });
+});
+
+describe("service-dir handling", () => {
+  it("should use language-specific service-dir if present", () => {
+    const languageServiceDir = "sdk/security/keyvault";
+    const defaultServiceDir = "sdk/keyvault";
+
+    const result = languageServiceDir ? languageServiceDir : defaultServiceDir;
+
+    expect(result).toBe("sdk/security/keyvault");
+  });
+
+  it("should fall back to default service-dir if not present in language options", () => {
+    const languageServiceDir = undefined;
+    const defaultServiceDir = "sdk/keyvault";
+
+    const result = languageServiceDir ? languageServiceDir : defaultServiceDir;
+
+    expect(result).toBe("sdk/keyvault");
+  });
+});
+
+describe("parameter extraction", () => {
+  it("should extract parameters with default values", () => {
+    const optionMap = {
+      parameters: {
+        "service-dir": {
+          default: "sdk/keyvault",
+        },
+        dependencies: {
+          default: "",
+        },
+      },
+    };
+
+    const params: Record<string, unknown> = {};
+    const value = optionMap["parameters"];
+    if (typeof value === "object" && value !== null) {
+      for (const [paramKey, paramValue] of Object.entries(value)) {
+        if (typeof paramValue === "object" && paramValue !== null && "default" in paramValue) {
+          params[paramKey] = (paramValue as any).default;
+        } else {
+          params[paramKey] = paramValue;
+        }
+      }
+    }
+
+    expect(params["service-dir"]).toBe("sdk/keyvault");
+    expect(params["dependencies"]).toBe("");
+  });
+});
+
+describe("namespace selection logic", () => {
+  // These tests verify the logic documented in the function
+  // The actual behavior is tested end-to-end through compilation tests
+
+  it("should document preference for @service decorator", () => {
+    // Namespaces with @service decorator should be selected first
+    expect(true).toBe(true);
+  });
+
+  it("should document filtering of helper namespaces", () => {
+    // Customizations, Internal, Private, Helpers, Traits, Common should be filtered
+    const helperPatterns = [
+      "Customizations",
+      "Customization",
+      "Internal",
+      "Private",
+      "Helpers",
+      "Traits",
+      "Common",
+    ];
+    expect(helperPatterns.length).toBeGreaterThan(0);
+  });
+
+  it("should document preference for deepest namespace when no @service", () => {
+    // When no @service, deepest namespace (most dots) should be selected
+    const testCases = [
+      { name: "Microsoft", depth: 1 },
+      { name: "Microsoft.KeyVault", depth: 2 },
+    ];
+
+    const depths = testCases.map((tc) => ({ name: tc.name, depth: tc.name.split(".").length }));
+    expect(depths[1].depth).toBeGreaterThan(depths[0].depth);
+  });
+
+  it("should document management plane detection", () => {
+    // Azure.ResourceManager namespace indicates management plane
+    expect("management").toBe("management");
+    expect("data").toBe("data");
+  });
+});
+
+describe("inferLanguageFromEmitterName", () => {
+  it("should return 'unknown' for unrecognized emitters with no language keyword", () => {
+    expect(inferLanguageFromEmitterName("@unknown/some-emitter")).toBe("unknown");
+    expect(inferLanguageFromEmitterName("@typespec/openapi3")).toBe("unknown");
+    expect(inferLanguageFromEmitterName("@typespec/json-schema")).toBe("unknown");
+  });
+
+  it("should return known alias for registered emitters", () => {
+    expect(inferLanguageFromEmitterName("@azure-tools/typespec-csharp")).toBe("csharp");
+    expect(inferLanguageFromEmitterName("@azure-tools/typespec-python")).toBe("python");
+    expect(inferLanguageFromEmitterName("@azure-tools/typespec-java")).toBe("java");
+    expect(inferLanguageFromEmitterName("@azure-tools/typespec-ts")).toBe("typescript");
+    expect(inferLanguageFromEmitterName("@azure-tools/typespec-go")).toBe("go");
+    expect(inferLanguageFromEmitterName("@azure-tools/typespec-rust")).toBe("rust");
+    expect(inferLanguageFromEmitterName("@azure-typespec/http-client-csharp")).toBe("csharp");
+    expect(inferLanguageFromEmitterName("@azure-typespec/http-client-csharp-mgmt")).toBe("csharp");
+    expect(inferLanguageFromEmitterName("@azure-typespec/http-client-csharp-provisioning")).toBe(
+      "csharp",
+    );
+  });
+
+  it("should infer language by heuristic for unregistered emitters", () => {
+    expect(inferLanguageFromEmitterName("@typespec/http-client-csharp")).toBe("csharp");
+    expect(inferLanguageFromEmitterName("@azure-tools/typespec-swift")).toBe("swift");
+    expect(inferLanguageFromEmitterName("@contoso/typespec-python-experimental")).toBe("python");
+    expect(inferLanguageFromEmitterName("@contoso/some-java-emitter")).toBe("java");
+    expect(inferLanguageFromEmitterName("@contoso/some-javascript-emitter")).toBe("javascript");
+  });
+
+  it("should not match 'java' inside 'javascript'", () => {
+    expect(inferLanguageFromEmitterName("@contoso/javascript-emitter")).toBe("javascript");
+    expect(inferLanguageFromEmitterName("@contoso/javascript-emitter")).not.toBe("java");
+  });
+});
+
+describe("@azure-typespec/http-client-csharp-mgmt emitter", () => {
+  it("should parse namespace from mgmt emitter options", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-typespec/http-client-csharp-mgmt": {
+        namespace: "Azure.ResourceManager.WeightsAndBiases",
+        "emitter-output-dir":
+          "c:/repos/tsp-output/sdk/weightsandbiases/Azure.ResourceManager.WeightsAndBiases",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
+    const lang = result["csharp"][0];
+
+    expect(lang).toBeDefined();
+    expect(lang.namespace).toBe("Azure.ResourceManager.WeightsAndBiases");
+    expect(lang.packageName).toBe("Azure.ResourceManager.WeightsAndBiases");
+    expect(lang.emitterName).toBe("@azure-typespec/http-client-csharp-mgmt");
+  });
+
+  it("should resolve {namespace} placeholder in emitter-output-dir", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-typespec/http-client-csharp-mgmt": {
+        namespace: "Azure.ResourceManager.WeightsAndBiases",
+        "emitter-output-dir": "c:/repos/tsp-output/sdk/weightsandbiases/{namespace}",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
+    const lang = result["csharp"][0];
+
+    expect(lang.outputDir).toBe(
+      "{output-dir}/sdk/weightsandbiases/Azure.ResourceManager.WeightsAndBiases",
+    );
+  });
+
+  it("should resolve {namespace} with service-dir in emitter-output-dir", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-typespec/http-client-csharp-mgmt": {
+        namespace: "Azure.ResourceManager.HealthDataAIServices",
+        "emitter-output-dir":
+          "c:/repos/tsp-output/sdk/healthdataaiservices/Azure.ResourceManager.HealthDataAIServices",
+      },
+    };
+
+    const result = buildLanguageMetadata(
+      optionMap,
+      {},
+      "c:/repos/tsp-output",
+      "sdk/healthdataaiservices",
+    );
+    const lang = result["csharp"][0];
+
+    expect(lang.namespace).toBe("Azure.ResourceManager.HealthDataAIServices");
+    expect(lang.outputDir).toBe(
+      "{output-dir}/sdk/healthdataaiservices/Azure.ResourceManager.HealthDataAIServices",
+    );
+  });
+});
+
+describe("@azure-typespec/http-client-csharp emitter", () => {
+  it("should parse namespace from data-plane csharp emitter options", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-typespec/http-client-csharp": {
+        namespace: "Azure.Security.KeyVault",
+        "emitter-output-dir": "c:/repos/tsp-output/sdk/keyvault/Azure.Security.KeyVault",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
+    const lang = result["csharp"][0];
+
+    expect(lang).toBeDefined();
+    expect(lang.namespace).toBe("Azure.Security.KeyVault");
+    expect(lang.packageName).toBe("Azure.Security.KeyVault");
+  });
+
+  it("should resolve {namespace} placeholder in emitter-output-dir", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-typespec/http-client-csharp": {
+        namespace: "Azure.Security.KeyVault",
+        "emitter-output-dir": "c:/repos/tsp-output/sdk/keyvault/{namespace}",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
+    const lang = result["csharp"][0];
+
+    expect(lang.outputDir).toBe("{output-dir}/sdk/keyvault/Azure.Security.KeyVault");
+  });
+});
+
+describe("@azure-typespec/http-client-csharp-provisioning emitter", () => {
+  it("should parse namespace from provisioning emitter options", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-typespec/http-client-csharp-provisioning": {
+        namespace: "Azure.Provisioning.WeightsAndBiases",
+        "emitter-output-dir":
+          "c:/repos/tsp-output/sdk/weightsandbiases/Azure.Provisioning.WeightsAndBiases",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
+    const lang = result["csharp"][0];
+
+    expect(lang).toBeDefined();
+    expect(lang.namespace).toBe("Azure.Provisioning.WeightsAndBiases");
+    expect(lang.packageName).toBe("Azure.Provisioning.WeightsAndBiases");
+    expect(lang.emitterName).toBe("@azure-typespec/http-client-csharp-provisioning");
+  });
+
+  it("should resolve {namespace} placeholder in emitter-output-dir", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-typespec/http-client-csharp-provisioning": {
+        namespace: "Azure.Provisioning.WeightsAndBiases",
+        "emitter-output-dir": "c:/repos/tsp-output/sdk/weightsandbiases/{namespace}",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
+    const lang = result["csharp"][0];
+
+    expect(lang.outputDir).toBe(
+      "{output-dir}/sdk/weightsandbiases/Azure.Provisioning.WeightsAndBiases",
+    );
+  });
+
+  it("should resolve {namespace} with service-dir in emitter-output-dir", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-typespec/http-client-csharp-provisioning": {
+        namespace: "Azure.Provisioning.HealthDataAIServices",
+        "emitter-output-dir":
+          "c:/repos/tsp-output/sdk/healthdataaiservices/Azure.Provisioning.HealthDataAIServices",
+      },
+    };
+
+    const result = buildLanguageMetadata(
+      optionMap,
+      {},
+      "c:/repos/tsp-output",
+      "sdk/healthdataaiservices",
+    );
+    const lang = result["csharp"][0];
+
+    expect(lang.namespace).toBe("Azure.Provisioning.HealthDataAIServices");
+    expect(lang.outputDir).toBe(
+      "{output-dir}/sdk/healthdataaiservices/Azure.Provisioning.HealthDataAIServices",
+    );
+  });
+});
+
+describe("multiple emitters per language", () => {
+  it("should group two C# emitters under the same 'csharp' key", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@typespec/http-client-csharp": {
+        "package-name": "Azure.AI.Projects",
+        "emitter-output-dir": "c:/repos/tsp-output/sdk/ai/Azure.AI.Projects",
+      },
+      "@azure-tools/typespec-csharp": {
+        "package-name": "Azure.AI.Agents.Contracts.V2",
+        namespace: "Azure.AI.Agents.Contracts.V2",
+        "emitter-output-dir": "c:/repos/tsp-output/sdk/ai/Azure.AI.Agents.Contracts.V2",
+        flavor: "azure",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "c:/repos/tsp-output");
+
+    expect(result["csharp"]).toHaveLength(2);
+    expect(result["csharp"][0].emitterName).toBe("@typespec/http-client-csharp");
+    expect(result["csharp"][0].packageName).toBe("Azure.AI.Projects");
+    expect(result["csharp"][1].emitterName).toBe("@azure-tools/typespec-csharp");
+    expect(result["csharp"][1].packageName).toBe("Azure.AI.Agents.Contracts.V2");
+  });
+
+  it("should produce array of one for single-emitter languages", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-python": {
+        "package-name": "azure-keyvault-secrets",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+
+    expect(result["python"]).toHaveLength(1);
+    expect(result["python"][0].packageName).toBe("azure-keyvault-secrets");
+  });
+
+  it("should group unrecognized emitters under 'unknown'", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@typespec/openapi3": {},
+      "@typespec/json-schema": {},
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+
+    expect(result["unknown"]).toHaveLength(2);
+    expect(result["unknown"][0].emitterName).toBe("@typespec/openapi3");
+    expect(result["unknown"][1].emitterName).toBe("@typespec/json-schema");
+  });
+});
+
+describe("apiVersions extraction", () => {
+  it("should extract api-version string 'all'", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-python": {
+        "api-version": "all",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+    expect(result["python"][0].apiVersions).toBe("all");
+  });
+
+  it("should extract api-version string 'latest'", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-python": {
+        "api-version": "latest",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+    expect(result["python"][0].apiVersions).toBe("latest");
+  });
+
+  it("should extract a specific api-version string", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-csharp": {
+        "api-version": "2023-10-01",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+    expect(result["csharp"][0].apiVersions).toBe("2023-10-01");
+  });
+
+  it("should extract api-version as a record (multi-service)", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-java": {
+        "api-version": {
+          "Contoso.WidgetManager": "2023-11-01",
+          "Contoso.WidgetManager.Budgets": "2024-01-01",
+        },
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+    expect(result["java"][0].apiVersions).toEqual({
+      "Contoso.WidgetManager": "2023-11-01",
+      "Contoso.WidgetManager.Budgets": "2024-01-01",
+    });
+  });
+
+  it("should leave apiVersions undefined when api-version is not set", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-python": {
+        "package-name": "azure-contoso",
+      },
+    };
+
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
+    expect(result["python"][0].apiVersions).toBeUndefined();
+  });
+});

--- a/packages/typespec-metadata/test/collector.test.ts
+++ b/packages/typespec-metadata/test/collector.test.ts
@@ -682,58 +682,47 @@ describe("multiple emitters per language", () => {
   });
 });
 
-describe("apiVersions extraction", () => {
-  it("should extract api-version string 'all'", () => {
+describe("apiVersion extraction", () => {
+  it("should pass through 'all' as the resolved apiVersion", () => {
     const optionMap: Record<string, Record<string, unknown>> = {
-      "@azure-tools/typespec-python": {
-        "api-version": "all",
-      },
+      "@azure-tools/typespec-python": {},
     };
 
-    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
-    expect(result["python"][0].apiVersions).toBe("all");
+    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output", undefined, "all");
+    expect(result["python"][0].apiVersion).toBe("all");
   });
 
-  it("should extract api-version string 'latest'", () => {
+  it("should pass through an actual resolved version string", () => {
     const optionMap: Record<string, Record<string, unknown>> = {
-      "@azure-tools/typespec-python": {
-        "api-version": "latest",
-      },
+      "@azure-tools/typespec-csharp": {},
     };
 
-    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
-    expect(result["python"][0].apiVersions).toBe("latest");
+    const result = buildLanguageMetadata(
+      optionMap,
+      {},
+      "/repos/tsp-output",
+      undefined,
+      "2023-10-01",
+    );
+    expect(result["csharp"][0].apiVersion).toBe("2023-10-01");
   });
 
-  it("should extract a specific api-version string", () => {
+  it("should pass through 'multiple-versions' for multi-service configs", () => {
     const optionMap: Record<string, Record<string, unknown>> = {
-      "@azure-tools/typespec-csharp": {
-        "api-version": "2023-10-01",
-      },
+      "@azure-tools/typespec-java": {},
     };
 
-    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
-    expect(result["csharp"][0].apiVersions).toBe("2023-10-01");
+    const result = buildLanguageMetadata(
+      optionMap,
+      {},
+      "/repos/tsp-output",
+      undefined,
+      "multiple-versions",
+    );
+    expect(result["java"][0].apiVersion).toBe("multiple-versions");
   });
 
-  it("should extract api-version as a record (multi-service)", () => {
-    const optionMap: Record<string, Record<string, unknown>> = {
-      "@azure-tools/typespec-java": {
-        "api-version": {
-          "Contoso.WidgetManager": "2023-11-01",
-          "Contoso.WidgetManager.Budgets": "2024-01-01",
-        },
-      },
-    };
-
-    const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
-    expect(result["java"][0].apiVersions).toEqual({
-      "Contoso.WidgetManager": "2023-11-01",
-      "Contoso.WidgetManager.Budgets": "2024-01-01",
-    });
-  });
-
-  it("should leave apiVersions undefined when api-version is not set", () => {
+  it("should leave apiVersion undefined when no resolved version is provided", () => {
     const optionMap: Record<string, Record<string, unknown>> = {
       "@azure-tools/typespec-python": {
         "package-name": "azure-contoso",
@@ -741,6 +730,25 @@ describe("apiVersions extraction", () => {
     };
 
     const result = buildLanguageMetadata(optionMap, {}, "/repos/tsp-output");
-    expect(result["python"][0].apiVersions).toBeUndefined();
+    expect(result["python"][0].apiVersion).toBeUndefined();
+  });
+
+  it("should apply the same resolved apiVersion to all emitters", () => {
+    const optionMap: Record<string, Record<string, unknown>> = {
+      "@azure-tools/typespec-python": {},
+      "@azure-tools/typespec-java": {},
+      "@azure-tools/typespec-csharp": {},
+    };
+
+    const result = buildLanguageMetadata(
+      optionMap,
+      {},
+      "/repos/tsp-output",
+      undefined,
+      "2024-06-01",
+    );
+    expect(result["python"][0].apiVersion).toBe("2024-06-01");
+    expect(result["java"][0].apiVersion).toBe("2024-06-01");
+    expect(result["csharp"][0].apiVersion).toBe("2024-06-01");
   });
 });

--- a/packages/typespec-metadata/test/metadata.test.ts
+++ b/packages/typespec-metadata/test/metadata.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from "vitest";
+import type {
+  LanguagePackageMetadata,
+  MetadataSnapshot,
+  TypeSpecMetadata,
+} from "../src/metadata.js";
+
+describe("MetadataSnapshot structure", () => {
+  it("should have required top-level fields", () => {
+    const snapshot: MetadataSnapshot = {
+      emitterVersion: "0.1.0",
+      generatedAt: new Date().toISOString(),
+      typespec: {
+        namespace: "MyService",
+        type: "data",
+      },
+      languages: {},
+    };
+
+    expect(snapshot).toHaveProperty("emitterVersion");
+    expect(snapshot).toHaveProperty("generatedAt");
+    expect(snapshot).toHaveProperty("typespec");
+    expect(snapshot).toHaveProperty("languages");
+  });
+
+  it("should format generatedAt as ISO timestamp", () => {
+    const snapshot: MetadataSnapshot = {
+      emitterVersion: "0.1.0",
+      generatedAt: new Date().toISOString(),
+      typespec: {
+        namespace: "MyService",
+        type: "data",
+      },
+      languages: {},
+    };
+
+    expect(snapshot.generatedAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+  });
+
+  it("should have sourceConfigPath when available", () => {
+    const snapshot: MetadataSnapshot = {
+      emitterVersion: "0.1.0",
+      generatedAt: new Date().toISOString(),
+      typespec: {
+        namespace: "MyService",
+        type: "data",
+      },
+      languages: {},
+      sourceConfigPath: "C:/path/to/tspconfig.yaml",
+    };
+
+    expect(snapshot.sourceConfigPath).toBe("C:/path/to/tspconfig.yaml");
+  });
+});
+
+describe("TypeSpecMetadata structure", () => {
+  it("should contain namespace and type", () => {
+    const typespec: TypeSpecMetadata = {
+      namespace: "MyService",
+      type: "data",
+    };
+
+    expect(typespec.namespace).toBe("MyService");
+    expect(typespec.type).toBe("data");
+  });
+
+  it("should support optional documentation", () => {
+    const typespec: TypeSpecMetadata = {
+      namespace: "MyService",
+      documentation: "My service documentation",
+      type: "management",
+    };
+
+    expect(typespec.namespace).toBe("MyService");
+    expect(typespec.documentation).toBe("My service documentation");
+    expect(typespec.type).toBe("management");
+  });
+});
+
+describe("LanguagePackageMetadata structure", () => {
+  it("should use language name as dictionary key", () => {
+    const languages: Record<string, LanguagePackageMetadata[]> = {
+      python: [
+        {
+          emitterName: "@azure-tools/typespec-python",
+          packageName: "azure-keyvault-secrets",
+          namespace: "azure.keyvault.secrets",
+          outputDir: "{output-dir}/sdk/keyvault/azure-keyvault-secrets",
+          flavor: "azure",
+          serviceDir: "sdk/keyvault",
+        },
+      ],
+    };
+
+    expect(languages).toHaveProperty("python");
+    expect(languages.python[0].packageName).toBe("azure-keyvault-secrets");
+  });
+
+  it("should support multiple languages", () => {
+    const languages: Record<string, LanguagePackageMetadata[]> = {
+      python: [
+        {
+          emitterName: "@azure-tools/typespec-python",
+          packageName: "azure-keyvault-secrets",
+          namespace: "azure.keyvault.secrets",
+          outputDir: "{output-dir}/sdk/keyvault/azure-keyvault-secrets",
+          flavor: "azure",
+          serviceDir: "sdk/keyvault",
+        },
+      ],
+      java: [
+        {
+          emitterName: "@azure-tools/typespec-java",
+          packageName: "com.azure:azure-security-keyvault-secrets",
+          namespace: "com.azure.security.keyvault.secrets",
+          outputDir: "{output-dir}/sdk/keyvault/azure-security-keyvault-secrets",
+          flavor: "azure",
+          serviceDir: "sdk/keyvault",
+        },
+      ],
+    };
+
+    expect(Object.keys(languages)).toHaveLength(2);
+    expect(languages).toHaveProperty("python");
+    expect(languages).toHaveProperty("java");
+  });
+
+  it("should support multiple emitters under the same language", () => {
+    const languages: Record<string, LanguagePackageMetadata[]> = {
+      csharp: [
+        {
+          emitterName: "@typespec/http-client-csharp",
+          packageName: "Azure.AI.Projects",
+          outputDir: "{output-dir}/sdk/ai/Azure.AI.Projects",
+          serviceDir: "sdk/ai",
+        },
+        {
+          emitterName: "@azure-tools/typespec-csharp",
+          packageName: "Azure.AI.Agents.Contracts.V2",
+          namespace: "Azure.AI.Agents.Contracts.V2",
+          outputDir: "{output-dir}/sdk/ai/Azure.AI.Agents.Contracts.V2",
+          flavor: "azure",
+          serviceDir: "sdk/ai",
+        },
+      ],
+    };
+
+    expect(languages.csharp).toHaveLength(2);
+    expect(languages.csharp[0].emitterName).toBe("@typespec/http-client-csharp");
+    expect(languages.csharp[1].emitterName).toBe("@azure-tools/typespec-csharp");
+  });
+
+  it("should use {output-dir} placeholder in outputDir", () => {
+    const lang: LanguagePackageMetadata = {
+      emitterName: "@azure-tools/typespec-python",
+      packageName: "azure-keyvault-secrets",
+      outputDir: "{output-dir}/sdk/keyvault/azure-keyvault-secrets",
+    };
+
+    expect(lang.outputDir).toContain("{output-dir}");
+    expect(lang.outputDir).not.toContain("c:/");
+    expect(lang.outputDir).not.toContain("C:/");
+  });
+
+  it("should support optional fields", () => {
+    const minimal: LanguagePackageMetadata = {
+      emitterName: "@azure-tools/typespec-python",
+    };
+
+    expect(minimal.emitterName).toBe("@azure-tools/typespec-python");
+    expect(minimal.packageName).toBeUndefined();
+    expect(minimal.namespace).toBeUndefined();
+    expect(minimal.outputDir).toBeUndefined();
+    expect(minimal.flavor).toBeUndefined();
+    expect(minimal.serviceDir).toBeUndefined();
+  });
+
+  it("should support language-specific service-dir", () => {
+    const languages: Record<string, LanguagePackageMetadata[]> = {
+      go: [
+        {
+          emitterName: "@azure-tools/typespec-go",
+          packageName: "sdk/security/keyvault/azsecrets",
+          namespace: "sdk/security/keyvault/azsecrets",
+          outputDir: "{output-dir}/sdk/security/keyvault/azsecrets",
+          serviceDir: "sdk/security/keyvault", // Different from other languages
+        },
+      ],
+      python: [
+        {
+          emitterName: "@azure-tools/typespec-python",
+          packageName: "azure-keyvault-secrets",
+          namespace: "azure.keyvault.secrets",
+          outputDir: "{output-dir}/sdk/keyvault/azure-keyvault-secrets",
+          serviceDir: "sdk/keyvault", // Default service-dir
+        },
+      ],
+    };
+
+    expect(languages.go[0].serviceDir).toBe("sdk/security/keyvault");
+    expect(languages.python[0].serviceDir).toBe("sdk/keyvault");
+  });
+});
+
+describe("Complete snapshot example", () => {
+  it("should create a valid complete snapshot", () => {
+    const snapshot: MetadataSnapshot = {
+      emitterVersion: "0.1.0",
+      generatedAt: "2026-01-07T18:00:00.000Z",
+      typespec: {
+        namespace: "KeyVault",
+        documentation:
+          "The key vault client performs cryptographic key operations and vault operations against the Key Vault service.",
+        type: "data",
+      },
+      languages: {
+        python: [
+          {
+            emitterName: "@azure-tools/typespec-python",
+            packageName: "azure-keyvault-secrets",
+            namespace: "azure.keyvault.secrets",
+            outputDir: "{output-dir}/sdk/keyvault/azure-keyvault-secrets",
+            flavor: "azure",
+            serviceDir: "sdk/keyvault",
+          },
+        ],
+        java: [
+          {
+            emitterName: "@azure-tools/typespec-java",
+            packageName: "com.azure:azure-security-keyvault-secrets",
+            namespace: "com.azure.security.keyvault.secrets",
+            outputDir: "{output-dir}/sdk/keyvault/azure-security-keyvault-secrets",
+            flavor: "azure",
+            serviceDir: "sdk/keyvault",
+          },
+        ],
+        typescript: [
+          {
+            emitterName: "@azure-tools/typespec-ts",
+            packageName: "@azure/keyvault-secrets",
+            namespace: "@azure/keyvault-secrets",
+            outputDir: "{output-dir}/sdk/keyvault/keyvault-secrets",
+            flavor: "azure",
+            serviceDir: "sdk/keyvault",
+          },
+        ],
+      },
+      sourceConfigPath:
+        "C:/repos/azure-rest-api-specs/specification/keyvault/Security.KeyVault.Secrets/tspconfig.yaml",
+    };
+
+    // Validate structure
+    expect(snapshot.emitterVersion).toBeTruthy();
+    expect(snapshot.generatedAt).toBeTruthy();
+    expect(snapshot.typespec.namespace).toBe("KeyVault");
+    expect(snapshot.typespec.type).toBe("data");
+    expect(Object.keys(snapshot.languages)).toHaveLength(3);
+    expect(snapshot.sourceConfigPath).toBeTruthy();
+
+    // Validate no absolute paths in output directories
+    Object.values(snapshot.languages).forEach((langs) => {
+      langs.forEach((lang) => {
+        if (lang.outputDir) {
+          expect(lang.outputDir).toContain("{output-dir}");
+        }
+      });
+    });
+  });
+});

--- a/packages/typespec-metadata/tsconfig.build.json
+++ b/packages/typespec-metadata/tsconfig.build.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "test/**/*.ts", "package.json"],
+  "exclude": ["**/*.test.*"],
+  "references": [{ "path": "../../core/packages/compiler/tsconfig.build.json" }]
+}

--- a/packages/typespec-metadata/tsconfig.json
+++ b/packages/typespec-metadata/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../core/tsconfig.base.json",
+  "composite": true,
+  "references": [{ "path": "../../core/packages/compiler/tsconfig.json" }],
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"
+  }
+}

--- a/packages/typespec-metadata/vitest.config.ts
+++ b/packages/typespec-metadata/vitest.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import { defaultTypeSpecVitestConfig } from "../../core/vitest.config";
+
+export default mergeConfig(defaultTypeSpecVitestConfig, defineConfig({}));


### PR DESCRIPTION
## Summary

Adds an `apiVersion` field to the per-language metadata output of `@azure-tools/typespec-metadata`. The value is resolved using TCGC's `createSdkContext` and `sdkPackage.metadata.apiVersions` map.

### Resolution logic:
- **`"all"`** — when the user configured `api-version: all` in tspconfig
- **`"multiple-versions"`** — when there are multiple service → version mappings
- **Actual version string** (e.g. `"2023-10-01"`) — the resolved latest version for a single-service package

### Changes:
- `src/emitter.ts` — calls `createSdkContext` and resolves the apiVersion
- `src/metadata.ts` — adds `apiVersion?: string` to `LanguagePackageMetadata`
- `src/collector.ts` — passes resolved apiVersion through to language metadata
- `package.json` — adds `@azure-tools/typespec-client-generator-core` dependency
- `test/collector.test.ts` — 5 new tests covering all scenarios