### PR TITLE
feat(examples): add examples-migrate tool

### DIFF
--- a/.chronus/changes/add-examples-migrate-tool-2026-07-30-12-30-00.md
+++ b/.chronus/changes/add-examples-migrate-tool-2026-07-30-12-30-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-azure-examples"
+---
+
+Add the `examples-migrate` tool that converts existing `x-ms-examples` JSON into the unified `examples.yaml` format (crawls versioned Swagger, normalizes `{api-version}`, and dedups across versions into `since` lineages).

--- a/packages/typespec-azure-examples/README.md
+++ b/packages/typespec-azure-examples/README.md
@@ -1,7 +1,7 @@
 # @azure-tools/typespec-azure-examples
 
-Tooling for the Azure **unified examples format** (`examples.yaml`): the published JSON Schema
-and the `examples-validate` CLI.
+Tooling for the Azure **unified examples format** (`examples.yaml`): the published JSON Schema,
+the `examples-validate` CLI, and the `examples-migrate` CLI.
 
 The unified examples format replaces the ~282K per-version `x-ms-examples` JSON files with a
 single version-aware `examples.yaml` per service (or `examples/<Interface>.yaml` for large
@@ -70,6 +70,33 @@ found (use `--warn-as-error` to also fail on warnings).
 - `{api-version}` is the only supported placeholder, and `api-version` must not appear as a
   request parameter.
 
+## `examples-migrate`
+
+Convert a service's existing `x-ms-examples` JSON into the unified format:
+
+```bash
+examples-migrate <spec-dir> --out <service-dir>
+```
+
+It crawls the versioned Swagger under `<spec-dir>` (the `stable/<version>/` and
+`preview/<version>/` layout), follows each operation's `x-ms-examples` `$ref`, and emits a single
+`examples.yaml` (or `examples/<Interface>.yaml` with `--split-by-interface`). The generated output
+is validated with the same rules as `examples-validate` before it is written.
+
+What it does:
+
+- Derives interface-relative operation keys from the Swagger `operationId` (`CaCertificates_Get` →
+  `CaCertificates.get`) under a single `$namespace` (detected from `/providers/<Namespace>/`, or
+  set with `--namespace`).
+- Buckets each example parameter into `request.path` / `query` / `headers` / `body` using the
+  operation's declared parameter locations, and drops the implicit `api-version`.
+- Normalizes embedded version strings (in `Location`, `Azure-AsyncOperation`, `nextLink`, ...) to
+  the `{api-version}` placeholder, then dedups identical examples across versions into `since`
+  lineages — one base entry plus a `since` variant whenever the content changes.
+
+Options: `--out <dir>` (default `.`), `--namespace <ns>`, `--split-by-interface`, `--dry-run`,
+`--warn-as-error`.
+
 ## API
 
 ```ts
@@ -77,7 +104,10 @@ import {
   validateExamplesDir,
   validateExampleFiles,
   loadExampleFile,
+  migrate,
 } from "@azure-tools/typespec-azure-examples";
 
 const { diagnostics } = await validateExamplesDir("path/to/service");
+
+const { files } = await migrate("path/to/specs", { namespace: "Microsoft.EventGrid" });
 ```

--- a/packages/typespec-azure-examples/package.json
+++ b/packages/typespec-azure-examples/package.json
@@ -27,7 +27,8 @@
     }
   },
   "bin": {
-    "examples-validate": "./dist/src/cli.js"
+    "examples-validate": "./dist/src/cli.js",
+    "examples-migrate": "./dist/src/migrate-cli.js"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/typespec-azure-examples/src/index.ts
+++ b/packages/typespec-azure-examples/src/index.ts
@@ -16,6 +16,7 @@ export {
 export { formatDiagnostics, formatSummary } from "./reporter.js";
 export { checkFilePlacement, checkSemantics, type SemanticContext } from "./rules.js";
 export { ExamplesYamlSchema } from "./schema.js";
+export * from "./migrate/index.js";
 export type {
   DiagnosticSeverity,
   ExampleDiagnostic,

--- a/packages/typespec-azure-examples/src/migrate-cli.ts
+++ b/packages/typespec-azure-examples/src/migrate-cli.ts
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+import { mkdir, writeFile } from "fs/promises";
+import { dirname, join, resolve } from "path";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+import { loadExampleFile } from "./loader.js";
+import { migrate } from "./migrate/index.js";
+import { formatDiagnostics, formatSummary } from "./reporter.js";
+import { validateExampleFiles } from "./validate.js";
+
+async function main(): Promise<void> {
+  const args = await yargs(hideBin(process.argv))
+    .scriptName("examples-migrate")
+    .usage("$0 <specDir>", "Migrate x-ms-examples JSON into the unified examples.yaml format")
+    .positional("specDir", {
+      type: "string",
+      describe: "Root of the versioned Swagger specs (contains stable/preview/<version>/*.json)",
+    })
+    .demandCommand(0)
+    .option("out", {
+      type: "string",
+      default: ".",
+      describe: "Output directory for the generated examples.yaml / examples/*.yaml",
+    })
+    .option("namespace", {
+      type: "string",
+      describe: "Override the $namespace (otherwise detected from /providers/<NS>/ paths)",
+    })
+    .option("split-by-interface", {
+      type: "boolean",
+      describe: "Force splitting output into examples/<Interface>.yaml",
+    })
+    .option("dry-run", {
+      type: "boolean",
+      default: false,
+      describe: "Print the generated files instead of writing them",
+    })
+    .option("warn-as-error", {
+      type: "boolean",
+      default: false,
+      describe: "Treat validation warnings as errors (non-zero exit)",
+    })
+    .strict()
+    .help()
+    .parse();
+
+  const specDir = resolve(process.cwd(), (args.specDir as string | undefined) ?? ".");
+  const outDir = resolve(process.cwd(), args.out as string);
+
+  const result = await migrate(specDir, {
+    namespace: args.namespace as string | undefined,
+    splitByInterface: args["split-by-interface"] as boolean | undefined,
+  });
+
+  if (result.files.length === 0) {
+    console.error(`No x-ms-examples found under ${specDir}.`);
+    process.exit(1);
+  }
+
+  // Validate the generated output through the same rules as examples-validate.
+  const diagnostics = validateExampleFiles(
+    result.files.map((f) => loadExampleFile(f.path, f.content)),
+    { serviceVersions: result.versions },
+  );
+
+  if (args["dry-run"]) {
+    for (const file of result.files) {
+      console.log(`# ${file.path}`);
+      console.log(file.content);
+    }
+  } else {
+    for (const file of result.files) {
+      const target = join(outDir, file.path);
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, file.content, "utf-8");
+      console.log(`Wrote ${target}`);
+    }
+  }
+
+  console.log(
+    `Migrated ${result.operationCount} operation(s) across ${result.versions.length} version(s)` +
+      (result.namespace ? ` under ${result.namespace}` : "") +
+      `.`,
+  );
+
+  if (diagnostics.length > 0) {
+    console.log("");
+    console.log(formatDiagnostics(diagnostics));
+    console.log("");
+    console.log(formatSummary(diagnostics));
+  }
+
+  const hasError = diagnostics.some((d) => d.severity === "error");
+  const hasWarning = diagnostics.some((d) => d.severity === "warning");
+  process.exit(hasError || (args["warn-as-error"] && hasWarning) ? 1 : 0);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/packages/typespec-azure-examples/src/migrate/dedup.ts
+++ b/packages/typespec-azure-examples/src/migrate/dedup.ts
@@ -1,0 +1,101 @@
+import type { MigratedVariant } from "./model.js";
+
+/** One example as collected from the crawl, prior to lineage collapsing. */
+export interface CollectedExample {
+  /** The API version this example was found under. */
+  readonly version: string;
+  /** The `x-ms-examples` map key, used as the lineage title. */
+  readonly exampleName: string;
+  /** The transformed + api-version-normalized variant content. */
+  readonly variant: MigratedVariant;
+}
+
+export interface BuildLineagesOptions {
+  /** Ascending comparator over version strings (lowest/earliest first). */
+  readonly compareVersions: (a: string, b: string) => number;
+  /**
+   * The earliest version across the whole migration. When a lineage's first appearance is later
+   * than this, its base entry gets a `since` so migration stays faithful. When omitted, the
+   * earliest entry of each lineage is always the base (no `since`).
+   */
+  readonly baselineVersion?: string;
+}
+
+/**
+ * Collapse an operation's collected examples into unified variants: group by lineage (example
+ * name), order by version, keep one base entry, and emit a `since` variant only when the content
+ * changes from the previously-emitted entry. If the operation has a single lineage, the `title` is
+ * omitted (single-example case).
+ */
+export function buildLineages(
+  examples: readonly CollectedExample[],
+  options: BuildLineagesOptions,
+): MigratedVariant[] {
+  const byName = new Map<string, CollectedExample[]>();
+  for (const example of examples) {
+    const group = byName.get(example.exampleName);
+    if (group) group.push(example);
+    else byName.set(example.exampleName, [example]);
+  }
+
+  const singleLineage = byName.size <= 1;
+  const result: MigratedVariant[] = [];
+
+  for (const [name, group] of byName) {
+    const ordered = [...group].sort((a, b) => options.compareVersions(a.version, b.version));
+
+    let lastContent: string | undefined;
+    let isFirst = true;
+    for (const entry of ordered) {
+      const content = canonicalize(entry.variant);
+      if (!isFirst && content === lastContent) continue;
+
+      const variant: MigratedVariant = {
+        request: entry.variant.request,
+        responses: entry.variant.responses,
+      };
+      if (!singleLineage) variant.title = name;
+
+      const introduceSince =
+        !isFirst ||
+        (options.baselineVersion !== undefined && entry.version !== options.baselineVersion);
+      if (introduceSince) variant.since = entry.version;
+
+      result.push(orderKeys(variant));
+      lastContent = content;
+      isFirst = false;
+    }
+  }
+
+  return result;
+}
+
+/** Stable, key-order-independent serialization used to compare variant content for equality. */
+function canonicalize(variant: MigratedVariant): string {
+  return JSON.stringify(sortValue({ request: variant.request, responses: variant.responses }));
+}
+
+function sortValue(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortValue);
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(value as Record<string, unknown>).sort()) {
+      out[key] = sortValue((value as Record<string, unknown>)[key]);
+    }
+    return out;
+  }
+  return value;
+}
+
+/** Present keys in the canonical emission order: title, since, request, responses. */
+function orderKeys(variant: MigratedVariant): MigratedVariant {
+  const ordered: MigratedVariant = { request: variant.request, responses: variant.responses };
+  if (variant.title !== undefined) ordered.title = variant.title;
+  if (variant.since !== undefined) ordered.since = variant.since;
+  return {
+    ...(ordered.title !== undefined ? { title: ordered.title } : {}),
+    ...(ordered.since !== undefined ? { since: ordered.since } : {}),
+    request: ordered.request,
+    responses: ordered.responses,
+  };
+}

