### PR TITLE
Migrate typespec-python scripts from tsx to native node

### DIFF
--- a/.chronus/changes/migrate-python-scripts-to-native-node-2026-07-27-14-06-00.md
+++ b/.chronus/changes/migrate-python-scripts-to-native-node-2026-07-27-14-06-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Migrate the Python emitter's build/dev scripts from `tsx` to native Node.js TypeScript execution. `tsx script.ts` invocations are now `node script.ts` (relying on Node's built-in type-stripping), sibling relative imports use explicit `.ts` extensions, and type-only imports are marked with `type`. The unused `tsx` dependency was removed.

--- a/packages/typespec-python/eng/scripts/ci/format.ts
+++ b/packages/typespec-python/eng/scripts/ci/format.ts
@@ -31,7 +31,7 @@ const argv = parseArgs({
 
 if (argv.values.help) {
   console.log(`
-${pc.bold("Usage:")} tsx format.ts [options]
+${pc.bold("Usage:")} node format.ts [options]
 
 ${pc.bold("Description:")}
   Format code using Prettier (TypeScript) and Black (Python).
@@ -51,13 +51,13 @@ ${pc.bold("Options:")}
 
 ${pc.bold("Examples:")}
   ${pc.dim("# Format all code (default)")}
-  tsx format.ts
+  node format.ts
 
   ${pc.dim("# Format only TypeScript")}
-  tsx format.ts --typescript
+  node format.ts --typescript
 
   ${pc.dim("# Check formatting without making changes")}
-  tsx format.ts --check
+  node format.ts --check
 `);
   process.exit(0);
 }

--- a/packages/typespec-python/eng/scripts/ci/lint.ts
+++ b/packages/typespec-python/eng/scripts/ci/lint.ts
@@ -11,7 +11,7 @@ const argv = parseArgs({
 
 if (argv.values.help) {
   console.log(`
-${pc.bold("Usage:")} tsx lint.ts [options]
+${pc.bold("Usage:")} node lint.ts [options]
 
 ${pc.bold("Description:")}
   Run extra linting checks beyond what tox provides.

--- a/packages/typespec-python/eng/scripts/ci/regenerate.ts
+++ b/packages/typespec-python/eng/scripts/ci/regenerate.ts
@@ -18,17 +18,17 @@ import pc from "picocolors";
 import { fileURLToPath } from "url";
 import { parseArgs } from "util";
 
-import { isSpecEnabled, loadSpectorConfig, SpectorConfig } from "@azure-tools/spector-runner";
+import { isSpecEnabled, loadSpectorConfig, type SpectorConfig } from "@azure-tools/spector-runner";
 
 import {
   buildTaskGroups,
   getSubdirectories,
   prepareBaselineOfGeneratedCode,
   preprocess,
-  RegenerateContext,
-  RegenerateFlags,
+  type RegenerateContext,
+  type RegenerateFlags,
   runParallel,
-} from "./regenerate-common.js";
+} from "./regenerate-common.ts";
 
 const argv = parseArgs({
   args: process.argv.slice(2),
@@ -46,7 +46,7 @@ const argv = parseArgs({
 
 if (argv.values.help) {
   console.log(`
-${pc.bold("Usage:")} tsx regenerate.ts [options]
+${pc.bold("Usage:")} node regenerate.ts [options]
 
 ${pc.bold("Description:")}
   Regenerates Python SDK code from TypeSpec definitions using in-process
@@ -75,16 +75,16 @@ ${pc.bold("Options:")}
 
 ${pc.bold("Examples:")}
   ${pc.dim("# Regenerate all packages for both flavors")}
-  tsx regenerate.ts
+  node regenerate.ts
 
   ${pc.dim("# Regenerate only Azure packages")}
-  tsx regenerate.ts --flavor azure
+  node regenerate.ts --flavor azure
 
   ${pc.dim("# Regenerate a specific package by name")}
-  tsx regenerate.ts --flavor azure --name authentication-api-key
+  node regenerate.ts --flavor azure --name authentication-api-key
 
   ${pc.dim("# Regenerate with more parallelism")}
-  tsx regenerate.ts --jobs 50
+  node regenerate.ts --jobs 50
 `);
   process.exit(0);
 }

--- a/packages/typespec-python/eng/scripts/setup/run-python3.ts
+++ b/packages/typespec-python/eng/scripts/setup/run-python3.ts
@@ -4,10 +4,10 @@
 // path resolution algorithm as AutoRest so that the behavior
 // is fully consistent (and also supports AUTOREST_PYTHON_EXE).
 //
-// Invoke it like so: "tsx run-python3.ts script.py"
+// Invoke it like so: "node run-python3.ts script.py"
 
 import cp from "child_process";
-import { patchPythonPath } from "./system-requirements.js";
+import { patchPythonPath } from "./system-requirements.ts";
 
 async function runPython3(...args: string[]) {
   const command = await patchPythonPath(["python", ...args], {

--- a/packages/typespec-python/eng/scripts/setup/system-requirements.ts
+++ b/packages/typespec-python/eng/scripts/setup/system-requirements.ts
@@ -1,4 +1,4 @@
-import { ChildProcess, spawn, SpawnOptions } from "child_process";
+import { type ChildProcess, spawn, type SpawnOptions } from "child_process";
 import { coerce, satisfies } from "semver";
 
 /*

--- a/packages/typespec-python/eng/scripts/sync.ts
+++ b/packages/typespec-python/eng/scripts/sync.ts
@@ -15,8 +15,8 @@
  * nothing.
  *
  * Usage:
- *   tsx eng/scripts/sync.ts          # write mode: overwrite local files
- *   tsx eng/scripts/sync.ts --check  # check mode: exit non-zero on drift (CI)
+ *   node eng/scripts/sync.ts          # write mode: overwrite local files
+ *   node eng/scripts/sync.ts --check  # check mode: exit non-zero on drift (CI)
  */
 import fs from "fs";
 import { dirname, join, relative, sep } from "path";
@@ -145,7 +145,7 @@ const argv = parseArgs({
 
 if (argv.values.help) {
   console.log(`
-${pc.bold("Usage:")} tsx eng/scripts/sync.ts [options]
+${pc.bold("Usage:")} node eng/scripts/sync.ts [options]
 
 ${pc.bold("Description:")}
   Copy the files (and recursive directories) listed in INCLUDES from
@@ -400,7 +400,7 @@ function main(): void {
     console.error(
       pc.red(
         `\nSynced files have drifted from core/packages/http-client-python.\n` +
-          `Run 'pnpm sync' (or 'tsx eng/scripts/sync.ts') and commit the result.`,
+          `Run 'pnpm sync' (or 'node eng/scripts/sync.ts') and commit the result.`,
       ),
     );
     process.exit(1);

--- a/packages/typespec-python/package.json
+++ b/packages/typespec-python/package.json
@@ -32,15 +32,15 @@
     "clean": "rimraf ./dist ./temp ./venv ./node_modules",
     "build": "tsc -p .",
     "watch": "tsc -p . --watch",
-    "install": "tsx ./eng/scripts/setup/run-python3.ts ./eng/scripts/setup/install.py",
-    "prepare": "tsx ./eng/scripts/setup/run-python3.ts ./eng/scripts/setup/prepare.py",
-    "lint:extra": "tsx ./eng/scripts/ci/lint.ts",
-    "format:extra": "tsx ./eng/scripts/ci/format.ts --python",
-    "format:extra:check": "tsx ./eng/scripts/ci/format.ts --python --check",
-    "regenerate": "tsx ./eng/scripts/ci/regenerate.ts",
-    "sync": "tsx ./eng/scripts/sync.ts",
-    "sync:check": "tsx ./eng/scripts/sync.ts --check",
-    "test:python:e2e": "tsx ./eng/scripts/ci/run-tests.ts",
+    "install": "node ./eng/scripts/setup/run-python3.ts ./eng/scripts/setup/install.py",
+    "prepare": "node ./eng/scripts/setup/run-python3.ts ./eng/scripts/setup/prepare.py",
+    "lint:extra": "node ./eng/scripts/ci/lint.ts",
+    "format:extra": "node ./eng/scripts/ci/format.ts --python",
+    "format:extra:check": "node ./eng/scripts/ci/format.ts --python --check",
+    "regenerate": "node ./eng/scripts/ci/regenerate.ts",
+    "sync": "node ./eng/scripts/sync.ts",
+    "sync:check": "node ./eng/scripts/sync.ts --check",
+    "test:python:e2e": "node ./eng/scripts/ci/run-tests.ts",
     "regen-docs": "pnpm run build && tspd doc . --enable-experimental --output-dir ../../website/src/content/docs/docs/emitters/clients/typespec-python/reference --skip-js"
   },
   "files": [
@@ -66,8 +66,7 @@
   },
   "dependencies": {
     "@typespec/http-client-python": "catalog:",
-    "semver": "catalog:",
-    "tsx": "catalog:"
+    "semver": "catalog:"
   },
   "devDependencies": {
     "@azure-tools/azure-http-specs": "workspace:^",

--- a/packages/typespec-python/tsconfig.json
+++ b/packages/typespec-python/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
+    "rewriteRelativeImportExtensions": true,
     "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"
   },
   "include": ["src/**/*.ts", "eng/**/*.ts"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -501,9 +501,6 @@ catalogs:
     tslib:
       specifier: ^2.3.1
       version: 2.8.1
-    tsx:
-      specifier: ^4.21.0
-      version: 4.23.1
     turbo:
       specifier: 2.9.14
       version: 2.9.14
@@ -3923,9 +3920,6 @@ importers:
       semver:
         specifier: 'catalog:'
         version: 7.8.5
-      tsx:
-        specifier: 'catalog:'
-        version: 4.23.1
     devDependencies:
       '@azure-tools/azure-http-specs':
         specifier: workspace:^

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -194,7 +194,6 @@ catalog:
   tree-sitter-typescript: ^0.23.2
   ts-morph: ^23.0.0
   tslib: ^2.3.1
-  tsx: ^4.21.0
   # Pinned to 2.9.14: "turbo 2.10.1+ ships libghostty-vt built with non-baseline"
   turbo: "2.9.14"
   typedoc: ^0.28.19


### PR DESCRIPTION
Split this from the rest of the repo migration as tsx was used as a prod dependency here.
This is still safe as we only support node versions that allow typescript to be run now(spec repo relies on that now too)