### PR TITLE
Bump version for hotfix: typespec-java@0.45.11

### DIFF
--- a/.chronus/changes/fix-release-july-2026-formatting-2026-6-28-20-28-45.md
+++ b/.chronus/changes/fix-release-july-2026-formatting-2026-6-28-20-28-45.md
@@ -1,9 +1,7 @@
 ---
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
 changeKind: internal
 packages:
   - "@azure-tools/typespec-autorest"
-  - "@azure-tools/typespec-java"
 ---
 
 fix(ci): cherry-pick CI fixes for release branch formatting and build checks

--- a/.chronus/changes/fix-typespec-java-response-headers-2026-07-29-11-48-00.md
+++ b/.chronus/changes/fix-typespec-java-response-headers-2026-07-29-11-48-00.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Sync core to microsoft/typespec commit `d320a53b`. Return response headers as a model from the convenience method when the operation has response headers (core [#11420](https://github.com/microsoft/typespec/pull/11420)).

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-java
 
+## 0.45.11
+
+### Bug Fixes
+
+- [#5090](https://github.com/Azure/typespec-azure/pull/5090) Sync core to microsoft/typespec commit `d320a53b`. Return response headers as a model from the convenience method when the operation has response headers (core [#11420](https://github.com/microsoft/typespec/pull/11420)).
+
+
 ## 0.45.10
 
 ### Features

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.45.11
 
-### Bug Fixes
+### Features
 
 - [#5090](https://github.com/Azure/typespec-azure/pull/5090) Sync core to microsoft/typespec commit `d320a53b`. Return response headers as a model from the convenience method when the operation has response headers (core [#11420](https://github.com/microsoft/typespec/pull/11420)).
 

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- [#5090](https://github.com/Azure/typespec-azure/pull/5090) Sync core to microsoft/typespec commit `d320a53b`. Return response headers as a model from the convenience method when the operation has response headers (core [#11420](https://github.com/microsoft/typespec/pull/11420)).
+- Return response headers as a model from the convenience method when the operation has response headers (core [#11420](https://github.com/microsoft/typespec/pull/11420)).
 
 
 ## 0.45.10

--- a/packages/typespec-java/emitter-tests/package.json
+++ b/packages/typespec-java/emitter-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java-tests",
-  "version": "0.45.10",
+  "version": "0.45.11",
   "type": "module",
   "scripts": {
     "format": "npm run -s prettier -- --write",
@@ -17,7 +17,7 @@
     "@typespec/spector": "0.1.0-alpha.26",
     "@typespec/http-specs": "0.1.0-alpha.39",
     "@azure-tools/azure-http-specs": "0.1.0-alpha.43",
-    "@azure-tools/typespec-java": "file:../azure-tools-typespec-java-0.45.10.tgz"
+    "@azure-tools/typespec-java": "file:../azure-tools-typespec-java-0.45.11.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": "^1.13.0",

--- a/packages/typespec-java/package.json
+++ b/packages/typespec-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.45.10",
+  "version": "0.45.11",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
Version bump for the typespec-java hotfix following the core sync in #5090.

## Changes
- `@azure-tools/typespec-java`: **0.45.10 → 0.45.11** (patch).
- Consumes the `fix` change from #5090 (response headers as a model, core #11420) into `CHANGELOG.md`.
- Bumps the `emitter-tests` project version + `.tgz` dependency to `0.45.11`.
- Trims the shared `fix-release-july-2026-formatting` change file to `@azure-tools/typespec-autorest` only (its typespec-java portion is now released).

Targets `release/july-2026`. The publish pipeline will release `0.45.11` to npm on merge.
