### PR TITLE
Add missing Spector tests for ARM resource IDs

### DIFF
--- a/.chronus/changes/go-commonpropsgroup-coverage-2026-6-29-8-1-52.md
+++ b/.chronus/changes/go-commonpropsgroup-coverage-2026-6-29-8-1-52.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-go"
+---
+
+Add missing coverage for ARM resource IDs.  Skip test for user-defined errors as we don't yet support this and the test as it currently is validates the wrong thing.

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/commonpropsgroup/armresourceidentifiers_client_test.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/commonpropsgroup/armresourceidentifiers_client_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package commonpropsgroup_test
+
+import (
+	"commonpropsgroup"
+	"fmt"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm"
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	simpleArmIDExpected           = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/myVnet", subscriptionIdExpected, resourceGroupExpected)
+	armIDWithTypeExpected         = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/myVnet", subscriptionIdExpected, resourceGroupExpected)
+	armIDWithTypeAndScopeExpected = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Network/virtualNetworks/myVnet", subscriptionIdExpected, resourceGroupExpected)
+	armIDWithAllScopesExpected    = fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Microsoft.Compute/virtualMachines/myVm", subscriptionIdExpected, resourceGroupExpected)
+	armIDWithGroupScopeExpected   = fmt.Sprintf("/providers/Microsoft.Management/serviceGroups/test-sg/providers/Microsoft.Authorization/roleDefinitions/%s", subscriptionIdExpected)
+
+	validArmResourceIdentifierResource = commonpropsgroup.ArmResourceIdentifierResource{
+		ID:       to.Ptr(fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/Azure.ResourceManager.CommonProperties/armResourceIdentifierResources/armId", subscriptionIdExpected, resourceGroupExpected)),
+		Location: to.Ptr(locationExpected),
+		Name:     to.Ptr("armId"),
+		Type:     to.Ptr("Azure.ResourceManager.CommonProperties/armResourceIdentifierResources"),
+		Properties: &commonpropsgroup.ArmResourceIdentifierResourceProperties{
+			ProvisioningState:     to.Ptr(commonpropsgroup.ResourceProvisioningStateSucceeded),
+			SimpleArmID:           to.Ptr(simpleArmIDExpected),
+			ArmIDWithType:         to.Ptr(armIDWithTypeExpected),
+			ArmIDWithTypeAndScope: to.Ptr(armIDWithTypeAndScopeExpected),
+			ArmIDWithAllScopes:    to.Ptr(armIDWithAllScopesExpected),
+			ArmIDWithGroupScope:   to.Ptr(armIDWithGroupScopeExpected),
+		},
+	}
+)
+
+func TestArmResourceIdentifiersClient_Get(t *testing.T) {
+	resp, err := clientFactory.NewArmResourceIdentifiersClient().Get(ctx, resourceGroupExpected, "armId", nil)
+	require.NoError(t, err)
+	require.Equal(t, *validArmResourceIdentifierResource.ID, *resp.ID)
+	require.Equal(t, *validArmResourceIdentifierResource.Location, *resp.Location)
+	require.Equal(t, *validArmResourceIdentifierResource.Name, *resp.Name)
+	require.Equal(t, *validArmResourceIdentifierResource.Type, *resp.Type)
+	require.Equal(t, *validArmResourceIdentifierResource.Properties, *resp.Properties)
+}
+
+// TestArmResourceIdentifiersClient_ParseResourceID demonstrates the customer pattern of
+// parsing the returned ARM resource identifiers with arm.ParseResourceID.
+func TestArmResourceIdentifiersClient_ParseResourceID(t *testing.T) {
+	resp, err := clientFactory.NewArmResourceIdentifiersClient().Get(ctx, resourceGroupExpected, "armId", nil)
+	require.NoError(t, err)
+
+	armID, err := arm.ParseResourceID(*resp.Properties.ArmIDWithAllScopes)
+	require.NoError(t, err)
+	require.Equal(t, subscriptionIdExpected, armID.SubscriptionID)
+	require.Equal(t, resourceGroupExpected, armID.ResourceGroupName)
+	require.Equal(t, "Microsoft.Compute", armID.ResourceType.Namespace)
+	require.Equal(t, "virtualMachines", armID.ResourceType.Type)
+	require.Equal(t, "myVm", armID.Name)
+
+	simpleArmID, err := arm.ParseResourceID(*resp.Properties.SimpleArmID)
+	require.NoError(t, err)
+	require.Equal(t, subscriptionIdExpected, simpleArmID.SubscriptionID)
+	require.Equal(t, resourceGroupExpected, simpleArmID.ResourceGroupName)
+	require.Equal(t, "Microsoft.Network", simpleArmID.ResourceType.Namespace)
+	require.Equal(t, "virtualNetworks", simpleArmID.ResourceType.Type)
+	require.Equal(t, "myVnet", simpleArmID.Name)
+
+	// A group-scoped ID has no subscription or resource group; the service group
+	// scope is surfaced through the parent chain rather than a dedicated field.
+	groupArmID, err := arm.ParseResourceID(*resp.Properties.ArmIDWithGroupScope)
+	require.NoError(t, err)
+	require.Empty(t, groupArmID.SubscriptionID)
+	require.Empty(t, groupArmID.ResourceGroupName)
+	require.Equal(t, "Microsoft.Authorization", groupArmID.ResourceType.Namespace)
+	require.Equal(t, "roleDefinitions", groupArmID.ResourceType.Type)
+	require.Equal(t, subscriptionIdExpected, groupArmID.Name)
+	require.NotNil(t, groupArmID.Parent)
+	require.Equal(t, "Microsoft.Management", groupArmID.Parent.ResourceType.Namespace)
+	require.Equal(t, "serviceGroups", groupArmID.Parent.ResourceType.Type)
+	require.Equal(t, "test-sg", groupArmID.Parent.Name)
+}
+
+func TestArmResourceIdentifiersClient_CreateOrReplace(t *testing.T) {
+	resp, err := clientFactory.NewArmResourceIdentifiersClient().CreateOrReplace(
+		ctx,
+		resourceGroupExpected,
+		"armId",
+		commonpropsgroup.ArmResourceIdentifierResource{
+			Location: to.Ptr(locationExpected),
+			Properties: &commonpropsgroup.ArmResourceIdentifierResourceProperties{
+				SimpleArmID:           to.Ptr(simpleArmIDExpected),
+				ArmIDWithType:         to.Ptr(armIDWithTypeExpected),
+				ArmIDWithTypeAndScope: to.Ptr(armIDWithTypeAndScopeExpected),
+				ArmIDWithAllScopes:    to.Ptr(armIDWithAllScopesExpected),
+				ArmIDWithGroupScope:   to.Ptr(armIDWithGroupScopeExpected),
+			},
+		},
+		nil,
+	)
+	require.NoError(t, err)
+	require.Equal(t, *validArmResourceIdentifierResource.ID, *resp.ID)
+	require.Equal(t, *validArmResourceIdentifierResource.Location, *resp.Location)
+	require.Equal(t, *validArmResourceIdentifierResource.Name, *resp.Name)
+	require.Equal(t, *validArmResourceIdentifierResource.Type, *resp.Type)
+	require.Equal(t, *validArmResourceIdentifierResource.Properties, *resp.Properties)
+}

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/commonpropsgroup/error_client_test.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/commonpropsgroup/error_client_test.go
@@ -14,6 +14,7 @@ import (
 )
 
 func TestErrorClient_CreateForUserDefinedError(t *testing.T) {
+	t.Skip("https://github.com/Azure/typespec-azure/issues/4946")
 	resp, err := clientFactory.NewErrorClient().CreateForUserDefinedError(ctx, resourceGroupExpected, "confidential", commonpropsgroup.ConfidentialResource{
 		Location: to.Ptr("eastus"),
 		Properties: &commonpropsgroup.ConfidentialResourceProperties{
@@ -40,6 +41,7 @@ func TestErrorClient_GetForPredefinedError(t *testing.T) {
 	var respErr *azcore.ResponseError
 	require.ErrorAs(t, err, &respErr)
 	require.EqualValues(t, http.StatusNotFound, respErr.StatusCode)
+	require.EqualValues(t, "ResourceNotFound", respErr.ErrorCode)
 	require.Zero(t, resp)
 	bodyBytes := make([]byte, respErr.RawResponse.ContentLength)
 	_, readErr := respErr.RawResponse.Body.Read(bodyBytes)


### PR DESCRIPTION
Skip the test for user-defined errors as this isn't yet supported in the emitter and the test is validating the wrong thing.