### PR TITLE
Fix visibility-sealed errors when ARM resource decorators are re-applied

### DIFF
--- a/.chronus/changes/fix-arm-visibility-sealed-reapply-2026-07-31.md
+++ b/.chronus/changes/fix-arm-visibility-sealed-reapply-2026-07-31.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Fix `visibility-sealed` errors reported for the resource `name` property when emitters or versioning re-apply the ARM resource decorators on a copy of the resource type

--- a/packages/typespec-azure-resource-manager/src/private.decorators.ts
+++ b/packages/typespec-azure-resource-manager/src/private.decorators.ts
@@ -10,6 +10,7 @@ import {
   getTypeName,
   Interface,
   isKey,
+  isSealed,
   isTemplateDeclarationOrInstance,
   isTemplateInstance,
   Model,
@@ -584,14 +585,20 @@ export function registerArmResource(
     // Set the name property to be read only
     if (primaryKeyProperty.name === "name") {
       const Lifecycle = getLifecycleVisibilityEnum(program);
-      clearVisibilityModifiersForClass(program, primaryKeyProperty, Lifecycle, context);
-      addVisibilityModifiers(
-        program,
-        primaryKeyProperty,
-        [Lifecycle.members.get("Read")!],
-        context,
-      );
-      sealVisibilityModifiers(program, primaryKeyProperty, Lifecycle);
+      // Decorators may be re-applied to copies of the resource (e.g. by versioning
+      // projections or emitters using the mutator framework), and such copies share the
+      // original property instances. Sealing is only done here, so an already sealed
+      // property means this decorator already ran and the visibility is already correct.
+      if (!isSealed(program, primaryKeyProperty, Lifecycle)) {
+        clearVisibilityModifiersForClass(program, primaryKeyProperty, Lifecycle, context);
+        addVisibilityModifiers(
+          program,
+          primaryKeyProperty,
+          [Lifecycle.members.get("Read")!],
+          context,
+        );
+        sealVisibilityModifiers(program, primaryKeyProperty, Lifecycle);
+      }
     }
 
     keyName = getKeyName(program, primaryKeyProperty);
@@ -729,8 +736,13 @@ const $baseTypeOptional: BaseTypeOptionalDecorator = (
   const { program } = context;
   if (!isPresent) {
     const lifecycle = getLifecycleVisibilityEnum(program);
-    clearVisibilityModifiersForClass(program, target, lifecycle);
-    sealVisibilityModifiers(program, target, lifecycle);
+    // Guard against this decorator being re-applied to a copy of the containing model
+    // (e.g. by versioning projections or the mutator framework), which shares the same
+    // property instance and would otherwise report `visibility-sealed`.
+    if (!isSealed(program, target, lifecycle)) {
+      clearVisibilityModifiersForClass(program, target, lifecycle);
+      sealVisibilityModifiers(program, target, lifecycle);
+    }
   } else if (isAppliance) {
     const lifecycle = getLifecycleVisibilityEnum(program);
     const readMember = lifecycle.members.get("Read");

--- a/packages/typespec-azure-resource-manager/test/resource.test.ts
+++ b/packages/typespec-azure-resource-manager/test/resource.test.ts
@@ -1,5 +1,6 @@
 import { Model, Operation } from "@typespec/compiler";
 import { expectDiagnosticEmpty, expectDiagnostics, t } from "@typespec/compiler/testing";
+import { $ } from "@typespec/compiler/typekit";
 import { getHttpOperation } from "@typespec/http";
 import { ok, strictEqual } from "assert";
 import { describe, expect, it } from "vitest";
@@ -1416,5 +1417,30 @@ describe("multiple services", () => {
     expect(ResA.armProviderNamespace).toEqual("Provider.A");
     expect(ResB.name).toEqual("ResB");
     expect(ResB.armProviderNamespace).toEqual("Provider.B");
+  });
+});
+
+describe("decorator re-application", () => {
+  // Emitters (and versioning) create copies of the resource types through the mutator
+  // framework, which re-runs the decorators on the copy. Those decorators must be
+  // idempotent, otherwise sealing the visibility of `name` a second time reports
+  // `visibility-sealed`.
+  it("does not report diagnostics when the resource decorators are applied again", async () => {
+    const { program, FooResource } = await Tester.compile(t.code`
+      @armProviderNamespace
+      namespace Microsoft.Test;
+
+      model FooResourceProperties {}
+
+      model ${t.model("FooResource")} is TrackedResource<FooResourceProperties> {
+        ...ResourceNameParameter<FooResource>;
+      }
+    `);
+
+    const reportedBefore = program.diagnostics.length;
+    const tk = $(program);
+    tk.type.finishType(tk.type.clone(FooResource));
+
+    expectDiagnosticEmpty(program.diagnostics.slice(reportedBefore));
   });
 });

--- a/packages/typespec-azure-resource-manager/test/resource.test.ts
+++ b/packages/typespec-azure-resource-manager/test/resource.test.ts
@@ -1437,10 +1437,9 @@ describe("decorator re-application", () => {
       }
     `);
 
-    const reportedBefore = program.diagnostics.length;
     const tk = $(program);
     tk.type.finishType(tk.type.clone(FooResource));
 
-    expectDiagnosticEmpty(program.diagnostics.slice(reportedBefore));
+    expectDiagnosticEmpty(program.diagnostics);
   });
 });


### PR DESCRIPTION
Compiling any ARM spec with an emitter built on the mutator framework fails. For example `@typespec/http-server-csharp` on the standard Contoso sample:

```
../../typespec-azure-resource-manager/lib/models.tsp:64:1 - error visibility-sealed: Visibility of property 'name' is sealed and cannot be changed.
> 64 | @armResourceInternal(Properties)
```

The mutator framework clones a type and then calls `finishType` on the clone, which re-runs its decorators. The clone shares the original `ModelProperty` instances, so when `@armResourceInternal` runs a second time it tries to clear and re-seal the visibility of a `name` property that it already sealed during the first pass — and the compiler rightly complains.

Sealing the `name` visibility is now skipped when the property is already sealed, so the decorator is idempotent. Since `registerArmResource` is the only place that seals it, an already-sealed property means the visibility is already exactly what we would set. The same guard is applied to `@baseTypeOptional`, which had the identical pattern.

This is the same class of problem the existing dedup workaround in `listArmResources` was added for.