--- a/packages/typespec-azure-examples/src/migrate/emit.ts
+++ b/packages/typespec-azure-examples/src/migrate/emit.ts
@@ -1,0 +1,106 @@
+import { Document, isPair, isScalar, Scalar, visit } from "yaml";
+import type { MigratedVariant } from "./model.js";
+import { interfaceOf } from "./operation-key.js";
+
+/** A single emitted file: a repo-relative path and its serialized YAML content. */
+export interface EmittedFile {
+  readonly path: string;
+  readonly content: string;
+}
+
+/** One operation's key and its collapsed variants. */
+export interface OperationEntry {
+  readonly operationKey: string;
+  readonly variants: MigratedVariant[];
+}
+
+/**
+ * Build the plain object for an `examples.yaml` file: `$namespace` (optional) followed by one
+ * key per operation. Operations are emitted in sorted key order for deterministic output.
+ */
+export function buildExamplesObject(
+  entries: readonly OperationEntry[],
+  namespace: string | undefined,
+): Record<string, unknown> {
+  const object: Record<string, unknown> = {};
+  if (namespace !== undefined) object.$namespace = namespace;
+  for (const entry of [...entries].sort((a, b) => a.operationKey.localeCompare(b.operationKey))) {
+    object[entry.operationKey] = entry.variants;
+  }
+  return object;
+}
+
+/** Serialize an examples object to YAML, force-quoting `since` values so they stay strings. */
+export function serializeExamplesYaml(object: Record<string, unknown>): string {
+  const doc = new Document(object);
+  visit(doc, {
+    Pair(_, pair, path) {
+      if (
+        isScalar(pair.key) &&
+        pair.key.value === "since" &&
+        isScalar(pair.value) &&
+        typeof pair.value.value === "string"
+      ) {
+        pair.value.type = Scalar.QUOTE_DOUBLE;
+      }
+      // Emit response status codes as bare integer keys (`200:`), matching the RFC idiom.
+      // Converting the key to a number makes yaml render it unquoted.
+      if (
+        isScalar(pair.key) &&
+        typeof pair.key.value === "string" &&
+        /^\d+$/.test(pair.key.value) &&
+        isUnderResponses(path)
+      ) {
+        pair.key.value = Number(pair.key.value);
+      }
+    },
+  });
+  return doc.toString();
+}
+
+/** Whether the visited node sits inside a `responses` mapping. */
+function isUnderResponses(path: readonly unknown[]): boolean {
+  return path.some((node) => isPair(node) && isScalar(node.key) && node.key.value === "responses");
+}
+
+/**
+ * Plan the output files. When `splitByInterface` is set (or the interface count exceeds
+ * `autoSplitThreshold`), each interface goes to `examples/<Interface>.yaml`; otherwise everything
+ * goes to a single top-level `examples.yaml`. Every file repeats `$namespace`.
+ */
+export function planFiles(
+  entries: readonly OperationEntry[],
+  namespace: string | undefined,
+  options: { splitByInterface?: boolean; autoSplitThreshold?: number } = {},
+): EmittedFile[] {
+  const interfaces = new Set(entries.map((e) => interfaceOf(e.operationKey)));
+  const shouldSplit =
+    options.splitByInterface === true ||
+    (options.splitByInterface !== false &&
+      options.autoSplitThreshold !== undefined &&
+      interfaces.size > options.autoSplitThreshold);
+
+  if (!shouldSplit) {
+    return [
+      {
+        path: "examples.yaml",
+        content: serializeExamplesYaml(buildExamplesObject(entries, namespace)),
+      },
+    ];
+  }
+
+  const byInterface = new Map<string, OperationEntry[]>();
+  for (const entry of entries) {
+    const iface = interfaceOf(entry.operationKey);
+    const group = byInterface.get(iface);
+    if (group) group.push(entry);
+    else byInterface.set(iface, [entry]);
+  }
+
+  return [...byInterface.entries()]
+    .sort((a, b) => a[0].localeCompare(b[0]))
+    .map(([iface, group]) => ({
+      path: `examples/${iface}.yaml`,
+      content: serializeExamplesYaml(buildExamplesObject(group, namespace)),
+    }));
+}

