### PR TITLE
Enable verbatimModuleSyntax in typespec-ts

### DIFF
--- a/.chronus/changes/verbatim-module-syntax-typespec-ts-2026-7-31-10-0-0.md
+++ b/.chronus/changes/verbatim-module-syntax-typespec-ts-2026-7-31-10-0-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Enable `verbatimModuleSyntax` and use `import type` for type-only imports. No runtime or public API changes.

--- a/packages/typespec-ts/src/context-manager.ts
+++ b/packages/typespec-ts/src/context-manager.ts
@@ -1,10 +1,10 @@
-import { SdkContext } from "@azure-tools/typespec-client-generator-core";
-import { EmitContext } from "@typespec/compiler";
+import type { SdkContext } from "@azure-tools/typespec-client-generator-core";
+import type { EmitContext } from "@typespec/compiler";
 import { Project, SourceFile } from "ts-morph";
-import { ExternalDependencies } from "./framework/dependency.js";
-import { Binder } from "./framework/hooks/binder.js";
-import { SdkTypeContext } from "./framework/hooks/sdk-types.js";
-import { ClientTypeMetaTree } from "./meta-tree.js";
+import type { ExternalDependencies } from "./framework/dependency.js";
+import type { Binder } from "./framework/hooks/binder.js";
+import type { SdkTypeContext } from "./framework/hooks/sdk-types.js";
+import type { ClientTypeMetaTree } from "./meta-tree.js";
 
 /**
  * Contexts Object Guidelines

--- a/packages/typespec-ts/src/framework/declaration.ts
+++ b/packages/typespec-ts/src/framework/declaration.ts
@@ -1,17 +1,17 @@
 import {
   ClassDeclaration,
-  ClassDeclarationStructure,
+  type ClassDeclarationStructure,
   EnumDeclaration,
-  EnumDeclarationStructure,
+  type EnumDeclarationStructure,
   FunctionDeclaration,
-  FunctionDeclarationStructure,
+  type FunctionDeclarationStructure,
   InterfaceDeclaration,
-  InterfaceDeclarationStructure,
+  type InterfaceDeclarationStructure,
   SourceFile,
-  StatementStructures,
+  type StatementStructures,
   StructureKind,
   TypeAliasDeclaration,
-  TypeAliasDeclarationStructure,
+  type TypeAliasDeclarationStructure,
 } from "ts-morph";
 import { useBinder } from "./hooks/binder.js";
 import { refkey as getRefKey } from "./refkey.js";

--- a/packages/typespec-ts/src/framework/hooks/binder.ts
+++ b/packages/typespec-ts/src/framework/hooks/binder.ts
@@ -1,15 +1,15 @@
 import { joinPaths, normalizePath } from "@typespec/compiler";
 import {
-  ImportDeclarationStructure,
-  ImportSpecifierStructure,
+  type ImportDeclarationStructure,
+  type ImportSpecifierStructure,
   Project,
   SourceFile,
   StructureKind,
 } from "ts-morph";
 import { provideContext, useContext } from "../../context-manager.js";
 import { generateLocallyUniqueName } from "../../modular/helpers/naming-helpers.js";
-import { ReferenceableSymbol } from "../dependency.js";
-import { SourceFileSymbol, StaticHelperMetadata } from "../load-static-helpers.js";
+import type { ReferenceableSymbol } from "../dependency.js";
+import { SourceFileSymbol, type StaticHelperMetadata } from "../load-static-helpers.js";
 import { refkey } from "../refkey.js";
 import { provideDependencies, useDependencies } from "./use-dependencies.js";
 

--- a/packages/typespec-ts/src/framework/hooks/sdk-types.ts
+++ b/packages/typespec-ts/src/framework/hooks/sdk-types.ts
@@ -1,20 +1,20 @@
 import {
-  SdkClientType,
-  SdkHttpOperation,
-  SdkModelPropertyType,
-  SdkModelType,
-  SdkServiceMethod,
-  SdkType,
+  type SdkClientType,
+  type SdkHttpOperation,
+  type SdkModelPropertyType,
+  type SdkModelType,
+  type SdkServiceMethod,
+  type SdkType,
   getClientType,
 } from "@azure-tools/typespec-client-generator-core";
-import { Operation, Type, getNamespaceFullName } from "@typespec/compiler";
+import { type Operation, type Type, getNamespaceFullName } from "@typespec/compiler";
 import { provideContext, useContext } from "../../context-manager.js";
 
 import { reportDiagnostic } from "../../lib.js";
 import { visitPackageTypes } from "../../modular/emit-models.js";
 import { getAllAncestors, getAllProperties } from "../../modular/helpers/operation-helpers.js";
 import { normalizeModelPropertyName } from "../../modular/type-expressions/get-type-expression.js";
-import { SdkContext } from "../../utils/interfaces.js";
+import type { SdkContext } from "../../utils/interfaces.js";
 import { NameType, normalizeName } from "../../utils/name-utils.js";
 
 export const emitQueue: Set<SdkType> = new Set<SdkType>();

--- a/packages/typespec-ts/src/framework/hooks/use-dependencies.ts
+++ b/packages/typespec-ts/src/framework/hooks/use-dependencies.ts
@@ -1,6 +1,6 @@
 import { provideContext, useContext } from "../../context-manager.js";
 import { DefaultCoreDependencies } from "../../modular/external-dependencies.js";
-import { ExternalDependencies } from "../dependency.js";
+import type { ExternalDependencies } from "../dependency.js";
 
 export function provideDependencies(customDependencies: Partial<ExternalDependencies> = {}) {
   const dependencies = {

--- a/packages/typespec-ts/src/framework/load-static-helpers.ts
+++ b/packages/typespec-ts/src/framework/load-static-helpers.ts
@@ -1,4 +1,4 @@
-import { type CompilerHost, joinPaths, NoTarget, Program } from "@typespec/compiler";
+import { type CompilerHost, joinPaths, NoTarget, type Program } from "@typespec/compiler";
 import {
   ClassDeclaration,
   EnumDeclaration,
@@ -9,7 +9,7 @@ import {
   TypeAliasDeclaration,
 } from "ts-morph";
 import { reportDiagnostic } from "../lib.js";
-import { ModularEmitterOptions } from "../modular/interfaces.js";
+import type { ModularEmitterOptions } from "../modular/interfaces.js";
 import { resolveProjectRoot } from "../utils/resolve-project-root.js";
 import { refkey } from "./refkey.js";
 export const SourceFileSymbol = Symbol("SourceFile");

--- a/packages/typespec-ts/src/framework/reference.ts
+++ b/packages/typespec-ts/src/framework/reference.ts
@@ -1,6 +1,6 @@
-import { ReferenceableSymbol } from "./dependency.js";
+import type { ReferenceableSymbol } from "./dependency.js";
 import { useBinder } from "./hooks/binder.js";
-import { SourceFileSymbol, StaticHelperMetadata } from "./load-static-helpers.js";
+import { SourceFileSymbol, type StaticHelperMetadata } from "./load-static-helpers.js";
 import { refkey as getRefkey } from "./refkey.js";
 
 export function resolveReference(refkey: unknown): string {

--- a/packages/typespec-ts/src/framework/sample.ts
+++ b/packages/typespec-ts/src/framework/sample.ts
@@ -1,6 +1,6 @@
 import {
-  FunctionDeclarationStructure,
-  InterfaceDeclarationStructure,
+  type FunctionDeclarationStructure,
+  type InterfaceDeclarationStructure,
   Project,
   StructureKind,
 } from "ts-morph";

--- a/packages/typespec-ts/src/framework/source-file-batch.ts
+++ b/packages/typespec-ts/src/framework/source-file-batch.ts
@@ -1,7 +1,7 @@
 import {
-  ExportDeclarationStructure,
+  type ExportDeclarationStructure,
   SourceFile,
-  StatementStructures,
+  type StatementStructures,
   StructureKind,
 } from "ts-morph";
 

--- a/packages/typespec-ts/src/index.ts
+++ b/packages/typespec-ts/src/index.ts
@@ -2,13 +2,13 @@
 // Licensed under the MIT License.
 
 import {
-  EmitContext,
-  Program,
+  type CompilerHost,
+  type EmitContext,
+  type Program,
   getBaseFileName,
   getDirectoryPath,
   joinPaths,
   resolvePath,
-  type CompilerHost,
 } from "@typespec/compiler";
 import { clearContexts, provideContext, useContext } from "./context-manager.js";
 import { buildRootIndex, buildSubClientIndexFile } from "./modular/build-root-index.js";
@@ -32,11 +32,11 @@ import {
 } from "./modular/static-helpers-metadata.js";
 import { emitContentByBuilder } from "./utils/emit-util.js";
 import { clearDirectory, emptyDir, pathExists } from "./utils/file-system-utils.js";
-import { GenerationDirDetail, SdkContext } from "./utils/interfaces.js";
+import type { GenerationDirDetail, SdkContext } from "./utils/interfaces.js";
 
 import {
-  SdkClientType,
-  SdkServiceOperation,
+  type SdkClientType,
+  type SdkServiceOperation,
   createSdkContext,
   listAllServiceNamespaces,
 } from "@azure-tools/typespec-client-generator-core";
@@ -44,8 +44,8 @@ import { Project } from "ts-morph";
 import { provideBinder } from "./framework/hooks/binder.js";
 import { provideSdkTypes, resetSdkTypesState } from "./framework/hooks/sdk-types.js";
 import { loadStaticHelpers } from "./framework/load-static-helpers.js";
-import { ClientModel, ClientOptions } from "./interfaces.js";
-import { EmitterOptions } from "./lib.js";
+import type { ClientModel, ClientOptions } from "./interfaces.js";
+import type { EmitterOptions } from "./lib.js";
 import { buildApiExtractorConfig } from "./metadata/build-api-extractor-config.js";
 import { buildChangelogFile } from "./metadata/build-changelog-file.js";
 import { buildEsLintConfig } from "./metadata/build-es-lint-config.js";
@@ -87,7 +87,7 @@ import { emitNonModelResponseTypes, emitTypes } from "./modular/emit-models.js";
 import { emitSamples } from "./modular/emit-samples.js";
 import { emitTests } from "./modular/emit-tests.js";
 import { getClassicalClientName } from "./modular/helpers/naming-helpers.js";
-import { ModularEmitterOptions } from "./modular/interfaces.js";
+import type { ModularEmitterOptions } from "./modular/interfaces.js";
 import { packageUsesXmlSerialization } from "./modular/serialization/build-xml-serializer-function.js";
 import { transformClientOptions } from "./transform/transform-client-options.js";
 import { transformClientModel } from "./transform/transform.js";

--- a/packages/typespec-ts/src/lib.ts
+++ b/packages/typespec-ts/src/lib.ts
@@ -1,9 +1,9 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { createTypeSpecLibrary, JSONSchemaType, paramMessage } from "@typespec/compiler";
-import { Options } from "prettier";
-import { PackageDetails } from "./interfaces.js";
+import { createTypeSpecLibrary, type JSONSchemaType, paramMessage } from "@typespec/compiler";
+import type { Options } from "prettier";
+import type { PackageDetails } from "./interfaces.js";
 
 export interface EmitterOptions {
   /**

--- a/packages/typespec-ts/src/meta-tree.ts
+++ b/packages/typespec-ts/src/meta-tree.ts
@@ -1,5 +1,5 @@
-import { Type } from "@typespec/compiler";
-import { Schema } from "./interfaces.js";
+import type { Type } from "@typespec/compiler";
+import type { Schema } from "./interfaces.js";
 
 export interface ClientTypeMetadata {
   clientType: Schema;

--- a/packages/typespec-ts/src/metadata/build-api-extractor-config.ts
+++ b/packages/typespec-ts/src/metadata/build-api-extractor-config.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Project } from "ts-morph";
-import { ClientModel } from "../interfaces.js";
+import type { ClientModel } from "../interfaces.js";
 
 export function buildApiExtractorConfig(_model: ClientModel) {
   const project = new Project({ useInMemoryFileSystem: true });

--- a/packages/typespec-ts/src/metadata/build-changelog-file.ts
+++ b/packages/typespec-ts/src/metadata/build-changelog-file.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ClientModel } from "../interfaces.js";
+import type { ClientModel } from "../interfaces.js";
 
 function getPackageVersion(model: ClientModel): string {
   return model.options?.packageDetails?.version ?? "1.0.0-beta.1";

--- a/packages/typespec-ts/src/metadata/build-es-lint-config.ts
+++ b/packages/typespec-ts/src/metadata/build-es-lint-config.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Project } from "ts-morph";
-import { ClientModel } from "../interfaces.js";
+import type { ClientModel } from "../interfaces.js";
 
 const esLintConfigEsmAzureSdk = `import azsdkEslint from "@azure/eslint-plugin-azure-sdk";
 

--- a/packages/typespec-ts/src/metadata/build-package-file.ts
+++ b/packages/typespec-ts/src/metadata/build-package-file.ts
@@ -2,10 +2,10 @@
 // Licensed under the MIT License.
 
 import { Project, SourceFile } from "ts-morph";
-import { ClientModel } from "../interfaces.js";
+import type { ClientModel } from "../interfaces.js";
 import { hasPollingOperations } from "../utils/operation-helpers.js";
 import { buildAzureMonorepoPackage } from "./package-json/build-azure-monorepo-package.js";
-import { PackageCommonInfoConfig, resolveWarpExports } from "./package-json/package-common.js";
+import { type PackageCommonInfoConfig, resolveWarpExports } from "./package-json/package-common.js";
 import { getPackageName } from "./utils.js";
 
 interface PackageFileOptions {

--- a/packages/typespec-ts/src/metadata/build-readme-file.ts
+++ b/packages/typespec-ts/src/metadata/build-readme-file.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ClientModel } from "../interfaces.js";
+import type { ClientModel } from "../interfaces.js";
 import { getClientName } from "../utils/name-constructors.js";
 import { NameType, normalizeName } from "../utils/name-utils.js";
 import { renderTemplate } from "./render-template.js";

--- a/packages/typespec-ts/src/metadata/build-sample-env-file.ts
+++ b/packages/typespec-ts/src/metadata/build-sample-env-file.ts
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
-import { ClientModel } from "../interfaces.js";
+import type { ClientModel } from "../interfaces.js";
 
 const sampleEnvText = `
 # Feel free to add your own environment variables.

--- a/packages/typespec-ts/src/metadata/build-test-config.ts
+++ b/packages/typespec-ts/src/metadata/build-test-config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ClientModel } from "../interfaces.js";
+import type { ClientModel } from "../interfaces.js";
 import { getPackageName } from "./utils.js";
 
 function shouldGenerateTestConfig(model: ClientModel): boolean {

--- a/packages/typespec-ts/src/metadata/build-ts-config.ts
+++ b/packages/typespec-ts/src/metadata/build-ts-config.ts
@@ -2,7 +2,7 @@
 // Licensed under the MIT License.
 
 import { Project } from "ts-morph";
-import { ClientModel } from "../interfaces.js";
+import type { ClientModel } from "../interfaces.js";
 
 /**
  * Builds the root tsconfig.json.

--- a/packages/typespec-ts/src/metadata/build-vitest-config.ts
+++ b/packages/typespec-ts/src/metadata/build-vitest-config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ClientModel } from "../interfaces.js";
+import type { ClientModel } from "../interfaces.js";
 
 const nodeConfig = `import viteConfig from "../../../vitest.shared.config.ts";
 

--- a/packages/typespec-ts/src/metadata/build-warp-config.ts
+++ b/packages/typespec-ts/src/metadata/build-warp-config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ClientModel } from "../interfaces.js";
+import type { ClientModel } from "../interfaces.js";
 
 export interface WarpConfigOptions {
   /** Source-level exports, e.g. { ".": "./src/index.ts", "./models": "./src/models/index.ts" } */

