### PR TITLE
Enable verbatimModuleSyntax in typespec-go

### DIFF
--- a/.chronus/changes/verbatim-module-syntax-typespec-go-2026-7-31-10-0-0.md
+++ b/.chronus/changes/verbatim-module-syntax-typespec-go-2026-7-31-10-0-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-go"
+---
+
+Enable `verbatimModuleSyntax` and use `import type` for type-only imports. No runtime or public API changes.

--- a/packages/typespec-go/src/codegen/core/errors.ts
+++ b/packages/typespec-go/src/codegen/core/errors.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { ErrorCode } from "../../codemodel/errors.js";
+import type { ErrorCode } from "../../codemodel/errors.js";
 
 /**
  * CodegenError is thrown when the emitter fails some condition

--- a/packages/typespec-go/src/codemodel/type.ts
+++ b/packages/typespec-go/src/codemodel/type.ts
@@ -7,7 +7,7 @@
 
 import * as path from "path";
 import { Client, ClientOptions } from "./client.js";
-import { PackageContent, PackageType, getPackageName } from "./module.js";
+import { type PackageContent, type PackageType, getPackageName } from "./module.js";
 import { ParameterGroup } from "./param.js";
 import { ResponseEnvelope } from "./result.js";
 

--- a/packages/typespec-go/src/emitter.ts
+++ b/packages/typespec-go/src/emitter.ts
@@ -3,14 +3,14 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { DiagnosticSeverity, EmitContext, NoTarget } from "@typespec/compiler";
+import { type DiagnosticSeverity, type EmitContext, NoTarget } from "@typespec/compiler";
 import { execSync } from "child_process";
 import { existsSync, opendirSync, readFileSync, unlinkSync } from "fs";
 import { mkdir, readFile, writeFile } from "fs/promises";
 import * as path from "path";
 import * as codegen from "./codegen/index.js";
 import { CodeModelError } from "./codemodel/errors.js";
-import { GoEmitterOptions, reportDiagnostic } from "./lib.js";
+import { type GoEmitterOptions, reportDiagnostic } from "./lib.js";
 import { Adapter, ExternalError } from "./tcgcadapter/adapter.js";
 import { AdapterError } from "./tcgcadapter/errors.js";
 

--- a/packages/typespec-go/src/lib.ts
+++ b/packages/typespec-go/src/lib.ts
@@ -3,7 +3,7 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { createTypeSpecLibrary, JSONSchemaType, paramMessage } from "@typespec/compiler";
+import { createTypeSpecLibrary, type JSONSchemaType, paramMessage } from "@typespec/compiler";
 
 export interface GoEmitterOptions {
   "azcore-version"?: string;

--- a/packages/typespec-go/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-go/src/tcgcadapter/adapter.ts
@@ -8,7 +8,7 @@
 import * as tcgc from "@azure-tools/typespec-client-generator-core";
 import * as tsp from "@typespec/compiler";
 import * as go from "../codemodel/index.js";
-import { GoEmitterOptions } from "../lib.js";
+import type { GoEmitterOptions } from "../lib.js";
 import * as naming from "../naming/index.js";
 import { ClientAdapter } from "./clients.js";
 import { AdapterError } from "./errors.js";

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -6,7 +6,7 @@
 /* eslint-disable @typescript-eslint/no-deprecated -- uses TCGC APIs marked deprecated (correspondingMethodParams). */
 
 import * as tcgc from "@azure-tools/typespec-client-generator-core";
-import { ModelProperty, NoTarget } from "@typespec/compiler";
+import { type ModelProperty, NoTarget } from "@typespec/compiler";
 import * as http from "@typespec/http";
 import * as go from "../codemodel/index.js";
 import {

--- a/packages/typespec-go/src/tcgcadapter/errors.ts
+++ b/packages/typespec-go/src/tcgcadapter/errors.ts
@@ -4,7 +4,7 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as tsp from "@typespec/compiler";
-import { ErrorCode } from "../codemodel/errors.js";
+import type { ErrorCode } from "../codemodel/errors.js";
 
 /**
  * AdapterError is thrown when the emitter fails to convert part of the tcgc code

--- a/packages/typespec-go/tsconfig.json
+++ b/packages/typespec-go/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "dist",
     "rootDir": ".",
-    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo"
+    "tsBuildInfoFile": "temp/tsconfig.tsbuildinfo",
+    "verbatimModuleSyntax": true
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
Type-only imports in `typespec-azure` are still emitted as runtime imports. That leaves dead runtime edges in the emitted JS, makes module side effects ambiguous, and blocks ever turning `verbatimModuleSyntax` on repo-wide — something `core` has already been rolling out package by package.

This enables the flag for **`typespec-go`** and rewrites the imports it flags:

```diff
-import { SdkContext } from "./interfaces.js";
+import type { SdkContext } from "./interfaces.js";
```

The rewrite was driven by the compiler rather than by regex: build the program with the flag on, collect the TS1484/TS1485/TS1205 diagnostics, and change exactly the specifiers TypeScript names — hoisting to `import type` when every specifier in a clause is type-only, otherwise adding an inline `type` modifier. `tsc` then reports zero new errors against a pre-change baseline, so no value binding was turned into a type-only one.

One of a series of PRs, one per package, so each diff stays reviewable. They are independent and can land in any order.

| PR | Scope |
| --- | --- |
| Azure/typespec-azure#5127 | `samples`, `typespec-python`, `benchmark`, `typespec-azure-playground-website`, `typespec-metadata`, `spector-runner` |
| Azure/typespec-azure#5128 | `azure-http-specs` |
| Azure/typespec-azure#5129 | `typespec-autorest` |
| Azure/typespec-azure#5130 | `typespec-azure-core` |
| Azure/typespec-azure#5131 | `typespec-azure-resource-manager` |
| Azure/typespec-azure#5132 | `typespec-client-generator-core` |
| Azure/typespec-azure#5133 | `typespec-go` |
| Azure/typespec-azure#5134 | `typespec-ts` |
| Azure/typespec-azure#5135 | `eng/` scripts |

`typespec-autorest-canonical`, `typespec-azure-portal-core` and `typespec-azure-rulesets` already had the flag. `typespec-java` is deliberately left out: its `src/` is copied in at build time from `azure-sdk-for-java`, so the flag would break its build until those sources are migrated upstream.

Once these land, a follow-up will hoist the flag into a repo-level `tsconfig.base.json` and drop the per-package copies, so new packages inherit it by default.
