### PR TITLE
Bump version for hotfix: typespec-java@0.45.12

### DIFF
--- a/.chronus/changes/fix-typespec-java-core-sync-2026-07-30-08-47-00.md
+++ b/.chronus/changes/fix-typespec-java-core-sync-2026-07-30-08-47-00.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Sync core to microsoft/typespec commit `38de4f58`. Includes fixes: exclude hidden maxpagesize param from generated sample (core [#11436](https://github.com/microsoft/typespec/pull/11436)), avoid credential phrase in random mock map key (core [#11435](https://github.com/microsoft/typespec/pull/11435)), and remove legacy AutorestSettings plus write Package api-version to CHANGELOG.md for Fluent Premium (core [#11433](https://github.com/microsoft/typespec/pull/11433)).

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -31,14 +31,14 @@
 
 ### Bug Fixes
 
-- [#5012](https://github.com/Azure/typespec-azure/pull/5012) Fix XML serialization to only apply for `azure-v1` data-plane clients, and to skip the XML `ObjectSerializer` for raw `byte[]`/`BinaryData` payloads that are not structured XML models. This avoids emitting a reference to a non-generated `XmlSerializerProviders` helper (which caused a build break) for operations that return raw XML bytes.
+- Fix XML serialization to only apply for `azure-v1` data-plane clients, and to skip the XML `ObjectSerializer` for raw `byte[]`/`BinaryData` payloads that are not structured XML models. This avoids emitting a reference to a non-generated `XmlSerializerProviders` helper (which caused a build break) for operations that return raw XML bytes.
 
 
 ## 0.45.8
 
 ### Features
 
-- [#4987](https://github.com/Azure/typespec-azure/pull/4987) Support XML serialization for models: generate XmlSerializer helper classes and use the XML ObjectSerializer overload of toObject/fromObject in convenience methods for XML request/response bodies.
+- Support XML serialization for models: generate XmlSerializer helper classes and use the XML ObjectSerializer overload of toObject/fromObject in convenience methods for XML request/response bodies.
 
 
 ## 0.45.7
@@ -47,11 +47,11 @@ Compatible with compiler 1.14.0.
 
 ### Features
 
-- [#4916](https://github.com/Azure/typespec-azure/pull/4916) Support `clientApiVersions`.
+- Support `clientApiVersions`.
 
 ### Bug Fixes
 
-- [#4916](https://github.com/Azure/typespec-azure/pull/4916) Fix per-client `ServiceVersion` regression after migrating from js-yaml and lodash.
+- Fix per-client `ServiceVersion` regression after migrating from js-yaml and lodash.
 
 
 ## 0.45.6 (2026-07-15)

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-java
 
+## 0.45.12
+
+### Bug Fixes
+
+- [#5106](https://github.com/Azure/typespec-azure/pull/5106) Sync core to microsoft/typespec commit `38de4f58`. Includes fixes: exclude hidden maxpagesize param from generated sample (core [#11436](https://github.com/microsoft/typespec/pull/11436)), avoid credential phrase in random mock map key (core [#11435](https://github.com/microsoft/typespec/pull/11435)), and remove legacy AutorestSettings plus write Package api-version to CHANGELOG.md for Fluent Premium (core [#11433](https://github.com/microsoft/typespec/pull/11433)).
+
+
 ## 0.45.11
 
 ### Features

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- [#5106](https://github.com/Azure/typespec-azure/pull/5106) Sync core to microsoft/typespec commit `38de4f58`. Includes fixes: exclude hidden maxpagesize param from generated sample (core [#11436](https://github.com/microsoft/typespec/pull/11436)), avoid credential phrase in random mock map key (core [#11435](https://github.com/microsoft/typespec/pull/11435)), and remove legacy AutorestSettings plus write Package api-version to CHANGELOG.md for Fluent Premium (core [#11433](https://github.com/microsoft/typespec/pull/11433)).
+- Sync core to microsoft/typespec commit `38de4f58`. Includes fixes: exclude hidden maxpagesize param from generated sample (core [#11436](https://github.com/microsoft/typespec/pull/11436)), avoid credential phrase in random mock map key (core [#11435](https://github.com/microsoft/typespec/pull/11435)), and remove legacy AutorestSettings plus write Package api-version to CHANGELOG.md for Fluent Premium (core [#11433](https://github.com/microsoft/typespec/pull/11433)).
 
 
 ## 0.45.11

--- a/packages/typespec-java/emitter-tests/package.json
+++ b/packages/typespec-java/emitter-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java-tests",
-  "version": "0.45.11",
+  "version": "0.45.12",
   "type": "module",
   "scripts": {
     "format": "npm run -s prettier -- --write",
@@ -17,7 +17,7 @@
     "@typespec/spector": "0.1.0-alpha.26",
     "@typespec/http-specs": "0.1.0-alpha.39",
     "@azure-tools/azure-http-specs": "0.1.0-alpha.43",
-    "@azure-tools/typespec-java": "file:../azure-tools-typespec-java-0.45.11.tgz"
+    "@azure-tools/typespec-java": "file:../azure-tools-typespec-java-0.45.12.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": "^1.13.0",

--- a/packages/typespec-java/package.json
+++ b/packages/typespec-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.45.11",
+  "version": "0.45.12",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
Version bump following the core sync in #5106.

- \@azure-tools/typespec-java\: **0.45.11 -> 0.45.12** (patch).
- Consumes the \ix\ change from #5106 (core 38de4f58: #11436, #11435, #11433) into CHANGELOG.md.
- Bumps emitter-tests project version + .tgz dependency to 0.45.12.

Targets release/july-2026. Publish pipeline releases 0.45.12 to npm on merge.