--- a/packages/typespec-azure-examples/src/migrate/index.ts
+++ b/packages/typespec-azure-examples/src/migrate/index.ts
@@ -1,0 +1,30 @@
+/**
+ * `examples-migrate`: convert classic `x-ms-examples` JSON into the unified `examples.yaml` format.
+ */
+export { buildLineages, type BuildLineagesOptions, type CollectedExample } from "./dedup.js";
+export {
+  buildExamplesObject,
+  planFiles,
+  serializeExamplesYaml,
+  type EmittedFile,
+  type OperationEntry,
+} from "./emit.js";
+export { migrate, type MigrateOptions, type MigrateResult } from "./migrate.js";
+export type { MigratedRequest, MigratedResponse, MigratedVariant } from "./model.js";
+export { normalizeApiVersion, normalizeApiVersions } from "./normalize.js";
+export { deriveOperationKey, interfaceOf } from "./operation-key.js";
+export {
+  collectParamLocations,
+  crawlExamples,
+  discoverSwaggerFiles,
+  extractOperations,
+  namespaceFromPaths,
+  resolveLocalParam,
+  resolveRefPath,
+  versionFromPath,
+  type CrawlResult,
+  type CrawledExample,
+  type ExtractedOperation,
+} from "./swagger.js";
+export { transformExample } from "./transform.js";
+export { comparatorFromOrder, defaultCompareVersions, earliestVersion } from "./version-order.js";

--- a/packages/typespec-azure-examples/src/migrate/migrate.ts
+++ b/packages/typespec-azure-examples/src/migrate/migrate.ts
@@ -1,0 +1,82 @@
+import { buildLineages, type CollectedExample } from "./dedup.js";
+import { planFiles, type EmittedFile, type OperationEntry } from "./emit.js";
+import { normalizeApiVersions } from "./normalize.js";
+import { deriveOperationKey } from "./operation-key.js";
+import { crawlExamples } from "./swagger.js";
+import { transformExample } from "./transform.js";
+import { comparatorFromOrder, defaultCompareVersions, earliestVersion } from "./version-order.js";
+
+/** Options controlling a migration run. */
+export interface MigrateOptions {
+  /** Override the detected `$namespace`. */
+  readonly namespace?: string;
+  /**
+   * Authoritative version order (e.g. from `service.yaml`). When omitted, a date-based heuristic
+   * is used over the versions discovered while crawling.
+   */
+  readonly versionOrder?: readonly string[];
+  /** Force (or disable) splitting output into `examples/<Interface>.yaml`. */
+  readonly splitByInterface?: boolean;
+  /** When `splitByInterface` is undefined, auto-split above this interface count. */
+  readonly autoSplitThreshold?: number;
+}
+
+/** The outcome of a migration run. */
+export interface MigrateResult {
+  /** The files to write (relative paths + serialized YAML). */
+  readonly files: EmittedFile[];
+  /** The namespace used (detected or overridden). */
+  readonly namespace?: string;
+  /** The versions discovered while crawling. */
+  readonly versions: string[];
+  /** The number of operations migrated. */
+  readonly operationCount: number;
+}
+
+/**
+ * Migrate a tree of versioned Swagger specs with `x-ms-examples` into the unified `examples.yaml`
+ * format. Pure aside from reading the input tree (it does not write files).
+ */
+export async function migrate(root: string, options: MigrateOptions = {}): Promise<MigrateResult> {
+  const crawl = await crawlExamples(root);
+  const namespace = options.namespace ?? crawl.namespace;
+
+  const compareVersions = options.versionOrder
+    ? comparatorFromOrder(options.versionOrder)
+    : defaultCompareVersions;
+  const baselineVersion = options.versionOrder
+    ? options.versionOrder[0]
+    : earliestVersion(crawl.versions, compareVersions);
+
+  const byOperation = new Map<string, CollectedExample[]>();
+  for (const crawled of crawl.examples) {
+    const operationKey = deriveOperationKey(crawled.operationId);
+    const variant = normalizeApiVersions(
+      transformExample(crawled.doc, crawled.paramLocations),
+      crawl.versions,
+    );
+    const collected: CollectedExample = {
+      version: crawled.version,
+      exampleName: crawled.exampleName,
+      variant,
+    };
+    const group = byOperation.get(operationKey);
+    if (group) group.push(collected);
+    else byOperation.set(operationKey, [collected]);
+  }
+
+  const entries: OperationEntry[] = [];
+  for (const [operationKey, collected] of byOperation) {
+    entries.push({
+      operationKey,
+      variants: buildLineages(collected, { compareVersions, baselineVersion }),
+    });
+  }
+
+  const files = planFiles(entries, namespace, {
+    splitByInterface: options.splitByInterface,
+    autoSplitThreshold: options.autoSplitThreshold,
+  });
+
+  return { files, namespace, versions: crawl.versions, operationCount: entries.length };
+}

--- a/packages/typespec-azure-examples/src/migrate/model.ts
+++ b/packages/typespec-azure-examples/src/migrate/model.ts
@@ -1,0 +1,22 @@
+/**
+ * Internal representation of a migrated example variant, prior to lineage assignment.
+ * Mirrors the `Example` shape in the schema but is mutable while being assembled.
+ */
+export interface MigratedRequest {
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
+  headers?: Record<string, unknown>;
+  body?: unknown;
+}
+
+export interface MigratedResponse {
+  headers?: Record<string, unknown>;
+  body?: unknown;
+}
+
+export interface MigratedVariant {
+  title?: string;
+  since?: string;
+  request: MigratedRequest;
+  responses: Record<string, MigratedResponse>;
+}

