### PR TITLE
Disable Dependabot cooldown for the core submodule

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,13 +10,10 @@ updates:
     schedule:
       interval: "daily"
     labels: [] # conflict with our labels in labels.ts
-
-  # Auto update the cadl-ranch-specs version used for e2e tests. It is pinned instead of always using the latest so we don't have a failure showing in random PRs blocking the flow.
-  - package-ecosystem: "npm"
-    directory: "/packages/e2e-tests/cadl-ranch-specs"
-    schedule:
-      interval: "daily"
-    labels: [] # conflict with our labels in labels.ts
+    # The `core` submodule points at our own repo(microsoft/typespec), so the default 3 day
+    # supply-chain cooldown only delays us. Opt out of it.
+    cooldown:
+      default-days: 0
 
   # GitHub Actions
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
In July 2026 GitHub turned on a [default 3-day cooldown](https://github.blog/security/supply-chain-security/the-case-for-a-cooldown-why-dependabot-now-waits-before-issuing-version-updates/) for all Dependabot version updates. It applies whether or not `cooldown` appears in `dependabot.yml`, so our `core` submodule bumps silently started lagging three days behind `microsoft/typespec`.

The cooldown exists to give the community time to catch malicious releases published to a public registry. That threat model doesn't apply here: `core` is our own repo, and we depend on picking up its commits promptly so breakage surfaces in this repo right away rather than three days later.

This opts the `gitsubmodule` entry out with `cooldown.default-days: 0`. The npm and github-actions entries keep the default cooldown, since those do pull third-party code.
