### PR TITLE
Add support for exact names

### DIFF
--- a/.chronus/changes/go-exactnamegroup-2026-6-30-10-1-12.md
+++ b/.chronus/changes/go-exactnamegroup-2026-6-30-10-1-12.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-go"
+---
+
+Honor isExactName for types and model properties. Note that if the type/property is public, the exact name will be slightly transformed to follow Go export rules.

--- a/packages/typespec-go/spector.config.azure.yaml
+++ b/packages/typespec-go/spector.config.azure.yaml
@@ -38,6 +38,7 @@ specs:
     { options: { module: coreclientlocationmoverootclientgroup } }
   "azure/client-generator-core/deserialize-empty-string-as-null":
     { options: { module: emptystringgroup } }
+  "azure/client-generator-core/exact-name": { options: { module: exactnamegroup } }
   "azure/client-generator-core/flatten-property": { options: { module: flattengroup } }
   "azure/client-generator-core/hierarchy-building": { options: { module: hierarchygroup } }
   "azure/client-generator-core/next-link-verb":
@@ -83,5 +84,3 @@ specs:
 
   # --- Not generated yet (tracked skips) ---
   "azure/client-generator-core/alternate-type": false
-  # emitter bug: generated fakes reference an unexported model (my_model)
-  "azure/client-generator-core/exact-name": false