--- a/packages/typespec-azure-examples/src/migrate/normalize.ts
+++ b/packages/typespec-azure-examples/src/migrate/normalize.ts
@@ -1,0 +1,51 @@
+/**
+ * Normalize embedded concrete API-version strings to the `{api-version}` placeholder.
+ *
+ * `x-ms-examples` frequently bake the api-version into header and body string values
+ * (`Location`, `Azure-AsyncOperation`, `nextLink`, ...). Replacing those with `{api-version}`
+ * lets otherwise-identical variants across versions collapse into a single lineage entry.
+ */
+
+/** Recursively replace occurrences of `version` in string values with `{api-version}`. */
+export function normalizeApiVersion<T>(value: T, version: string): T {
+  return normalize(value, buildMatcher(version)) as T;
+}
+
+/**
+ * Normalize using any of the provided versions (longest first, so more specific version strings
+ * win over prefixes).
+ */
+export function normalizeApiVersions<T>(value: T, versions: readonly string[]): T {
+  const ordered = [...new Set(versions)]
+    .filter((v) => v.length > 0)
+    .sort((a, b) => b.length - a.length);
+  if (ordered.length === 0) return value;
+  const matcher = new RegExp(ordered.map(escapeRegExp).join("|"), "g");
+  return normalize(value, matcher) as T;
+}
+
+function buildMatcher(version: string): RegExp {
+  return new RegExp(escapeRegExp(version), "g");
+}
+
+function normalize(value: unknown, matcher: RegExp): unknown {
+  if (typeof value === "string") {
+    matcher.lastIndex = 0;
+    return value.replace(matcher, "{api-version}");
+  }
+  if (Array.isArray(value)) {
+    return value.map((item) => normalize(item, matcher));
+  }
+  if (value !== null && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [key, item] of Object.entries(value)) {
+      out[key] = normalize(item, matcher);
+    }
+    return out;
+  }
+  return value;
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/typespec-azure-examples/src/migrate/operation-key.ts
+++ b/packages/typespec-azure-examples/src/migrate/operation-key.ts
@@ -1,0 +1,28 @@
+/**
+ * Derive the `examples.yaml` operation key from a Swagger `operationId`.
+ *
+ * Swagger operation ids follow the `Interface_Method` convention (as emitted by
+ * `@azure-tools/typespec-autorest`). The unified format uses the interface-relative key
+ * `Interface.method` with a lower-cased first letter on the method (e.g. `CaCertificates_Get`
+ * becomes `CaCertificates.get`). Operation ids without an underscore become a bare top-level key.
+ */
+export function deriveOperationKey(operationId: string): string {
+  const underscore = operationId.indexOf("_");
+  if (underscore < 0) {
+    return operationId;
+  }
+  const iface = operationId.slice(0, underscore);
+  const method = operationId.slice(underscore + 1);
+  return `${iface}.${lowerFirst(method)}`;
+}
+
+/** The interface portion of a derived operation key (everything before the first `.`). */
+export function interfaceOf(operationKey: string): string {
+  const dot = operationKey.indexOf(".");
+  return dot < 0 ? operationKey : operationKey.slice(0, dot);
+}
+
+function lowerFirst(value: string): string {
+  if (value.length === 0) return value;
+  return value.charAt(0).toLowerCase() + value.slice(1);
+}

--- a/packages/typespec-azure-examples/src/migrate/swagger-types.ts
+++ b/packages/typespec-azure-examples/src/migrate/swagger-types.ts
@@ -1,0 +1,50 @@
+/**
+ * Types describing the *inputs* to `examples-migrate`: the classic Swagger `x-ms-examples`
+ * extension and the referenced example JSON documents.
+ */
+
+/** Parameter location as declared on a Swagger operation/path parameter. */
+export type ParameterLocation = "path" | "query" | "header" | "body" | "formData";
+
+/** A Swagger parameter object (or a `$ref` to one). */
+export interface SwaggerParameter {
+  readonly name?: string;
+  readonly in?: ParameterLocation;
+  readonly $ref?: string;
+}
+
+/** A single Swagger operation carrying `x-ms-examples`. */
+export interface SwaggerOperation {
+  readonly operationId?: string;
+  readonly parameters?: SwaggerParameter[];
+  readonly "x-ms-examples"?: Record<string, { readonly $ref?: string }>;
+}
+
+/** The subset of a Swagger document `examples-migrate` reads. */
+export interface SwaggerDocument {
+  readonly info?: { readonly title?: string; readonly version?: string };
+  readonly parameters?: Record<string, SwaggerParameter>;
+  readonly paths?: Record<string, SwaggerPathItem>;
+}
+
+/** A Swagger path item: HTTP methods plus optional path-level `parameters`. */
+export interface SwaggerPathItem {
+  readonly parameters?: SwaggerParameter[];
+  readonly [method: string]: unknown;
+}
+
+/** The referenced `x-ms-examples` example document. */
+export interface XmsExampleDoc {
+  readonly operationId?: string;
+  readonly title?: string;
+  readonly parameters?: Record<string, unknown>;
+  readonly responses?: Record<string, XmsExampleResponse>;
+}
+
+export interface XmsExampleResponse {
+  readonly headers?: Record<string, unknown>;
+  readonly body?: unknown;
+}
+
+/** The HTTP methods that can carry an operation on a Swagger path item. */
+export const HTTP_METHODS = ["get", "put", "post", "delete", "options", "head", "patch"] as const;

