### PR TITLE
Fix suppression docs and require Impact/Suppression/LintDiff sections for linter rules

### DIFF
--- a/.github/skills/create-linter-rule/SKILL.md
+++ b/.github/skills/create-linter-rule/SKILL.md
@@ -148,6 +148,9 @@ Edit `packages/<pkg>/src/rules/<rule-name>.md`:
 - Replace all placeholder text
 - Write a clear description of what the rule checks and why
 - Provide realistic ❌ Incorrect and ✅ Correct examples using actual TypeSpec patterns
+- Add a required **`## Impact`** section: a bulleted `**Area:**` line (e.g. `API`, `SDK`, `Emitters`) followed by a short paragraph describing what breaks or degrades when the rule is violated
+- Add a required **`## Suppression`** section: state whether suppression is acceptable and why, and point to the correct fix. Suppressions use the `#suppress "<rule-id>" "<justification-string>"` **directive** placed on the line above the target — NOT a `// suppress` comment
+- Add a **`## LintDiff Equivalent`** section when an equivalent LintDiff (azure-openapi-validator) rule exists, deep-linking to the specific rule id in the [OpenAPI authoring automated guidelines](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md). Omit only when no equivalent exists
 - This file holds only the extended documentation body — the page title, rule id, and
   short description are generated from the rule definition. `tspd` renders the page at
   `website/src/content/docs/docs/libraries/<pkg>/rules/<rule-name>.md`
@@ -196,7 +199,7 @@ New linter rules MUST NOT break existing Azure service specs. After pushing your
 If the check fails, your rule produces diagnostics on existing specs. To resolve:
 
 1. **Apply an API-neutral fix to the spec** (preferred): If the fix doesn't change API behavior, submit a PR to `Azure/azure-rest-api-specs` on the **main** branch.
-2. **Suppress the rule**: If the spec cannot be fixed without changing API behavior, add a suppress comment. Suppressions always go to the **main** branch.
+2. **Suppress the rule**: If the spec cannot be fixed without changing API behavior, add a `#suppress "<rule-id>" "<justification-string>"` directive on the line above the target (NOT a `// suppress` comment). Suppressions always go to the **main** branch.
 3. **Fix on typespec-next**: If the fix requires unreleased TypeSpec APIs or behavior, submit to the **typespec-next** branch (uses nightly builds).
 4. **Link your spec fix PR**: Always link the spec fix PR in your linter rule PR description.
 

--- a/website/src/content/docs/docs/howtos/contributing/creating-linter-rules.md
+++ b/website/src/content/docs/docs/howtos/contributing/creating-linter-rules.md
@@ -408,13 +408,44 @@ the **extended** documentation (no frontmatter and no `Full name` code block —
 those are generated):
 
 - A plain-language explanation
+- An **`## Impact`** section (required) — see below
 - `#### ❌ Incorrect` examples
 - `#### ✅ Correct` examples