--- a/packages/typespec-ts/src/metadata/package-json/azure-package-common.ts
+++ b/packages/typespec-ts/src/metadata/package-json/azure-package-common.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { PackageCommonInfoConfig } from "./package-common.js";
+import type { PackageCommonInfoConfig } from "./package-common.js";
 
 export interface AzurePackageInfoConfig extends PackageCommonInfoConfig {
   hasLro: boolean;

--- a/packages/typespec-ts/src/metadata/package-json/build-azure-monorepo-package.ts
+++ b/packages/typespec-ts/src/metadata/package-json/build-azure-monorepo-package.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { AzurePackageInfoConfig, getAzureCommonPackageInfo } from "./azure-package-common.js";
+import { type AzurePackageInfoConfig, getAzureCommonPackageInfo } from "./azure-package-common.js";
 import { getCommonPackageScripts, getPackageCommonInfo } from "./package-common.js";
 
 export interface AzureMonorepoInfoConfig extends AzurePackageInfoConfig {

--- a/packages/typespec-ts/src/metadata/test/build-recorded-client.ts
+++ b/packages/typespec-ts/src/metadata/test/build-recorded-client.ts
@@ -1,4 +1,4 @@
-import { ClientModel } from "../../interfaces.js";
+import type { ClientModel } from "../../interfaces.js";
 import { recordedClientContent } from "./template.js";
 
 export function buildRecordedClientFile(_model: ClientModel) {

--- a/packages/typespec-ts/src/metadata/test/build-sample-test.ts
+++ b/packages/typespec-ts/src/metadata/test/build-sample-test.ts
@@ -1,4 +1,4 @@
-import { ClientModel } from "../../interfaces.js";
+import type { ClientModel } from "../../interfaces.js";
 import { sampleTestContent } from "./template.js";
 
 export function buildSampleTest(_model: ClientModel) {

--- a/packages/typespec-ts/src/metadata/test/build-snippets.ts
+++ b/packages/typespec-ts/src/metadata/test/build-snippets.ts
@@ -1,4 +1,4 @@
-import { ClientModel } from "../../interfaces.js";
+import type { ClientModel } from "../../interfaces.js";
 import { getClientName } from "../../utils/name-constructors.js";
 import { renderTemplate } from "../render-template.js";
 import { snippetsContent } from "./template.js";

--- a/packages/typespec-ts/src/metadata/utils.ts
+++ b/packages/typespec-ts/src/metadata/utils.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ClientModel } from "../interfaces.js";
+import type { ClientModel } from "../interfaces.js";
 
 export function getPackageName(model: ClientModel): string {
   return model.options?.packageDetails?.name ?? model.libraryName;

--- a/packages/typespec-ts/src/modular/build-classical-client.ts
+++ b/packages/typespec-ts/src/modular/build-classical-client.ts
@@ -1,26 +1,26 @@
 import {
   ClassDeclaration,
-  MethodDeclarationStructure,
+  type MethodDeclarationStructure,
   Scope,
   SourceFile,
   StructureKind,
 } from "ts-morph";
 import { getClientParametersDeclaration } from "./helpers/client-helpers.js";
 import { getClassicalClientName, getClientName } from "./helpers/naming-helpers.js";
-import { ModularEmitterOptions } from "./interfaces.js";
+import type { ModularEmitterOptions } from "./interfaces.js";
 
 import {
   InitializedByFlags,
-  SdkClientType,
-  SdkServiceMethod,
-  SdkServiceOperation,
+  type SdkClientType,
+  type SdkServiceMethod,
+  type SdkServiceOperation,
 } from "@azure-tools/typespec-client-generator-core";
 import { useContext } from "../context-manager.js";
 import { useDependencies } from "../framework/hooks/use-dependencies.js";
 import { resolveReference } from "../framework/reference.js";
 import { refkey } from "../framework/refkey.js";
 import { getClientModuleInfo, isMultiEndpointClient } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { NameType, normalizeName } from "../utils/name-utils.js";
 import { getMethodHierarchiesMap, isTenantLevelOperation } from "../utils/operation-util.js";
 import { AzurePollingDependencies } from "./external-dependencies.js";

--- a/packages/typespec-ts/src/modular/build-classical-operation-groups.ts
+++ b/packages/typespec-ts/src/modular/build-classical-operation-groups.ts
@@ -1,13 +1,16 @@
-import { SdkClientType, SdkServiceOperation } from "@azure-tools/typespec-client-generator-core";
+import type {
+  SdkClientType,
+  SdkServiceOperation,
+} from "@azure-tools/typespec-client-generator-core";
 import { SourceFile } from "ts-morph";
 import { useContext } from "../context-manager.js";
 import { getClientModuleInfo } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { NameType } from "../utils/name-utils.js";
 import { getMethodHierarchiesMap } from "../utils/operation-util.js";
 import { getClassicalOperation } from "./helpers/classical-operation-helpers.js";
 import { getClassicalLayerPrefix } from "./helpers/naming-helpers.js";
-import { ModularEmitterOptions } from "./interfaces.js";
+import type { ModularEmitterOptions } from "./interfaces.js";
 
 export function buildClassicOperationFiles(
   dpgContext: SdkContext,

--- a/packages/typespec-ts/src/modular/build-client-context.ts
+++ b/packages/typespec-ts/src/modular/build-client-context.ts
@@ -6,9 +6,9 @@ import {
   getClientParameters,
   getClientParametersDeclaration,
 } from "./helpers/client-helpers.js";
-import { ModularEmitterOptions } from "./interfaces.js";
+import type { ModularEmitterOptions } from "./interfaces.js";
 
-import {
+import type {
   SdkClientType,
   SdkCredentialParameter,
   SdkEndpointParameter,
@@ -24,7 +24,7 @@ import { resolveReference } from "../framework/reference.js";
 import { refkey } from "../framework/refkey.js";
 import { reportDiagnostic } from "../lib.js";
 import { getClientModuleInfo } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { NameType, normalizeName } from "../utils/name-utils.js";
 import { buildEnumTypes, getApiVersionEnum } from "./emit-models.js";
 import { getDocsFromDescription } from "./helpers/docs-helpers.js";

--- a/packages/typespec-ts/src/modular/build-modular-options.ts
+++ b/packages/typespec-ts/src/modular/build-modular-options.ts
@@ -1,5 +1,5 @@
-import { SdkContext } from "../utils/interfaces.js";
-import { ModularEmitterOptions } from "./interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
+import type { ModularEmitterOptions } from "./interfaces.js";
 
 let CASING: "camel" | "snake" = "snake";
 

--- a/packages/typespec-ts/src/modular/build-operations.ts
+++ b/packages/typespec-ts/src/modular/build-operations.ts
@@ -1,4 +1,4 @@
-import { InterfaceDeclarationStructure, SourceFile, StructureKind } from "ts-morph";
+import { type InterfaceDeclarationStructure, SourceFile, StructureKind } from "ts-morph";
 import {
   getDeserializeExceptionHeadersPrivateFunction,
   getDeserializeHeadersPrivateFunction,
@@ -10,9 +10,9 @@ import {
   isLroAndPagingOperation,
   isLroOnlyOperation,
 } from "./helpers/operation-helpers.js";
-import { ModularEmitterOptions } from "./interfaces.js";
+import type { ModularEmitterOptions } from "./interfaces.js";
 
-import {
+import type {
   SdkClientType,
   SdkMethodParameter,
   SdkServiceOperation,
@@ -23,16 +23,16 @@ import { useDependencies } from "../framework/hooks/use-dependencies.js";
 import { resolveReference } from "../framework/reference.js";
 import { refkey } from "../framework/refkey.js";
 import { getClientModuleInfo, isMultiEndpointClient } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { NameType, normalizeName } from "../utils/name-utils.js";
 import {
   getMethodHierarchiesMap,
   hasDualFormatSupport,
-  ServiceOperation,
+  type ServiceOperation,
 } from "../utils/operation-util.js";
 import { getDocsFromDescription } from "./helpers/docs-helpers.js";
 import { getOperationName } from "./helpers/naming-helpers.js";
-import { OperationPathAndDeserDetails } from "./interfaces.js";
+import type { OperationPathAndDeserDetails } from "./interfaces.js";
 import { getTypeExpression } from "./type-expressions/get-type-expression.js";
 
 /**

--- a/packages/typespec-ts/src/modular/build-project-files.ts
+++ b/packages/typespec-ts/src/modular/build-project-files.ts
@@ -1,11 +1,11 @@
 import { getRelativePathFromDirectory, joinPaths } from "@typespec/compiler";
 import { useContext } from "../context-manager.js";
 import { getClientHierarchyMap, getClientModuleInfo } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { NameType } from "../utils/name-utils.js";
 import { getMethodHierarchiesMap } from "../utils/operation-util.js";
 import { getClassicalLayerPrefix } from "./helpers/naming-helpers.js";
-import { ModularEmitterOptions } from "./interfaces.js";
+import type { ModularEmitterOptions } from "./interfaces.js";
 
 /**
  * Computes the relative path prefix (e.g. `./src` or `./src/generated`) from

--- a/packages/typespec-ts/src/modular/build-restore-poller.ts
+++ b/packages/typespec-ts/src/modular/build-restore-poller.ts
@@ -1,18 +1,21 @@
-import { SdkClientType, SdkServiceOperation } from "@azure-tools/typespec-client-generator-core";
+import type {
+  SdkClientType,
+  SdkServiceOperation,
+} from "@azure-tools/typespec-client-generator-core";
 import { joinPaths } from "@typespec/compiler";
 import { SourceFile } from "ts-morph";
 import { useContext } from "../context-manager.js";
 import { useDependencies } from "../framework/hooks/use-dependencies.js";
 import { resolveReference } from "../framework/reference.js";
 import { getClientModuleInfo } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { NameType, normalizeName } from "../utils/name-utils.js";
 import { getMethodHierarchiesMap } from "../utils/operation-util.js";
 import { buildLroDeserDetailMap } from "./build-operations.js";
 import { AzurePollingDependencies } from "./external-dependencies.js";
 import { getClassicalClientName } from "./helpers/naming-helpers.js";
 import { isLroOnlyOperation } from "./helpers/operation-helpers.js";
-import { ModularEmitterOptions } from "./interfaces.js";
+import type { ModularEmitterOptions } from "./interfaces.js";
 import { PollingHelpers } from "./static-helpers-metadata.js";
 
 export function buildRestorePoller(

--- a/packages/typespec-ts/src/modular/build-root-index.ts
+++ b/packages/typespec-ts/src/modular/build-root-index.ts
@@ -1,4 +1,7 @@
-import { SdkClientType, SdkServiceOperation } from "@azure-tools/typespec-client-generator-core";
+import type {
+  SdkClientType,
+  SdkServiceOperation,
+} from "@azure-tools/typespec-client-generator-core";
 import { joinPaths, NoTarget } from "@typespec/compiler";
 import { Project, SourceFile, StructureKind } from "ts-morph";
 import { useContext } from "../context-manager.js";
@@ -12,14 +15,14 @@ import {
 } from "../framework/source-file-batch.js";
 import { reportDiagnostic } from "../lib.js";
 import { getClientModuleInfo } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { NameType, normalizeName } from "../utils/name-utils.js";
 import { getMethodHierarchiesMap } from "../utils/operation-util.js";
 import { partitionAndEmitExports } from "./build-subpath-index.js";
 import { AzureCoreDependencies } from "./external-dependencies.js";
 import { getClassicalClientName } from "./helpers/naming-helpers.js";
 import { isLroOnlyOperation } from "./helpers/operation-helpers.js";
-import { ModularEmitterOptions } from "./interfaces.js";
+import type { ModularEmitterOptions } from "./interfaces.js";
 import { CloudSettingHelpers, MultipartHelpers, PagingHelpers } from "./static-helpers-metadata.js";
 
 export function buildRootIndex(

--- a/packages/typespec-ts/src/modular/build-subpath-index.ts
+++ b/packages/typespec-ts/src/modular/build-subpath-index.ts
@@ -1,6 +1,9 @@
-import { SdkClientType, SdkServiceOperation } from "@azure-tools/typespec-client-generator-core";
+import type {
+  SdkClientType,
+  SdkServiceOperation,
+} from "@azure-tools/typespec-client-generator-core";
 import { joinPaths } from "@typespec/compiler";
-import { ModularEmitterOptions } from "./interfaces.js";
+import type { ModularEmitterOptions } from "./interfaces.js";
 
 import { Node, SourceFile, StructureKind } from "ts-morph";
 import { useContext } from "../context-manager.js";

--- a/packages/typespec-ts/src/modular/emit-logger-file.ts
+++ b/packages/typespec-ts/src/modular/emit-logger-file.ts
@@ -1,5 +1,5 @@
 import { useContext } from "../context-manager.js";
-import { ModularEmitterOptions } from "./interfaces.js";
+import type { ModularEmitterOptions } from "./interfaces.js";
 
 export function emitLoggerFile(emitterOptions: ModularEmitterOptions, srcPath: string = "src") {
   const project = useContext("outputProject");

--- a/packages/typespec-ts/src/modular/emit-models-options.ts
+++ b/packages/typespec-ts/src/modular/emit-models-options.ts
@@ -1,11 +1,14 @@
 import { joinPaths } from "@typespec/compiler";
 
-import { ModularEmitterOptions } from "./interfaces.js";
+import type { ModularEmitterOptions } from "./interfaces.js";
 
-import { SdkClientType, SdkServiceOperation } from "@azure-tools/typespec-client-generator-core";
+import type {
+  SdkClientType,
+  SdkServiceOperation,
+} from "@azure-tools/typespec-client-generator-core";
 import { useContext } from "../context-manager.js";
 import { getClientModuleInfo } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { NameType, normalizeName } from "../utils/name-utils.js";
 import { getMethodHierarchiesMap } from "../utils/operation-util.js";
 import { buildOperationOptions } from "./build-operations.js";

--- a/packages/typespec-ts/src/modular/emit-models.ts
+++ b/packages/typespec-ts/src/modular/emit-models.ts
@@ -2,31 +2,31 @@ import {
   isPagedResultModel,
   isReadOnly,
   listAllServiceNamespaces,
-  SdkArrayType,
-  SdkClientType,
-  SdkDictionaryType,
-  SdkEnumType,
-  SdkEnumValueType,
-  SdkHttpOperation,
-  SdkMethod,
-  SdkModelPropertyType,
-  SdkModelType,
-  SdkNullableType,
-  SdkServiceMethod,
-  SdkServiceOperation,
-  SdkType,
-  SdkUnionType,
+  type SdkArrayType,
+  type SdkClientType,
+  type SdkDictionaryType,
+  type SdkEnumType,
+  type SdkEnumValueType,
+  type SdkHttpOperation,
+  type SdkMethod,
+  type SdkModelPropertyType,
+  type SdkModelType,
+  type SdkNullableType,
+  type SdkServiceMethod,
+  type SdkServiceOperation,
+  type SdkType,
+  type SdkUnionType,
   UsageFlags,
 } from "@azure-tools/typespec-client-generator-core";
 import {
-  EnumDeclarationStructure,
-  EnumMemberStructure,
-  InterfaceDeclarationStructure,
-  OptionalKind,
-  PropertySignatureStructure,
+  type EnumDeclarationStructure,
+  type EnumMemberStructure,
+  type InterfaceDeclarationStructure,
+  type OptionalKind,
+  type PropertySignatureStructure,
   SourceFile,
   StructureKind,
-  TypeAliasDeclarationStructure,
+  type TypeAliasDeclarationStructure,
 } from "ts-morph";
 // import { isKey } from "@typespec/compiler";
 import {
@@ -49,7 +49,7 @@ import { refkey } from "../framework/refkey.js";
 import { beginSourceFileBatch, flushSourceFileBatch } from "../framework/source-file-batch.js";
 import { reportDiagnostic } from "../lib.js";
 import { getClientHierarchyMap } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { isAzureCoreErrorType } from "../utils/model-utils.js";
 import { fixLeadingNumber, NameType, normalizeName } from "../utils/name-utils.js";
 import { getMethodHierarchiesMap } from "../utils/operation-util.js";

--- a/packages/typespec-ts/src/modular/emit-samples.ts
+++ b/packages/typespec-ts/src/modular/emit-samples.ts
@@ -1,27 +1,27 @@
 import {
   isReadOnly,
-  SdkClientInitializationType,
-  SdkClientType,
-  SdkExampleValue,
-  SdkHttpOperationExample,
-  SdkHttpParameterExampleValue,
-  SdkModelPropertyType,
-  SdkServiceOperation,
+  type SdkClientInitializationType,
+  type SdkClientType,
+  type SdkExampleValue,
+  type SdkHttpOperationExample,
+  type SdkHttpParameterExampleValue,
+  type SdkModelPropertyType,
+  type SdkServiceOperation,
 } from "@azure-tools/typespec-client-generator-core";
 import { joinPaths, NoTarget } from "@typespec/compiler";
-import { FunctionDeclarationStructure, SourceFile, StructureKind } from "ts-morph";
+import { type FunctionDeclarationStructure, SourceFile, StructureKind } from "ts-morph";
 import { useContext } from "../context-manager.js";
 import { resolveReference } from "../framework/reference.js";
 import { reportDiagnostic } from "../index.js";
 import { AzureIdentityDependencies } from "../modular/external-dependencies.js";
 import { getSubscriptionId } from "../transform/transform-client-options.js";
 import { hasKeyCredential, hasTokenCredential } from "../utils/credential-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { NameType, normalizeName } from "../utils/name-utils.js";
 import {
   getMethodHierarchiesMap,
   isTenantLevelOperation,
-  ServiceOperation,
+  type ServiceOperation,
 } from "../utils/operation-util.js";
 import {
   getClientParameterName,
@@ -32,7 +32,7 @@ import {
 import { getClassicalClientName } from "./helpers/naming-helpers.js";
 import { getOperationFunction } from "./helpers/operation-helpers.js";
 import { buildPropertyNameMapper, isSpreadBodyParameter } from "./helpers/type-helpers.js";
-import { ModelOverrideOptions } from "./serialization/serialize-utils.js";
+import type { ModelOverrideOptions } from "./serialization/serialize-utils.js";
 
 /**
  * Interfaces for samples generations

--- a/packages/typespec-ts/src/modular/emit-tests.ts
+++ b/packages/typespec-ts/src/modular/emit-tests.ts
@@ -1,13 +1,13 @@
 import { type CompilerHost, joinPaths } from "@typespec/compiler";
 import { SourceFile } from "ts-morph";
 import { resolveReference } from "../framework/reference.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { NameType, normalizeName } from "../utils/name-utils.js";
-import { ServiceOperation } from "../utils/operation-util.js";
+import type { ServiceOperation } from "../utils/operation-util.js";
 import { AzureTestDependencies } from "./external-dependencies.js";
 import {
   buildParameterValueMap,
-  ClientEmitOptions,
+  type ClientEmitOptions,
   createSourceFile,
   generateMethodCall,
   generateResponseAssertions,

--- a/packages/typespec-ts/src/modular/external-dependencies.ts
+++ b/packages/typespec-ts/src/modular/external-dependencies.ts
@@ -1,4 +1,4 @@
-import { CoreDependencies } from "../framework/dependency.js";
+import type { CoreDependencies } from "../framework/dependency.js";
 
 export const DefaultCoreDependencies: CoreDependencies = {
   Client: {

--- a/packages/typespec-ts/src/modular/helpers/classical-operation-helpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/classical-operation-helpers.ts
@@ -1,9 +1,12 @@
-import { SdkClientType, SdkServiceOperation } from "@azure-tools/typespec-client-generator-core";
+import type {
+  SdkClientType,
+  SdkServiceOperation,
+} from "@azure-tools/typespec-client-generator-core";
 import {
-  FunctionDeclarationStructure,
-  InterfaceDeclarationStructure,
-  OptionalKind,
-  PropertySignatureStructure,
+  type FunctionDeclarationStructure,
+  type InterfaceDeclarationStructure,
+  type OptionalKind,
+  type PropertySignatureStructure,
   SourceFile,
   StructureKind,
 } from "ts-morph";
@@ -11,9 +14,9 @@ import { addDeclaration } from "../../framework/declaration.js";
 import { resolveReference } from "../../framework/reference.js";
 import { refkey } from "../../framework/refkey.js";
 import { getClientModuleInfo } from "../../utils/client-utils.js";
-import { SdkContext } from "../../utils/interfaces.js";
+import type { SdkContext } from "../../utils/interfaces.js";
 import { NameType, normalizeName } from "../../utils/name-utils.js";
-import { ServiceOperation } from "../../utils/operation-util.js";
+import type { ServiceOperation } from "../../utils/operation-util.js";
 import { AzurePollingDependencies } from "../external-dependencies.js";
 import { PagingHelpers, SimplePollerHelpers } from "../static-helpers-metadata.js";
 import { getClassicalLayerPrefix } from "./naming-helpers.js";

--- a/packages/typespec-ts/src/modular/helpers/client-helpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/client-helpers.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   SdkClientType,
   SdkCredentialParameter,
   SdkEndpointParameter,
@@ -6,11 +6,16 @@ import {
   SdkMethodParameter,
   SdkServiceOperation,
 } from "@azure-tools/typespec-client-generator-core";
-import { Node, OptionalKind, ParameterDeclarationStructure, StatementedNode } from "ts-morph";
-import { ModularEmitterOptions } from "../interfaces.js";
+import {
+  Node,
+  type OptionalKind,
+  type ParameterDeclarationStructure,
+  StatementedNode,
+} from "ts-morph";
+import type { ModularEmitterOptions } from "../interfaces.js";
 
 import { resolveReference } from "../../framework/reference.js";
-import { SdkContext } from "../../utils/interfaces.js";
+import type { SdkContext } from "../../utils/interfaces.js";
 import { NameType, normalizeName } from "../../utils/name-utils.js";
 import { CloudSettingHelpers } from "../static-helpers-metadata.js";
 import { getTypeExpression } from "../type-expressions/get-type-expression.js";

--- a/packages/typespec-ts/src/modular/helpers/client-option-helpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/client-option-helpers.ts
@@ -1,4 +1,4 @@
-import { DecoratedType, SdkModelType } from "@azure-tools/typespec-client-generator-core";
+import type { DecoratedType, SdkModelType } from "@azure-tools/typespec-client-generator-core";
 
 /**
  * Represents a header-to-property mapping from @clientOption("header", ...).

--- a/packages/typespec-ts/src/modular/helpers/example-value-helpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/example-value-helpers.ts
@@ -1,12 +1,12 @@
 import {
   isReadOnly,
-  SdkClientInitializationType,
-  SdkClientType,
-  SdkExampleValue,
-  SdkHttpOperationExample,
-  SdkHttpParameterExampleValue,
-  SdkModelPropertyType,
-  SdkServiceOperation,
+  type SdkClientInitializationType,
+  type SdkClientType,
+  type SdkExampleValue,
+  type SdkHttpOperationExample,
+  type SdkHttpParameterExampleValue,
+  type SdkModelPropertyType,
+  type SdkServiceOperation,
 } from "@azure-tools/typespec-client-generator-core";
 import { joinPaths } from "@typespec/compiler";
 import { SourceFile } from "ts-morph";
@@ -14,9 +14,9 @@ import { useContext } from "../../context-manager.js";
 import { resolveReference } from "../../framework/reference.js";
 import { getSubscriptionId } from "../../transform/transform-client-options.js";
 import { hasKeyCredential, hasTokenCredential } from "../../utils/credential-utils.js";
-import { SdkContext } from "../../utils/interfaces.js";
+import type { SdkContext } from "../../utils/interfaces.js";
 import { NameType, normalizeName } from "../../utils/name-utils.js";
-import { getMethodHierarchiesMap, ServiceOperation } from "../../utils/operation-util.js";
+import { getMethodHierarchiesMap, type ServiceOperation } from "../../utils/operation-util.js";
 import { AzureIdentityDependencies, AzureTestDependencies } from "../external-dependencies.js";
 import { getClientParametersDeclaration } from "./client-helpers.js";
 import { getClassicalClientName } from "./naming-helpers.js";

--- a/packages/typespec-ts/src/modular/helpers/naming-helpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/naming-helpers.ts
@@ -1,7 +1,10 @@
-import { SdkClientType, SdkServiceOperation } from "@azure-tools/typespec-client-generator-core";
-import { SdkContext } from "../../utils/interfaces.js";
+import type {
+  SdkClientType,
+  SdkServiceOperation,
+} from "@azure-tools/typespec-client-generator-core";
+import type { SdkContext } from "../../utils/interfaces.js";
 import { NameType, normalizeName, ReservedModelNames } from "../../utils/name-utils.js";
-import { ServiceOperation } from "../../utils/operation-util.js";
+import type { ServiceOperation } from "../../utils/operation-util.js";
 
 export function getClientName(client: SdkClientType<SdkServiceOperation>): string {
   return client.name.replace(/Client$/, "");

--- a/packages/typespec-ts/src/modular/helpers/operation-helpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/operation-helpers.ts
@@ -2,30 +2,30 @@ import {
   getClientOptions,
   isHttpMetadata,
   isReadOnly,
-  SdkBodyParameter,
-  SdkClientType,
-  SdkConstantType,
-  SdkEnumType,
-  SdkHttpOperation,
-  SdkHttpParameter,
-  SdkLroPagingServiceMethod,
-  SdkLroServiceMethod,
-  SdkMethod,
-  SdkMethodParameter,
-  SdkModelPropertyType,
-  SdkModelType,
-  SdkPagingServiceMethod,
-  SdkServiceResponseHeader,
-  SdkType,
+  type SdkBodyParameter,
+  type SdkClientType,
+  type SdkConstantType,
+  type SdkEnumType,
+  type SdkHttpOperation,
+  type SdkHttpParameter,
+  type SdkLroPagingServiceMethod,
+  type SdkLroServiceMethod,
+  type SdkMethod,
+  type SdkMethodParameter,
+  type SdkModelPropertyType,
+  type SdkModelType,
+  type SdkPagingServiceMethod,
+  type SdkServiceResponseHeader,
+  type SdkType,
 } from "@azure-tools/typespec-client-generator-core";
-import { NoTarget, Program } from "@typespec/compiler";
+import { NoTarget, type Program } from "@typespec/compiler";
 import { isHeader, isMetadata } from "@typespec/http";
 import {
-  FunctionDeclarationStructure,
-  OptionalKind,
-  ParameterDeclarationStructure,
+  type FunctionDeclarationStructure,
+  type OptionalKind,
+  type ParameterDeclarationStructure,
   StructureKind,
-  TypeAliasDeclarationStructure,
+  type TypeAliasDeclarationStructure,
 } from "ts-morph";
 import { useContext } from "../../context-manager.js";
 import { useSdkTypes } from "../../framework/hooks/sdk-types.js";
@@ -33,7 +33,7 @@ import { useDependencies } from "../../framework/hooks/use-dependencies.js";
 import { resolveReference } from "../../framework/reference.js";
 import { refkey } from "../../framework/refkey.js";
 import { reportDiagnostic } from "../../lib.js";
-import { SdkContext } from "../../utils/interfaces.js";
+import type { SdkContext } from "../../utils/interfaces.js";
 import { isAzureCoreErrorType } from "../../utils/model-utils.js";
 import { NameType, normalizeName } from "../../utils/name-utils.js";
 import {
@@ -46,7 +46,7 @@ import {
   isMultipartPayload,
   isXmlPayload,
   KnownCollectionFormat,
-  ServiceOperation,
+  type ServiceOperation,
 } from "../../utils/operation-util.js";
 import { AzureCoreDependencies, AzurePollingDependencies } from "../external-dependencies.js";
 import {
@@ -66,7 +66,7 @@ import {
   getPropertyWithOverrides,
   isNormalUnion,
   isSpecialHandledUnion,
-  ModelOverrideOptions,
+  type ModelOverrideOptions,
 } from "../serialization/serialize-utils.js";
 import {
   PagingHelpers,

--- a/packages/typespec-ts/src/modular/helpers/type-helpers.ts
+++ b/packages/typespec-ts/src/modular/helpers/type-helpers.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   SdkBodyParameter,
   SdkCredentialParameter,
   SdkEndpointParameter,
@@ -6,11 +6,11 @@ import {
   SdkModelType,
   SdkType,
 } from "@azure-tools/typespec-client-generator-core";
-import { SdkContext } from "../../utils/interfaces.js";
+import type { SdkContext } from "../../utils/interfaces.js";
 import { NameType, normalizeName } from "../../utils/name-utils.js";
 import {
   getPropertyWithOverrides,
-  ModelOverrideOptions,
+  type ModelOverrideOptions,
 } from "../serialization/serialize-utils.js";
 import { getAllAncestors, getAllProperties } from "./operation-helpers.js";
 

--- a/packages/typespec-ts/src/modular/interfaces.ts
+++ b/packages/typespec-ts/src/modular/interfaces.ts
@@ -1,4 +1,4 @@
-import { ClientOptions } from "../interfaces.js";
+import type { ClientOptions } from "../interfaces.js";
 
 export interface ModularOptions {
   sourceRoot: string;

--- a/packages/typespec-ts/src/modular/serialization/build-deserializer-function.ts
+++ b/packages/typespec-ts/src/modular/serialization/build-deserializer-function.ts
@@ -1,19 +1,19 @@
 import {
-  SdkArrayType,
-  SdkDictionaryType,
-  SdkModelPropertyType,
-  SdkModelType,
-  SdkType,
-  SdkUnionType,
+  type SdkArrayType,
+  type SdkDictionaryType,
+  type SdkModelPropertyType,
+  type SdkModelType,
+  type SdkType,
+  type SdkUnionType,
   UsageFlags,
 } from "@azure-tools/typespec-client-generator-core";
 import { NoTarget } from "@typespec/compiler";
-import { FunctionDeclarationStructure, StructureKind } from "ts-morph";
+import { type FunctionDeclarationStructure, StructureKind } from "ts-morph";
 import { useContext } from "../../context-manager.js";
 import { resolveReference } from "../../framework/reference.js";
 import { refkey } from "../../framework/refkey.js";
 import { reportDiagnostic } from "../../lib.js";
-import { SdkContext } from "../../utils/interfaces.js";
+import type { SdkContext } from "../../utils/interfaces.js";
 import { isAzureCoreErrorType } from "../../utils/model-utils.js";
 import { NameType, normalizeName } from "../../utils/name-utils.js";
 import { getAdditionalPropertiesName, normalizeModelName } from "../emit-models.js";
@@ -29,7 +29,7 @@ import {
   getAllDiscriminatedValues,
   isDiscriminatedUnion,
   isSupportedSerializeType,
-  ModelSerializeOptions,
+  type ModelSerializeOptions,
 } from "./serialize-utils.js";
 
 export function buildPropertyDeserializer(

--- a/packages/typespec-ts/src/modular/serialization/build-serializer-function.ts
+++ b/packages/typespec-ts/src/modular/serialization/build-serializer-function.ts
@@ -1,20 +1,20 @@
 import {
-  SdkArrayType,
-  SdkDictionaryType,
-  SdkModelPropertyType,
-  SdkModelType,
-  SdkType,
-  SdkUnionType,
+  type SdkArrayType,
+  type SdkDictionaryType,
+  type SdkModelPropertyType,
+  type SdkModelType,
+  type SdkType,
+  type SdkUnionType,
   UsageFlags,
 } from "@azure-tools/typespec-client-generator-core";
 import { NoTarget } from "@typespec/compiler";
 import { isOrExtendsHttpFile } from "@typespec/http";
-import { FunctionDeclarationStructure, StructureKind } from "ts-morph";
+import { type FunctionDeclarationStructure, StructureKind } from "ts-morph";
 import { useContext } from "../../context-manager.js";
 import { resolveReference } from "../../framework/reference.js";
 import { refkey } from "../../framework/refkey.js";
 import { reportDiagnostic } from "../../lib.js";
-import { SdkContext } from "../../utils/interfaces.js";
+import type { SdkContext } from "../../utils/interfaces.js";
 import { isAzureCoreErrorType } from "../../utils/model-utils.js";
 import { NameType, normalizeName } from "../../utils/name-utils.js";
 import { getAdditionalPropertiesName, normalizeModelName } from "../emit-models.js";
@@ -31,7 +31,7 @@ import {
   getAllDiscriminatedValues,
   isDiscriminatedUnion,
   isSupportedSerializeType,
-  ModelSerializeOptions,
+  type ModelSerializeOptions,
 } from "./serialize-utils.js";
 
 export function buildPropertySerializer(

--- a/packages/typespec-ts/src/modular/serialization/build-xml-serializer-function.ts
+++ b/packages/typespec-ts/src/modular/serialization/build-xml-serializer-function.ts
@@ -3,20 +3,20 @@
 
 import {
   isReadOnly,
-  SdkModelPropertyType,
-  SdkModelType,
-  SdkPackage,
-  SdkType,
+  type SdkModelPropertyType,
+  type SdkModelType,
+  type SdkPackage,
+  type SdkType,
   UsageFlags,
 } from "@azure-tools/typespec-client-generator-core";
 import { NoTarget } from "@typespec/compiler";
 import { isMetadata } from "@typespec/http";
-import { FunctionDeclarationStructure, StructureKind } from "ts-morph";
+import { type FunctionDeclarationStructure, StructureKind } from "ts-morph";
 import { useDependencies } from "../../framework/hooks/use-dependencies.js";
 import { resolveReference } from "../../framework/reference.js";
 import { refkey } from "../../framework/refkey.js";
 import { reportDiagnostic } from "../../lib.js";
-import { SdkContext } from "../../utils/interfaces.js";
+import type { SdkContext } from "../../utils/interfaces.js";
 import { isAzureCoreErrorType } from "../../utils/model-utils.js";
 import { NameType } from "../../utils/name-utils.js";
 import { getAdditionalPropertiesName, normalizeModelName } from "../emit-models.js";
@@ -24,7 +24,7 @@ import { getAllAncestors, getAllProperties } from "../helpers/operation-helpers.
 import { getAdditionalPropertiesType } from "../helpers/type-helpers.js";
 import { XmlHelpers } from "../static-helpers-metadata.js";
 import { normalizeModelPropertyName } from "../type-expressions/get-type-expression.js";
-import { isSupportedSerializeType, ModelSerializeOptions } from "./serialize-utils.js";
+import { isSupportedSerializeType, type ModelSerializeOptions } from "./serialize-utils.js";
 
 /**
  * Checks if a model type has XML serialization options defined

--- a/packages/typespec-ts/src/modular/serialization/serialize-utils.ts
+++ b/packages/typespec-ts/src/modular/serialization/serialize-utils.ts
@@ -1,4 +1,4 @@
-import {
+import type {
   SdkModelPropertyType,
   SdkModelType,
   SdkType,

--- a/packages/typespec-ts/src/modular/type-expressions/get-credential-expression.ts
+++ b/packages/typespec-ts/src/modular/type-expressions/get-credential-expression.ts
@@ -1,4 +1,4 @@
-import { SdkCredentialType } from "@azure-tools/typespec-client-generator-core";
+import type { SdkCredentialType } from "@azure-tools/typespec-client-generator-core";
 import { useDependencies } from "../../framework/hooks/use-dependencies.js";
 import { resolveReference } from "../../framework/reference.js";
 

--- a/packages/typespec-ts/src/modular/type-expressions/get-enum-expression.ts
+++ b/packages/typespec-ts/src/modular/type-expressions/get-enum-expression.ts
@@ -1,7 +1,7 @@
-import { SdkEnumType } from "@azure-tools/typespec-client-generator-core";
+import type { SdkEnumType } from "@azure-tools/typespec-client-generator-core";
 import { resolveReference } from "../../framework/reference.js";
-import { SdkContext } from "../../utils/interfaces.js";
-import { EmitTypeOptions, getTypeExpression } from "./get-type-expression.js";
+import type { SdkContext } from "../../utils/interfaces.js";
+import { type EmitTypeOptions, getTypeExpression } from "./get-type-expression.js";
 import { shouldEmitInline } from "./utils.js";
 
 export function getEnumExpression(

--- a/packages/typespec-ts/src/modular/type-expressions/get-model-expression.ts
+++ b/packages/typespec-ts/src/modular/type-expressions/get-model-expression.ts
@@ -1,10 +1,10 @@
 import {
-  EmitTypeOptions,
+  type EmitTypeOptions,
   getTypeExpression,
   normalizeModelPropertyName,
 } from "./get-type-expression.js";
 
-import {
+import type {
   SdkModelPropertyType,
   SdkModelType,
   SdkServiceResponseHeader,
@@ -12,7 +12,7 @@ import {
 import { useContext } from "../../context-manager.js";
 import { resolveReference } from "../../framework/reference.js";
 import { refkey } from "../../framework/refkey.js";
-import { SdkContext } from "../../utils/interfaces.js";
+import type { SdkContext } from "../../utils/interfaces.js";
 import { MultipartHelpers } from "../static-helpers-metadata.js";
 import { shouldEmitInline } from "./utils.js";
 

--- a/packages/typespec-ts/src/modular/type-expressions/get-nullable-expression.ts
+++ b/packages/typespec-ts/src/modular/type-expressions/get-nullable-expression.ts
@@ -1,7 +1,7 @@
-import { SdkNullableType } from "@azure-tools/typespec-client-generator-core";
+import type { SdkNullableType } from "@azure-tools/typespec-client-generator-core";
 import { resolveReference } from "../../framework/reference.js";
-import { SdkContext } from "../../utils/interfaces.js";
-import { EmitTypeOptions, getTypeExpression } from "./get-type-expression.js";
+import type { SdkContext } from "../../utils/interfaces.js";
+import { type EmitTypeOptions, getTypeExpression } from "./get-type-expression.js";
 import { shouldEmitInline } from "./utils.js";
 
 export function getNullableExpression(

--- a/packages/typespec-ts/src/modular/type-expressions/get-type-expression.ts
+++ b/packages/typespec-ts/src/modular/type-expressions/get-type-expression.ts
@@ -1,10 +1,10 @@
-import {
+import type {
   SdkHttpParameter,
   SdkModelPropertyType,
   SdkServiceResponseHeader,
   SdkType,
 } from "@azure-tools/typespec-client-generator-core";
-import { SdkContext } from "../../utils/interfaces.js";
+import type { SdkContext } from "../../utils/interfaces.js";
 import { NameType, normalizeName } from "../../utils/name-utils.js";
 import { getCredentialExpression } from "./get-credential-expression.js";
 import { getEnumExpression } from "./get-enum-expression.js";

--- a/packages/typespec-ts/src/modular/type-expressions/get-union-expression.ts
+++ b/packages/typespec-ts/src/modular/type-expressions/get-union-expression.ts
@@ -1,7 +1,7 @@
-import { SdkUnionType } from "@azure-tools/typespec-client-generator-core";
+import type { SdkUnionType } from "@azure-tools/typespec-client-generator-core";
 import { resolveReference } from "../../framework/reference.js";
-import { SdkContext } from "../../utils/interfaces.js";
-import { EmitTypeOptions, getTypeExpression } from "./get-type-expression.js";
+import type { SdkContext } from "../../utils/interfaces.js";
+import { type EmitTypeOptions, getTypeExpression } from "./get-type-expression.js";
 import { shouldEmitInline } from "./utils.js";
 
 export function getUnionExpression(

--- a/packages/typespec-ts/src/modular/type-expressions/utils.ts
+++ b/packages/typespec-ts/src/modular/type-expressions/utils.ts
@@ -1,4 +1,4 @@
-import { EmitTypeOptions } from "./get-type-expression.js";
+import type { EmitTypeOptions } from "./get-type-expression.js";
 
 export function shouldEmitInline(
   type: { isGeneratedName?: boolean },

--- a/packages/typespec-ts/src/transform/transform-api-version-info.ts
+++ b/packages/typespec-ts/src/transform/transform-api-version-info.ts
@@ -1,12 +1,17 @@
 import {
   getHttpOperationWithCache,
   isApiVersion,
-  SdkClient,
+  type SdkClient,
 } from "@azure-tools/typespec-client-generator-core";
-import { ApiVersionInfo, ApiVersionPosition, SchemaContext, UrlInfo } from "../interfaces.js";
+import {
+  type ApiVersionInfo,
+  type ApiVersionPosition,
+  SchemaContext,
+  type UrlInfo,
+} from "../interfaces.js";
 import { extractDefinedPosition, extractPathApiVersion } from "../utils/api-version-util.js";
 import { listOperationsUnderClient } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { getDefaultApiVersionString, getSchemaForType, trimUsage } from "../utils/model-utils.js";
 
 export function transformApiVersionInfo(

--- a/packages/typespec-ts/src/transform/transform-client-options.ts
+++ b/packages/typespec-ts/src/transform/transform-client-options.ts
@@ -1,12 +1,12 @@
 import { getHttpOperationWithCache } from "@azure-tools/typespec-client-generator-core";
-import { getDoc, NoTarget, Program } from "@typespec/compiler";
+import { getDoc, NoTarget, type Program } from "@typespec/compiler";
 import { getAuthentication } from "@typespec/http";
-import { ClientOptions, PackageDetails, ServiceInfo } from "../interfaces.js";
-import { EmitterOptions, reportDiagnostic } from "../lib.js";
+import type { ClientOptions, PackageDetails, ServiceInfo } from "../interfaces.js";
+import { type EmitterOptions, reportDiagnostic } from "../lib.js";
 import { getClientParameters } from "../modular/helpers/client-helpers.js";
 import { getClients, listOperationsUnderClient } from "../utils/client-utils.js";
 import { getSupportedHttpAuth } from "../utils/credential-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { getDefaultService } from "../utils/model-utils.js";
 import { NameType, normalizeName, pascalCase } from "../utils/name-utils.js";
 import { detectModelConflicts } from "../utils/namespace-utils.js";

--- a/packages/typespec-ts/src/transform/transform-helper-function-details.ts
+++ b/packages/typespec-ts/src/transform/transform-helper-function-details.ts
@@ -1,7 +1,10 @@
-import { getHttpOperationWithCache, SdkClient } from "@azure-tools/typespec-client-generator-core";
-import { HelperFunctionDetails } from "../interfaces.js";
+import {
+  getHttpOperationWithCache,
+  type SdkClient,
+} from "@azure-tools/typespec-client-generator-core";
+import type { HelperFunctionDetails } from "../interfaces.js";
 import { listOperationsUnderClient } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { getCollectionFormat } from "../utils/model-utils.js";
 import {
   extractPageDetails,

--- a/packages/typespec-ts/src/transform/transform-parameters.ts
+++ b/packages/typespec-ts/src/transform/transform-parameters.ts
@@ -2,25 +2,29 @@
 // Licensed under the MIT License.
 
 import {
-  SdkClient,
+  type SdkClient,
   getHttpOperationWithCache,
   isApiVersion,
 } from "@azure-tools/typespec-client-generator-core";
-import { NoTarget, Type, isVoidType } from "@typespec/compiler";
-import { HttpOperation, HttpOperationParameter, HttpOperationParameters } from "@typespec/http";
+import { NoTarget, type Type, isVoidType } from "@typespec/compiler";
+import type {
+  HttpOperation,
+  HttpOperationParameter,
+  HttpOperationParameters,
+} from "@typespec/http";
 import {
-  ApiVersionInfo,
-  Imports,
-  ObjectSchema,
-  OperationParameter,
-  ParameterBodyMetadata,
-  ParameterMetadata,
-  Schema,
+  type ApiVersionInfo,
+  type Imports,
+  type ObjectSchema,
+  type OperationParameter,
+  type ParameterBodyMetadata,
+  type ParameterMetadata,
+  type Schema,
   SchemaContext,
 } from "../interfaces.js";
 import { reportDiagnostic } from "../lib.js";
 import { listOperationsUnderClient } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import {
   KnownMediaType,
   extractMediaTypes,

--- a/packages/typespec-ts/src/transform/transform-paths.ts
+++ b/packages/typespec-ts/src/transform/transform-paths.ts
@@ -2,11 +2,11 @@
 // Licensed under the MIT License.
 
 import {
-  SdkClient,
+  type SdkClient,
   getHttpOperationWithCache,
   isApiVersion,
 } from "@azure-tools/typespec-client-generator-core";
-import { HttpOperation, HttpOperationParameters } from "@typespec/http";
+import type { HttpOperation, HttpOperationParameters } from "@typespec/http";
 import { getImportedModelName, getSchemaForType, isBodyRequired } from "../utils/model-utils.js";
 import {
   extractOperationLroDetail,
@@ -20,9 +20,15 @@ import {
 } from "../utils/operation-util.js";
 
 import { getDoc } from "@typespec/compiler";
-import { Imports, OperationMethod, PathMetadata, Paths, SchemaContext } from "../interfaces.js";
+import {
+  type Imports,
+  type OperationMethod,
+  type PathMetadata,
+  type Paths,
+  SchemaContext,
+} from "../interfaces.js";
 import { listOperationsUnderClient } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import { getParameterTypeName, getResponseTypeName } from "../utils/name-constructors.js";
 import { getParameterSerializationInfo } from "../utils/parameter-utils.js";
 

--- a/packages/typespec-ts/src/transform/transform-responses.ts
+++ b/packages/typespec-ts/src/transform/transform-responses.ts
@@ -1,19 +1,22 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { getHttpOperationWithCache, SdkClient } from "@azure-tools/typespec-client-generator-core";
-import { getDoc, isVoidType } from "@typespec/compiler";
-import { HttpOperation, HttpOperationResponse } from "@typespec/http";
 import {
-  Imports,
-  OperationResponse,
-  ResponseHeaderSchema,
-  ResponseMetadata,
-  Schema,
+  getHttpOperationWithCache,
+  type SdkClient,
+} from "@azure-tools/typespec-client-generator-core";
+import { getDoc, isVoidType } from "@typespec/compiler";
+import type { HttpOperation, HttpOperationResponse } from "@typespec/http";
+import {
+  type Imports,
+  type OperationResponse,
+  type ResponseHeaderSchema,
+  type ResponseMetadata,
+  type Schema,
   SchemaContext,
 } from "../interfaces.js";
 import { listOperationsUnderClient } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import {
   getBinaryType,
   getImportedModelName,

--- a/packages/typespec-ts/src/transform/transform-schemas.ts
+++ b/packages/typespec-ts/src/transform/transform-schemas.ts
@@ -1,9 +1,12 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { SdkClient, getHttpOperationWithCache } from "@azure-tools/typespec-client-generator-core";
-import { Model, Type } from "@typespec/compiler";
-import { HttpOperation, getServers } from "@typespec/http";
+import {
+  type SdkClient,
+  getHttpOperationWithCache,
+} from "@azure-tools/typespec-client-generator-core";
+import type { Model, Type } from "@typespec/compiler";
+import { type HttpOperation, getServers } from "@typespec/http";
 import { KnownMediaType, extractMediaTypes } from "../utils/media-types.js";
 import {
   getBodyType,
@@ -17,7 +20,7 @@ import {
 import { useContext } from "../context-manager.js";
 import { SchemaContext } from "../interfaces.js";
 import { listOperationsUnderClient } from "../utils/client-utils.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 
 export function transformSchemas(client: SdkClient, dpgContext: SdkContext) {
   const program = dpgContext.program;

--- a/packages/typespec-ts/src/transform/transform-telemetry-info.ts
+++ b/packages/typespec-ts/src/transform/transform-telemetry-info.ts
@@ -1,9 +1,9 @@
 import {
   getHttpOperationWithCache,
-  SdkClient,
-  SdkContext,
+  type SdkClient,
+  type SdkContext,
 } from "@azure-tools/typespec-client-generator-core";
-import { TelemetryInfo } from "../interfaces.js";
+import type { TelemetryInfo } from "../interfaces.js";
 import { listOperationsUnderClient } from "../utils/client-utils.js";
 import { getCustomRequestHeaderNameForOperation } from "../utils/operation-util.js";
 

--- a/packages/typespec-ts/src/transform/transform.ts
+++ b/packages/typespec-ts/src/transform/transform.ts
@@ -1,23 +1,23 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { SdkClient } from "@azure-tools/typespec-client-generator-core";
+import type { SdkClient } from "@azure-tools/typespec-client-generator-core";
 import { getDoc, joinPaths } from "@typespec/compiler";
 import { getServers } from "@typespec/http";
 import {
-  ClientModel,
-  ClientOptions,
-  Imports,
-  OperationParameter,
-  OperationResponse,
-  PathParameter,
-  Paths,
-  Schema,
+  type ClientModel,
+  type ClientOptions,
+  type Imports,
+  type OperationParameter,
+  type OperationResponse,
+  type PathParameter,
+  type Paths,
+  type Schema,
   SchemaContext,
-  UrlInfo,
+  type UrlInfo,
 } from "../interfaces.js";
 import { buildRuntimeImports, initInternalImports } from "../utils/imports-util.js";
-import { SdkContext } from "../utils/interfaces.js";
+import type { SdkContext } from "../utils/interfaces.js";
 import {
   getDefaultService,
   getFormattedPropertyDoc,

--- a/packages/typespec-ts/src/utils/api-version-util.ts
+++ b/packages/typespec-ts/src/utils/api-version-util.ts
@@ -1,4 +1,4 @@
-import { ApiVersionInfo, ApiVersionPosition, UrlInfo } from "../interfaces.js";
+import type { ApiVersionInfo, ApiVersionPosition, UrlInfo } from "../interfaces.js";
 
 /**
  * Extract the path api-version detail from UrlInfo, return undefined if no valid api-version parameter

--- a/packages/typespec-ts/src/utils/client-utils.ts
+++ b/packages/typespec-ts/src/utils/client-utils.ts
@@ -2,20 +2,20 @@ import {
   InitializedByFlags,
   listAllServiceNamespaces,
   listClients,
-  SdkClient,
-  SdkClientType,
-  SdkServiceOperation,
+  type SdkClient,
+  type SdkClientType,
+  type SdkServiceOperation,
 } from "@azure-tools/typespec-client-generator-core";
 import {
   getNamespaceFullName,
-  Interface,
+  type Interface,
   isTemplateDeclaration,
   isTemplateDeclarationOrInstance,
-  Namespace,
-  Operation,
+  type Namespace,
+  type Operation,
 } from "@typespec/compiler";
-import { ClientModuleInfo } from "../modular/interfaces.js";
-import { SdkContext } from "./interfaces.js";
+import type { ClientModuleInfo } from "../modular/interfaces.js";
+import type { SdkContext } from "./interfaces.js";
 import { NameType, normalizeName } from "./name-utils.js";
 
 export function getClients(dpgContext: SdkContext): SdkClient[] {

--- a/packages/typespec-ts/src/utils/credential-utils.ts
+++ b/packages/typespec-ts/src/utils/credential-utils.ts
@@ -1,6 +1,6 @@
-import { SdkClientInitializationType } from "@azure-tools/typespec-client-generator-core";
-import { NoTarget, Program } from "@typespec/compiler";
-import { Authentication, HttpAuth } from "@typespec/http";
+import type { SdkClientInitializationType } from "@azure-tools/typespec-client-generator-core";
+import { NoTarget, type Program } from "@typespec/compiler";
+import type { Authentication, HttpAuth } from "@typespec/http";
 import { reportDiagnostic } from "../lib.js";
 
 /**

--- a/packages/typespec-ts/src/utils/cross-language-def.ts
+++ b/packages/typespec-ts/src/utils/cross-language-def.ts
@@ -3,7 +3,7 @@
 
 import { UsageFlags } from "@azure-tools/typespec-client-generator-core";
 import { transformModularEmitterOptions } from "../modular/build-modular-options.js";
-import { SdkContext } from "./interfaces.js";
+import type { SdkContext } from "./interfaces.js";
 import { NameType, normalizeName } from "./name-utils.js";
 import { getMethodHierarchiesMap } from "./operation-util.js";
 

--- a/packages/typespec-ts/src/utils/emit-util.ts
+++ b/packages/typespec-ts/src/utils/emit-util.ts
@@ -1,9 +1,15 @@
-import { CompilerHost, getDirectoryPath, joinPaths, NoTarget, Program } from "@typespec/compiler";
+import {
+  type CompilerHost,
+  getDirectoryPath,
+  joinPaths,
+  NoTarget,
+  type Program,
+} from "@typespec/compiler";
 import { format } from "prettier";
 import prettierPluginBabel from "prettier/plugins/babel";
 import prettierPluginEstree from "prettier/plugins/estree";
 import prettierPluginTypescript from "prettier/plugins/typescript";
-import { ClientModel, ContentBuilder, File } from "../interfaces.js";
+import type { ClientModel, ContentBuilder, File } from "../interfaces.js";
 import { prettierJSONOptions, prettierTypeScriptOptions, reportDiagnostic } from "../lib.js";
 
 export async function emitContentByBuilder(

--- a/packages/typespec-ts/src/utils/file-system-utils.ts
+++ b/packages/typespec-ts/src/utils/file-system-utils.ts
@@ -1,4 +1,4 @@
-import { NoTarget, Program, resolvePath, type CompilerHost } from "@typespec/compiler";
+import { NoTarget, resolvePath, type CompilerHost, type Program } from "@typespec/compiler";
 import { reportDiagnostic } from "../lib.js";
 
 export async function pathExists(host: CompilerHost, targetPath: string): Promise<boolean> {

--- a/packages/typespec-ts/src/utils/imports-util.ts
+++ b/packages/typespec-ts/src/utils/imports-util.ts
@@ -1,5 +1,5 @@
 import { SourceFile } from "ts-morph";
-import { ImportType, Imports } from "../interfaces.js";
+import type { ImportType, Imports } from "../interfaces.js";
 
 /**
  * Build the common imports for generated SDK. Azure Core packages are always used.

--- a/packages/typespec-ts/src/utils/interfaces.ts
+++ b/packages/typespec-ts/src/utils/interfaces.ts
@@ -1,6 +1,6 @@
-import { SdkContext as TCGCSdkContext } from "@azure-tools/typespec-client-generator-core";
-import { ModelProperty, Namespace } from "@typespec/compiler";
-import { ClientOptions, SchemaContext } from "../interfaces.js";
+import type { SdkContext as TCGCSdkContext } from "@azure-tools/typespec-client-generator-core";
+import type { ModelProperty, Namespace } from "@typespec/compiler";
+import { type ClientOptions, SchemaContext } from "../interfaces.js";
 import { KnownMediaType } from "./media-types.js";
 
 export interface SdkContext extends TCGCSdkContext {

--- a/packages/typespec-ts/src/utils/model-utils.ts
+++ b/packages/typespec-ts/src/utils/model-utils.ts
@@ -8,20 +8,20 @@ import {
   isApiVersion,
 } from "@azure-tools/typespec-client-generator-core";
 import {
-  Discriminator,
-  EncodeData,
-  Enum,
-  EnumMember,
-  Model,
-  ModelProperty,
+  type Discriminator,
+  type EncodeData,
+  type Enum,
+  type EnumMember,
+  type Model,
+  type ModelProperty,
   NoTarget,
-  Program,
-  Scalar,
-  Service,
-  Type,
-  Union,
-  UnionVariant,
-  Value,
+  type Program,
+  type Scalar,
+  type Service,
+  type Type,
+  type Union,
+  type UnionVariant,
+  type Value,
   getDiscriminator,
   getDoc,
   getEffectiveModelType,
@@ -50,11 +50,11 @@ import {
   listServices,
 } from "@typespec/compiler";
 import {
-  HttpOperation,
-  HttpOperationHeaderParameter,
-  HttpOperationParameters,
-  HttpOperationPathParameter,
-  HttpOperationQueryParameter,
+  type HttpOperation,
+  type HttpOperationHeaderParameter,
+  type HttpOperationParameters,
+  type HttpOperationPathParameter,
+  type HttpOperationQueryParameter,
   Visibility,
   getHeaderFieldName,
   getHttpFileModel,
@@ -64,14 +64,14 @@ import {
   isBody,
   isStatusCode,
 } from "@typespec/http";
-import { GetSchemaOptions, SdkContext } from "./interfaces.js";
+import type { GetSchemaOptions, SdkContext } from "./interfaces.js";
 import { KnownMediaType, hasMediaType, isMediaTypeMultipartFormData } from "./media-types.js";
 
 import {
-  ArraySchema,
-  DictionarySchema,
-  ObjectSchema,
-  Schema,
+  type ArraySchema,
+  type DictionarySchema,
+  type ObjectSchema,
+  type Schema,
   SchemaContext,
 } from "../interfaces.js";
 import { reportDiagnostic } from "../lib.js";

--- a/packages/typespec-ts/src/utils/name-constructors.ts
+++ b/packages/typespec-ts/src/utils/name-constructors.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ClientModel } from "../interfaces.js";
+import type { ClientModel } from "../interfaces.js";
 import { NameType, normalizeName } from "./name-utils.js";
 
 /**

--- a/packages/typespec-ts/src/utils/namespace-utils.ts
+++ b/packages/typespec-ts/src/utils/namespace-utils.ts
@@ -1,7 +1,13 @@
 import { getAllModels, UsageFlags } from "@azure-tools/typespec-client-generator-core";
-import { isGlobalNamespace, isService, Namespace, NoTarget, Operation } from "@typespec/compiler";
+import {
+  isGlobalNamespace,
+  isService,
+  type Namespace,
+  NoTarget,
+  type Operation,
+} from "@typespec/compiler";
 import { reportDiagnostic } from "../lib.js";
-import { SdkContext } from "./interfaces.js";
+import type { SdkContext } from "./interfaces.js";
 
 export function getModelNamespaceName(dpgContext: SdkContext, namespace: Namespace): string[] {
   const result: string[] = [];

--- a/packages/typespec-ts/src/utils/operation-helpers.ts
+++ b/packages/typespec-ts/src/utils/operation-helpers.ts
@@ -1,14 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { MethodSignatureStructure, OptionalKind, ParameterDeclarationStructure } from "ts-morph";
+import type {
+  MethodSignatureStructure,
+  OptionalKind,
+  ParameterDeclarationStructure,
+} from "ts-morph";
 import {
-  ClientModel,
-  Methods,
-  ObjectSchema,
-  ParameterMetadata,
-  PathParameter,
-  Schema,
+  type ClientModel,
+  type Methods,
+  type ObjectSchema,
+  type ParameterMetadata,
+  type PathParameter,
+  type Schema,
   SchemaContext,
 } from "../interfaces.js";
 import { NameType, normalizeName, pascalCase } from "./name-utils.js";

--- a/packages/typespec-ts/src/utils/operation-util.ts
+++ b/packages/typespec-ts/src/utils/operation-util.ts
@@ -7,19 +7,26 @@ import {
   getHttpOperationWithCache,
   getWireName,
   InitializedByFlags,
-  SdkBodyParameter,
-  SdkClient,
-  SdkClientType,
-  SdkHttpOperation,
-  SdkHttpParameter,
-  SdkMethod,
-  SdkMethodParameter,
-  SdkServiceMethod,
-  SdkServiceOperation,
+  type SdkBodyParameter,
+  type SdkClient,
+  type SdkClientType,
+  type SdkHttpOperation,
+  type SdkHttpParameter,
+  type SdkMethod,
+  type SdkMethodParameter,
+  type SdkServiceMethod,
+  type SdkServiceOperation,
 } from "@azure-tools/typespec-client-generator-core";
-import { isList, ModelProperty, NoTarget, Operation, Program, Type } from "@typespec/compiler";
-import { $ } from "@typespec/compiler/typekit";
 import {
+  isList,
+  type ModelProperty,
+  NoTarget,
+  type Operation,
+  type Program,
+  type Type,
+} from "@typespec/compiler";
+import { $ } from "@typespec/compiler/typekit";
+import type {
   HttpOperation,
   HttpOperationParameter,
   HttpOperationResponse,
@@ -29,15 +36,15 @@ import { resolveReference } from "../framework/reference.js";
 import {
   OPERATION_LRO_HIGH_PRIORITY,
   OPERATION_LRO_LOW_PRIORITY,
-  OperationLroDetail,
-  Paths,
-  ResponseMetadata,
-  ResponseTypes,
+  type OperationLroDetail,
+  type Paths,
+  type ResponseMetadata,
+  type ResponseTypes,
 } from "../interfaces.js";
 import { reportDiagnostic } from "../lib.js";
 import { SerializationHelpers } from "../modular/static-helpers-metadata.js";
 import { listOperationsUnderClient } from "./client-utils.js";
-import { SdkContext } from "./interfaces.js";
+import type { SdkContext } from "./interfaces.js";
 import {
   isMediaTypeMultipart,
   isMediaTypeXml,

--- a/packages/typespec-ts/src/utils/parameter-utils.ts
+++ b/packages/typespec-ts/src/utils/parameter-utils.ts
@@ -1,8 +1,8 @@
-import { getEncode, NoTarget, Program } from "@typespec/compiler";
-import { HttpOperationParameter } from "@typespec/http";
-import { Schema, SchemaContext } from "../interfaces.js";
+import { getEncode, NoTarget, type Program } from "@typespec/compiler";
+import type { HttpOperationParameter } from "@typespec/http";
+import { type Schema, SchemaContext } from "../interfaces.js";
 import { reportDiagnostic } from "../lib.js";
-import { SdkContext } from "./interfaces.js";
+import type { SdkContext } from "./interfaces.js";
 import { getTypeName, isArrayType, isObjectOrDictType } from "./model-utils.js";
 import { NameType, normalizeName } from "./name-utils.js";
 

--- a/packages/typespec-ts/src/utils/schema-helpers.ts
+++ b/packages/typespec-ts/src/utils/schema-helpers.ts
@@ -1,7 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { ArraySchema, ClientModel, ObjectSchema, Schema, SchemaContext } from "../interfaces.js";
+import {
+  type ArraySchema,
+  type ClientModel,
+  type ObjectSchema,
+  type Schema,
+  SchemaContext,
+} from "../interfaces.js";
 
 export interface IsDictionaryOptions {
   filterEmpty?: boolean;

--- a/packages/typespec-ts/src/utils/type-util.ts
+++ b/packages/typespec-ts/src/utils/type-util.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { Schema } from "../interfaces.js";
+import type { Schema } from "../interfaces.js";
 
 export function isRecord(type: string) {
   return /^Record<([a-zA-Z]+),(\s*)(?<type>.+)>$/.test(type);

--- a/packages/typespec-ts/tsconfig.json
+++ b/packages/typespec-ts/tsconfig.json
@@ -12,7 +12,8 @@
     "noPropertyAccessFromIndexSignature": true,
     "allowUnusedLabels": false,
     "allowUnreachableCode": false,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["dist", "node_modules", "typespec-output"]

--- a/packages/typespec-ts/tsconfig.test.json
+++ b/packages/typespec-ts/tsconfig.test.json
@@ -3,6 +3,8 @@
   "include": ["src/**/*.ts", "static/**/*.ts"],
   "compilerOptions": {
     "module": "node16",
-    "moduleResolution": "node16"
+    "moduleResolution": "node16",
+    // `static/` is copied verbatim into generated SDKs, so it is migrated separately.
+    "verbatimModuleSyntax": false
   }
 }


### PR DESCRIPTION
Type-only imports in `typespec-azure` are still emitted as runtime imports. That leaves dead runtime edges in the emitted JS, makes module side effects ambiguous, and blocks ever turning `verbatimModuleSyntax` on repo-wide — something `core` has already been rolling out package by package.

This enables the flag for **`typespec-ts`** and rewrites the imports it flags:

```diff
-import { SdkContext } from "./interfaces.js";
+import type { SdkContext } from "./interfaces.js";
```

The rewrite was driven by the compiler rather than by regex: build the program with the flag on, collect the TS1484/TS1485/TS1205 diagnostics, and change exactly the specifiers TypeScript names — hoisting to `import type` when every specifier in a clause is type-only, otherwise adding an inline `type` modifier. `tsc` then reports zero new errors against a pre-change baseline, so no value binding was turned into a type-only one.

One of a series of PRs, one per package, so each diff stays reviewable. They are independent and can land in any order.

`static/` is deliberately untouched: those helpers are copied verbatim into generated SDKs, so migrating them changes emitted output and needs baseline regeneration. `tsconfig.test.json`, the only project that pulls them in, opts out explicitly.

| PR | Scope |
| --- | --- |
| Azure/typespec-azure#5127 | `samples`, `typespec-python`, `benchmark`, `typespec-azure-playground-website`, `typespec-metadata`, `spector-runner` |
| Azure/typespec-azure#5128 | `azure-http-specs` |
| Azure/typespec-azure#5129 | `typespec-autorest` |
| Azure/typespec-azure#5130 | `typespec-azure-core` |
| Azure/typespec-azure#5131 | `typespec-azure-resource-manager` |
| Azure/typespec-azure#5132 | `typespec-client-generator-core` |
| Azure/typespec-azure#5133 | `typespec-go` |
| Azure/typespec-azure#5134 | `typespec-ts` |
| Azure/typespec-azure#5135 | `eng/` scripts |

`typespec-autorest-canonical`, `typespec-azure-portal-core` and `typespec-azure-rulesets` already had the flag. `typespec-java` is deliberately left out: its `src/` is copied in at build time from `azure-sdk-for-java`, so the flag would break its build until those sources are migrated upstream.

Once these land, a follow-up will hoist the flag into a repo-level `tsconfig.base.json` and drop the per-package copies, so new packages inherit it by default.