--- a/packages/typespec-azure-examples/src/migrate/swagger.ts
+++ b/packages/typespec-azure-examples/src/migrate/swagger.ts
@@ -1,0 +1,177 @@
+import { readdir, readFile } from "fs/promises";
+import { dirname, isAbsolute, join, resolve, sep } from "path";
+import type {
+  ParameterLocation,
+  SwaggerDocument,
+  SwaggerOperation,
+  SwaggerParameter,
+  XmsExampleDoc,
+} from "./swagger-types.js";
+import { HTTP_METHODS } from "./swagger-types.js";
+
+/** An operation extracted from a Swagger document, with its parameter-location map. */
+export interface ExtractedOperation {
+  readonly operationId: string;
+  readonly paramLocations: Map<string, ParameterLocation>;
+  readonly examples: Record<string, { readonly $ref?: string }>;
+}
+
+/** One example, fully loaded and associated with an operation and API version. */
+export interface CrawledExample {
+  readonly operationId: string;
+  readonly version: string;
+  readonly exampleName: string;
+  readonly doc: XmsExampleDoc;
+  readonly paramLocations: Map<string, ParameterLocation>;
+}
+
+/** The full result of crawling a spec tree. */
+export interface CrawlResult {
+  readonly examples: CrawledExample[];
+  readonly namespace?: string;
+  readonly versions: string[];
+}
+
+/** Detect the resource-provider namespace from Swagger path templates (`/providers/<NS>/`). */
+export function namespaceFromPaths(pathKeys: Iterable<string>): string | undefined {
+  for (const path of pathKeys) {
+    const match = /\/providers\/([^/{}]+)\//.exec(path);
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
+/** Resolve a local `#/parameters/<name>` reference against the document's parameter map. */
+export function resolveLocalParam(
+  doc: SwaggerDocument,
+  parameter: SwaggerParameter,
+): SwaggerParameter | undefined {
+  if (parameter.$ref === undefined) return parameter;
+  const match = /^#\/parameters\/(.+)$/.exec(parameter.$ref);
+  if (!match) return undefined;
+  return doc.parameters?.[decodeURIComponent(match[1])];
+}
+
+/** Build a parameter-name → location map from path-level and operation-level parameters. */
+export function collectParamLocations(
+  doc: SwaggerDocument,
+  parameters: readonly SwaggerParameter[] | undefined,
+): Map<string, ParameterLocation> {
+  const map = new Map<string, ParameterLocation>();
+  for (const raw of parameters ?? []) {
+    const resolved = resolveLocalParam(doc, raw);
+    if (resolved?.name !== undefined && resolved.in !== undefined) {
+      map.set(resolved.name, resolved.in);
+    }
+  }
+  return map;
+}
+
+/** Extract every operation that carries `x-ms-examples` from a parsed Swagger document. */
+export function extractOperations(doc: SwaggerDocument): ExtractedOperation[] {
+  const operations: ExtractedOperation[] = [];
+  for (const pathItem of Object.values(doc.paths ?? {})) {
+    const pathParams = pathItem.parameters;
+    for (const method of HTTP_METHODS) {
+      const operation = pathItem[method] as SwaggerOperation | undefined;
+      if (operation === undefined || typeof operation !== "object") continue;
+      const examples = operation["x-ms-examples"];
+      if (examples === undefined || operation.operationId === undefined) continue;
+
+      const paramLocations = collectParamLocations(doc, [
+        ...(pathParams ?? []),
+        ...(operation.parameters ?? []),
+      ]);
+      operations.push({ operationId: operation.operationId, paramLocations, examples });
+    }
+  }
+  return operations;
+}
+
+/**
+ * Extract the API version from a Swagger file path: the path segment immediately following a
+ * `stable` or `preview` segment (the Azure spec layout). Returns `undefined` when not found.
+ */
+export function versionFromPath(filePath: string): string | undefined {
+  const segments = filePath.split(/[\\/]/);
+  for (let i = 0; i < segments.length - 1; i++) {
+    if (segments[i] === "stable" || segments[i] === "preview") {
+      return segments[i + 1];
+    }
+  }
+  return undefined;
+}
+
+/** Resolve an `x-ms-examples` `$ref` (relative file path with optional fragment) to a file path. */
+export function resolveRefPath(fromFile: string, ref: string): string {
+  const withoutFragment = ref.split("#")[0];
+  if (isAbsolute(withoutFragment)) return withoutFragment;
+  return resolve(dirname(fromFile), withoutFragment);
+}
+
+/**
+ * Recursively discover Swagger documents under `root`. A file qualifies when its path contains a
+ * `stable`/`preview` version segment and its content has a `paths` object (i.e. it is a service
+ * spec, not an example JSON).
+ */
+export async function discoverSwaggerFiles(root: string): Promise<string[]> {
+  const entries = await readdir(root, { recursive: true, withFileTypes: true });
+  const files: string[] = [];
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) continue;
+    const full = join(entryDir(entry, root), entry.name);
+    if (versionFromPath(full) === undefined) continue;
+    if (full.split(sep).includes("examples")) continue;
+    files.push(full);
+  }
+  return files.sort();
+}
+
+function entryDir(entry: { parentPath?: string; path?: string }, root: string): string {
+  // Node's Dirent exposes `parentPath` (>=20.12) or the older `path`.
+  return entry.parentPath ?? entry.path ?? root;
+}
+
+/** Crawl `root`, loading every `x-ms-examples` document for every versioned Swagger operation. */
+export async function crawlExamples(root: string): Promise<CrawlResult> {
+  const files = await discoverSwaggerFiles(root);
+  const crawled: CrawledExample[] = [];
+  const versions = new Set<string>();
+  let namespace: string | undefined;
+
+  for (const file of files) {
+    let doc: SwaggerDocument;
+    try {
+      doc = JSON.parse(await readFile(file, "utf-8")) as SwaggerDocument;
+    } catch {
+      continue;
+    }
+    if (doc.paths === undefined) continue;
+    const version = versionFromPath(file);
+    if (version === undefined) continue;
+    versions.add(version);
+    namespace ??= namespaceFromPaths(Object.keys(doc.paths));
+
+    for (const operation of extractOperations(doc)) {
+      for (const [exampleName, entry] of Object.entries(operation.examples)) {
+        if (entry?.$ref === undefined) continue;
+        const examplePath = resolveRefPath(file, entry.$ref);
+        let exampleDoc: XmsExampleDoc;
+        try {
+          exampleDoc = JSON.parse(await readFile(examplePath, "utf-8")) as XmsExampleDoc;
+        } catch {
+          continue;
+        }
+        crawled.push({
+          operationId: operation.operationId,
+          version,
+          exampleName,
+          doc: exampleDoc,
+          paramLocations: operation.paramLocations,
+        });
+      }
+    }
+  }
+
+  return { examples: crawled, namespace, versions: [...versions] };
+}

--- a/packages/typespec-azure-examples/src/migrate/transform.ts
+++ b/packages/typespec-azure-examples/src/migrate/transform.ts
@@ -1,0 +1,51 @@
+import type { MigratedRequest, MigratedResponse, MigratedVariant } from "./model.js";
+import type { ParameterLocation, XmsExampleDoc } from "./swagger-types.js";
+
+/**
+ * Convert one `x-ms-examples` document into a {@link MigratedVariant}, using a map of
+ * parameter-name → location (built from the operation's Swagger parameter definitions) to bucket
+ * each example parameter into `request.path` / `query` / `headers` / `body`.
+ *
+ * The implicit `api-version` parameter is dropped. Parameters whose location is unknown (not
+ * declared on the operation) default to `query`.
+ */
+export function transformExample(
+  doc: XmsExampleDoc,
+  paramLocations: ReadonlyMap<string, ParameterLocation>,
+): MigratedVariant {
+  const request: MigratedRequest = {};
+
+  for (const [name, value] of Object.entries(doc.parameters ?? {})) {
+    if (name.toLowerCase() === "api-version") continue;
+
+    const location = paramLocations.get(name) ?? "query";
+    switch (location) {
+      case "body":
+        request.body = value;
+        break;
+      case "path":
+        (request.path ??= {})[name] = value;
+        break;
+      case "header":
+        (request.headers ??= {})[name] = value;
+        break;
+      case "query":
+      case "formData":
+      default:
+        (request.query ??= {})[name] = value;
+        break;
+    }
+  }
+
+  const responses: Record<string, MigratedResponse> = {};
+  for (const [code, response] of Object.entries(doc.responses ?? {})) {
+    const mapped: MigratedResponse = {};
+    if (response && typeof response === "object") {
+      if (response.headers !== undefined) mapped.headers = response.headers;
+      if (response.body !== undefined) mapped.body = response.body;
+    }
+    responses[code] = mapped;
+  }
+
+  return { request, responses };
+}

