### PR TITLE
Bump version for hotfix: typespec-java@0.45.13

### DIFF
--- a/.chronus/changes/fix-typespec-java-core-sync-2026-08-03-11-50-00.md
+++ b/.chronus/changes/fix-typespec-java-core-sync-2026-08-03-11-50-00.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Sync core to microsoft/typespec commit `2e1649b83`. Includes support for nested property paths and XML payloads in Azure pageable responses (core [#11504](https://github.com/microsoft/typespec/pull/11504)).

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## 0.45.13
 
-### Bug Fixes
+### Features
 
 - [#5138](https://github.com/Azure/typespec-azure/pull/5138) Sync core to microsoft/typespec commit `2e1649b83`. Includes support for nested property paths and XML payloads in Azure pageable responses (core [#11504](https://github.com/microsoft/typespec/pull/11504)).
 

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-java
 
+## 0.45.13
+
+### Bug Fixes
+
+- [#5138](https://github.com/Azure/typespec-azure/pull/5138) Sync core to microsoft/typespec commit `2e1649b83`. Includes support for nested property paths and XML payloads in Azure pageable responses (core [#11504](https://github.com/microsoft/typespec/pull/11504)).
+
+
 ## 0.45.12
 
 ### Bug Fixes

--- a/packages/typespec-java/emitter-tests/package.json
+++ b/packages/typespec-java/emitter-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java-tests",
-  "version": "0.45.12",
+  "version": "0.45.13",
   "type": "module",
   "scripts": {
     "format": "npm run -s prettier -- --write",
@@ -17,7 +17,7 @@
     "@typespec/spector": "0.1.0-alpha.26",
     "@typespec/http-specs": "0.1.0-alpha.39",
     "@azure-tools/azure-http-specs": "0.1.0-alpha.43",
-    "@azure-tools/typespec-java": "file:../azure-tools-typespec-java-0.45.12.tgz"
+    "@azure-tools/typespec-java": "file:../azure-tools-typespec-java-0.45.13.tgz"
   },
   "devDependencies": {
     "@typespec/prettier-plugin-typespec": "^1.13.0",

--- a/packages/typespec-java/package.json
+++ b/packages/typespec-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.45.12",
+  "version": "0.45.13",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
## Summary
- publish `@azure-tools/typespec-java` 0.45.13
- include nested and XML pageable response support from microsoft/typespec#11504
- keep the legacy emitter-tests package aligned at 0.45.13
