### PR TITLE
feat(typespec-go): support paging with a relative nextLink

### DIFF
--- a/.chronus/changes/typespec-go-relative-nextlink-2026-07-28-15-45-00.md
+++ b/.chronus/changes/typespec-go-relative-nextlink-2026-07-28-15-45-00.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-go"
 ---
 
-Support paging with a relative nextLink. Pagers now pass the client endpoint to `runtime.FetcherForNextLink` so a next link relative to the endpoint can be resolved; absolute next links are unchanged. Requires azcore v1.22.1 or later.
+Support paging with a relative nextLink. Pagers now pass the client endpoint to `runtime.FetcherForNextLink` so a next link relative to the endpoint can be resolved; absolute next links are unchanged.

--- a/.chronus/changes/typespec-go-relative-nextlink-2026-07-28-15-45-00.md
+++ b/.chronus/changes/typespec-go-relative-nextlink-2026-07-28-15-45-00.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-go"
 ---
 
-Support paging with a relative nextLink. Pagers now resolve a next link that's relative to the client endpoint before fetching the next page; absolute next links are unchanged.
+Support paging with a relative nextLink. Pagers now pass the client endpoint to `runtime.FetcherForNextLink` so a next link relative to the endpoint can be resolved; absolute next links are unchanged. Requires azcore v1.22.1 or later.

--- a/.chronus/changes/typespec-go-relative-nextlink-2026-07-28-15-45-00.md
+++ b/.chronus/changes/typespec-go-relative-nextlink-2026-07-28-15-45-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-go"
+---
+
+Support paging with a relative nextLink. Pagers now resolve a next link that's relative to the client endpoint before fetching the next page; absolute next links are unchanged.

