### PR TITLE
Sync typespec-java core to 38de4f58 (3 fixes)

### DIFF
--- a/.chronus/changes/fix-typespec-java-core-sync-2026-07-30-08-47-00.md
+++ b/.chronus/changes/fix-typespec-java-core-sync-2026-07-30-08-47-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-java"
+---
+
+Sync core to microsoft/typespec commit `38de4f58`. Includes fixes: exclude hidden maxpagesize param from generated sample (core [#11436](https://github.com/microsoft/typespec/pull/11436)), avoid credential phrase in random mock map key (core [#11435](https://github.com/microsoft/typespec/pull/11435)), and remove legacy AutorestSettings plus write Package api-version to CHANGELOG.md for Fluent Premium (core [#11433](https://github.com/microsoft/typespec/pull/11433)).

--- a/packages/typespec-java/core-commit.json
+++ b/packages/typespec-java/core-commit.json
@@ -1,1 +1,1 @@
-{ "sha": "d320a53bb33cf1cbf7f5e2742b9da369944ae9be" }
+{ "sha": "38de4f58cffc6429f8ae0234441cbc3b6b429777" }


### PR DESCRIPTION
Bump core-commit.json d320a53b -> 38de4f58. Brings core fixes #11436 (exclude hidden maxpagesize from sample), #11435 (avoid credential phrase in mock key), #11433 (remove legacy AutorestSettings + Fluent Premium api-version in CHANGELOG). All Java-generator-only; no emitter option/script changes. Targets release/july-2026 for a follow-up hotfix.