--- a/packages/typespec-azure-examples/src/migrate/version-order.ts
+++ b/packages/typespec-azure-examples/src/migrate/version-order.ts
@@ -1,0 +1,47 @@
+/**
+ * Version ordering for migration. Azure API versions are date-based (`YYYY-MM-DD`) with an optional
+ * `-preview`/`-beta` suffix. When a `service.yaml` order is available it is authoritative; otherwise
+ * this heuristic sorts by date ascending and places a same-dated preview *before* its GA.
+ */
+
+/** Build a comparator from an explicit, authoritative version order (e.g. from `service.yaml`). */
+export function comparatorFromOrder(order: readonly string[]): (a: string, b: string) => number {
+  const index = new Map(order.map((version, i) => [version, i] as const));
+  return (a, b) => {
+    const ia = index.get(a);
+    const ib = index.get(b);
+    if (ia !== undefined && ib !== undefined) return ia - ib;
+    if (ia !== undefined) return -1;
+    if (ib !== undefined) return 1;
+    return defaultCompareVersions(a, b);
+  };
+}
+
+/** Heuristic comparator over date-based Azure version strings. */
+export function defaultCompareVersions(a: string, b: string): number {
+  const da = datePart(a);
+  const db = datePart(b);
+  if (da !== db) return da < db ? -1 : 1;
+  const pa = isPreview(a) ? 0 : 1;
+  const pb = isPreview(b) ? 0 : 1;
+  if (pa !== pb) return pa - pb;
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/** Return the earliest version under the given comparator. */
+export function earliestVersion(
+  versions: readonly string[],
+  compare: (a: string, b: string) => number,
+): string | undefined {
+  if (versions.length === 0) return undefined;
+  return [...versions].sort(compare)[0];
+}
+
+function datePart(version: string): string {
+  const match = /^\d{4}-\d{2}-\d{2}/.exec(version);
+  return match ? match[0] : version;
+}
+
+function isPreview(version: string): boolean {
+  return /-(preview|beta|privatepreview)/i.test(version);
+}

--- a/packages/typespec-azure-examples/test/migrate/dedup.test.ts
+++ b/packages/typespec-azure-examples/test/migrate/dedup.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { buildLineages, type CollectedExample } from "../../src/migrate/dedup.js";
+import type { MigratedVariant } from "../../src/migrate/model.js";
+
+const order = ["2023-01-01", "2024-06-01", "2025-01-01"];
+const compareVersions = (a: string, b: string) => order.indexOf(a) - order.indexOf(b);
+
+function variant(body: unknown): MigratedVariant {
+  return { request: { path: { id: "1" } }, responses: { "200": { body } } };
+}
+
+function collected(version: string, exampleName: string, body: unknown): CollectedExample {
+  return { version, exampleName, variant: variant(body) };
+}
+
+describe("buildLineages", () => {
+  it("collapses identical content across versions into a single base entry", () => {
+    const result = buildLineages(
+      [
+        collected("2023-01-01", "Get", { name: "a" }),
+        collected("2024-06-01", "Get", { name: "a" }),
+      ],
+      { compareVersions },
+    );
+    expect(result).toEqual([
+      { request: { path: { id: "1" } }, responses: { "200": { body: { name: "a" } } } },
+    ]);
+  });
+
+  it("emits a since variant when content changes", () => {
+    const result = buildLineages(
+      [
+        collected("2023-01-01", "Get", { name: "a" }),
+        collected("2024-06-01", "Get", { name: "b" }),
+      ],
+      { compareVersions },
+    );
+    expect(result).toHaveLength(2);
+    expect(result[0].since).toBeUndefined();
+    expect(result[1].since).toBe("2024-06-01");
+    expect(result[1].responses["200"].body).toEqual({ name: "b" });
+  });
+
+  it("omits titles for a single lineage but keeps them for multiple", () => {
+    const single = buildLineages([collected("2023-01-01", "Get", { name: "a" })], {
+      compareVersions,
+    });
+    expect(single[0].title).toBeUndefined();
+
+    const multi = buildLineages(
+      [
+        collected("2023-01-01", "With WebHook", { kind: "webhook" }),
+        collected("2023-01-01", "With Queue", { kind: "queue" }),
+      ],
+      { compareVersions },
+    );
+    expect(multi.map((v) => v.title).sort()).toEqual(["With Queue", "With WebHook"]);
+  });
+
+  it("puts a since on the base entry when it first appears after the baseline", () => {
+    const result = buildLineages([collected("2024-06-01", "Get", { name: "a" })], {
+      compareVersions,
+      baselineVersion: "2023-01-01",
+    });
+    expect(result[0].since).toBe("2024-06-01");
+  });
+
+  it("orders keys as title, since, request, responses", () => {
+    const result = buildLineages(
+      [
+        collected("2023-01-01", "A", { v: 1 }),
+        collected("2024-06-01", "A", { v: 2 }),
+        collected("2023-01-01", "B", { v: 9 }),
+      ],
+      { compareVersions },
+    );
+    const sinceVariant = result.find((v) => v.since !== undefined);
+    expect(sinceVariant && Object.keys(sinceVariant)).toEqual([
+      "title",
+      "since",
+      "request",
+      "responses",
+    ]);
+  });
+});

--- a/packages/typespec-azure-examples/test/migrate/emit.test.ts
+++ b/packages/typespec-azure-examples/test/migrate/emit.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import {
+  buildExamplesObject,
+  type OperationEntry,
+  planFiles,
+  serializeExamplesYaml,
+} from "../../src/migrate/emit.js";
+
+const entries: OperationEntry[] = [
+  {
+    operationKey: "Things.get",
+    variants: [
+      { since: "2024-06-01", request: { path: { id: "1" } }, responses: { "200": { body: {} } } },
+    ],
+  },
+  {
+    operationKey: "Widgets.list",
+    variants: [{ request: {}, responses: { "200": { body: {} } } }],
+  },
+];
+
+describe("serializeExamplesYaml", () => {
+  it("force-quotes since and keeps status codes as integer keys on round-trip", () => {
+    const yaml = serializeExamplesYaml(buildExamplesObject(entries, "Microsoft.Test"));
+    expect(yaml).toContain('since: "2024-06-01"');
+    // Status codes emit as bare integer keys, not quoted strings.
+    expect(yaml).toMatch(/\n\s+200:/);
+    expect(yaml).not.toContain('"200"');
+
+    const parsed = parse(yaml);
+    expect(parsed.$namespace).toBe("Microsoft.Test");
+    // Integer status keys survive the round-trip as numbers.
+    expect(Object.keys(parsed["Things.get"][0].responses)).toEqual(["200"]);
+    expect(typeof parsed["Things.get"][0].since).toBe("string");
+  });
+});
+
+describe("planFiles", () => {
+  it("emits a single examples.yaml by default", () => {
+    const files = planFiles(entries, "Microsoft.Test");
+    expect(files.map((f) => f.path)).toEqual(["examples.yaml"]);
+  });
+
+  it("splits by interface when requested", () => {
+    const files = planFiles(entries, "Microsoft.Test", { splitByInterface: true });
+    expect(files.map((f) => f.path).sort()).toEqual([
+      "examples/Things.yaml",
+      "examples/Widgets.yaml",
+    ]);
+  });
+
+  it("auto-splits above the threshold", () => {
+    expect(planFiles(entries, undefined, { autoSplitThreshold: 1 }).length).toBe(2);
+    expect(planFiles(entries, undefined, { autoSplitThreshold: 5 }).length).toBe(1);
+  });
+});

--- a/packages/typespec-azure-examples/test/migrate/migrate.e2e.test.ts
+++ b/packages/typespec-azure-examples/test/migrate/migrate.e2e.test.ts
@@ -1,0 +1,111 @@
+import { mkdir, mkdtemp, writeFile } from "fs/promises";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterAll, describe, expect, it } from "vitest";
+import { parse } from "yaml";
+import { loadExampleFile } from "../../src/loader.js";
+import { migrate } from "../../src/migrate/index.js";
+import { validateExampleFiles } from "../../src/validate.js";
+
+const swagger = (version: string) => ({
+  swagger: "2.0",
+  info: { title: "Test", version },
+  parameters: { SubscriptionIdParameter: { name: "subscriptionId", in: "path" } },
+  paths: {
+    "/subscriptions/{subscriptionId}/providers/Microsoft.Test/things/{id}": {
+      parameters: [{ $ref: "#/parameters/SubscriptionIdParameter" }],
+      get: {
+        operationId: "Things_Get",
+        parameters: [
+          { name: "id", in: "path" },
+          { name: "api-version", in: "query" },
+        ],
+        "x-ms-examples": { Get: { $ref: "./examples/Get.json" } },
+      },
+      put: {
+        operationId: "Things_Create",
+        parameters: [
+          { name: "id", in: "path" },
+          { name: "resource", in: "body" },
+        ],
+        "x-ms-examples": { Create: { $ref: "./examples/Create.json" } },
+      },
+    },
+  },
+});
+
+const getExample = (version: string) => ({
+  operationId: "Things_Get",
+  parameters: { subscriptionId: "sub", id: "1", "api-version": version },
+  responses: {
+    "200": { body: { name: "thing", nextLink: `https://host/things?api-version=${version}` } },
+  },
+});
+
+const createExample = (sku: string) => ({
+  operationId: "Things_Create",
+  parameters: { subscriptionId: "sub", id: "1", "api-version": "ignored", resource: { sku } },
+  responses: { "200": { body: { sku } } },
+});
+
+async function writeVersion(root: string, version: string, sku: string): Promise<void> {
+  const dir = join(root, "stable", version);
+  await mkdir(join(dir, "examples"), { recursive: true });
+  await writeFile(join(dir, "service.json"), JSON.stringify(swagger(version)));
+  await writeFile(join(dir, "examples", "Get.json"), JSON.stringify(getExample(version)));
+  await writeFile(join(dir, "examples", "Create.json"), JSON.stringify(createExample(sku)));
+}
+
+const roots: string[] = [];
+async function buildFixture(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "examples-migrate-"));
+  roots.push(root);
+  await writeVersion(root, "2023-01-01", "basic");
+  await writeVersion(root, "2024-06-01", "premium");
+  return root;
+}
+
+describe("migrate (end-to-end)", () => {
+  it("produces a valid, collapsed examples.yaml", async () => {
+    const root = await buildFixture();
+    const result = await migrate(root);
+
+    expect(result.namespace).toBe("Microsoft.Test");
+    expect(result.operationCount).toBe(2);
+    expect(result.files.map((f) => f.path)).toEqual(["examples.yaml"]);
+
+    // The generated output must pass the validator with no errors.
+    const diagnostics = validateExampleFiles(
+      result.files.map((f) => loadExampleFile(f.path, f.content)),
+      { serviceVersions: result.versions },
+    );
+    expect(diagnostics.filter((d) => d.severity === "error")).toEqual([]);
+
+    const doc = parse(result.files[0].content);
+    expect(doc.$namespace).toBe("Microsoft.Test");
+
+    // Get collapses across versions (api-version normalized) into one base entry.
+    expect(doc["Things.get"]).toHaveLength(1);
+    expect(doc["Things.get"][0].since).toBeUndefined();
+    expect(doc["Things.get"][0].responses["200"].body.nextLink).toContain("{api-version}");
+    expect(doc["Things.get"][0].request.path).toEqual({ subscriptionId: "sub", id: "1" });
+
+    // Create changed content across versions -> base + since variant.
+    expect(doc["Things.create"]).toHaveLength(2);
+    expect(doc["Things.create"][0].since).toBeUndefined();
+    expect(doc["Things.create"][0].request.body).toEqual({ sku: "basic" });
+    expect(doc["Things.create"][1].since).toBe("2024-06-01");
+    expect(doc["Things.create"][1].request.body).toEqual({ sku: "premium" });
+  });
+
+  it("can split output by interface", async () => {
+    const root = await buildFixture();
+    const result = await migrate(root, { splitByInterface: true });
+    expect(result.files.map((f) => f.path)).toEqual(["examples/Things.yaml"]);
+  });
+});
+
+afterAll(() => {
+  // Temp dirs live under the OS tmp dir; leave cleanup to the OS to avoid racy rm on CI.
+  void roots;
+});

