### PR TITLE
Fix handling of @responseAsBool decorator

### DIFF
--- a/.chronus/changes/go-headasboolgroup-2026-6-29-15-17-23.md
+++ b/.chronus/changes/go-headasboolgroup-2026-6-29-15-17-23.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-go"
+---
+
+Fixed handling of @responseAsBool decorator.

--- a/packages/typespec-go/.scripts/tspcompile.js
+++ b/packages/typespec-go/.scripts/tspcompile.js
@@ -6,9 +6,6 @@ import { existsSync, opendirSync, readFileSync, unlinkSync, writeFileSync } from
 import { semaphore } from "./semaphore.js";
 import { syncAzureRestApiSpecs } from "./sync-azure-rest-api-specs.js";
 
-// limit to 8 concurrent builds
-const sem = semaphore(8);
-
 const pkgRoot =
   execSync("git rev-parse --show-toplevel").toString().trim() + "/packages/typespec-go/";
 
@@ -74,6 +71,9 @@ for (var i = 0; i < args.length; i += 1) {
       // the emitter has been installed so use that one instead
       emitter = "@azure-tools/typespec-go";
       break;
+    case "--debugger":
+      switches.push("--debugger");
+      break;
     default:
       break;
   }
@@ -82,6 +82,20 @@ for (var i = 0; i < args.length; i += 1) {
 if (filter !== undefined) {
   console.log("Using filter: " + filter);
 }
+
+// the emitter runs in a child process, so a debugger attached to this script won't stop
+// in it. with --debugger we launch each child with --inspect-brk (see below) so the
+// debugger reliably attaches and binds breakpoints before the short-lived emitter runs.
+// run serially so only one child waits for the debugger at a time.
+const debug = switches.includes("--debugger");
+if (debug && filter === undefined) {
+  console.warn(
+    "warning: --debugger without --filter pauses on every spec; pass --filter to debug a single test",
+  );
+}
+
+// limit concurrent builds; serialize when debugging
+const sem = semaphore(debug ? 1 : 8);
 
 function should_generate(name) {
   if (filter !== undefined) {
@@ -204,10 +218,11 @@ function generate(moduleName, input, outputDir, perTestOptions) {
     for (const option of allOptions) {
       options.push(`--option="@azure-tools/typespec-go.${option}"`);
     }
-    if (switches.includes("--debugger")) {
-      options.push(`--option="@azure-tools/typespec-go.debugger=true"`);
-    }
-    const command = `node ${compiler} compile ${input} --emit=${emitter} --config=${stubConfig} ${options.join(" ")}`;
+    // --inspect-brk makes the compiler child wait for the debugger on a fixed port so
+    // VS Code can attach (via the "Attach to Default Port" launch config) and bind
+    // breakpoints before the short-lived emitter runs.
+    const nodeArgs = debug ? "--inspect-brk=9229 " : "";
+    const command = `node ${nodeArgs}${compiler} compile ${input} --emit=${emitter} --config=${stubConfig} ${options.join(" ")}`;
     if (switches.includes("--verbose")) {
       console.log(command);
     }

--- a/packages/typespec-go/docs/development.md
+++ b/packages/typespec-go/docs/development.md
@@ -187,10 +187,18 @@ Make sure `$(go env GOPATH)/bin` is on your `PATH` so both tools are discoverabl
 
 ### Debug
 
-To debug the emitter:
+This repo manages Node with [mise](https://mise.jdx.dev/), so `node` resolves to a mise shim (`…/mise/shims/node.exe`). VS Code's JavaScript Debug Terminal implements auto-attach by wrapping the `node` it launches, and the mise shim bypasses that wrapper — so breakpoints set in the emitter never bind (you'll notice the terminal never prints "Debugger attached."). Pass `--debugger` to sidestep this: it launches the compiler child with `--inspect-brk=9229`, so the child opens its own inspector on a fixed port and waits for you to attach explicitly, independent of the mise shim.
 
-1. Set a breakpoint in the TypeScript source.
-2. In the VS Code JavaScript Debug Terminal, run `pnpm tspcompile` (optionally with `--filter`) from the [Regenerate the Go fixtures](#regenerate-the-go-fixtures) section.
+1. Build the emitter (`pnpm build:deps`) so the compiled `dist/` matches your source — breakpoints bind through source maps against `dist/`, so a stale build makes them drift.
+2. Set a breakpoint in the TypeScript source.
+3. In a terminal, run `pnpm tspcompile` with `--debugger` and a `--filter` for the test you're debugging:
+
+   ```terminal
+   pnpm tspcompile --filter=TestName --debugger
+   ```
+
+   The command hangs while the compiler child waits for a debugger. (The "Debugger listening…" banner is buffered by `exec` and won't print until the child exits — this is expected.)
+4. In VS Code, press F5 and select the **Attach to Default Port** launch configuration. Execution stops at the compiler's entry point; press Continue (F5) once and it runs to your breakpoint after the emitter loads. With `--debugger` the specs run one at a time, so omit `--filter` only if you intend to step through every spec in turn.
 
 ## Step 4: Update emitter documentation
 

--- a/packages/typespec-go/docs/development.md
+++ b/packages/typespec-go/docs/development.md
@@ -198,6 +198,7 @@ This repo manages Node with [mise](https://mise.jdx.dev/), so `node` resolves to
    ```
 
    The command hangs while the compiler child waits for a debugger. (The "Debugger listening…" banner is buffered by `exec` and won't print until the child exits — this is expected.)
+
 4. In VS Code, press F5 and select the **Attach to Default Port** launch configuration. Execution stops at the compiler's entry point; press Continue (F5) once and it runs to your breakpoint after the emitter loads. With `--debugger` the specs run one at a time, so omit `--filter` only if you intend to step through every spec in turn.
 
 ## Step 4: Update emitter documentation

--- a/packages/typespec-go/spector.config.azure.yaml
+++ b/packages/typespec-go/spector.config.azure.yaml
@@ -43,6 +43,7 @@ specs:
   "azure/client-generator-core/next-link-verb":
     { options: { module: nextlinkverbgroup, slice-elements-byval: true } }
   "azure/client-generator-core/override/client.tsp": { options: { module: overridegroup } }
+  "azure/client-generator-core/response-as-bool": { options: { module: headasboolgroup } }
   "azure/client-generator-core/usage": { options: { module: coreusagegroup } }
   "azure/core/basic": { options: { module: basicgroup } }
   "azure/core/lro/rpc": { options: { module: lrorpcgroup } }
@@ -84,5 +85,3 @@ specs:
   "azure/client-generator-core/alternate-type": false
   # emitter bug: generated fakes reference an unexported model (my_model)
   "azure/client-generator-core/exact-name": false
-  # emitter error: didn't find HTTP response for kind boolean (@responseAsBool on HEAD)
-  "azure/client-generator-core/response-as-bool": false

--- a/packages/typespec-go/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-go/src/tcgcadapter/adapter.ts
@@ -35,7 +35,11 @@ export class Adapter {
     // however, it's filtered out by default so we need
     // to add it to the allow list of decorators
     const ctx = await tcgc.createSdkContext(context, "@azure-tools/typespec-go", {
-      additionalDecorators: ["TypeSpec\\.@encodedName", "@deserializeEmptyStringAsNull"],
+      additionalDecorators: [
+        "TypeSpec\\.@encodedName",
+        "@deserializeEmptyStringAsNull",
+        "@responseAsBool",
+      ],
       disableUsageAccessPropagationToBase: true,
     });
 

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -1779,10 +1779,15 @@ export class ClientAdapter {
     // since HEAD requests don't return a type, we must check this before checking sdkResponseType
     if (
       method.httpMethod === "head" &&
-      this.ta.ctx.emitContext.options["head-as-boolean"] === true
+      (helpers.hasDecorator("@responseAsBool", sdkMethod.decorators) ||
+        this.ta.ctx.emitContext.options["head-as-boolean"] === true)
     ) {
       respEnv.result = new go.HeadAsBooleanResult("Success");
       respEnv.result.docs.summary = "Success indicates if the operation succeeded or failed.";
+      // NOTE: tcgc models a boolean response type for us. however, we use the presence of
+      // a response type as a predicate to mean "this operation returns a modeled response"
+      // which would send us down an incorrect code path. so we clear it here instead.
+      sdkResponseType = undefined;
     }
 
     if (!sdkResponseType) {

--- a/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/headasboolgroup/responseasboolheadasboolean_client_test.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/headasboolgroup/responseasboolheadasboolean_client_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package headasboolgroup_test
+
+import (
+	"context"
+	"headasboolgroup"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResponseAsBoolHeadAsBooleanClient_Exists(t *testing.T) {
+	client, err := headasboolgroup.NewResponseAsBoolClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	resp, err := client.NewResponseAsBoolHeadAsBooleanClient().Exists(context.Background(), nil)
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+}
+
+func TestResponseAsBoolHeadAsBooleanClient_NotExists(t *testing.T) {
+	client, err := headasboolgroup.NewResponseAsBoolClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	resp, err := client.NewResponseAsBoolHeadAsBooleanClient().NotExists(context.Background(), nil)
+	require.NoError(t, err)
+	require.False(t, resp.Success)
+}


### PR DESCRIPTION
Add decorator to the allow-list so we can check for it. Clear sdkResponseType so we don't attempt to model the response.