+- A **`## Suppression`** section (required) — see below
+- A **`## LintDiff Equivalent`** section (when applicable) — see below
+
+#### Required sections
+
+Every rule's `docs` file must include an **Impact** statement and a
+**Suppression** statement, and must include a **LintDiff Equivalent** section
+whenever an equivalent LintDiff (azure-openapi-validator) rule exists.
+
+- **`## Impact`** — Describe the practical consequence of a violation. Start with
+  a bulleted `**Area:**` line listing the affected areas (for example `API`,
+  `SDK`, `Emitters`), followed by a short paragraph explaining what breaks or
+  degrades when the rule is violated.
+- **`## Suppression`** — State whether suppression is acceptable and why. If the
+  rule should never be suppressed, say so and point to the correct fix. If
+  suppression is acceptable in narrow cases, describe exactly when. Suppressions
+  use the `#suppress "<rule-id>" "<justification>"` directive (see
+  [Step 10](#step-10-external-integration-check)).
+- **`## LintDiff Equivalent`** — If this rule corresponds to one or more LintDiff
+  rules from
+  [azure-openapi-validator](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md),
+  link them here (deep-link to the specific rule id, e.g. `#r2007`). This tells
+  spec authors which Swagger-era check the TypeSpec rule replaces. Omit the
+  section only when no LintDiff equivalent exists.
 
 Example `docs` markdown (`packages/<pkg>/src/rules/my-new-rule.md`):
 
 ````markdown
 Brief description of the rule.
+
+## Impact
+
+- **Area:** API, SDK
+
+Explain what breaks or degrades when this rule is violated.
 
 #### ❌ Incorrect
 
@@ -431,6 +462,15 @@ model GoodThing {
   goodName: string;
 }
 ```
+
+## LintDiff Equivalent
+
+This rule corresponds to the LintDiff rule
+[RuleName](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md#r2007).
+
+## Suppression
+
+Do not suppress. Use `goodName` instead of `badName`.
 ````
 
 After editing the rule docs, regenerate package docs:
@@ -508,8 +548,19 @@ existing specs in `Azure/azure-rest-api-specs`. To resolve this:
    follow conventions), submit a PR to `Azure/azure-rest-api-specs` on the
    **main** branch.
 2. **Suppress the rule** — If the spec cannot be fixed without changing API
-   behavior, add a `// suppress` comment. Suppressions can always go to the
+   behavior, add a `#suppress` directive. Suppressions can always go to the
    **main** branch.
+
+   Suppressions use the `#suppress` **directive**, not a `// suppress` comment.
+   Place it on the line directly above the target, passing the fully-qualified
+   rule id and a justification string:
+
+   ```tsp
+   #suppress "@azure-tools/typespec-azure-core/no-openapi-client-extensions" "Emitter-only annotation with no TypeSpec construct."
+   @OpenAPI.extension("x-ms-example-annotation", true)
+   op example(): void;
+   ```
+
 3. **Fix on typespec-next branch** — If the fix requires unreleased TypeSpec
    APIs, types, or behavior that aren't yet available in the published
    packages, submit the fix to the **typespec-next** branch, which uses nightly
@@ -634,6 +685,9 @@ website/
 - [ ] Rule registered in `linter.ts`
 - [ ] Rule listed in appropriate ruleset(s)
 - [ ] Documentation has realistic examples
+- [ ] Documentation has an `## Impact` section
+- [ ] Documentation has a `## Suppression` section
+- [ ] Documentation has a `## LintDiff Equivalent` section (if a LintDiff equivalent exists)
 - [ ] Reference docs regenerated
 - [ ] Changeset created
 - [ ] `pnpm validate:pr` passes


### PR DESCRIPTION
## Summary

Fixes inaccurate suppression guidance and adds the now-required documentation sections for TypeSpec Azure linter rules. Applies to both the contributor how-to and the `create-linter-rule` skill so human and agent authors follow the same conventions.

### Corrections

- **Suppression mechanism** — The docs previously said to add a `// suppress` comment. That is inaccurate. Suppressions use the `#suppress "<rule-id>" "<justification-string>"` **directive**, placed on the line directly above the target. Both the how-to (Step 10) and the skill (Step 10) are corrected, and the how-to now includes a concrete `#suppress` example.

### New requirements

Every rule's `docs` markdown must now include:

- An **`## Impact`** section — an `**Area:**` bullet (e.g. `API`, `SDK`, `Emitters`) plus a short paragraph on what breaks or degrades when the rule is violated.
- A **`## Suppression`** section — whether suppression is acceptable and why, pointing to the correct fix.
- A **`## LintDiff Equivalent`** section — when an equivalent [azure-openapi-validator (LintDiff)](https://github.com/Azure/azure-rest-api-specs/blob/main/documentation/openapi-authoring-automated-guidelines.md) rule exists, deep-linked to the specific rule id.

Updated Step 7, the example `docs` markdown block, and the checklist in the how-to, and the corresponding step in `SKILL.md`.

## Validation

- `prettier` formatting and `cspell` are clean. Documentation/skill-only change (no package code, no changeset required).