--- a/packages/typespec-go/src/codegen/core/gomod.ts
+++ b/packages/typespec-go/src/codegen/core/gomod.ts
@@ -25,7 +25,8 @@ export function generateGoModFile(
 
   // here we specify the minimum version of azcore as required by the code generator.
   // the version can be overwritten by passing the --azcore-version switch during generation.
-  let version = "1.22.0";
+  // TODO: replace this pseudo-version with 1.22.1 after it's released.
+  let version = "1.22.1-0.20260731225345-5811a2e9dc69";
   if (options.azcoreVersion) {
     // when matching versions, we need to handle beta, non-beta, and pseudo versions
     // 1.2.3-beta.1, 1.2.3, 0.22.1-0.20220315231014-ed309e73db6b

--- a/packages/typespec-go/src/codegen/core/operations.ts
+++ b/packages/typespec-go/src/codegen/core/operations.ts
@@ -179,9 +179,9 @@ export function generateOperations(
       // it must be done before the imports are written out
       if (go.isLROMethod(method)) {
         // generate Begin method
-        opText += generateLROBeginMethod(method, options, imports, indent);
+        opText += generateLROBeginMethod(method, options, imports, indent, azureARM);
       }
-      opText += generateOperation(method, options, imports, indent);
+      opText += generateOperation(method, options, imports, indent, azureARM);
       opText += createProtocolRequest(azureARM, method, imports, indent);
       if (method.kind !== "lroMethod") {
         // LRO responses are handled elsewhere, with the exception of pageable LROs
@@ -692,12 +692,67 @@ function generateNilChecks(
 }
 
 /**
+ * returns the expression used to obtain the client's service endpoint, or undefined
+ * when the endpoint can't be determined from the client alone.
+ *
+ * @param client the client for which to obtain the endpoint expression
+ * @param azureARM indicates if the client is an ARM client
+ * @returns the endpoint expression or undefined
+ */
+function getClientEndpointExpr(client: go.Client, azureARM: boolean): string | undefined {
+  if (azureARM) {
+    // for ARM, the endpoint is handled via the azcore/arm.Client
+    return "client.internal.Endpoint()";
+  }
+  if (client.instance?.kind === "templatedHost") {
+    // NOTE: this is an Autorest-only compat case. the host is assembled per
+    // method as it can require method params, so there's no client endpoint.
+    return undefined;
+  }
+  const hostParams = client.parameters.filter((param) => param.kind === "uriParam");
+  if (hostParams.length === 1) {
+    return `client.${hostParams[0].name}`;
+  }
+  return undefined;
+}
+
+/**
+ * emits code that resolves a relative next link against the client's service endpoint.
+ * services are allowed to return a next link that's relative to the endpoint (e.g.
+ * "/foo/page/2"), however runtime.FetcherForNextLink requires an absolute URL. absolute
+ * next links are passed through unmodified.
+ *
+ * @param nextLinkVar the name of the local var containing the next link
+ * @param endpointExpr the expression used to obtain the client's service endpoint
+ * @param imports the import manager currently in scope
+ * @param indent the indentation helper currently in scope
+ * @returns the code to resolve a relative next link
+ */
+function emitRelativeNextLinkResolution(
+  nextLinkVar: string,
+  endpointExpr: string,
+  imports: ImportManager,
+  indent: helpers.Indentation,
+): string {
+  imports.add("net/url");
+  let text = `${indent.get()}// the service can return a next link that's relative to the endpoint, however\n`;
+  text += `${indent.get()}// runtime.FetcherForNextLink requires an absolute URL, so resolve it here.\n`;
+  text += `${indent.get()}if ${nextLinkVar} != "" {\n`;
+  text += `${indent.push().get()}if u, err := url.Parse(${nextLinkVar}); err == nil && !u.IsAbs() {\n`;
+  text += `${indent.push().get()}${nextLinkVar} = runtime.JoinPaths(${endpointExpr}, ${nextLinkVar})\n`;
+  text += `${indent.pop().get()}}\n`;
+  text += `${indent.pop().get()}}\n`;
+  return text;
+}
+
+/**
  * emits code that calls runtime.NewPager
  *
  * @param method the pageable method
  * @param options emitter options
  * @param imports the import manager currently in scope
  * @param indent the indentation helper currently in scope
+ * @param azureARM indicates if the client is an ARM client
  * @returns the complete call to runtime.NewPager(...)
  */
 function emitPagerDefinition(
@@ -705,6 +760,7 @@ function emitPagerDefinition(
   options: go.Options,
   imports: ImportManager,
   indent: helpers.Indentation,
+  azureARM: boolean,
 ): string {
   imports.add("context");
   let text = `runtime.NewPager(runtime.PagingHandler[${method.returns.name}]{\n`;
@@ -806,6 +862,11 @@ function emitPagerDefinition(
       }
       case "nextLink": {
         const nextLinkPath = helpers.buildNextLinkPath(method.strategy);
+        // a custom next page operation builds the request itself, so the next
+        // link must be passed through to it unmodified.
+        const endpointExpr = method.strategy.method
+          ? undefined
+          : getClientEndpointExpr(method.receiver.type, azureARM);
         let nextLinkVar: string;
         if (method.kind === "pageableMethod") {
           text += `${indent.get()}nextLink := ""\n`;
@@ -813,8 +874,14 @@ function emitPagerDefinition(
           text += `${indent.get()}if page != nil {\n`;
           text += `${indent.push().get()}nextLink = *page.${nextLinkPath}\n`;
           text += `${indent.pop().get()}}\n`;
+        } else if (endpointExpr) {
+          text += `${indent.get()}nextLink := *page.${nextLinkPath}\n`;
+          nextLinkVar = "nextLink";
         } else {
           nextLinkVar = `*page.${nextLinkPath}`;
+        }
+        if (endpointExpr) {
+          text += emitRelativeNextLinkResolution(nextLinkVar, endpointExpr, imports, indent);
         }
         text += `${indent.get()}resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), ${nextLinkVar}, func(ctx context.Context) (*policy.Request, error) {\n`;
         text += `${indent.push().get()}return client.${method.naming.requestMethod}(${reqParams})\n`;
@@ -937,6 +1004,7 @@ function generateOperation(
   options: go.Options,
   imports: ImportManager,
   indent: helpers.Indentation,
+  azureARM: boolean,
 ): string {
   const params = getAPIParametersSig(method, imports);
   const returns = generateReturnsInfo(method, "op");
@@ -965,7 +1033,7 @@ function generateOperation(
   text += `func ${getClientReceiverDefinition(method.receiver)} ${methodName}(${params}) (${returns.join(", ")}) {\n`;
   if (method.kind === "pageableMethod") {
     text += `${indent.get()}return `;
-    text += emitPagerDefinition(method, options, imports, indent);
+    text += emitPagerDefinition(method, options, imports, indent, azureARM);
     text += "}\n\n";
     return text;
   }
@@ -2122,6 +2190,7 @@ function generateLROBeginMethod(
   options: go.Options,
   imports: ImportManager,
   indent: helpers.Indentation,
+  azureARM: boolean,
 ): string {
   const params = getAPIParametersSig(method, imports);
   const returns = generateReturnsInfo(method, "api");
@@ -2144,7 +2213,7 @@ function generateLROBeginMethod(
     pollerTypeParam = `[*runtime.Pager${pollerTypeParam}]`;
     pollerType = "&pager";
     text += `${indent.get()}pager := `;
-    text += emitPagerDefinition(method, options, imports, indent);
+    text += emitPagerDefinition(method, options, imports, indent, azureARM);
   }
 
   text += `${indent.get()}if options == nil || options.ResumeToken == "" {\n`;

--- a/packages/typespec-go/src/codegen/core/operations.ts
+++ b/packages/typespec-go/src/codegen/core/operations.ts
@@ -717,35 +717,6 @@ function getClientEndpointExpr(client: go.Client, azureARM: boolean): string | u
 }
 
 /**
- * emits code that resolves a relative next link against the client's service endpoint.
- * services are allowed to return a next link that's relative to the endpoint (e.g.
- * "/foo/page/2"), however runtime.FetcherForNextLink requires an absolute URL. absolute
- * next links are passed through unmodified.
- *
- * @param nextLinkVar the name of the local var containing the next link
- * @param endpointExpr the expression used to obtain the client's service endpoint
- * @param imports the import manager currently in scope
- * @param indent the indentation helper currently in scope
- * @returns the code to resolve a relative next link
- */
-function emitRelativeNextLinkResolution(
-  nextLinkVar: string,
-  endpointExpr: string,
-  imports: ImportManager,
-  indent: helpers.Indentation,
-): string {
-  imports.add("net/url");
-  let text = `${indent.get()}// the service can return a next link that's relative to the endpoint, however\n`;
-  text += `${indent.get()}// runtime.FetcherForNextLink requires an absolute URL, so resolve it here.\n`;
-  text += `${indent.get()}if ${nextLinkVar} != "" {\n`;
-  text += `${indent.push().get()}if u, err := url.Parse(${nextLinkVar}); err == nil && !u.IsAbs() {\n`;
-  text += `${indent.push().get()}${nextLinkVar} = runtime.JoinPaths(${endpointExpr}, ${nextLinkVar})\n`;
-  text += `${indent.pop().get()}}\n`;
-  text += `${indent.pop().get()}}\n`;
-  return text;
-}
-
-/**
  * emits code that calls runtime.NewPager
  *
  * @param method the pageable method
@@ -874,43 +845,44 @@ function emitPagerDefinition(
           text += `${indent.get()}if page != nil {\n`;
           text += `${indent.push().get()}nextLink = *page.${nextLinkPath}\n`;
           text += `${indent.pop().get()}}\n`;
-        } else if (endpointExpr) {
-          text += `${indent.get()}nextLink := *page.${nextLinkPath}\n`;
-          nextLinkVar = "nextLink";
         } else {
           nextLinkVar = `*page.${nextLinkPath}`;
-        }
-        if (endpointExpr) {
-          text += emitRelativeNextLinkResolution(nextLinkVar, endpointExpr, imports, indent);
         }
         text += `${indent.get()}resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), ${nextLinkVar}, func(ctx context.Context) (*policy.Request, error) {\n`;
         text += `${indent.push().get()}return client.${method.naming.requestMethod}(${reqParams})\n`;
         text += `${indent.pop().get()}}, `;
         // nextPageMethod might be absent in some cases, see https://github.com/Azure/autorest/issues/4393
-        if (method.strategy.method) {
-          const nextOpParams = helpers
-            .getCreateRequestParametersSig(method.strategy.method)
-            .split(",");
-          // keep the parameter names from the name/type tuples and find nextLink param
-          for (let i = 0; i < nextOpParams.length; ++i) {
-            const paramName = nextOpParams[i].trim().split(" ")[0];
-            const paramType = nextOpParams[i].trim().split(" ")[1];
-            if (paramName.startsWith("next") && paramType === "string") {
-              nextOpParams[i] = "encodedNextLink";
-            } else {
-              nextOpParams[i] = paramName;
-            }
-          }
-          // add a definition for the nextReq func that uses the nextLinkOperation
+        const nextReq = method.strategy.method;
+        const httpVerb =
+          !nextReq && method.nextLinkVerb !== "get"
+            ? `http.Method${naming.capitalize(method.nextLinkVerb)}`
+            : undefined;
+        if (nextReq || httpVerb || endpointExpr) {
+          text += `&runtime.FetcherForNextLinkOptions{\n`;
           indent.push();
-          text += `&runtime.FetcherForNextLinkOptions{\n`;
-          text += `${indent.get()}NextReq: func(ctx context.Context, encodedNextLink string) (*policy.Request, error) {\n`;
-          text += `${indent.push().get()}return client.${method.strategy.method.name}(${nextOpParams.join(", ")})\n`;
-          text += `${indent.pop().get()}},\n`;
-          text += `${indent.pop().get()}})\n`;
-        } else if (method.nextLinkVerb !== "get") {
-          text += `&runtime.FetcherForNextLinkOptions{\n`;
-          text += `${indent.push().get()}HTTPVerb: http.Method${naming.capitalize(method.nextLinkVerb)},\n`;
+          if (nextReq) {
+            const nextOpParams = helpers.getCreateRequestParametersSig(nextReq).split(",");
+            // keep the parameter names from the name/type tuples and find nextLink param
+            for (let i = 0; i < nextOpParams.length; ++i) {
+              const paramName = nextOpParams[i].trim().split(" ")[0];
+              const paramType = nextOpParams[i].trim().split(" ")[1];
+              if (paramName.startsWith("next") && paramType === "string") {
+                nextOpParams[i] = "encodedNextLink";
+              } else {
+                nextOpParams[i] = paramName;
+              }
+            }
+            // add a definition for the nextReq func that uses the nextLinkOperation
+            text += `${indent.get()}NextReq: func(ctx context.Context, encodedNextLink string) (*policy.Request, error) {\n`;
+            text += `${indent.push().get()}return client.${nextReq.name}(${nextOpParams.join(", ")})\n`;
+            text += `${indent.pop().get()}},\n`;
+          }
+          if (httpVerb) {
+            text += `${indent.get()}HTTPVerb: ${httpVerb},\n`;
+          }
+          if (endpointExpr) {
+            text += `${indent.get()}Endpoint: ${endpointExpr},\n`;
+          }
           text += `${indent.pop().get()}})\n`;
         } else {
           text += "nil)\n";

--- a/packages/typespec-go/test/azure-http-specs/azure/core/azurepagegroup/custom_client_test.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/core/azurepagegroup/custom_client_test.go
@@ -110,8 +110,7 @@ func TestPageClient_NewListWithParametersPager(t *testing.T) {
 	require.EqualValues(t, 2, pages)
 }*/
 
-// TODO: runtime.FetcherForNextLink doesn't support relative next link URLs
-/*func TestPageClient_NewWithRelativeNextLinkPager(t *testing.T) {
+func TestPageClient_NewWithRelativeNextLinkPager(t *testing.T) {
 	client, err := azurepagegroup.NewPageClientWithNoCredential("http://localhost:3000", nil)
 	require.NoError(t, err)
 	pager := client.NewWithRelativeNextLinkPager(nil)
@@ -142,4 +141,4 @@ func TestPageClient_NewListWithParametersPager(t *testing.T) {
 		}
 	}
 	require.EqualValues(t, 2, pages)
-}*/
+}

--- a/packages/typespec-go/test/unittest/scenarios/pageable-lro.md
+++ b/packages/typespec-go/test/unittest/scenarios/pageable-lro.md
@@ -102,17 +102,11 @@ func (client *PageableLROsClient) BeginListPrivateEndPoints(ctx context.Context,
 			return page.NextLink != nil && len(*page.NextLink) > 0
 		},
 		Fetcher: func(ctx context.Context, page *PageableLROsClientListPrivateEndPointsResponse) (PageableLROsClientListPrivateEndPointsResponse, error) {
-			nextLink := *page.NextLink
-			// the service can return a next link that's relative to the endpoint, however
-			// runtime.FetcherForNextLink requires an absolute URL, so resolve it here.
-			if nextLink != "" {
-				if u, err := url.Parse(nextLink); err == nil && !u.IsAbs() {
-					nextLink = runtime.JoinPaths(client.internal.Endpoint(), nextLink)
-				}
-			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
+			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), *page.NextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listPrivateEndPointsCreateRequest(ctx, apiVersion, resourceGroupName, resourceName, options)
-			}, nil)
+			}, &runtime.FetcherForNextLinkOptions{
+				Endpoint: client.internal.Endpoint(),
+			})
 			if err != nil {
 				return PageableLROsClientListPrivateEndPointsResponse{}, err
 			}

--- a/packages/typespec-go/test/unittest/scenarios/pageable-lro.md
+++ b/packages/typespec-go/test/unittest/scenarios/pageable-lro.md
@@ -102,7 +102,15 @@ func (client *PageableLROsClient) BeginListPrivateEndPoints(ctx context.Context,
 			return page.NextLink != nil && len(*page.NextLink) > 0
 		},
 		Fetcher: func(ctx context.Context, page *PageableLROsClientListPrivateEndPointsResponse) (PageableLROsClientListPrivateEndPointsResponse, error) {
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), *page.NextLink, func(ctx context.Context) (*policy.Request, error) {
+			nextLink := *page.NextLink
+			// the service can return a next link that's relative to the endpoint, however
+			// runtime.FetcherForNextLink requires an absolute URL, so resolve it here.
+			if nextLink != "" {
+				if u, err := url.Parse(nextLink); err == nil && !u.IsAbs() {
+					nextLink = runtime.JoinPaths(client.internal.Endpoint(), nextLink)
+				}
+			}
+			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listPrivateEndPointsCreateRequest(ctx, apiVersion, resourceGroupName, resourceName, options)
 			}, nil)
 			if err != nil {

--- a/packages/typespec-go/test/unittest/scenarios/tenant-resource.md
+++ b/packages/typespec-go/test/unittest/scenarios/tenant-resource.md
@@ -287,16 +287,11 @@ func (client *TenantItemsClient) NewListPager(apiVersion string, options *Tenant
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			// the service can return a next link that's relative to the endpoint, however
-			// runtime.FetcherForNextLink requires an absolute URL, so resolve it here.
-			if nextLink != "" {
-				if u, err := url.Parse(nextLink); err == nil && !u.IsAbs() {
-					nextLink = runtime.JoinPaths(client.internal.Endpoint(), nextLink)
-				}
-			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, apiVersion, options)
-			}, nil)
+			}, &runtime.FetcherForNextLinkOptions{
+				Endpoint: client.internal.Endpoint(),
+			})
 			if err != nil {
 				return TenantItemsClientListResponse{}, err
 			}

--- a/packages/typespec-go/test/unittest/scenarios/tenant-resource.md
+++ b/packages/typespec-go/test/unittest/scenarios/tenant-resource.md
@@ -287,6 +287,13 @@ func (client *TenantItemsClient) NewListPager(apiVersion string, options *Tenant
 			if page != nil {
 				nextLink = *page.NextLink
 			}
+			// the service can return a next link that's relative to the endpoint, however
+			// runtime.FetcherForNextLink requires an absolute URL, so resolve it here.
+			if nextLink != "" {
+				if u, err := url.Parse(nextLink); err == nil && !u.IsAbs() {
+					nextLink = runtime.JoinPaths(client.internal.Endpoint(), nextLink)
+				}
+			}
 			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 				return client.listCreateRequest(ctx, apiVersion, options)
 			}, nil)


### PR DESCRIPTION
Fixes #4994

### Summary

Supports paging when the service returns a `nextLink` that's relative to the endpoint, e.g. `"/azure/core/page/with-relative-next-link/page/2"`. Today this fails with `no Host in request URL`.

Per review feedback, the resolution itself lives in azcore ([Azure/azure-sdk-for-go#27291](https://github.com/Azure/azure-sdk-for-go/pull/27291)). This PR only passes the client endpoint through the new `runtime.FetcherForNextLinkOptions.Endpoint` field:

```diff
 		resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
 			return client.listCreateRequest(ctx, apiVersion, options)
-		}, nil)
+		}, &runtime.FetcherForNextLinkOptions{
+			Endpoint: client.endpoint,
+		})
```

The endpoint expression is `client.internal.Endpoint()` for ARM and the client's single URI parameter otherwise. It's omitted for templated hosts (assembled per method) and when a custom next page operation builds the request itself.

Enables the previously disabled `Azure_Core_Page_withRelativeNextLink` Spector test.

### Dependency

Uses azcore main pseudo-version `v1.22.1-0.20260731225345-5811a2e9dc69`, which contains the merged [Azure/azure-sdk-for-go#27291](https://github.com/Azure/azure-sdk-for-go/pull/27291). It will be replaced with `v1.22.1` after that version is released.

### Validation

- 48/48 unit tests, oxlint and prettier clean
- all 105 generated Go modules build
- relative-nextLink Spector test passes against the azcore main pseudo-version