### PR TITLE
Set typespec-metadata test timeout to 30s

### DIFF
--- a/.chronus/changes/metadata-test-timeout-2026-6-31-10-49-19.md
+++ b/.chronus/changes/metadata-test-timeout-2026-6-31-10-49-19.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-metadata"
+---
+
+Set test timeout to 30 seconds to avoid spurious timeouts in CI.

--- a/packages/typespec-metadata/vitest.config.ts
+++ b/packages/typespec-metadata/vitest.config.ts
@@ -1,4 +1,11 @@
 import { defineConfig, mergeConfig } from "vitest/config";
 import { defaultTypeSpecVitestConfig } from "../../core/vitest.config";
 
-export default mergeConfig(defaultTypeSpecVitestConfig, defineConfig({}));
+export default mergeConfig(
+  defaultTypeSpecVitestConfig,
+  defineConfig({
+    test: {
+      testTimeout: 30000,
+    },
+  }),
+);


### PR DESCRIPTION
The inherited 5s seems to be too short in some cases, leading to spurious timeouts in CI.