### PR TITLE
Enable verbatimModuleSyntax in azure-http-specs

### DIFF
--- a/.chronus/changes/verbatim-module-syntax-azure-http-specs-2026-7-31-10-0-0.md
+++ b/.chronus/changes/verbatim-module-syntax-azure-http-specs-2026-7-31-10-0-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Enable `verbatimModuleSyntax` and use `import type` for type-only imports. No runtime or public API changes.

--- a/packages/azure-http-specs/specs/azure/client-generator-core/access/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/access/mockapi.ts
@@ -1,4 +1,9 @@
-import { json, MockApiDefinition, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import {
+  json,
+  type MockApiDefinition,
+  passOnSuccess,
+  type ScenarioMockApi,
+} from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/alternate-type/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/alternate-type/mockapi.ts
@@ -1,9 +1,9 @@
 import {
   json,
-  MockApiDefinition,
-  MockBody,
+  type MockApiDefinition,
+  type MockBody,
   passOnSuccess,
-  ScenarioMockApi,
+  type ScenarioMockApi,
 } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};

--- a/packages/azure-http-specs/specs/azure/client-generator-core/api-version/client-api-versions/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/api-version/client-api-versions/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/api-version/header/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/api-version/header/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/api-version/path/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/api-version/path/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/api-version/query/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/api-version/query/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-default-value/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-default-value/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-doc/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-doc/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/default/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/default/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/individually/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/individually/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/individuallyParent/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-initialization/individuallyParent/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-location/move-method-parameter-to-client/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-location/move-method-parameter-to-client/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-location/move-to-existing-sub-client/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-location/move-to-existing-sub-client/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-location/move-to-new-sub-client/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-location/move-to-new-sub-client/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/client-location/move-to-root-client/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/client-location/move-to-root-client/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/deserialize-empty-string-as-null/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/deserialize-empty-string-as-null/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/exact-name/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/flatten-property/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/flatten-property/mockapi.ts
@@ -1,4 +1,9 @@
-import { json, MockApiDefinition, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import {
+  json,
+  type MockApiDefinition,
+  passOnSuccess,
+  type ScenarioMockApi,
+} from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 function createMockApiDefinitions(route: string, request: any, response: any): MockApiDefinition {

--- a/packages/azure-http-specs/specs/azure/client-generator-core/hierarchy-building/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/hierarchy-building/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/next-link-verb/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/next-link-verb/mockapi.ts
@@ -1,4 +1,4 @@
-import { dyn, dynItem, json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { dyn, dynItem, json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/override/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/override/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/response-as-bool/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/response-as-bool/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnCode, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnCode, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/client-generator-core/usage/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/client-generator-core/usage/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/core/basic/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/basic/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 const validUser = { id: 1, name: "Madge", etag: "11bdc430-65e8-45ad-81d9-8ffa60d55b59" };

--- a/packages/azure-http-specs/specs/azure/core/lro/rpc/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/lro/rpc/mockapi.ts
@@ -4,7 +4,7 @@ import {
   json,
   MockRequest,
   passOnSuccess,
-  ScenarioMockApi,
+  type ScenarioMockApi,
 } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};

--- a/packages/azure-http-specs/specs/azure/core/lro/standard/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/lro/standard/mockapi.ts
@@ -4,7 +4,7 @@ import {
   json,
   MockRequest,
   passOnSuccess,
-  ScenarioMockApi,
+  type ScenarioMockApi,
 } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};

--- a/packages/azure-http-specs/specs/azure/core/model/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/model/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/core/page/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/page/mockapi.ts
@@ -1,4 +1,4 @@
-import { dyn, dynItem, json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { dyn, dynItem, json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 const validUser = { id: 1, name: "Madge", etag: "11bdc430-65e8-45ad-81d9-8ffa60d55b59" };

--- a/packages/azure-http-specs/specs/azure/core/scalar/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/scalar/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/core/traits/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/core/traits/mockapi.ts
@@ -2,7 +2,7 @@ import {
   json,
   MockRequest,
   passOnSuccess,
-  ScenarioMockApi,
+  type ScenarioMockApi,
   validateValueFormat,
   ValidationError,
 } from "@typespec/spec-api";

--- a/packages/azure-http-specs/specs/azure/encode/duration/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/encode/duration/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/example/basic/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/example/basic/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/payload/pageable/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/payload/pageable/mockapi.ts
@@ -1,7 +1,7 @@
 import {
   json,
   MockRequest,
-  ScenarioMockApi,
+  type ScenarioMockApi,
   ValidationError,
   withServiceKeys,
 } from "@typespec/spec-api";

--- a/packages/azure-http-specs/specs/azure/resource-manager/common-properties/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/common-properties/mockapi.ts
@@ -3,7 +3,7 @@ import {
   json,
   passOnCode,
   passOnSuccess,
-  ScenarioMockApi,
+  type ScenarioMockApi,
   ValidationError,
 } from "@typespec/spec-api";
 

--- a/packages/azure-http-specs/specs/azure/resource-manager/large-header/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/large-header/mockapi.ts
@@ -4,7 +4,7 @@ import {
   json,
   MockRequest,
   passOnSuccess,
-  ScenarioMockApi,
+  type ScenarioMockApi,
   ValidationError,
 } from "@typespec/spec-api";
 

--- a/packages/azure-http-specs/specs/azure/resource-manager/management-group/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/management-group/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/resource-manager/method-subscription-id/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/method-subscription-id/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/resource-manager/multi-service-shared-models/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/multi-service-shared-models/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/resource-manager/multi-service/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/multi-service/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/resource-manager/non-resource/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/non-resource/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/resource-manager/operation-templates/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/operation-templates/mockapi.ts
@@ -4,7 +4,7 @@ import {
   json,
   MockRequest,
   passOnSuccess,
-  ScenarioMockApi,
+  type ScenarioMockApi,
   withServiceKeys,
 } from "@typespec/spec-api";
 

--- a/packages/azure-http-specs/specs/azure/resource-manager/resources/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/resources/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi, ValidationError } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi, ValidationError } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/resource-manager/service-group/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/resource-manager/service-group/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/special-headers/client-request-id/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/special-headers/client-request-id/mockapi.ts
@@ -1,7 +1,7 @@
 import {
   MockRequest,
   passOnSuccess,
-  ScenarioMockApi,
+  type ScenarioMockApi,
   validateValueFormat,
 } from "@typespec/spec-api";
 

--- a/packages/azure-http-specs/specs/azure/special-headers/conditional-request/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/special-headers/conditional-request/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/azure/versioning/previewVersion/mockapi.ts
+++ b/packages/azure-http-specs/specs/azure/versioning/previewVersion/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/client/namespace/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/namespace/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/client/naming/enum-conflict/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/naming/enum-conflict/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/client/naming/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/naming/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/client/overload/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/overload/mockapi.ts
@@ -1,4 +1,4 @@
-import { json, passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { json, passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/client/structure/client-operation-group/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/structure/client-operation-group/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 import { createServerTests } from "../common/service.js";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};

--- a/packages/azure-http-specs/specs/client/structure/common/service.ts
+++ b/packages/azure-http-specs/specs/client/structure/common/service.ts
@@ -1,4 +1,4 @@
-import { MockApiDefinition } from "@typespec/spec-api";
+import type { MockApiDefinition } from "@typespec/spec-api";
 
 export function createServerTests(uri: string): MockApiDefinition {
   return {

--- a/packages/azure-http-specs/specs/client/structure/default/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/structure/default/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 import { createServerTests } from "../common/service.js";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};

--- a/packages/azure-http-specs/specs/client/structure/multi-client/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/structure/multi-client/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 import { createServerTests } from "../common/service.js";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};

--- a/packages/azure-http-specs/specs/client/structure/renamed-operation/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/structure/renamed-operation/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 import { createServerTests } from "../common/service.js";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};

--- a/packages/azure-http-specs/specs/client/structure/two-operation-group/mockapi.ts
+++ b/packages/azure-http-specs/specs/client/structure/two-operation-group/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 import { createServerTests } from "../common/service.js";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};

--- a/packages/azure-http-specs/specs/resiliency/srv-driven/mockapi.ts
+++ b/packages/azure-http-specs/specs/resiliency/srv-driven/mockapi.ts
@@ -1,4 +1,9 @@
-import { MockRequest, ScenarioMockApi, ValidationError, passOnSuccess } from "@typespec/spec-api";
+import {
+  MockRequest,
+  type ScenarioMockApi,
+  ValidationError,
+  passOnSuccess,
+} from "@typespec/spec-api";
 
 export const commonBase = "/resiliency/service-driven";
 

--- a/packages/azure-http-specs/specs/service/multi-service/mockapi.ts
+++ b/packages/azure-http-specs/specs/service/multi-service/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/specs/service/multiple-services/mockapi.ts
+++ b/packages/azure-http-specs/specs/service/multiple-services/mockapi.ts
@@ -1,4 +1,4 @@
-import { passOnSuccess, ScenarioMockApi } from "@typespec/spec-api";
+import { passOnSuccess, type ScenarioMockApi } from "@typespec/spec-api";
 
 export const Scenarios: Record<string, ScenarioMockApi> = {};
 

--- a/packages/azure-http-specs/tsconfig.json
+++ b/packages/azure-http-specs/tsconfig.json
@@ -4,6 +4,7 @@
     "outDir": "dist",
     "rootDir": ".",
     "tsBuildInfoFile": "temp/.tsbuildinfo",
-    "allowJs": true
+    "allowJs": true,
+    "verbatimModuleSyntax": true
   }
 }


