### PR TITLE
Enable verbatimModuleSyntax for eng scripts

### DIFF
--- a/eng/feeds/test/init-templates.e2e.ts
+++ b/eng/feeds/test/init-templates.e2e.ts
@@ -1,6 +1,6 @@
 import { NodeHost, resolvePath } from "@typespec/compiler";
 import { ok } from "assert";
-import { SpawnOptions, spawn } from "child_process";
+import { type SpawnOptions, spawn } from "child_process";
 import { mkdir, readFile, rm } from "fs/promises";
 import { resolve } from "path/posix";
 import { beforeAll, describe, it } from "vitest";

--- a/tsconfig.eng.json
+++ b/tsconfig.eng.json
@@ -2,7 +2,8 @@
   "extends": "./core/tsconfig.base.json",
   "compilerOptions": {
     "allowJs": true,
-    "allowImportingTsExtensions": true
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true
   },
   "include": ["./eng", "./core/eng"],
   "exclude": ["./core/eng/vitest.config.ts", "./eng/vitest.config.ts", "./eng/scripts/doc-updater"]


### PR DESCRIPTION
Type-only imports in `typespec-azure` are still emitted as runtime imports. That leaves dead runtime edges in the emitted JS, makes module side effects ambiguous, and blocks ever turning `verbatimModuleSyntax` on repo-wide — something `core` has already been rolling out package by package.

This enables the flag for **the `eng/` scripts (`tsconfig.eng.json`)** and rewrites the imports it flags:

```diff
-import { SdkContext } from "./interfaces.js";
+import type { SdkContext } from "./interfaces.js";
```

The rewrite was driven by the compiler rather than by regex: build the program with the flag on, collect the TS1484/TS1485/TS1205 diagnostics, and change exactly the specifiers TypeScript names — hoisting to `import type` when every specifier in a clause is type-only, otherwise adding an inline `type` modifier. `tsc` then reports zero new errors against a pre-change baseline, so no value binding was turned into a type-only one.

One of a series of PRs, one per package, so each diff stays reviewable. They are independent and can land in any order.

| PR | Scope |
| --- | --- |
| Azure/typespec-azure#5127 | `samples`, `typespec-python`, `benchmark`, `typespec-azure-playground-website`, `typespec-metadata`, `spector-runner` |
| Azure/typespec-azure#5128 | `azure-http-specs` |
| Azure/typespec-azure#5129 | `typespec-autorest` |
| Azure/typespec-azure#5130 | `typespec-azure-core` |
| Azure/typespec-azure#5131 | `typespec-azure-resource-manager` |
| Azure/typespec-azure#5132 | `typespec-client-generator-core` |
| Azure/typespec-azure#5133 | `typespec-go` |
| Azure/typespec-azure#5134 | `typespec-ts` |
| Azure/typespec-azure#5135 | `eng/` scripts |

`typespec-autorest-canonical`, `typespec-azure-portal-core` and `typespec-azure-rulesets` already had the flag. `typespec-java` is deliberately left out: its `src/` is copied in at build time from `azure-sdk-for-java`, so the flag would break its build until those sources are migrated upstream.

Once these land, a follow-up will hoist the flag into a repo-level `tsconfig.base.json` and drop the per-package copies, so new packages inherit it by default.