--- a/packages/typespec-go/src/tcgcadapter/helpers.ts
+++ b/packages/typespec-go/src/tcgcadapter/helpers.ts
@@ -288,20 +288,34 @@ export function isExtensibleEnum(type: tcgc.SdkType): boolean {
 /**
  * returns the effective Go name for a tcgc item that may carry an isExactName marker.
  * when isExactName is true (set by the tsp exact() function on @clientName), the name
- * (with any provided suffix appended verbatim) is returned without built-in naming
- * canonization or first-character casing changes - exact names are honored as-authored.
- * otherwise the name (with any provided suffix appended) is canonicalized via
+ * (with any provided suffix appended verbatim) is honored as-authored apart from the
+ * first character, whose casing must still obey Go's export rules: unexported/parameter
+ * identifiers (lowerFirst, or access "internal") are lower-cased while exported ones are
+ * upper-cased. otherwise the name (with any provided suffix appended) is canonicalized via
  * naming.ensureNameCase(), with lowerFirst optionally lowercasing the first character
  * for unexported/parameter identifiers.
  */
 export function getEffectiveName(
-  src: { name: string; isExactName?: boolean },
+  src: { name: string; isExactName?: boolean; access?: tcgc.AccessFlags },
   lowerFirst?: boolean,
   suffix?: string,
 ): string {
   const name = suffix ? `${src.name}${suffix}` : src.name;
   if (src.isExactName) {
-    return name;
+    // exact names are honored as-authored, but Go's export rules still dictate
+    // the first character's casing.
+    if (lowerFirst || src.access === "internal") {
+      return naming.uncapitalize(name);
+    }
+    // NOTE: for exact names, we don't want to use naming.ensureNameCase() because it will
+    // apply additional transformations (e.g. acronym upper-casing) that would violate the
+    // "exact" contract. Go only exports identifiers that begin with an upper-case letter,
+    // so strip any leading non-letter characters (e.g. '_', digits) before upper-casing.
+    const exportable = name.replace(/^[^\p{L}]+/u, "");
+    if (exportable.length === 0) {
+      return name;
+    }
+    return exportable.charAt(0).toUpperCase() + exportable.slice(1);
   }
   return naming.ensureNameCase(name, lowerFirst);
 }

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -808,9 +808,11 @@ export class TypeAdapter {
       serializedName = prop.serializedName;
     }
 
-    const fieldName = prop.isExactName
-      ? prop.name
-      : naming.capitalize(naming.ensureNameCase(prop.name));
+    const fieldName = helpers.getEffectiveName({
+      name: prop.name,
+      isExactName: prop.isExactName,
+      access: prop.access,
+    });
     const field = new go.ModelField(fieldName, type, fieldByValue, serializedName, annotations);
     field.docs.summary = prop.summary;
     field.docs.description = prop.doc;

--- a/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/coreusagegroup/namespaceusage_client_test.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/coreusagegroup/namespaceusage_client_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package coreusagegroup_test
+
+import (
+	"context"
+	"coreusagegroup"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNamespaceUsageClient_NamespaceModelSerializable(t *testing.T) {
+	client, err := coreusagegroup.NewUsageClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	resp, err := client.NewUsageNamespaceUsageClient().NamespaceModelSerializable(context.Background(), coreusagegroup.NamespaceModel{
+		Name: to.Ptr("test"),
+	}, nil)
+	require.NoError(t, err)
+	require.Zero(t, resp)
+}

--- a/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/exactnamegroup/exactname_client_test.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/client-generator-core/exactnamegroup/exactname_client_test.go
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package exactnamegroup_test
+
+import (
+	"context"
+	"exactnamegroup"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/stretchr/testify/require"
+)
+
+func TestExactNameEnumValueClient_Send(t *testing.T) {
+	client, err := exactnamegroup.NewExactNameClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	resp, err := client.NewExactNameEnumValueClient().Send(context.Background(), exactnamegroup.EndpointConfig{
+		Protocol: to.Ptr(exactnamegroup.AgentEndpointProtocolA2A),
+	}, nil)
+	require.NoError(t, err)
+	require.Equal(t, exactnamegroup.EndpointConfig{
+		Protocol: to.Ptr(exactnamegroup.AgentEndpointProtocolA2A),
+	}, resp.EndpointConfig)
+}
+
+func TestExactNameModelClient_Send(t *testing.T) {
+	client, err := exactnamegroup.NewExactNameClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	resp, err := client.NewExactNameModelClient().Send(context.Background(), exactnamegroup.My_model{
+		Name: to.Ptr("test"),
+	}, nil)
+	require.NoError(t, err)
+	require.Equal(t, exactnamegroup.My_model{
+		Name: to.Ptr("test"),
+	}, resp.My_model)
+}
+
+func TestExactNameOperationClient_MyOp(t *testing.T) {
+	client, err := exactnamegroup.NewExactNameClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	_, err = client.NewExactNameOperationClient().MyOp(context.Background(), nil)
+	require.NoError(t, err)
+}
+
+func TestExactNameParameterClient_Send(t *testing.T) {
+	client, err := exactnamegroup.NewExactNameClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	_, err = client.NewExactNameParameterClient().Send(context.Background(), "hello", nil)
+	require.NoError(t, err)
+}
+
+func TestExactNamePropertyClient_Send(t *testing.T) {
+	client, err := exactnamegroup.NewExactNameClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+	resp, err := client.NewExactNamePropertyClient().Send(context.Background(), exactnamegroup.ScopedModel{
+		MyName: to.Ptr("test"),
+	}, nil)
+	require.NoError(t, err)
+	require.Equal(t, exactnamegroup.ScopedModel{
+		MyName: to.Ptr("test"),
+	}, resp.ScopedModel)
+}

--- a/packages/typespec-go/test/http-specs/payload/xmlgroup/xmlmodelwithdatetimevalue_client_test.go
+++ b/packages/typespec-go/test/http-specs/payload/xmlgroup/xmlmodelwithdatetimevalue_client_test.go
@@ -27,7 +27,6 @@ func TestXMLModelWithDatetimeValueClient_Get(t *testing.T) {
 }
 
 func TestXMLModelWithDatetimeValueClient_Put(t *testing.T) {
-	t.Skip("Go's datetime.RFC1123 marshals as 'UTC' but the mock server expects 'GMT'")
 	client, err := xmlgroup.NewXMLClientWithNoCredential("http://localhost:3000", nil)
 	require.NoError(t, err)
 	rfc3339 := time.Date(2022, 8, 26, 18, 38, 0, 0, time.UTC)


### PR DESCRIPTION
Note that due to visibility rules in Go, public types/fields must begin with an upper-case letter.  So, if an exact name violates this rule, it will be slightly transformed to be public.
Added missing test for coreusagegroup.