### PR TITLE
Sync typespec-java core: return response headers as a model (typespec#11420)

### DIFF
--- a/.chronus/changes/fix-typespec-java-response-headers-2026-07-29-11-48-00.md
+++ b/.chronus/changes/fix-typespec-java-response-headers-2026-07-29-11-48-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-java"
+---
+
+Sync core to microsoft/typespec commit `d320a53b`. Return response headers as a model from the convenience method when the operation has response headers (core [#11420](https://github.com/microsoft/typespec/pull/11420)).

--- a/packages/typespec-java/core-commit.json
+++ b/packages/typespec-java/core-commit.json
@@ -1,1 +1,1 @@
-{ "sha": "ec09e28b3d2990734d1b54ebad85411adb148d12" }
+{ "sha": "d320a53bb33cf1cbf7f5e2742b9da369944ae9be" }

--- a/packages/typespec-java/emitter-tests/src/test/java/tsptest/responseheaders/ResponseHeadersTests.java
+++ b/packages/typespec-java/emitter-tests/src/test/java/tsptest/responseheaders/ResponseHeadersTests.java
@@ -1,0 +1,52 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package tsptest.responseheaders;
+
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.HttpHeaders;
+import com.azure.core.test.http.MockHttpResponse;
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import tsptest.responseheaders.models.ResponseHeaderOpsGetResourceMetadataHeaders;
+
+public class ResponseHeadersTests {
+
+    private ResponseHeadersClient createClient(HttpHeaders responseHeaders) {
+        return new ResponseHeadersClientBuilder().endpoint("http://localhost:3000")
+            .httpClient(request -> Mono.just(new MockHttpResponse(request, 200, responseHeaders)))
+            .buildClient();
+    }
+
+    @Test
+    public void testResponseHeadersAsModel() {
+        HttpHeaders responseHeaders = new HttpHeaders().set(HttpHeaderName.ETAG, "\"0x8D9\"")
+            .set(HttpHeaderName.fromString("x-resource-count"), "42")
+            .set(HttpHeaderName.LAST_MODIFIED, "Mon, 26 Aug 2022 14:38:00 GMT");
+
+        ResponseHeaderOpsGetResourceMetadataHeaders headers = createClient(responseHeaders).getResourceMetadata();
+
+        // the convenience method returns a strongly-typed header model built from the response headers,
+        // instead of "void"; the model itself has no JSON/XML serialization.
+        Assertions.assertEquals("\"0x8D9\"", headers.getETag());
+        Assertions.assertEquals(42, headers.getResourceCount());
+        Assertions.assertEquals(OffsetDateTime.of(2022, 8, 26, 14, 38, 0, 0, ZoneOffset.UTC),
+            headers.getLastModified());
+    }
+
+    @Test
+    public void testOptionalHeaderAbsent() {
+        // "Last-Modified" is an optional header; when absent, the model property is null.
+        HttpHeaders responseHeaders = new HttpHeaders().set(HttpHeaderName.ETAG, "\"0x8D9\"")
+            .set(HttpHeaderName.fromString("x-resource-count"), "7");
+
+        ResponseHeaderOpsGetResourceMetadataHeaders headers = createClient(responseHeaders).getResourceMetadata();
+
+        Assertions.assertEquals("\"0x8D9\"", headers.getETag());
+        Assertions.assertEquals(7, headers.getResourceCount());
+        Assertions.assertNull(headers.getLastModified());
+    }
+}

--- a/packages/typespec-java/emitter-tests/tsp/response-headers.tsp
+++ b/packages/typespec-java/emitter-tests/tsp/response-headers.tsp
@@ -1,0 +1,31 @@
+import "@typespec/rest";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+
+@service(#{ title: "ResponseHeaders" })
+namespace TspTest.ResponseHeaders;
+
+@route("/response-headers")
+interface ResponseHeaderOp {
+  // HEAD operation with significant response headers but no response body.
+  // Opts in (via "responseHeadersAsModel" client option) to return the strongly-typed
+  // response-headers model from the convenience method, instead of "void".
+  @route("/resource-metadata")
+  @head
+  getResourceMetadata(): {
+    @statusCode statusCode: 200;
+
+    // required header, with mixed-case header name
+    @header("ETag") eTag: string;
+
+    // required header
+    @header("x-resource-count") resourceCount: int32;
+
+    // optional header, with mixed-case header name
+    @header("Last-Modified") lastModified?: utcDateTime;
+  };
+}
+
+@@clientOption(ResponseHeaderOp.getResourceMetadata, "responseHeadersAsModel", true, "java");


### PR DESCRIPTION
Sync `@azure-tools/typespec-java` core to microsoft/typespec `d320a53b` (HEAD of `main`).

## Changes
- Bump `core-commit.json` `ec09e28b` → `d320a53b`.
- Brings core [#11420](https://github.com/microsoft/typespec/pull/11420): **return response headers as a model from the convenience method**, plus its `response-headers` test (`ResponseHeadersTests.java` + `response-headers.tsp`) into the emitter-tests suite.

## Notes
- #11420 only touches emitter internals (`code-model-builder.ts`, `operation.ts`, `lib.ts`) — no emitter-option / `Copy-Sources.ps1` / `Generate.ps1` changes required.
- Changelog added as `fix` (patch).

Targets `release/july-2026` for a follow-up 0.45.11 hotfix.