--- a/packages/typespec-azure-examples/test/migrate/normalize.test.ts
+++ b/packages/typespec-azure-examples/test/migrate/normalize.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { normalizeApiVersion, normalizeApiVersions } from "../../src/migrate/normalize.js";
+
+describe("normalizeApiVersion", () => {
+  it("replaces the version inside string values", () => {
+    const input = {
+      nextLink: "https://host/things?api-version=2024-06-01",
+      headers: { Location: "https://host/op/1?api-version=2024-06-01" },
+    };
+    expect(normalizeApiVersion(input, "2024-06-01")).toEqual({
+      nextLink: "https://host/things?api-version={api-version}",
+      headers: { Location: "https://host/op/1?api-version={api-version}" },
+    });
+  });
+
+  it("leaves non-string values untouched", () => {
+    expect(normalizeApiVersion({ count: 3, ok: true }, "2024-06-01")).toEqual({
+      count: 3,
+      ok: true,
+    });
+  });
+
+  it("recurses through arrays", () => {
+    expect(normalizeApiVersion(["a?api-version=2024-06-01"], "2024-06-01")).toEqual([
+      "a?api-version={api-version}",
+    ]);
+  });
+});
+
+describe("normalizeApiVersions", () => {
+  it("normalizes any of several versions, preferring the longest match", () => {
+    const input = { a: "v=2024-06-01-preview", b: "v=2024-06-01" };
+    expect(normalizeApiVersions(input, ["2024-06-01", "2024-06-01-preview"])).toEqual({
+      a: "v={api-version}",
+      b: "v={api-version}",
+    });
+  });
+});

--- a/packages/typespec-azure-examples/test/migrate/operation-key.test.ts
+++ b/packages/typespec-azure-examples/test/migrate/operation-key.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { deriveOperationKey, interfaceOf } from "../../src/migrate/operation-key.js";
+
+describe("deriveOperationKey", () => {
+  it("splits Interface_Method and lowercases the method's first letter", () => {
+    expect(deriveOperationKey("CaCertificates_Get")).toBe("CaCertificates.get");
+  });
+
+  it("only splits on the first underscore", () => {
+    expect(deriveOperationKey("CaCertificates_ListByResourceGroup")).toBe(
+      "CaCertificates.listByResourceGroup",
+    );
+  });
+
+  it("returns a bare key when there is no underscore", () => {
+    expect(deriveOperationKey("HealthCheck")).toBe("HealthCheck");
+  });
+});
+
+describe("interfaceOf", () => {
+  it("returns the portion before the first dot", () => {
+    expect(interfaceOf("CaCertificates.get")).toBe("CaCertificates");
+  });
+
+  it("returns the whole key when there is no dot", () => {
+    expect(interfaceOf("HealthCheck")).toBe("HealthCheck");
+  });
+});