### PR DESCRIPTION
Type-only imports in `typespec-azure` are still emitted as runtime imports. That leaves dead runtime edges in the emitted JS, makes module side effects ambiguous, and blocks ever turning `verbatimModuleSyntax` on repo-wide — something `core` has already been rolling out package by package.

This enables the flag for **`azure-http-specs`** and rewrites the imports it flags:

```diff
-import { SdkContext } from "./interfaces.js";
+import type { SdkContext } from "./interfaces.js";
```

The rewrite was driven by the compiler rather than by regex: build the program with the flag on, collect the TS1484/TS1485/TS1205 diagnostics, and change exactly the specifiers TypeScript names — hoisting to `import type` when every specifier in a clause is type-only, otherwise adding an inline `type` modifier. `tsc` then reports zero new errors against a pre-change baseline, so no value binding was turned into a type-only one.

One of a series of PRs, one per package, so each diff stays reviewable. They are independent and can land in any order.

| PR | Scope |
| --- | --- |
| Azure/typespec-azure#5127 | `samples`, `typespec-python`, `benchmark`, `typespec-azure-playground-website`, `typespec-metadata`, `spector-runner` |
| Azure/typespec-azure#5128 | `azure-http-specs` |
| Azure/typespec-azure#5129 | `typespec-autorest` |
| Azure/typespec-azure#5130 | `typespec-azure-core` |
| Azure/typespec-azure#5131 | `typespec-azure-resource-manager` |
| Azure/typespec-azure#5132 | `typespec-client-generator-core` |
| Azure/typespec-azure#5133 | `typespec-go` |
| Azure/typespec-azure#5134 | `typespec-ts` |
| Azure/typespec-azure#5135 | `eng/` scripts |

`typespec-autorest-canonical`, `typespec-azure-portal-core` and `typespec-azure-rulesets` already had the flag. `typespec-java` is deliberately left out: its `src/` is copied in at build time from `azure-sdk-for-java`, so the flag would break its build until those sources are migrated upstream.

Once these land, a follow-up will hoist the flag into a repo-level `tsconfig.base.json` and drop the per-package copies, so new packages inherit it by default.
