### PR TITLE
Enable verbatimModuleSyntax in small packages

### DIFF
--- a/.chronus/changes/verbatim-module-syntax-easy-tier-2026-7-31-10-0-0.md
+++ b/.chronus/changes/verbatim-module-syntax-easy-tier-2026-7-31-10-0-0.md
@@ -1,0 +1,8 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-python"
+  - "@azure-tools/typespec-metadata"
+---
+
+Enable `verbatimModuleSyntax` and use `import type` for type-only imports. No runtime or public API changes.

--- a/packages/benchmark/tsconfig.json
+++ b/packages/benchmark/tsconfig.json
@@ -3,6 +3,7 @@
   "include": ["src/**/*.ts"],
   "compilerOptions": {
     "outDir": "dist",
-    "rootDir": "."
+    "rootDir": ".",
+    "verbatimModuleSyntax": true
   }
 }

--- a/packages/samples/tsconfig.json
+++ b/packages/samples/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
-    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo",
+    "verbatimModuleSyntax": true
   }
 }

--- a/packages/spector-runner/src/loader.ts
+++ b/packages/spector-runner/src/loader.ts
@@ -1,12 +1,12 @@
 import { readFileSync } from "fs";
 import { parse } from "yaml";
 import {
-  ResolvedSpec,
-  SpecEntry,
-  SpecEntryOptions,
-  SpecOptions,
-  SpecOptionValue,
-  SpectorConfig,
+  type ResolvedSpec,
+  type SpecEntry,
+  type SpecEntryOptions,
+  type SpecOptions,
+  type SpecOptionValue,
+  type SpectorConfig,
   SpectorConfigError,
 } from "./types.js";
 

--- a/packages/spector-runner/tsconfig.json
+++ b/packages/spector-runner/tsconfig.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
-    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo",
+    "verbatimModuleSyntax": true
   }
 }

--- a/packages/typespec-azure-playground-website/tsconfig.json
+++ b/packages/typespec-azure-playground-website/tsconfig.json
@@ -15,6 +15,7 @@
     "allowJs": true,
     "lib": ["DOM", "ES2022"],
     "skipLibCheck": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "verbatimModuleSyntax": true
   }
 }

--- a/packages/typespec-metadata/src/collector.ts
+++ b/packages/typespec-metadata/src/collector.ts
@@ -7,7 +7,7 @@ import {
   type Namespace,
   type Program,
 } from "@typespec/compiler";
-import { LanguagePackageMetadata, TypeSpecMetadata } from "./metadata.js";
+import type { LanguagePackageMetadata, TypeSpecMetadata } from "./metadata.js";
 
 const PACKAGE_NAME_KEYS = ["package-name", "packageName", "package"];
 const NAMESPACE_KEYS = ["namespace", "namespace-name", "namespaceName"];

--- a/packages/typespec-metadata/tsconfig.json
+++ b/packages/typespec-metadata/tsconfig.json
@@ -5,6 +5,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
-    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo",
+    "verbatimModuleSyntax": true
   }
 }

--- a/packages/typespec-python/src/emitter.ts
+++ b/packages/typespec-python/src/emitter.ts
@@ -1,6 +1,6 @@
-import { EmitContext } from "@typespec/compiler";
+import type { EmitContext } from "@typespec/compiler";
 import { $onEmit as httpClientPythonOnEmit } from "@typespec/http-client-python";
-import { PythonAzureEmitterOptions } from "./lib.js";
+import type { PythonAzureEmitterOptions } from "./lib.js";
 
 export async function $onEmit(context: EmitContext<PythonAzureEmitterOptions>) {
   // set flavor to azure if not set for python azure emitter

--- a/packages/typespec-python/src/lib.ts
+++ b/packages/typespec-python/src/lib.ts
@@ -1,10 +1,13 @@
 import {
   BrandedSdkEmitterOptions,
-  SdkContext,
-  SdkServiceOperation,
+  type SdkContext,
+  type SdkServiceOperation,
 } from "@azure-tools/typespec-client-generator-core";
-import { createTypeSpecLibrary, JSONSchemaType } from "@typespec/compiler";
-import { PythonEmitterOptions, PythonEmitterOptionsSchema } from "@typespec/http-client-python";
+import { createTypeSpecLibrary, type JSONSchemaType } from "@typespec/compiler";
+import {
+  type PythonEmitterOptions,
+  PythonEmitterOptionsSchema,
+} from "@typespec/http-client-python";
 
 export interface PythonAzureEmitterOptions extends PythonEmitterOptions {
   "examples-dir"?: string;

--- a/packages/typespec-python/tsconfig.json
+++ b/packages/typespec-python/tsconfig.json
@@ -4,7 +4,8 @@
     "outDir": "dist",
     "rootDir": ".",
     "rewriteRelativeImportExtensions": true,
-    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo",
+    "verbatimModuleSyntax": true
   },
   "include": ["src/**/*.ts", "eng/**/*.ts"]
 }


### PR DESCRIPTION
Type-only imports in `typespec-azure` are still emitted as runtime imports. That leaves dead runtime edges in the emitted JS, makes module side effects ambiguous, and blocks ever turning `verbatimModuleSyntax` on repo-wide — something `core` has already been rolling out package by package.

This enables the flag for **`samples`, `typespec-python`, `benchmark`, `typespec-azure-playground-website`, `typespec-metadata` and `spector-runner`** and rewrites the imports it flags:

```diff
-import { SdkContext } from "./interfaces.js";
+import type { SdkContext } from "./interfaces.js";
```

The rewrite was driven by the compiler rather than by regex: build the program with the flag on, collect the TS1484/TS1485/TS1205 diagnostics, and change exactly the specifiers TypeScript names — hoisting to `import type` when every specifier in a clause is type-only, otherwise adding an inline `type` modifier. `tsc` then reports zero new errors against a pre-change baseline, so no value binding was turned into a type-only one.

One of a series of PRs, one per package, so each diff stays reviewable. They are independent and can land in any order.

| PR | Scope |
| --- | --- |
| Azure/typespec-azure#5127 | `samples`, `typespec-python`, `benchmark`, `typespec-azure-playground-website`, `typespec-metadata`, `spector-runner` |
| Azure/typespec-azure#5128 | `azure-http-specs` |
| Azure/typespec-azure#5129 | `typespec-autorest` |
| Azure/typespec-azure#5130 | `typespec-azure-core` |
| Azure/typespec-azure#5131 | `typespec-azure-resource-manager` |
| Azure/typespec-azure#5132 | `typespec-client-generator-core` |
| Azure/typespec-azure#5133 | `typespec-go` |
| Azure/typespec-azure#5134 | `typespec-ts` |
| Azure/typespec-azure#5135 | `eng/` scripts |

`typespec-autorest-canonical`, `typespec-azure-portal-core` and `typespec-azure-rulesets` already had the flag. `typespec-java` is deliberately left out: its `src/` is copied in at build time from `azure-sdk-for-java`, so the flag would break its build until those sources are migrated upstream.

Once these land, a follow-up will hoist the flag into a repo-level `tsconfig.base.json` and drop the per-package copies, so new packages inherit it by default.
