### PR TITLE
Disable C# standard acronym rule

### DIFF
--- a/.chronus/changes/disable-csharp-standard-acronyms-2026-08-06.md
+++ b/.chronus/changes/disable-csharp-standard-acronyms-2026-08-06.md
@@ -1,5 +1,5 @@
 ---
-changeKind: fix
+changeKind: internal
 packages:
   - "@azure-tools/typespec-azure-rulesets"
 ---

--- a/.chronus/changes/disable-csharp-standard-acronyms-2026-08-06.md
+++ b/.chronus/changes/disable-csharp-standard-acronyms-2026-08-06.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-rulesets"
+---
+
+Disable `csharp-use-standard-acronyms` in the client SDK ruleset until the C# emitter handles standard acronym casing.

--- a/packages/typespec-azure-rulesets/src/rulesets/client-sdk.ts
+++ b/packages/typespec-azure-rulesets/src/rulesets/client-sdk.ts
@@ -6,6 +6,9 @@ export default {
   enable: {
     "@azure-tools/typespec-client-generator-core/csharp-no-url-suffix": true,
     "@azure-tools/typespec-client-generator-core/csharp-model-suffix": true,
-    "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms": true,
+  },
+  disable: {
+    "@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms":
+      "Disabled until the C# emitter handles standard acronym casing.",
   },
 } satisfies LinterRuleSet;

--- a/packages/typespec-azure-rulesets/test/validate-rules-defined.test.ts
+++ b/packages/typespec-azure-rulesets/test/validate-rules-defined.test.ts
@@ -51,13 +51,13 @@ describe("expect all rules to be defined", () => {
     });
   });
 
-  it("client-sdk enables C# naming rules", () => {
+  it("client-sdk configures C# naming rules", () => {
     const ruleset = $linter.ruleSets?.["client-sdk"];
     ok(ruleset);
     ok(ruleset.enable?.["@azure-tools/typespec-client-generator-core/csharp-no-url-suffix"]);
     ok(ruleset.enable?.["@azure-tools/typespec-client-generator-core/csharp-model-suffix"]);
     ok(
-      ruleset.enable?.["@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms"],
+      ruleset.disable?.["@azure-tools/typespec-client-generator-core/csharp-use-standard-acronyms"],
     );
   });
 });


### PR DESCRIPTION
Disable `csharp-use-standard-acronyms` in the client SDK ruleset until the C# emitter handles standard acronym casing.

This avoids requiring widespread suppressions and C# client-name overrides for common IP/DB-style names.