### PR TITLE
Bump version for hotfix: typespec-ts@0.55.2

### DIFF
--- a/.chronus/changes/fix-multi-client-tsconfig-src-include-2026-7-13-6-30-0.md
+++ b/.chronus/changes/fix-multi-client-tsconfig-src-include-2026-7-13-6-30-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-ts"
----
-
-Fix multi-client package build failures by syncing the generated `config/tsconfig.src.*.json` `include` lists with the `warp.config.yml` exports, so every client entry point is compiled and emitted to `dist` (previously warp failed with `DIST_MISSING`).

--- a/packages/typespec-ts/CHANGELOG.md
+++ b/packages/typespec-ts/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-ts
 
+## 0.55.2
+
+### Bug Fixes
+
+- [#5096](https://github.com/Azure/typespec-azure/pull/5096) Fix multi-client package build failures by syncing the generated `config/tsconfig.src.*.json` `include` lists with the `warp.config.yml` exports, so every client entry point is compiled and emitted to `dist` (previously warp failed with `DIST_MISSING`).
+
+
 ## 0.55.1
 
 ### Bug Fixes

--- a/packages/typespec-ts/package.json
+++ b/packages/typespec-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-ts",
-  "version": "0.55.1",
+  "version": "0.55.2",
   "description": "A TypeSpec emitter for TypeScript",
   "main": "dist/src/index.js",
   "type": "module",


### PR DESCRIPTION
This PR bumps `@azure-tools/typespec-ts` to **0.55.2** as a hotfix on the `release/july-2026` branch.

### Bug Fixes included
- [#5096](https://github.com/Azure/typespec-azure/pull/5096) Fix multi-client package build failures by syncing the generated `config/tsconfig.src.*.json` `include` lists with the `warp.config.yml` exports, so every client entry point is compiled and emitted to `dist` (previously warp failed with `DIST_MISSING`).

> Targets `release/july-2026` (not `main`). Squash-merge to trigger the npm publish pipeline. Backmerge to `main` to follow after publish.