### PR TITLE
Fix python spector job by pointing uv at the authenticated dev feed

### DIFF
--- a/eng/common/pipelines/templates/steps/pip-authenticate.yml
+++ b/eng/common/pipelines/templates/steps/pip-authenticate.yml
@@ -10,3 +10,16 @@ steps:
     inputs:
       artifactFeeds: ${{ parameters.ArtifactFeeds }}
       onlyAddExtraIndex: false
+
+  # uv does not read PIP_INDEX_URL, so anything running through it (tox-uv,
+  # `uv pip install`) would fall back to pypi.org and fail under CFSClean.
+  # Mirror the authenticated URL into uv's own setting; tox-uv forwards UV_*
+  # into every tox environment.
+  - pwsh: |
+      if (-not $env:PIP_INDEX_URL) {
+        Write-Host "##vso[task.logissue type=error]PIP_INDEX_URL was not set by PipAuthenticate, uv would fall back to pypi.org."
+        exit 1
+      }
+      # UV_DEFAULT_INDEX is the replacement for the deprecated UV_INDEX_URL (uv 0.4.23+).
+      Write-Host "##vso[task.setvariable variable=UV_DEFAULT_INDEX]$env:PIP_INDEX_URL"
+    displayName: "Uv Authenticate"


### PR DESCRIPTION
fix #5155 
The Spector Coverage (Python) job in the publish pipeline is failing under CFSClean network isolation:

```
test-unbranded: install_deps> .../venv/bin/uv pip install -r .../base.txt -r .../unbranded.txt
error: Request failed after 3 retries in 4.6s
  Caused by: Failed to fetch: `https://pypi.org/simple/colorama/`
  Caused by: tcp connect error
  Caused by: Operation not permitted (os error 1)
```

`PipAuthenticate@1` already runs for every job via `install.yml`, but it only exports `PIP_INDEX_URL` — and **uv doesn't read it**. `typespec-python` runs its test envs through `tox-uv`, so every dependency install went straight to pypi.org, which the isolated pool blocks.

Mirroring the authenticated URL into uv's own `UV_DEFAULT_INDEX` is enough to fix it everywhere at once:

- the value comes from `PipAuthenticate@1`, which sets `PIP_INDEX_URL` as a normal (non-secret) variable while separately registering the token via `task.setsecret`, so it stays masked in logs;
- `tox-uv` adds `UV_*` to `pass_env`, so it reaches every tox environment — unlike `PIP_*`, which base tox only forwards for virtualenv runners, never for uv ones;
- `UV_DEFAULT_INDEX` is the current spelling (uv 0.4.23+) of the deprecated `UV_INDEX_URL`.

The step hard-fails instead of warning: silently falling back to pypi.org is what made this hard to spot in the first place.

Supersedes #5137, which duplicated the existing `pip-authenticate.yml` template rather than fixing it.