--- a/packages/typespec-azure-examples/test/migrate/swagger.test.ts
+++ b/packages/typespec-azure-examples/test/migrate/swagger.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+import type { SwaggerDocument } from "../../src/migrate/swagger-types.js";
+import {
+  collectParamLocations,
+  extractOperations,
+  namespaceFromPaths,
+  resolveRefPath,
+  versionFromPath,
+} from "../../src/migrate/swagger.js";
+
+describe("versionFromPath", () => {
+  it("reads the segment after stable/preview", () => {
+    expect(versionFromPath("specs/Foo/stable/2024-06-01/foo.json")).toBe("2024-06-01");
+    expect(versionFromPath("specs/Foo/preview/2024-06-01-preview/foo.json")).toBe(
+      "2024-06-01-preview",
+    );
+  });
+
+  it("returns undefined when there is no version segment", () => {
+    expect(versionFromPath("specs/Foo/foo.json")).toBeUndefined();
+  });
+});
+
+describe("namespaceFromPaths", () => {
+  it("extracts the provider namespace", () => {
+    expect(namespaceFromPaths(["/subscriptions/{id}/providers/Microsoft.EventGrid/topics"])).toBe(
+      "Microsoft.EventGrid",
+    );
+  });
+
+  it("returns undefined without a providers segment", () => {
+    expect(namespaceFromPaths(["/health"])).toBeUndefined();
+  });
+});
+
+describe("resolveRefPath", () => {
+  it("resolves relative refs against the swagger file and strips fragments", () => {
+    expect(resolveRefPath("/specs/foo.json", "./examples/Get.json#/x")).toBe(
+      "/specs/examples/Get.json",
+    );
+  });
+});
+
+describe("collectParamLocations", () => {
+  const doc: SwaggerDocument = {
+    parameters: {
+      SubscriptionIdParameter: { name: "subscriptionId", in: "path" },
+    },
+  };
+
+  it("resolves local $refs and inline params", () => {
+    const map = collectParamLocations(doc, [
+      { $ref: "#/parameters/SubscriptionIdParameter" },
+      { name: "$top", in: "query" },
+    ]);
+    expect(map.get("subscriptionId")).toBe("path");
+    expect(map.get("$top")).toBe("query");
+  });
+});
+
+describe("extractOperations", () => {
+  it("collects operations with x-ms-examples and merges path + operation params", () => {
+    const doc: SwaggerDocument = {
+      parameters: { Sub: { name: "subscriptionId", in: "path" } },
+      paths: {
+        "/things/{id}": {
+          parameters: [{ $ref: "#/parameters/Sub" }],
+          get: {
+            operationId: "Things_Get",
+            parameters: [{ name: "id", in: "path" }],
+            "x-ms-examples": { "Get a thing": { $ref: "./examples/Get.json" } },
+          },
+          post: { operationId: "Things_NoExamples" },
+        },
+      },
+    };
+    const ops = extractOperations(doc);
+    expect(ops).toHaveLength(1);
+    expect(ops[0].operationId).toBe("Things_Get");
+    expect(ops[0].paramLocations.get("subscriptionId")).toBe("path");
+    expect(ops[0].paramLocations.get("id")).toBe("path");
+    expect(Object.keys(ops[0].examples)).toEqual(["Get a thing"]);
+  });
+});

--- a/packages/typespec-azure-examples/test/migrate/transform.test.ts
+++ b/packages/typespec-azure-examples/test/migrate/transform.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { ParameterLocation, XmsExampleDoc } from "../../src/migrate/swagger-types.js";
+import { transformExample } from "../../src/migrate/transform.js";
+
+const locations = new Map<string, ParameterLocation>([
+  ["subscriptionId", "path"],
+  ["resourceGroupName", "path"],
+  ["$filter", "query"],
+  ["If-Match", "header"],
+  ["resource", "body"],
+]);
+
+describe("transformExample", () => {
+  it("buckets parameters by location and drops api-version", () => {
+    const doc: XmsExampleDoc = {
+      parameters: {
+        "api-version": "2024-06-01",
+        subscriptionId: "sub",
+        $filter: "name eq 'x'",
+        "If-Match": "*",
+        resource: { name: "cert" },
+      },
+      responses: { 200: { headers: { Location: "/op/1" }, body: { name: "cert" } } },
+    };
+    const variant = transformExample(doc, locations);
+    expect(variant.request).toEqual({
+      path: { subscriptionId: "sub" },
+      query: { $filter: "name eq 'x'" },
+      headers: { "If-Match": "*" },
+      body: { name: "cert" },
+    });
+    expect(variant.responses).toEqual({
+      "200": { headers: { Location: "/op/1" }, body: { name: "cert" } },
+    });
+  });
+
+  it("defaults unknown parameter locations to query", () => {
+    const doc: XmsExampleDoc = { parameters: { mystery: "value" }, responses: {} };
+    expect(transformExample(doc, locations).request).toEqual({ query: { mystery: "value" } });
+  });
+
+  it("produces an empty request when there are no parameters", () => {
+    const doc: XmsExampleDoc = { responses: { 204: {} } };
+    const variant = transformExample(doc, locations);
+    expect(variant.request).toEqual({});
+    expect(variant.responses).toEqual({ "204": {} });
+  });
+});

--- a/packages/typespec-azure-examples/test/migrate/version-order.test.ts
+++ b/packages/typespec-azure-examples/test/migrate/version-order.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  comparatorFromOrder,
+  defaultCompareVersions,
+  earliestVersion,
+} from "../../src/migrate/version-order.js";
+
+describe("defaultCompareVersions", () => {
+  it("orders by date ascending", () => {
+    const versions = ["2025-01-01", "2023-01-01", "2024-06-01"];
+    expect([...versions].sort(defaultCompareVersions)).toEqual([
+      "2023-01-01",
+      "2024-06-01",
+      "2025-01-01",
+    ]);
+  });
+
+  it("places a same-dated preview before its GA", () => {
+    expect(defaultCompareVersions("2024-06-01-preview", "2024-06-01")).toBeLessThan(0);
+  });
+});
+
+describe("comparatorFromOrder", () => {
+  it("honors the explicit order", () => {
+    const compare = comparatorFromOrder(["b", "a", "c"]);
+    expect([...["a", "b", "c"]].sort(compare)).toEqual(["b", "a", "c"]);
+  });
+});
+
+describe("earliestVersion", () => {
+  it("returns the lowest version under the comparator", () => {
+    expect(earliestVersion(["2024-06-01", "2023-01-01"], defaultCompareVersions)).toBe(
+      "2023-01-01",
+    );
+  });
+
+  it("returns undefined for an empty list", () => {
+    expect(earliestVersion([], defaultCompareVersions)).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Part of the Unified Examples Format epic (Azure/typespec-azure#4831), tracking Azure/typespec-azure#4833.

## Stack
- Azure/typespec-azure#4908 — `examples.yaml` schema + `examples-validate` (base)
- **This PR** → `examples-migrate` (base: `examples-file-format`)
- `examples-resolve` (stacked on top of this)

> Stacked PR — review/merge after the PR below it. Targets `examples-file-format`, not `main`.

## What
Adds the `examples-migrate` tool + `examples-migrate` CLI to `@azure-tools/typespec-azure-examples`, which converts versioned Swagger `x-ms-examples` into the unified `examples.yaml` format.

- Operation key derived by splitting `operationId` on the first `_` and lowercasing the method segment (e.g. `CaCertificates_Get` → `CaCertificates.get`).
- De-duplicates example variants across API versions into `since`-anchored lineages.
- Emits `examples.yaml` (bare integer status keys, quoted `since`, single-file or per-interface split).

Tests added (vitest); `tsc`, `oxlint`, `prettier` clean.

## Update — preserve legacy file names and keys

Migration now records the original `x-ms-examples` file name and key so the round-trip can reproduce the exact legacy files. It emits the **minimal** deviation from convention: nothing when the key equals the `operationId` and the file is `<OperationId>.json`, just `legacyFilename` when the key is recoverable from the file name, and an explicit `title` (plus `legacyFilename` when needed) otherwise. The convention itself comes from the shared naming helper in Azure/typespec-azure#4908.
