### PR TITLE
Skip Spotless during Java emitter build

### DIFF
--- a/.chronus/changes/skip-java-spotless-build-2026-08-05-10-45-00.md
+++ b/.chronus/changes/skip-java-spotless-build-2026-08-05-10-45-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-java"
+---
+
+Skip Spotless formatting during the Java emitter build so transient Eclipse download failures do not fail `pnpm build`.

--- a/packages/typespec-java/Build-Generator.ps1
+++ b/packages/typespec-java/Build-Generator.ps1
@@ -25,7 +25,7 @@ if (-not (Test-Path $generatorPom)) {
 }
 
 Write-Host "Build JAR"
-mvn clean install -DskipTests --define spotless:skip --no-transfer-progress -T 1C -f $generatorPom
+mvn clean install -DskipTests --define spotless.apply.skip=true --define spotless.check.skip=true --no-transfer-progress -T 1C -f $generatorPom
 if ($LASTEXITCODE -ne 0) {
     exit $LASTEXITCODE
 }


### PR DESCRIPTION
## Summary

- skip Spotless apply and check during the Java emitter Maven build
- avoid transient failures downloading the Eclipse formatter during publish builds

Fixes #5156