### PR TITLE
Document public API surface ahead of the library-linter documentation rules

### DIFF
--- a/.chronus/changes/library-linter-missing-docs-2026-8-7-9-30-0.md
+++ b/.chronus/changes/library-linter-missing-docs-2026-8-7-9-30-0.md
@@ -1,0 +1,10 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-azure-core"
+  - "@azure-tools/typespec-azure-portal-core"
+  - "@azure-tools/typespec-azure-resource-manager"
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Document public declarations and members that were missing documentation, and remove doc tags that referenced template parameters which no longer exist

--- a/packages/samples/common-types/openapi/v3/types.json
+++ b/packages/samples/common-types/openapi/v3/types.json
@@ -495,13 +495,16 @@
           "readOnly": true
         },
         "identity": {
-          "$ref": "#/definitions/Identity"
+          "$ref": "#/definitions/Identity",
+          "description": "The identity of the resource."
         },
         "sku": {
-          "$ref": "#/definitions/Sku"
+          "$ref": "#/definitions/Sku",
+          "description": "The SKU of the resource."
         },
         "plan": {
-          "$ref": "#/definitions/Plan"
+          "$ref": "#/definitions/Plan",
+          "description": "The plan of the resource."
         }
       },
       "allOf": [

--- a/packages/samples/common-types/openapi/v4/managedidentitywithdelegation.json
+++ b/packages/samples/common-types/openapi/v4/managedidentitywithdelegation.json
@@ -41,7 +41,8 @@
       "description": "Managed service identity (system assigned and/or user assigned identities and/or delegated identities) - internal use only.",
       "properties": {
         "delegatedResources": {
-          "$ref": "#/definitions/DelegatedResources"
+          "$ref": "#/definitions/DelegatedResources",
+          "description": "The delegated resources of the identity - internal use only."
         }
       },
       "allOf": [

--- a/packages/samples/common-types/openapi/v4/types.json
+++ b/packages/samples/common-types/openapi/v4/types.json
@@ -498,13 +498,16 @@
           "readOnly": true
         },
         "identity": {
-          "$ref": "#/definitions/Identity"
+          "$ref": "#/definitions/Identity",
+          "description": "The identity of the resource."
         },
         "sku": {
-          "$ref": "#/definitions/Sku"
+          "$ref": "#/definitions/Sku",
+          "description": "The SKU of the resource."
         },
         "plan": {
-          "$ref": "#/definitions/Plan"
+          "$ref": "#/definitions/Plan",
+          "description": "The plan of the resource."
         }
       },
       "allOf": [

--- a/packages/samples/common-types/openapi/v5/managedidentitywithdelegation.json
+++ b/packages/samples/common-types/openapi/v5/managedidentitywithdelegation.json
@@ -41,7 +41,8 @@
       "description": "Managed service identity (system assigned and/or user assigned identities and/or delegated identities) - internal use only.",
       "properties": {
         "delegatedResources": {
-          "$ref": "#/definitions/DelegatedResources"
+          "$ref": "#/definitions/DelegatedResources",
+          "description": "The delegated resources of the identity - internal use only."
         }
       },
       "allOf": [

--- a/packages/samples/common-types/openapi/v5/networksecurityperimeter.json
+++ b/packages/samples/common-types/openapi/v5/networksecurityperimeter.json
@@ -17,7 +17,8 @@
           "description": "Name of the access rule"
         },
         "properties": {
-          "$ref": "#/definitions/AccessRuleProperties"
+          "$ref": "#/definitions/AccessRuleProperties",
+          "description": "Properties of the access rule"
         }
       }
     },
@@ -50,7 +51,8 @@
       "description": "Properties of Access Rule",
       "properties": {
         "direction": {
-          "$ref": "#/definitions/AccessRuleDirection"
+          "$ref": "#/definitions/AccessRuleDirection",
+          "description": "Direction of the access rule"
         },
         "addressPrefixes": {
           "type": "array",
@@ -175,7 +177,8 @@
       "description": "Network security perimeter (NSP) configuration resource",
       "properties": {
         "properties": {
-          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProperties"
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProperties",
+          "description": "Network security configuration properties."
         }
       },
       "allOf": [
@@ -208,6 +211,7 @@
       "properties": {
         "provisioningState": {
           "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProvisioningState",
+          "description": "Provisioning state of the network security perimeter configuration",
           "readOnly": true
         },
         "provisioningIssues": {
@@ -220,13 +224,16 @@
           "x-ms-identifiers": []
         },
         "networkSecurityPerimeter": {
-          "$ref": "#/definitions/NetworkSecurityPerimeter"
+          "$ref": "#/definitions/NetworkSecurityPerimeter",
+          "description": "Information about the network security perimeter (NSP)"
         },
         "resourceAssociation": {
-          "$ref": "#/definitions/ResourceAssociation"
+          "$ref": "#/definitions/ResourceAssociation",
+          "description": "Information about the resource association"
         },
         "profile": {
-          "$ref": "#/definitions/NetworkSecurityProfile"
+          "$ref": "#/definitions/NetworkSecurityProfile",
+          "description": "Network security perimeter configuration profile"
         }
       }
     },
@@ -248,31 +255,38 @@
         "values": [
           {
             "name": "Succeeded",
-            "value": "Succeeded"
+            "value": "Succeeded",
+            "description": "The configuration was provisioned successfully."
           },
           {
             "name": "Creating",
-            "value": "Creating"
+            "value": "Creating",
+            "description": "The configuration is being created."
           },
           {
             "name": "Updating",
-            "value": "Updating"
+            "value": "Updating",
+            "description": "The configuration is being updated."
           },
           {
             "name": "Deleting",
-            "value": "Deleting"
+            "value": "Deleting",
+            "description": "The configuration is being deleted."
           },
           {
             "name": "Accepted",
-            "value": "Accepted"
+            "value": "Accepted",
+            "description": "The configuration request was accepted and provisioning has not started yet."
           },
           {
             "name": "Failed",
-            "value": "Failed"
+            "value": "Failed",
+            "description": "The configuration failed to provision."
           },
           {
             "name": "Canceled",
-            "value": "Canceled"
+            "value": "Canceled",
+            "description": "The configuration provisioning was canceled."
           }
         ]
       }
@@ -325,6 +339,7 @@
         },
         "properties": {
           "$ref": "#/definitions/ProvisioningIssueProperties",
+          "description": "Details of the provisioning issue",
           "readOnly": true
         }
       }
@@ -408,7 +423,8 @@
           "description": "Name of the resource association"
         },
         "accessMode": {
-          "$ref": "#/definitions/ResourceAssociationAccessMode"
+          "$ref": "#/definitions/ResourceAssociationAccessMode",
+          "description": "Access mode of the resource association"
         }
       }
     },
@@ -455,11 +471,13 @@
         "values": [
           {
             "name": "Warning",
-            "value": "Warning"
+            "value": "Warning",
+            "description": "The issue is a warning and does not prevent the configuration from being applied."
           },
           {
             "name": "Error",
-            "value": "Error"
+            "value": "Error",
+            "description": "The issue is an error and prevents the configuration from being applied."
           }
         ]
       }

--- a/packages/samples/common-types/openapi/v5/types.json
+++ b/packages/samples/common-types/openapi/v5/types.json
@@ -505,13 +505,16 @@
           "readOnly": true
         },
         "identity": {
-          "$ref": "#/definitions/Identity"
+          "$ref": "#/definitions/Identity",
+          "description": "The identity of the resource."
         },
         "sku": {
-          "$ref": "#/definitions/Sku"
+          "$ref": "#/definitions/Sku",
+          "description": "The SKU of the resource."
         },
         "plan": {
-          "$ref": "#/definitions/Plan"
+          "$ref": "#/definitions/Plan",
+          "description": "The plan of the resource."
         }
       },
       "allOf": [

--- a/packages/samples/common-types/openapi/v6/managedidentitywithdelegation.json
+++ b/packages/samples/common-types/openapi/v6/managedidentitywithdelegation.json
@@ -41,7 +41,8 @@
       "description": "Managed service identity (system assigned and/or user assigned identities and/or delegated identities) - internal use only.",
       "properties": {
         "delegatedResources": {
-          "$ref": "#/definitions/DelegatedResources"
+          "$ref": "#/definitions/DelegatedResources",
+          "description": "The delegated resources of the identity - internal use only."
         }
       },
       "allOf": [

--- a/packages/samples/common-types/openapi/v6/networksecurityperimeter.json
+++ b/packages/samples/common-types/openapi/v6/networksecurityperimeter.json
@@ -17,7 +17,8 @@
           "description": "Name of the access rule"
         },
         "properties": {
-          "$ref": "#/definitions/AccessRuleProperties"
+          "$ref": "#/definitions/AccessRuleProperties",
+          "description": "Properties of the access rule"
         }
       }
     },
@@ -50,7 +51,8 @@
       "description": "Properties of Access Rule",
       "properties": {
         "direction": {
-          "$ref": "#/definitions/AccessRuleDirection"
+          "$ref": "#/definitions/AccessRuleDirection",
+          "description": "Direction of the access rule"
         },
         "addressPrefixes": {
           "type": "array",
@@ -175,7 +177,8 @@
       "description": "Network security perimeter (NSP) configuration resource",
       "properties": {
         "properties": {
-          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProperties"
+          "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProperties",
+          "description": "Network security configuration properties."
         }
       },
       "allOf": [
@@ -208,6 +211,7 @@
       "properties": {
         "provisioningState": {
           "$ref": "#/definitions/NetworkSecurityPerimeterConfigurationProvisioningState",
+          "description": "Provisioning state of the network security perimeter configuration",
           "readOnly": true
         },
         "provisioningIssues": {
@@ -220,13 +224,16 @@
           "x-ms-identifiers": []
         },
         "networkSecurityPerimeter": {
-          "$ref": "#/definitions/NetworkSecurityPerimeter"
+          "$ref": "#/definitions/NetworkSecurityPerimeter",
+          "description": "Information about the network security perimeter (NSP)"
         },
         "resourceAssociation": {
-          "$ref": "#/definitions/ResourceAssociation"
+          "$ref": "#/definitions/ResourceAssociation",
+          "description": "Information about the resource association"
         },
         "profile": {
-          "$ref": "#/definitions/NetworkSecurityProfile"
+          "$ref": "#/definitions/NetworkSecurityProfile",
+          "description": "Network security perimeter configuration profile"
         }
       }
     },
@@ -248,31 +255,38 @@
         "values": [
           {
             "name": "Succeeded",
-            "value": "Succeeded"
+            "value": "Succeeded",
+            "description": "The configuration was provisioned successfully."
           },
           {
             "name": "Creating",
-            "value": "Creating"
+            "value": "Creating",
+            "description": "The configuration is being created."
           },
           {
             "name": "Updating",
-            "value": "Updating"
+            "value": "Updating",
+            "description": "The configuration is being updated."
           },
           {
             "name": "Deleting",
-            "value": "Deleting"
+            "value": "Deleting",
+            "description": "The configuration is being deleted."
           },
           {
             "name": "Accepted",
-            "value": "Accepted"
+            "value": "Accepted",
+            "description": "The configuration request was accepted and provisioning has not started yet."
           },
           {
             "name": "Failed",
-            "value": "Failed"
+            "value": "Failed",
+            "description": "The configuration failed to provision."
           },
           {
             "name": "Canceled",
-            "value": "Canceled"
+            "value": "Canceled",
+            "description": "The configuration provisioning was canceled."
           }
         ]
       }
@@ -325,6 +339,7 @@
         },
         "properties": {
           "$ref": "#/definitions/ProvisioningIssueProperties",
+          "description": "Details of the provisioning issue",
           "readOnly": true
         }
       }
@@ -408,7 +423,8 @@
           "description": "Name of the resource association"
         },
         "accessMode": {
-          "$ref": "#/definitions/ResourceAssociationAccessMode"
+          "$ref": "#/definitions/ResourceAssociationAccessMode",
+          "description": "Access mode of the resource association"
         }
       }
     },
@@ -455,11 +471,13 @@
         "values": [
           {
             "name": "Warning",
-            "value": "Warning"
+            "value": "Warning",
+            "description": "The issue is a warning and does not prevent the configuration from being applied."
           },
           {
             "name": "Error",
-            "value": "Error"
+            "value": "Error",
+            "description": "The issue is an error and prevents the configuration from being applied."
           }
         ]
       }

--- a/packages/samples/common-types/openapi/v6/types.json
+++ b/packages/samples/common-types/openapi/v6/types.json
@@ -483,13 +483,16 @@
           "readOnly": true
         },
         "identity": {
-          "$ref": "./managedidentity.json#/definitions/ManagedServiceIdentity"
+          "$ref": "./managedidentity.json#/definitions/ManagedServiceIdentity",
+          "description": "The identity of the resource."
         },
         "sku": {
-          "$ref": "#/definitions/Sku"
+          "$ref": "#/definitions/Sku",
+          "description": "The SKU of the resource."
         },
         "plan": {
-          "$ref": "#/definitions/Plan"
+          "$ref": "#/definitions/Plan",
+          "description": "The plan of the resource."
         }
       },
       "allOf": [

--- a/packages/samples/test/output/azure/core/data-plane/widget-manager/@typespec/openapi3/openapi.2022-08-31.yaml
+++ b/packages/samples/test/output/azure/core/data-plane/widget-manager/@typespec/openapi3/openapi.2022-08-31.yaml
@@ -853,7 +853,6 @@ paths:
           headers:
             Location:
               required: true
-              description: The location of an instance of WidgetPart
               schema:
                 type: string
                 format: uri

--- a/packages/samples/test/output/azure/core/data-plane/widget-manager/@typespec/openapi3/openapi.2022-08-31.yaml
+++ b/packages/samples/test/output/azure/core/data-plane/widget-manager/@typespec/openapi3/openapi.2022-08-31.yaml
@@ -853,6 +853,7 @@ paths:
           headers:
             Location:
               required: true
+              description: The location of an instance of WidgetPart
               schema:
                 type: string
                 format: uri

--- a/packages/samples/test/output/azure/resource-manager/legacy/legacy-operations/@azure-tools/typespec-autorest/2021-10-01-preview/openapi.json
+++ b/packages/samples/test/output/azure/resource-manager/legacy/legacy-operations/@azure-tools/typespec-autorest/2021-10-01-preview/openapi.json
@@ -561,6 +561,7 @@
         },
         "extendedLocation": {
           "$ref": "#/definitions/ExtendedLocation",
+          "description": "The extended location of the resource.",
           "x-ms-mutability": [
             "read",
             "create"

--- a/packages/samples/test/output/azure/resource-manager/resource-common-properties/common-properties/@azure-tools/typespec-autorest/2023-03-01-preview/openapi.json
+++ b/packages/samples/test/output/azure/resource-manager/resource-common-properties/common-properties/@azure-tools/typespec-autorest/2023-03-01-preview/openapi.json
@@ -455,6 +455,7 @@
         },
         "extendedLocation": {
           "$ref": "#/definitions/Azure.ResourceManager.CommonTypes.ExtendedLocation",
+          "description": "The extended location of the resource.",
           "x-ms-mutability": [
             "read",
             "create"

--- a/packages/typespec-azure-core/lib/auth.tsp
+++ b/packages/typespec-azure-core/lib/auth.tsp
@@ -19,9 +19,16 @@ namespace Azure.Core;
  */
 model AadTokenAuthFlow<Scopes extends string[], AuthUrl extends string, TokenUrl extends string>
   extends TypeSpec.Http.AuthorizationCodeFlow {
+  /** The OAuth2 flow type, always the authorization code flow. */
   type: OAuth2FlowType.authorizationCode;
+
+  /** The authorization URL used to obtain an authorization code. */
   authorizationUrl: AuthUrl;
+
+  /** The token URL used to exchange the authorization code for a token. */
   tokenUrl: TokenUrl;
+
+  /** The list of scopes the token applies to. */
   scopes: Scopes;
 }
 

--- a/packages/typespec-azure-core/lib/foundations.tsp
+++ b/packages/typespec-azure-core/lib/foundations.tsp
@@ -85,6 +85,7 @@ alias ResourceCreatedOrOkResponse<Resource extends TypeSpec.Reflection.Model> =
 model LocationOfCreatedResourceResponse<Resource extends TypeSpec.Reflection.Model>
   is TypeSpec.Http.CreatedResponse {
   /** The location of the created resource. */
+  @doc("The location of an instance of {name}", Resource)
   @finalLocation
   @TypeSpec.Http.header("Location")
   location: ResourceLocation<Resource>;
@@ -97,6 +98,7 @@ model LocationOfCreatedResourceResponse<Resource extends TypeSpec.Reflection.Mod
 model LocationOfCreatedResourceWithServiceProvidedNameResponse<Resource extends TypeSpec.Reflection.Model>
   is TypeSpec.Http.AcceptedResponse {
   /** The location of the created resource. */
+  @doc("The location of an instance of {name}", Resource)
   @finalLocation
   @TypeSpec.Http.header("Location")
   location: ResourceLocation<Resource>;

--- a/packages/typespec-azure-core/lib/foundations.tsp
+++ b/packages/typespec-azure-core/lib/foundations.tsp
@@ -85,7 +85,7 @@ alias ResourceCreatedOrOkResponse<Resource extends TypeSpec.Reflection.Model> =
 model LocationOfCreatedResourceResponse<Resource extends TypeSpec.Reflection.Model>
   is TypeSpec.Http.CreatedResponse {
   /** The location of the created resource. */
-  @doc("The location of an instance of {name}", Resource)
+  @doc("")
   @finalLocation
   @TypeSpec.Http.header("Location")
   location: ResourceLocation<Resource>;
@@ -98,7 +98,7 @@ model LocationOfCreatedResourceResponse<Resource extends TypeSpec.Reflection.Mod
 model LocationOfCreatedResourceWithServiceProvidedNameResponse<Resource extends TypeSpec.Reflection.Model>
   is TypeSpec.Http.AcceptedResponse {
   /** The location of the created resource. */
-  @doc("The location of an instance of {name}", Resource)
+  @doc("")
   @finalLocation
   @TypeSpec.Http.header("Location")
   location: ResourceLocation<Resource>;

--- a/packages/typespec-azure-core/lib/foundations.tsp
+++ b/packages/typespec-azure-core/lib/foundations.tsp
@@ -84,8 +84,6 @@ alias ResourceCreatedOrOkResponse<Resource extends TypeSpec.Reflection.Model> =
  */
 model LocationOfCreatedResourceResponse<Resource extends TypeSpec.Reflection.Model>
   is TypeSpec.Http.CreatedResponse {
-  /** The location of the created resource. */
-  @doc("The location of an instance of {name}", Resource)
   @finalLocation
   @TypeSpec.Http.header("Location")
   location: ResourceLocation<Resource>;
@@ -97,8 +95,6 @@ model LocationOfCreatedResourceResponse<Resource extends TypeSpec.Reflection.Mod
  */
 model LocationOfCreatedResourceWithServiceProvidedNameResponse<Resource extends TypeSpec.Reflection.Model>
   is TypeSpec.Http.AcceptedResponse {
-  /** The location of the created resource. */
-  @doc("The location of an instance of {name}", Resource)
   @finalLocation
   @TypeSpec.Http.header("Location")
   location: ResourceLocation<Resource>;

--- a/packages/typespec-azure-core/lib/foundations.tsp
+++ b/packages/typespec-azure-core/lib/foundations.tsp
@@ -85,7 +85,7 @@ alias ResourceCreatedOrOkResponse<Resource extends TypeSpec.Reflection.Model> =
 model LocationOfCreatedResourceResponse<Resource extends TypeSpec.Reflection.Model>
   is TypeSpec.Http.CreatedResponse {
   /** The location of the created resource. */
-  @doc("")
+  @doc("The location of an instance of {name}", Resource)
   @finalLocation
   @TypeSpec.Http.header("Location")
   location: ResourceLocation<Resource>;
@@ -98,7 +98,7 @@ model LocationOfCreatedResourceResponse<Resource extends TypeSpec.Reflection.Mod
 model LocationOfCreatedResourceWithServiceProvidedNameResponse<Resource extends TypeSpec.Reflection.Model>
   is TypeSpec.Http.AcceptedResponse {
   /** The location of the created resource. */
-  @doc("")
+  @doc("The location of an instance of {name}", Resource)
   @finalLocation
   @TypeSpec.Http.header("Location")
   location: ResourceLocation<Resource>;

--- a/packages/typespec-azure-core/lib/foundations.tsp
+++ b/packages/typespec-azure-core/lib/foundations.tsp
@@ -80,10 +80,11 @@ alias ResourceCreatedOrOkResponse<Resource extends TypeSpec.Reflection.Model> =
 
 /**
  * Response describing the location of a created resource.
- * @template T The type of the created resource.
+ * @template Resource The type of the created resource.
  */
 model LocationOfCreatedResourceResponse<Resource extends TypeSpec.Reflection.Model>
   is TypeSpec.Http.CreatedResponse {
+  /** The location of the created resource. */
   @finalLocation
   @TypeSpec.Http.header("Location")
   location: ResourceLocation<Resource>;
@@ -91,10 +92,11 @@ model LocationOfCreatedResourceResponse<Resource extends TypeSpec.Reflection.Mod
 
 /**
  * Response describing the location of a resource created with a service-provided name.
- * @template T The type of the created resource.
+ * @template Resource The type of the created resource.
  */
 model LocationOfCreatedResourceWithServiceProvidedNameResponse<Resource extends TypeSpec.Reflection.Model>
   is TypeSpec.Http.AcceptedResponse {
+  /** The location of the created resource. */
   @finalLocation
   @TypeSpec.Http.header("Location")
   location: ResourceLocation<Resource>;

--- a/packages/typespec-azure-core/lib/legacy.tsp
+++ b/packages/typespec-azure-core/lib/legacy.tsp
@@ -18,6 +18,8 @@ namespace Azure.Core.Legacy;
  *   @nextLink nextLink: Azure.Core.Legacy.parameterizedNextLink<[ListCertificateOptions.includePending]>;
  * }
  * ```
+ *
+ * @template ParameterizedParams The model properties whose values must be reapplied to the next link.
  */
 @Azure.Core.Foundations.Private.parameterizedNextLinkConfig(ParameterizedParams)
 scalar parameterizedNextLink<ParameterizedParams extends TypeSpec.Reflection.ModelProperty[]>

--- a/packages/typespec-azure-core/lib/models.tsp
+++ b/packages/typespec-azure-core/lib/models.tsp
@@ -38,7 +38,7 @@ model RequestParameter<Name extends valueof string> {}
 model ResponseProperty<Name extends valueof string> {}
 
 /**
- * @dev Provides the status of a resource operation.
+ * Provides the status of a resource operation.
  * @template Resource The resource type.
  * @template StatusResult Model describing the status result object. If not specified, the default is the resource type.
  * @template StatusError Model describing the status error object. If not specified, the default is the Foundations.Error.
@@ -383,6 +383,7 @@ scalar armResourceIdentifier<AllowedResourceTypes extends ArmResourceIdentifierA
   extends string;
 
 // Consider replacing `*`
+/** The deployment scopes in which an Azure Resource Manager resource identifier may be used. */
 union ArmResourceDeploymentScope {
   "Tenant",
   "Subscription",
@@ -401,6 +402,7 @@ alias AllArmResourceDeploymentScopes = [
   "Extension"
 ];
 
+/** Describes a resource type, and the scopes it applies to, that an `armResourceIdentifier` is allowed to refer to. */
 model ArmResourceIdentifierAllowedResource {
   /** The type of resource that is being referred to. For example Microsoft.Network/virtualNetworks or Microsoft.Network/virtualNetworks/subnets. See Example Types for more examples. */
   type: armResourceType;

--- a/packages/typespec-azure-core/lib/models.tsp
+++ b/packages/typespec-azure-core/lib/models.tsp
@@ -43,6 +43,7 @@ model ResponseProperty<Name extends valueof string> {}
  * @template StatusResult Model describing the status result object. If not specified, the default is the resource type.
  * @template StatusError Model describing the status error object. If not specified, the default is the Foundations.Error.
  */
+@doc("Provides status details for long running operations.")
 @resource("operations")
 @parentResource(Resource)
 model ResourceOperationStatus<

--- a/packages/typespec-azure-core/lib/traits.tsp
+++ b/packages/typespec-azure-core/lib/traits.tsp
@@ -62,6 +62,7 @@ model TraitOverride<Trait extends Model> {}
 @trait
 @Private.ensureAllQueryParams(Parameters)
 model QueryParametersTrait<Parameters extends Model, Contexts = unknown> {
+  /** The query parameters contributed by this trait. */
   @traitContext(Contexts)
   queryParams: {
     @traitLocation(TraitLocation.Parameters)
@@ -87,6 +88,7 @@ model ListQueryParametersTrait<Parameters extends Model> is QueryParametersTrait
 @trait
 @Private.ensureAllHeaderParams(Headers)
 model RequestHeadersTrait<Headers extends Model, Contexts = unknown> {
+  /** The request headers contributed by this trait. */
   @traitContext(Contexts)
   requestHeaders: {
     @traitLocation(TraitLocation.Parameters)
@@ -102,6 +104,7 @@ model RequestHeadersTrait<Headers extends Model, Contexts = unknown> {
 @trait
 @Private.ensureAllHeaderParams(Headers)
 model ResponseHeadersTrait<Headers extends Model, Contexts = unknown> {
+  /** The response headers contributed by this trait. */
   @traitContext(Contexts)
   responseHeaders: {
     @traitLocation(TraitLocation.Response)
@@ -115,6 +118,7 @@ model ResponseHeadersTrait<Headers extends Model, Contexts = unknown> {
  */
 @trait("VersionParameter")
 model VersionParameterTrait<VersionParameter> {
+  /** The API version parameter contributed by this trait. */
   versionParameter: {
     @traitLocation(TraitLocation.ApiVersionParameter)
     apiVersionParam: VersionParameter;
@@ -129,6 +133,7 @@ model VersionParameterTrait<VersionParameter> {
 @trait("ClientRequestId")
 @traitAdded(VersionAdded)
 model SupportsClientRequestId<VersionAdded extends EnumMember | null = null> {
+  /** The client request id headers contributed by this trait. */
   #suppress "@azure-tools/typespec-providerhub/no-inline-model" "This inline model is never used directly in operations."
   clientRequestId: {
     @traitLocation(TraitLocation.Parameters)
@@ -144,6 +149,7 @@ model SupportsClientRequestId<VersionAdded extends EnumMember | null = null> {
  */
 @trait("ClientRequestId")
 model NoClientRequestId {
+  /** Empty, indicating that client request id headers are not supported. */
   clientRequestId: {};
 }
 
@@ -155,6 +161,7 @@ model NoClientRequestId {
 @trait("ConditionalRequests")
 @traitAdded(VersionAdded)
 model SupportsConditionalRequests<VersionAdded extends EnumMember | null = null> {
+  /** The conditional request headers and ETag headers contributed by this trait. */
   #suppress "@azure-tools/typespec-providerhub/no-inline-model" "This inline model is never used directly in operations."
   conditionalRequests: {
     @traitContext(
@@ -174,6 +181,7 @@ model SupportsConditionalRequests<VersionAdded extends EnumMember | null = null>
  */
 @trait("ConditionalRequests")
 model NoConditionalRequests {
+  /** Empty, indicating that conditional requests are not supported. */
   conditionalRequests: {};
 }
 
@@ -185,6 +193,7 @@ model NoConditionalRequests {
 @trait("RepeatableRequests")
 @traitAdded(VersionAdded)
 model SupportsRepeatableRequests<VersionAdded extends EnumMember | null = null> {
+  /** The repeatable request headers contributed by this trait. */
   #suppress "@azure-tools/typespec-providerhub/no-inline-model" "This inline model is never used directly in operations."
   @traitContext(
     TraitContext.Create | TraitContext.Update | TraitContext.Delete | TraitContext.Action
@@ -203,6 +212,7 @@ model SupportsRepeatableRequests<VersionAdded extends EnumMember | null = null> 
  */
 @trait("RepeatableRequests")
 model NoRepeatableRequests {
+  /** Empty, indicating that repeatable requests are not supported. */
   repeatableRequests: {};
 }
 

--- a/packages/typespec-azure-portal-core/README.md
+++ b/packages/typespec-azure-portal-core/README.md
@@ -68,9 +68,9 @@ Provides a Model Property a display name
 
 ##### Parameters
 
-| Name | Type             | Description |
-| ---- | ---------------- | ----------- |
-| name | `valueof string` |             |
+| Name | Type             | Description                                |
+| ---- | ---------------- | ------------------------------------------ |
+| name | `valueof string` | The display name to show for the property. |
 
 #### `@marketplaceOffer`
 

--- a/packages/typespec-azure-portal-core/lib/decorators.tsp
+++ b/packages/typespec-azure-portal-core/lib/decorators.tsp
@@ -30,6 +30,7 @@ extern dec marketplaceOffer(target: Model, options: MarketplaceOfferOptions);
 
 /**
  * Provides a Model Property a display name
+ * @param name The display name to show for the property.
  */
 extern dec displayName(target: ModelProperty, name: valueof string);
 
@@ -73,18 +74,27 @@ model AboutOptions {
 
 /** Options for promotion of ARM resource. */
 model PromotionOptions {
+  /** The API version to promote, either a literal version string or a version enum member. */
   apiVersion: string | EnumMember;
+
+  /** Whether the promoted API version should be updated automatically. */
   autoUpdate?: boolean;
 }
 
 /** Options for learnMoreDocs of ARM resources. */
 model LearnMoreDocsOptions {
+  /** The title of the documentation link. */
   title: string;
+
+  /** The URI of the documentation link. */
   uri: string;
 }
 
 /** Options for displayNames of ARM resources. */
 model DisplayNamesOptions {
+  /** The singular display name of the resource. */
   singular: string;
+
+  /** The plural display name of the resource. */
   plural: string;
 }

--- a/packages/typespec-azure-resource-manager/lib/common-types/managed-identity-with-delegation.tsp
+++ b/packages/typespec-azure-resource-manager/lib/common-types/managed-identity-with-delegation.tsp
@@ -6,6 +6,7 @@ namespace Azure.ResourceManager.CommonTypes;
 /** Managed service identity (system assigned and/or user assigned identities and/or delegated identities) - internal use only. */
 @added(Versions.v4)
 model ManagedServiceIdentityWithDelegation extends ManagedServiceIdentity {
+  /** The delegated resources of the identity - internal use only. */
   delegatedResources?: DelegatedResources;
 }
 

--- a/packages/typespec-azure-resource-manager/lib/common-types/network-security-perimeter.tsp
+++ b/packages/typespec-azure-resource-manager/lib/common-types/network-security-perimeter.tsp
@@ -24,12 +24,26 @@ union AccessRuleDirection {
 @added(Versions.v5)
 union NetworkSecurityPerimeterConfigurationProvisioningState {
   string,
+
+  /** The configuration was provisioned successfully. */
   Succeeded: "Succeeded",
+
+  /** The configuration is being created. */
   Creating: "Creating",
+
+  /** The configuration is being updated. */
   Updating: "Updating",
+
+  /** The configuration is being deleted. */
   Deleting: "Deleting",
+
+  /** The configuration request was accepted and provisioning has not started yet. */
   Accepted: "Accepted",
+
+  /** The configuration failed to provision. */
   Failed: "Failed",
+
+  /** The configuration provisioning was canceled. */
   Canceled: "Canceled",
 }
 
@@ -55,7 +69,11 @@ union IssueType {
 @added(Versions.v5)
 union Severity {
   string,
+
+  /** The issue is a warning and does not prevent the configuration from being applied. */
   Warning: "Warning",
+
+  /** The issue is an error and prevents the configuration from being applied. */
   Error: "Error",
 }
 
@@ -95,12 +113,14 @@ model AccessRule {
   /** Name of the access rule */
   name?: string;
 
+  /** Properties of the access rule */
   properties?: AccessRuleProperties;
 }
 
 /** Properties of Access Rule */
 @added(Versions.v5)
 model AccessRuleProperties {
+  /** Direction of the access rule */
   direction?: AccessRuleDirection;
 
   /** Address prefixes in the CIDR format for inbound rules */
@@ -146,12 +166,14 @@ model NetworkSecurityPerimeter {
 /** Network security perimeter (NSP) configuration resource */
 @added(Versions.v5)
 model NetworkSecurityPerimeterConfiguration extends ProxyResource {
+  /** Network security configuration properties. */
   properties?: NetworkSecurityPerimeterConfigurationProperties;
 }
 
 /** Network security configuration properties. */
 @added(Versions.v5)
 model NetworkSecurityPerimeterConfigurationProperties {
+  /** Provisioning state of the network security perimeter configuration */
   @visibility(Lifecycle.Read)
   provisioningState?: NetworkSecurityPerimeterConfigurationProvisioningState;
 
@@ -160,8 +182,13 @@ model NetworkSecurityPerimeterConfigurationProperties {
   @Azure.ResourceManager.identifiers(#[])
   provisioningIssues?: ProvisioningIssue[];
 
+  /** Information about the network security perimeter (NSP) */
   networkSecurityPerimeter?: NetworkSecurityPerimeter;
+
+  /** Information about the resource association */
   resourceAssociation?: ResourceAssociation;
+
+  /** Network security perimeter configuration profile */
   profile?: NetworkSecurityProfile;
 }
 
@@ -172,6 +199,7 @@ model ProvisioningIssue {
   @visibility(Lifecycle.Read)
   name?: string;
 
+  /** Details of the provisioning issue */
   @visibility(Lifecycle.Read)
   properties?: ProvisioningIssueProperties;
 }
@@ -207,6 +235,7 @@ model ResourceAssociation {
   /** Name of the resource association */
   name?: string;
 
+  /** Access mode of the resource association */
   accessMode?: ResourceAssociationAccessMode;
 }
 

--- a/packages/typespec-azure-resource-manager/lib/common-types/types.tsp
+++ b/packages/typespec-azure-resource-manager/lib/common-types/types.tsp
@@ -80,10 +80,14 @@ model ResourceModelWithAllowedPropertySet extends TrackedResource {
   @visibility(Lifecycle.Read)
   etag?: string;
 
+  /** The identity of the resource. */
   @typeChangedFrom(Versions.v6, Identity)
   identity?: ManagedServiceIdentity;
 
+  /** The SKU of the resource. */
   sku?: Sku;
+
+  /** The plan of the resource. */
   plan?: Plan;
 }
 
@@ -346,6 +350,7 @@ union createdByType {
 
 /** Resource Identity Type */
 union ResourceIdentityType {
+  /** The identity is assigned by the system. */
   SystemAssigned: "SystemAssigned",
 }
 

--- a/packages/typespec-azure-resource-manager/lib/extension/parameters.tsp
+++ b/packages/typespec-azure-resource-manager/lib/extension/parameters.tsp
@@ -173,6 +173,7 @@ model ExternalResource<
   Description extends valueof string = "The name of the resource",
   ParentType extends valueof "Tenant" | "Subscription" | "ResourceGroup" = "ResourceGroup"
 > {
+  /** The name of the resource. */
   @doc(Description)
   @visibility(Lifecycle.Read)
   @path
@@ -223,6 +224,7 @@ model ExternalChildResource<
   NameType extends string = string,
   Description extends valueof string = "The name of the resource"
 > {
+  /** The name of the resource. */
   @doc(Description)
   @visibility(Lifecycle.Read)
   @path

--- a/packages/typespec-azure-resource-manager/lib/foundations/arm.foundations.tsp
+++ b/packages/typespec-azure-resource-manager/lib/foundations/arm.foundations.tsp
@@ -190,6 +190,7 @@ model ProxyResourceUpdateModel<
   Resource extends Foundations.SimpleResource,
   Properties extends TypeSpec.Reflection.Model
 > {
+  /** The resource-specific properties for this resource. */
   properties?: ResourceUpdateModelProperties<Resource, Properties>;
 }
 

--- a/packages/typespec-azure-resource-manager/lib/interfaces.tsp
+++ b/packages/typespec-azure-resource-manager/lib/interfaces.tsp
@@ -33,11 +33,12 @@ interface Operations {
 }
 
 /**
- * @deprecated Use Azure.ResourceManager.TrackedResourceOperations instead
  * A composite interface for resources that include `ResourceInstanceOperations<Resource, Properties>`
  * and `ResourceCollectionOperations<Resource>`. It includes: `GET`, `PUT`, `PATCH`, `DELETE`, ListByParent,
  * ListBySubscription operations. The actual route depends on the resource model.
  * This is the most common API pattern for Tracked Resources to use.
+ *
+ * Deprecated: use `Azure.ResourceManager.TrackedResourceOperations` instead.
  * @template Resource the ArmResource that provides these operations
  * @template Properties RP-specific property bag for the resource
  * @template BaseParameters The http parameters that are part of the request
@@ -147,7 +148,6 @@ interface ResourceCollectionOperations<
 interface ResourceListBySubscription<Resource extends Foundations.SimpleResource> {
   /**
    * List resources by subscription.
-   * @template Resource The ArmResource to list.
    */
   @doc("List {name} resources by subscription ID", Resource)
   listBySubscription is ArmListBySubscription<Resource>;
@@ -168,10 +168,6 @@ interface ResourceListByParent<
 > {
   /**
    * List resources by parent.
-   * @template Resource The ArmResource to list.
-   * @template BaseParameters The http parameters that are part of the request
-   * @template ParentName The name of the parent resource
-   * @template ParentFriendlyName The friendly name of the parent resource
    */
   @Private.armRenameListByOperation(Resource, ParentName, ParentFriendlyName, true) // This must come before @armResourceList!
   listByParent is ArmResourceListByParent<Resource, BaseParameters, ParentName, ParentFriendlyName>;
@@ -188,8 +184,6 @@ interface ResourceRead<
 > {
   /**
    * Retrieve a resource.
-   * @template Resource The ArmResource to retrieve.
-   * @template BaseParameters The http parameters that are part of the request
    */
   @doc("Get a {name}", Resource)
   get is ArmResourceRead<Resource, BaseParameters>;
@@ -206,8 +200,6 @@ interface ResourceCreateSync<
 > {
   /**
    * Create or update a resource using the synchronous call pattern.
-   * @template Resource The ArmResource to create or update.
-   * @template BaseParameters The http parameters that are part of the request
    */
   @doc("Create a {name}", Resource)
   createOrUpdate is ArmResourceCreateOrReplaceSync<Resource, BaseParameters>;
@@ -224,8 +216,6 @@ interface ResourceCreateAsync<
 > {
   /**
    * Create or update a resource using the asynchronous call pattern.
-   * @template Resource The ArmResource to create or update.
-   * @template BaseParameters The http parameters that are part of the request
    */
   @doc("Create a {name}", Resource)
   createOrUpdate is ArmResourceCreateOrUpdateAsync<Resource, BaseParameters>;
@@ -245,8 +235,6 @@ interface ResourceDeleteAsync<
 > {
   /**
    * Delete a resource using the asynchronous call pattern.
-   * @template Resource The ArmResource to delete.
-   * @template BaseParameters The http parameters that are part of the request
    */
   @doc("Delete a {name}", Resource)
   delete is ArmResourceDeleteAsync<Resource, BaseParameters>;
@@ -265,8 +253,6 @@ interface ResourceDeleteWithoutOkAsync<
 > {
   /**
    * Delete a resource using the asynchronous call pattern.
-   * @template Resource The ArmResource to delete.
-   * @template BaseParameters The http parameters that are part of the request
    */
   @doc("Delete a {name}", Resource)
   delete is ArmResourceDeleteWithoutOkAsync<Resource, BaseParameters>;
@@ -284,8 +270,6 @@ interface ResourceDeleteSync<
 > {
   /**
    * Delete a resource using the synchronous call pattern.
-   * @template Resource The ArmResource to delete.
-   * @template BaseParameters The http parameters that are part of the request
    */
   @doc("Delete a {name}", Resource)
   delete is ArmResourceDeleteSync<Resource, BaseParameters>;
@@ -305,9 +289,6 @@ interface ResourceUpdateAsync<
 > {
   /**
    * Update a resource using the asynchronous call pattern.
-   * @template Resource The ArmResource to update.
-   * @template Properties RP-specific property bag for the resource
-   * @template BaseParameters The http parameters that are part of the request
    */
   @doc("Update a {name}", Resource)
   update is ArmCustomPatchAsync<
@@ -331,9 +312,6 @@ interface ResourceUpdateSync<
 > {
   /**
    * Update a resource using the synchronous call pattern.
-   * @template Resource The ArmResource to update.
-   * @template Properties RP-specific property bag for the resource
-   * @template BaseParameters The http parameters that are part of the request
    */
   #suppress "@typespec/http/deprecated-implicit-optionality" "Legacy"
   @patch(#{ implicitOptionality: true })

--- a/packages/typespec-azure-resource-manager/lib/legacy-types/resource.tsp
+++ b/packages/typespec-azure-resource-manager/lib/legacy-types/resource.tsp
@@ -70,6 +70,7 @@ alias EntityTagProperty = {
  * ```
  */
 model ExtendedLocationOptionalProperty {
+  /** The extended location of the resource. */
   @visibility(Lifecycle.Read, Lifecycle.Create)
   extendedLocation?: ExtendedLocationOptional;
 }

--- a/packages/typespec-azure-resource-manager/lib/models.tsp
+++ b/packages/typespec-azure-resource-manager/lib/models.tsp
@@ -11,7 +11,7 @@ namespace Azure.ResourceManager;
  * is specified, the resource name will be properly camel cased and pluralized for `@key` and `@segment`
  * automatically. You can also apply explicit override with `KeyName` and `SegmentName` template parameters.
  *
- * For additional decorators such as @minLength, you can use either augment decorator on `[Resource].name` or passing in a scalar string type with decorators.
+ * For additional decorators such as `@minLength`, you can use either augment decorator on `[Resource].name` or passing in a scalar string type with decorators.
  *
  * @template Resource The ARM resource this name parameter is applying to.
  * @template KeyName Override default key name of the resource.
@@ -229,6 +229,7 @@ model DefaultProvisioningStateProperty {
  * ```
  */
 model ExtendedLocationProperty {
+  /** The extended location of the resource. */
   @visibility(Lifecycle.Read, Lifecycle.Create)
   extendedLocation?: Foundations.ExtendedLocation;
 }

--- a/packages/typespec-azure-resource-manager/lib/private-endpoints.tsp
+++ b/packages/typespec-azure-resource-manager/lib/private-endpoints.tsp
@@ -60,8 +60,6 @@ interface PrivateEndpoints<
    * @template ParentResource the parent resource of the PrivateEndpointConnection
    * @template Resource Optional. The PrivateEndpointConnection resource being listed
    * @template BaseParameters Optional. Allows overriding the operation parameters
-   * @template ParentName Optional. The name of the parent resource
-   * @template ParentFriendlyName Optional. The friendly name of the parent resource
    * @template Parameters Optional. Additional parameters after the path parameters
    * @template Response Optional. The success response for the list operation
    * @template Error Optional. The error response, if non-standard.

--- a/packages/typespec-azure-resource-manager/lib/private-links.tsp
+++ b/packages/typespec-azure-resource-manager/lib/private-links.tsp
@@ -10,7 +10,6 @@ namespace Azure.ResourceManager;
  * Resource providers must declare a private link resource type in their provider namespace if
  * they support private link resources
  * @template Description Optional. The documentary description of the private link resource name parameter.
- * @template KeyName Optional. The name of the private link resource name parameter.
  * @example
  * ```ts
  * namespace Microsoft.Contoso;
@@ -61,8 +60,6 @@ interface PrivateLinks<
    * @template ParentResource the parent resource of the PrivateLink
    * @template Resource Optional. The PrivateLink resource being listed
    * @template BaseParameters Optional. Allows overriding the operation parameters
-   * @template ParentName Optional. The name of the parent resource
-   * @template ParentFriendlyName Optional. The friendly name of the parent resource
    * @template Parameters Optional. Additional parameters after the path parameters
    * @template Response Optional. The success response for the list operation
    * @template Error Optional. The error response, if non-standard.
@@ -95,8 +92,6 @@ interface PrivateLinks<
    * @template ParentResource the parent resource of the PrivateLink
    * @template Resource Optional. The PrivateLink resource being listed
    * @template BaseParameters Optional. Allows overriding the operation parameters
-   * @template ParentName Optional. The name of the parent resource
-   * @template ParentFriendlyName Optional. The friendly name of the parent resource
    * @template Parameters Optional. Additional parameters after the path parameters
    * @template Response Optional. The success response for the list operation
    * @template Error Optional. The error response, if non-standard.

--- a/packages/typespec-client-generator-core/README.md
+++ b/packages/typespec-client-generator-core/README.md
@@ -991,6 +991,12 @@ model MyModel {
 
 #### `@operationGroup`
 
+Define the sub client generated in the client SDK.
+If there is any `@client` definition or `@operationGroup` definition, then each `@client` is a root client and each `@operationGroup` is a sub client with hierarchy.
+This decorator cannot be used along with `@clientLocation`. This decorator cannot be used as augmentation.
+
+Deprecated: use `@client` instead. Sub clients should be represented using `@client`.
+
 ```typespec
 @Azure.ClientGenerator.Core.operationGroup(scope?: valueof string)
 ```

--- a/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.ts
+++ b/packages/typespec-client-generator-core/generated-defs/Azure.ClientGenerator.Core.ts
@@ -197,13 +197,12 @@ export type ClientDecorator = (
 ) => DecoratorValidatorCallbacks | void;
 
 /**
- *
- *
- *
- * @deprecated Use `@client` instead. The `@operationGroup` decorator is deprecated. Sub clients should be represented using `@client`.
  * Define the sub client generated in the client SDK.
  * If there is any `@client` definition or `@operationGroup` definition, then each `@client` is a root client and each `@operationGroup` is a sub client with hierarchy.
  * This decorator cannot be used along with `@clientLocation`. This decorator cannot be used as augmentation.
+ *
+ * Deprecated: use `@client` instead. Sub clients should be represented using `@client`.
+ *
  * @param target The target namespace or interface that you want to define as a sub client.
  * @param scope Specifies the target language emitters that the decorator should apply. If not set, the decorator will be applied to all language emitters by default.
  *

--- a/packages/typespec-client-generator-core/lib/decorators.tsp
+++ b/packages/typespec-client-generator-core/lib/decorators.tsp
@@ -204,10 +204,11 @@ model ClientOptions {
 }
 
 /**
- * @deprecated Use `@client` instead. The `@operationGroup` decorator is deprecated. Sub clients should be represented using `@client`.
  * Define the sub client generated in the client SDK.
  * If there is any `@client` definition or `@operationGroup` definition, then each `@client` is a root client and each `@operationGroup` is a sub client with hierarchy.
  * This decorator cannot be used along with `@clientLocation`. This decorator cannot be used as augmentation.
+ *
+ * Deprecated: use `@client` instead. Sub clients should be represented using `@client`.
  * @param target The target namespace or interface that you want to define as a sub client.
  * @param scope Specifies the target language emitters that the decorator should apply. If not set, the decorator will be applied to all language emitters by default.
  *

--- a/website/src/content/docs/docs/libraries/azure-core/reference/data-types.md
+++ b/website/src/content/docs/docs/libraries/azure-core/reference/data-types.md
@@ -857,10 +857,10 @@ model Azure.Core.Foundations.LocationOfCreatedResourceResponse<Resource>
 
 #### Properties
 
-| Name       | Type                             | Description                           |
-| ---------- | -------------------------------- | ------------------------------------- |
-| statusCode | `201`                            | The status code.                      |
-| location   | `TypeSpec.Rest.ResourceLocation` | The location of the created resource. |
+| Name       | Type                             | Description      |
+| ---------- | -------------------------------- | ---------------- |
+| statusCode | `201`                            | The status code. |
+| location   | `TypeSpec.Rest.ResourceLocation` |                  |
 
 ### `LocationOfCreatedResourceWithServiceProvidedNameResponse` {#Azure.Core.Foundations.LocationOfCreatedResourceWithServiceProvidedNameResponse}
 
@@ -878,10 +878,10 @@ model Azure.Core.Foundations.LocationOfCreatedResourceWithServiceProvidedNameRes
 
 #### Properties
 
-| Name       | Type                             | Description                           |
-| ---------- | -------------------------------- | ------------------------------------- |
-| statusCode | `202`                            | The status code.                      |
-| location   | `TypeSpec.Rest.ResourceLocation` | The location of the created resource. |
+| Name       | Type                             | Description      |
+| ---------- | -------------------------------- | ---------------- |
+| statusCode | `202`                            | The status code. |
+| location   | `TypeSpec.Rest.ResourceLocation` |                  |
 
 ### `LongRunningStatusLocation` {#Azure.Core.Foundations.LongRunningStatusLocation}
 

--- a/website/src/content/docs/docs/libraries/azure-core/reference/data-types.md
+++ b/website/src/content/docs/docs/libraries/azure-core/reference/data-types.md
@@ -48,14 +48,16 @@ model Azure.Core.AadTokenAuthFlow<Scopes, AuthUrl, TokenUrl>
 
 #### Properties
 
-| Name             | Type                                             | Description |
-| ---------------- | ------------------------------------------------ | ----------- |
-| type             | `TypeSpec.Http.OAuth2FlowType.authorizationCode` |             |
-| authorizationUrl | `AuthUrl`                                        |             |
-| tokenUrl         | `TokenUrl`                                       |             |
-| scopes           | `Scopes`                                         |             |
+| Name             | Type                                             | Description                                                        |
+| ---------------- | ------------------------------------------------ | ------------------------------------------------------------------ |
+| type             | `TypeSpec.Http.OAuth2FlowType.authorizationCode` | The OAuth2 flow type, always the authorization code flow.          |
+| authorizationUrl | `AuthUrl`                                        | The authorization URL used to obtain an authorization code.        |
+| tokenUrl         | `TokenUrl`                                       | The token URL used to exchange the authorization code for a token. |
+| scopes           | `Scopes`                                         | The list of scopes the token applies to.                           |
 
 ### `ArmResourceIdentifierAllowedResource` {#Azure.Core.ArmResourceIdentifierAllowedResource}
+
+Describes a resource type, and the scopes it applies to, that an `armResourceIdentifier` is allowed to refer to.
 
 ```typespec
 model Azure.Core.ArmResourceIdentifierAllowedResource
@@ -332,6 +334,8 @@ None
 
 ### `ResourceOperationStatus` {#Azure.Core.ResourceOperationStatus}
 
+Provides the status of a resource operation.
+
 ```typespec
 model Azure.Core.ResourceOperationStatus<Resource, StatusResult, StatusError>
 ```
@@ -470,6 +474,8 @@ model Azure.Core.TopQueryParameter
 | top? | `int32` | The number of result items to return. |
 
 ### `ArmResourceDeploymentScope` {#Azure.Core.ArmResourceDeploymentScope}
+
+The deployment scopes in which an Azure Resource Manager resource identifier may be used.
 
 ```typespec
 union Azure.Core.ArmResourceDeploymentScope
@@ -845,16 +851,16 @@ model Azure.Core.Foundations.LocationOfCreatedResourceResponse<Resource>
 
 #### Template Parameters
 
-| Name     | Description |
-| -------- | ----------- |
-| Resource |             |
+| Name     | Description                       |
+| -------- | --------------------------------- |
+| Resource | The type of the created resource. |
 
 #### Properties
 
-| Name       | Type                             | Description      |
-| ---------- | -------------------------------- | ---------------- |
-| statusCode | `201`                            | The status code. |
-| location   | `TypeSpec.Rest.ResourceLocation` |                  |
+| Name       | Type                             | Description                           |
+| ---------- | -------------------------------- | ------------------------------------- |
+| statusCode | `201`                            | The status code.                      |
+| location   | `TypeSpec.Rest.ResourceLocation` | The location of the created resource. |
 
 ### `LocationOfCreatedResourceWithServiceProvidedNameResponse` {#Azure.Core.Foundations.LocationOfCreatedResourceWithServiceProvidedNameResponse}
 
@@ -866,16 +872,16 @@ model Azure.Core.Foundations.LocationOfCreatedResourceWithServiceProvidedNameRes
 
 #### Template Parameters
 
-| Name     | Description |
-| -------- | ----------- |
-| Resource |             |
+| Name     | Description                       |
+| -------- | --------------------------------- |
+| Resource | The type of the created resource. |
 
 #### Properties
 
-| Name       | Type                             | Description      |
-| ---------- | -------------------------------- | ---------------- |
-| statusCode | `202`                            | The status code. |
-| location   | `TypeSpec.Rest.ResourceLocation` |                  |
+| Name       | Type                             | Description                           |
+| ---------- | -------------------------------- | ------------------------------------- |
+| statusCode | `202`                            | The status code.                      |
+| location   | `TypeSpec.Rest.ResourceLocation` | The location of the created resource. |
 
 ### `LongRunningStatusLocation` {#Azure.Core.Foundations.LongRunningStatusLocation}
 
@@ -1072,10 +1078,10 @@ model Azure.Core.Traits.ListQueryParametersTrait<Parameters>
 
 #### Properties
 
-| Name                   | Type         | Description |
-| ---------------------- | ------------ | ----------- |
-| queryParams            | `{...}`      |             |
-| queryParams.parameters | `Parameters` |             |
+| Name                   | Type         | Description                                     |
+| ---------------------- | ------------ | ----------------------------------------------- |
+| queryParams            | `{...}`      | The query parameters contributed by this trait. |
+| queryParams.parameters | `Parameters` |                                                 |
 
 ### `NoClientRequestId` {#Azure.Core.Traits.NoClientRequestId}
 
@@ -1087,9 +1093,9 @@ model Azure.Core.Traits.NoClientRequestId
 
 #### Properties
 
-| Name            | Type | Description |
-| --------------- | ---- | ----------- |
-| clientRequestId | `{}` |             |
+| Name            | Type | Description                                                         |
+| --------------- | ---- | ------------------------------------------------------------------- |
+| clientRequestId | `{}` | Empty, indicating that client request id headers are not supported. |
 
 ### `NoConditionalRequests` {#Azure.Core.Traits.NoConditionalRequests}
 
@@ -1101,9 +1107,9 @@ model Azure.Core.Traits.NoConditionalRequests
 
 #### Properties
 
-| Name                | Type | Description |
-| ------------------- | ---- | ----------- |
-| conditionalRequests | `{}` |             |
+| Name                | Type | Description                                                    |
+| ------------------- | ---- | -------------------------------------------------------------- |
+| conditionalRequests | `{}` | Empty, indicating that conditional requests are not supported. |
 
 ### `NoRepeatableRequests` {#Azure.Core.Traits.NoRepeatableRequests}
 
@@ -1115,9 +1121,9 @@ model Azure.Core.Traits.NoRepeatableRequests
 
 #### Properties
 
-| Name               | Type | Description |
-| ------------------ | ---- | ----------- |
-| repeatableRequests | `{}` |             |
+| Name               | Type | Description                                                   |
+| ------------------ | ---- | ------------------------------------------------------------- |
+| repeatableRequests | `{}` | Empty, indicating that repeatable requests are not supported. |
 
 ### `QueryParametersTrait` {#Azure.Core.Traits.QueryParametersTrait}
 
@@ -1136,10 +1142,10 @@ model Azure.Core.Traits.QueryParametersTrait<Parameters, Contexts>
 
 #### Properties
 
-| Name                   | Type         | Description |
-| ---------------------- | ------------ | ----------- |
-| queryParams            | `{...}`      |             |
-| queryParams.parameters | `Parameters` |             |
+| Name                   | Type         | Description                                     |
+| ---------------------- | ------------ | ----------------------------------------------- |
+| queryParams            | `{...}`      | The query parameters contributed by this trait. |
+| queryParams.parameters | `Parameters` |                                                 |
 
 ### `RequestHeadersTrait` {#Azure.Core.Traits.RequestHeadersTrait}
 
@@ -1158,10 +1164,10 @@ model Azure.Core.Traits.RequestHeadersTrait<Headers, Contexts>
 
 #### Properties
 
-| Name                      | Type      | Description |
-| ------------------------- | --------- | ----------- |
-| requestHeaders            | `{...}`   |             |
-| requestHeaders.parameters | `Headers` |             |
+| Name                      | Type      | Description                                    |
+| ------------------------- | --------- | ---------------------------------------------- |
+| requestHeaders            | `{...}`   | The request headers contributed by this trait. |
+| requestHeaders.parameters | `Headers` |                                                |
 
 ### `ResponseHeadersTrait` {#Azure.Core.Traits.ResponseHeadersTrait}
 
@@ -1180,10 +1186,10 @@ model Azure.Core.Traits.ResponseHeadersTrait<Headers, Contexts>
 
 #### Properties
 
-| Name                       | Type      | Description |
-| -------------------------- | --------- | ----------- |
-| responseHeaders            | `{...}`   |             |
-| responseHeaders.parameters | `Headers` |             |
+| Name                       | Type      | Description                                     |
+| -------------------------- | --------- | ----------------------------------------------- |
+| responseHeaders            | `{...}`   | The response headers contributed by this trait. |
+| responseHeaders.parameters | `Headers` |                                                 |
 
 ### `SupportsClientRequestId` {#Azure.Core.Traits.SupportsClientRequestId}
 
@@ -1201,11 +1207,11 @@ model Azure.Core.Traits.SupportsClientRequestId<VersionAdded>
 
 #### Properties
 
-| Name                       | Type                                                                        | Description |
-| -------------------------- | --------------------------------------------------------------------------- | ----------- |
-| clientRequestId            | `{...}`                                                                     |             |
-| clientRequestId.parameters | [`ClientRequestIdHeader`](./data-types.md#Azure.Core.ClientRequestIdHeader) |             |
-| clientRequestId.response   | [`ClientRequestIdHeader`](./data-types.md#Azure.Core.ClientRequestIdHeader) |             |
+| Name                       | Type                                                                        | Description                                              |
+| -------------------------- | --------------------------------------------------------------------------- | -------------------------------------------------------- |
+| clientRequestId            | `{...}`                                                                     | The client request id headers contributed by this trait. |
+| clientRequestId.parameters | [`ClientRequestIdHeader`](./data-types.md#Azure.Core.ClientRequestIdHeader) |                                                          |
+| clientRequestId.response   | [`ClientRequestIdHeader`](./data-types.md#Azure.Core.ClientRequestIdHeader) |                                                          |
 
 ### `SupportsConditionalRequests` {#Azure.Core.Traits.SupportsConditionalRequests}
 
@@ -1223,11 +1229,11 @@ model Azure.Core.Traits.SupportsConditionalRequests<VersionAdded>
 
 #### Properties
 
-| Name                           | Type                                                                                | Description |
-| ------------------------------ | ----------------------------------------------------------------------------------- | ----------- |
-| conditionalRequests            | `{...}`                                                                             |             |
-| conditionalRequests.parameters | [`ConditionalRequestHeaders`](./data-types.md#Azure.Core.ConditionalRequestHeaders) |             |
-| conditionalRequests.response   | [`EtagResponseEnvelope`](./data-types.md#Azure.Core.EtagResponseEnvelope)           |             |
+| Name                           | Type                                                                                | Description                                                                 |
+| ------------------------------ | ----------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| conditionalRequests            | `{...}`                                                                             | The conditional request headers and ETag headers contributed by this trait. |
+| conditionalRequests.parameters | [`ConditionalRequestHeaders`](./data-types.md#Azure.Core.ConditionalRequestHeaders) |                                                                             |
+| conditionalRequests.response   | [`EtagResponseEnvelope`](./data-types.md#Azure.Core.EtagResponseEnvelope)           |                                                                             |
 
 ### `SupportsRepeatableRequests` {#Azure.Core.Traits.SupportsRepeatableRequests}
 
@@ -1245,11 +1251,11 @@ model Azure.Core.Traits.SupportsRepeatableRequests<VersionAdded>
 
 #### Properties
 
-| Name                          | Type                                                                                      | Description |
-| ----------------------------- | ----------------------------------------------------------------------------------------- | ----------- |
-| repeatableRequests            | `{...}`                                                                                   |             |
-| repeatableRequests.parameters | [`RepeatabilityRequestHeaders`](./data-types.md#Azure.Core.RepeatabilityRequestHeaders)   |             |
-| repeatableRequests.response   | [`RepeatabilityResponseHeaders`](./data-types.md#Azure.Core.RepeatabilityResponseHeaders) |             |
+| Name                          | Type                                                                                      | Description                                               |
+| ----------------------------- | ----------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| repeatableRequests            | `{...}`                                                                                   | The repeatable request headers contributed by this trait. |
+| repeatableRequests.parameters | [`RepeatabilityRequestHeaders`](./data-types.md#Azure.Core.RepeatabilityRequestHeaders)   |                                                           |
+| repeatableRequests.response   | [`RepeatabilityResponseHeaders`](./data-types.md#Azure.Core.RepeatabilityResponseHeaders) |                                                           |
 
 ### `TraitOverride` {#Azure.Core.Traits.TraitOverride}
 
@@ -1285,10 +1291,10 @@ model Azure.Core.Traits.VersionParameterTrait<VersionParameter>
 
 #### Properties
 
-| Name                             | Type               | Description |
-| -------------------------------- | ------------------ | ----------- |
-| versionParameter                 | `{...}`            |             |
-| versionParameter.apiVersionParam | `VersionParameter` |             |
+| Name                             | Type               | Description                                          |
+| -------------------------------- | ------------------ | ---------------------------------------------------- |
+| versionParameter                 | `{...}`            | The API version parameter contributed by this trait. |
+| versionParameter.apiVersionParam | `VersionParameter` |                                                      |
 
 ### `TraitContext` {#Azure.Core.Traits.TraitContext}
 

--- a/website/src/content/docs/docs/libraries/azure-portal-core/reference/data-types.md
+++ b/website/src/content/docs/docs/libraries/azure-portal-core/reference/data-types.md
@@ -46,10 +46,10 @@ model Azure.Portal.DisplayNamesOptions
 
 #### Properties
 
-| Name     | Type     | Description |
-| -------- | -------- | ----------- |
-| singular | `string` |             |
-| plural   | `string` |             |
+| Name     | Type     | Description                                |
+| -------- | -------- | ------------------------------------------ |
+| singular | `string` | The singular display name of the resource. |
+| plural   | `string` | The plural display name of the resource.   |
 
 ### `FilePath` {#Azure.Portal.FilePath}
 
@@ -75,10 +75,10 @@ model Azure.Portal.LearnMoreDocsOptions
 
 #### Properties
 
-| Name  | Type     | Description |
-| ----- | -------- | ----------- |
-| title | `string` |             |
-| uri   | `string` |             |
+| Name  | Type     | Description                          |
+| ----- | -------- | ------------------------------------ |
+| title | `string` | The title of the documentation link. |
+| uri   | `string` | The URI of the documentation link.   |
 
 ### `MarketplaceOfferOptions` {#Azure.Portal.MarketplaceOfferOptions}
 
@@ -104,7 +104,7 @@ model Azure.Portal.PromotionOptions
 
 #### Properties
 
-| Name        | Type                   | Description |
-| ----------- | ---------------------- | ----------- |
-| apiVersion  | `string \| EnumMember` |             |
-| autoUpdate? | `boolean`              |             |
+| Name        | Type                   | Description                                                                           |
+| ----------- | ---------------------- | ------------------------------------------------------------------------------------- |
+| apiVersion  | `string \| EnumMember` | The API version to promote, either a literal version string or a version enum member. |
+| autoUpdate? | `boolean`              | Whether the promoted API version should be updated automatically.                     |

--- a/website/src/content/docs/docs/libraries/azure-portal-core/reference/decorators.md
+++ b/website/src/content/docs/docs/libraries/azure-portal-core/reference/decorators.md
@@ -57,9 +57,9 @@ Provides a Model Property a display name
 
 #### Parameters
 
-| Name | Type             | Description |
-| ---- | ---------------- | ----------- |
-| name | `valueof string` |             |
+| Name | Type             | Description                                |
+| ---- | ---------------- | ------------------------------------------ |
+| name | `valueof string` | The display name to show for the property. |
 
 ### `@marketplaceOffer` {#@Azure.Portal.marketplaceOffer}
 

--- a/website/src/content/docs/docs/libraries/azure-resource-manager/reference/data-types.md
+++ b/website/src/content/docs/docs/libraries/azure-resource-manager/reference/data-types.md
@@ -742,9 +742,9 @@ model Employee is TrackedResource<EmployeeProperties> {
 
 #### Properties
 
-| Name              | Type                                                                                     | Description |
-| ----------------- | ---------------------------------------------------------------------------------------- | ----------- |
-| extendedLocation? | [`ExtendedLocation`](./data-types.md#Azure.ResourceManager.CommonTypes.ExtendedLocation) |             |
+| Name              | Type                                                                                     | Description                            |
+| ----------------- | ---------------------------------------------------------------------------------------- | -------------------------------------- |
+| extendedLocation? | [`ExtendedLocation`](./data-types.md#Azure.ResourceManager.CommonTypes.ExtendedLocation) | The extended location of the resource. |
 
 ### `ExtensionActionScope` {#Azure.ResourceManager.ExtensionActionScope}
 
@@ -1221,7 +1221,7 @@ Spread this model into ARM resource models to specify resource name parameter fo
 is specified, the resource name will be properly camel cased and pluralized for `@key` and `@segment`
 automatically. You can also apply explicit override with `KeyName` and `SegmentName` template parameters.
 
-For additional decorators such as
+For additional decorators such as `@minLength`, you can use either augment decorator on `[Resource].name` or passing in a scalar string type with decorators.
 
 ```typespec
 model Azure.ResourceManager.ResourceNameParameter<Resource, KeyName, SegmentName, NamePattern, Type>
@@ -2054,10 +2054,10 @@ model Azure.ResourceManager.CommonTypes.AccessRule
 
 #### Properties
 
-| Name        | Type                                                                                             | Description             |
-| ----------- | ------------------------------------------------------------------------------------------------ | ----------------------- |
-| name?       | `string`                                                                                         | Name of the access rule |
-| properties? | [`AccessRuleProperties`](./data-types.md#Azure.ResourceManager.CommonTypes.AccessRuleProperties) |                         |
+| Name        | Type                                                                                             | Description                   |
+| ----------- | ------------------------------------------------------------------------------------------------ | ----------------------------- |
+| name?       | `string`                                                                                         | Name of the access rule       |
+| properties? | [`AccessRuleProperties`](./data-types.md#Azure.ResourceManager.CommonTypes.AccessRuleProperties) | Properties of the access rule |
 
 ### `AccessRuleProperties` {#Azure.ResourceManager.CommonTypes.AccessRuleProperties}
 
@@ -2071,7 +2071,7 @@ model Azure.ResourceManager.CommonTypes.AccessRuleProperties
 
 | Name                       | Type                                                                                           | Description                                            |
 | -------------------------- | ---------------------------------------------------------------------------------------------- | ------------------------------------------------------ |
-| direction?                 | [`AccessRuleDirection`](./data-types.md#Azure.ResourceManager.CommonTypes.AccessRuleDirection) |                                                        |
+| direction?                 | [`AccessRuleDirection`](./data-types.md#Azure.ResourceManager.CommonTypes.AccessRuleDirection) | Direction of the access rule                           |
 | addressPrefixes?           | `string[]`                                                                                     | Address prefixes in the CIDR format for inbound rules  |
 | subscriptions?             | `Azure.ResourceManager.CommonTypes.{ id: Azure.Core.armResourceIdentifier }[]`                 | Subscriptions for inbound rules                        |
 | networkSecurityPerimeters? | `Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeter[]`                                 | Network security perimeters for inbound rules          |
@@ -2514,9 +2514,9 @@ model Azure.ResourceManager.CommonTypes.ManagedServiceIdentityWithDelegation
 
 #### Properties
 
-| Name                | Type                                                                                         | Description |
-| ------------------- | -------------------------------------------------------------------------------------------- | ----------- |
-| delegatedResources? | [`DelegatedResources`](./data-types.md#Azure.ResourceManager.CommonTypes.DelegatedResources) |             |
+| Name                | Type                                                                                         | Description                                                  |
+| ------------------- | -------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| delegatedResources? | [`DelegatedResources`](./data-types.md#Azure.ResourceManager.CommonTypes.DelegatedResources) | The delegated resources of the identity - internal use only. |
 
 ### `ManagementGroupNameParameter` {#Azure.ResourceManager.CommonTypes.ManagementGroupNameParameter}
 
@@ -2572,9 +2572,9 @@ model Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeterConfiguration
 
 #### Properties
 
-| Name        | Type                                                                                                                                                   | Description |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
-| properties? | [`NetworkSecurityPerimeterConfigurationProperties`](./data-types.md#Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeterConfigurationProperties) |             |
+| Name        | Type                                                                                                                                                   | Description                                |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
+| properties? | [`NetworkSecurityPerimeterConfigurationProperties`](./data-types.md#Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeterConfigurationProperties) | Network security configuration properties. |
 
 ### `NetworkSecurityPerimeterConfigurationListResult` {#Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeterConfigurationListResult}
 
@@ -2615,13 +2615,13 @@ model Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeterConfigurationPro
 
 #### Properties
 
-| Name                      | Type                                                                                                                                                                 | Description                         |
-| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------- |
-| provisioningState?        | [`NetworkSecurityPerimeterConfigurationProvisioningState`](./data-types.md#Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeterConfigurationProvisioningState) |                                     |
-| provisioningIssues?       | `Azure.ResourceManager.CommonTypes.ProvisioningIssue[]`                                                                                                              | List of provisioning issues, if any |
-| networkSecurityPerimeter? | [`NetworkSecurityPerimeter`](./data-types.md#Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeter)                                                             |                                     |
-| resourceAssociation?      | [`ResourceAssociation`](./data-types.md#Azure.ResourceManager.CommonTypes.ResourceAssociation)                                                                       |                                     |
-| profile?                  | [`NetworkSecurityProfile`](./data-types.md#Azure.ResourceManager.CommonTypes.NetworkSecurityProfile)                                                                 |                                     |
+| Name                      | Type                                                                                                                                                                 | Description                                                        |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| provisioningState?        | [`NetworkSecurityPerimeterConfigurationProvisioningState`](./data-types.md#Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeterConfigurationProvisioningState) | Provisioning state of the network security perimeter configuration |
+| provisioningIssues?       | `Azure.ResourceManager.CommonTypes.ProvisioningIssue[]`                                                                                                              | List of provisioning issues, if any                                |
+| networkSecurityPerimeter? | [`NetworkSecurityPerimeter`](./data-types.md#Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeter)                                                             | Information about the network security perimeter (NSP)             |
+| resourceAssociation?      | [`ResourceAssociation`](./data-types.md#Azure.ResourceManager.CommonTypes.ResourceAssociation)                                                                       | Information about the resource association                         |
+| profile?                  | [`NetworkSecurityProfile`](./data-types.md#Azure.ResourceManager.CommonTypes.NetworkSecurityProfile)                                                                 | Network security perimeter configuration profile                   |
 
 ### `NetworkSecurityProfile` {#Azure.ResourceManager.CommonTypes.NetworkSecurityProfile}
 
@@ -2695,9 +2695,9 @@ interface Employees {
 
 #### Properties
 
-| Name        | Type                                                                                                                                                   | Description |
-| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ----------- |
-| properties? | [`NetworkSecurityPerimeterConfigurationProperties`](./data-types.md#Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeterConfigurationProperties) |             |
+| Name        | Type                                                                                                                                                   | Description                                |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------ |
+| properties? | [`NetworkSecurityPerimeterConfigurationProperties`](./data-types.md#Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeterConfigurationProperties) | Network security configuration properties. |
 
 ### `Operation` {#Azure.ResourceManager.CommonTypes.Operation}
 
@@ -3110,10 +3110,10 @@ model Azure.ResourceManager.CommonTypes.ProvisioningIssue
 
 #### Properties
 
-| Name        | Type                                                                                                           | Description       |
-| ----------- | -------------------------------------------------------------------------------------------------------------- | ----------------- |
-| name?       | `string`                                                                                                       | Name of the issue |
-| properties? | [`ProvisioningIssueProperties`](./data-types.md#Azure.ResourceManager.CommonTypes.ProvisioningIssueProperties) |                   |
+| Name        | Type                                                                                                           | Description                       |
+| ----------- | -------------------------------------------------------------------------------------------------------------- | --------------------------------- |
+| name?       | `string`                                                                                                       | Name of the issue                 |
+| properties? | [`ProvisioningIssueProperties`](./data-types.md#Azure.ResourceManager.CommonTypes.ProvisioningIssueProperties) | Details of the provisioning issue |
 
 ### `ProvisioningIssueProperties` {#Azure.ResourceManager.CommonTypes.ProvisioningIssueProperties}
 
@@ -3172,10 +3172,10 @@ model Azure.ResourceManager.CommonTypes.ResourceAssociation
 
 #### Properties
 
-| Name        | Type                                                                                                               | Description                      |
-| ----------- | ------------------------------------------------------------------------------------------------------------------ | -------------------------------- |
-| name?       | `string`                                                                                                           | Name of the resource association |
-| accessMode? | [`ResourceAssociationAccessMode`](./data-types.md#Azure.ResourceManager.CommonTypes.ResourceAssociationAccessMode) |                                  |
+| Name        | Type                                                                                                               | Description                             |
+| ----------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------- |
+| name?       | `string`                                                                                                           | Name of the resource association        |
+| accessMode? | [`ResourceAssociationAccessMode`](./data-types.md#Azure.ResourceManager.CommonTypes.ResourceAssociationAccessMode) | Access mode of the resource association |
 
 ### `ResourceGroupNameParameter` {#Azure.ResourceManager.CommonTypes.ResourceGroupNameParameter}
 
@@ -3206,9 +3206,9 @@ model Azure.ResourceManager.CommonTypes.ResourceModelWithAllowedPropertySet
 | managedBy? | `string`                                                                                             | The fully qualified resource ID of the resource that manages this resource. Indicates if this resource is managed by another Azure resource.<br />If this is present, complete mode deployment will not delete the resource if it is removed from the template since it is managed by another resource.                                                                                                        |
 | kind?      | `string`                                                                                             | Metadata used by portal/tooling/etc to render different UX experiences for resources of the same type; e.g. ApiApps are a kind of Microsoft.Web/sites type.<br />If supported, the resource provider must validate and persist this value.                                                                                                                                                                     |
 | etag?      | `string`                                                                                             | The etag field is _not_ required. If it is provided in the response body, it must also be provided as a header per the normal etag convention.<br />Entity tags are used for comparing two or more entities from the same requested resource. HTTP/1.1 uses entity tags in the etag (section 14.19),<br />If-Match (section 14.24), If-None-Match (section 14.26), and If-Range (section 14.27) header fields. |
-| identity?  | [`ManagedServiceIdentity`](./data-types.md#Azure.ResourceManager.CommonTypes.ManagedServiceIdentity) |                                                                                                                                                                                                                                                                                                                                                                                                                |
-| sku?       | [`Sku`](./data-types.md#Azure.ResourceManager.CommonTypes.Sku)                                       |                                                                                                                                                                                                                                                                                                                                                                                                                |
-| plan?      | [`Plan`](./data-types.md#Azure.ResourceManager.CommonTypes.Plan)                                     |                                                                                                                                                                                                                                                                                                                                                                                                                |
+| identity?  | [`ManagedServiceIdentity`](./data-types.md#Azure.ResourceManager.CommonTypes.ManagedServiceIdentity) | The identity of the resource.                                                                                                                                                                                                                                                                                                                                                                                  |
+| sku?       | [`Sku`](./data-types.md#Azure.ResourceManager.CommonTypes.Sku)                                       | The SKU of the resource.                                                                                                                                                                                                                                                                                                                                                                                       |
+| plan?      | [`Plan`](./data-types.md#Azure.ResourceManager.CommonTypes.Plan)                                     | The plan of the resource.                                                                                                                                                                                                                                                                                                                                                                                      |
 
 ### `ScopeParameter` {#Azure.ResourceManager.CommonTypes.ScopeParameter}
 
@@ -3622,15 +3622,15 @@ union Azure.ResourceManager.CommonTypes.NetworkSecurityPerimeterConfigurationPro
 
 #### Variants
 
-| Name      | Type          | Description |
-| --------- | ------------- | ----------- |
-| Succeeded | `"Succeeded"` |             |
-| Creating  | `"Creating"`  |             |
-| Updating  | `"Updating"`  |             |
-| Deleting  | `"Deleting"`  |             |
-| Accepted  | `"Accepted"`  |             |
-| Failed    | `"Failed"`    |             |
-| Canceled  | `"Canceled"`  |             |
+| Name      | Type          | Description                                                                  |
+| --------- | ------------- | ---------------------------------------------------------------------------- |
+| Succeeded | `"Succeeded"` | The configuration was provisioned successfully.                              |
+| Creating  | `"Creating"`  | The configuration is being created.                                          |
+| Updating  | `"Updating"`  | The configuration is being updated.                                          |
+| Deleting  | `"Deleting"`  | The configuration is being deleted.                                          |
+| Accepted  | `"Accepted"`  | The configuration request was accepted and provisioning has not started yet. |
+| Failed    | `"Failed"`    | The configuration failed to provision.                                       |
+| Canceled  | `"Canceled"`  | The configuration provisioning was canceled.                                 |
 
 ### `Origin` {#Azure.ResourceManager.CommonTypes.Origin}
 
@@ -3723,9 +3723,9 @@ union Azure.ResourceManager.CommonTypes.ResourceIdentityType
 
 #### Variants
 
-| Name           | Type               | Description |
-| -------------- | ------------------ | ----------- |
-| SystemAssigned | `"SystemAssigned"` |             |
+| Name           | Type               | Description                             |
+| -------------- | ------------------ | --------------------------------------- |
+| SystemAssigned | `"SystemAssigned"` | The identity is assigned by the system. |
 
 ### `Severity` {#Azure.ResourceManager.CommonTypes.Severity}
 
@@ -3737,10 +3737,10 @@ union Azure.ResourceManager.CommonTypes.Severity
 
 #### Variants
 
-| Name    | Type        | Description |
-| ------- | ----------- | ----------- |
-| Warning | `"Warning"` |             |
-| Error   | `"Error"`   |             |
+| Name    | Type        | Description                                                                       |
+| ------- | ----------- | --------------------------------------------------------------------------------- |
+| Warning | `"Warning"` | The issue is a warning and does not prevent the configuration from being applied. |
+| Error   | `"Error"`   | The issue is an error and prevents the configuration from being applied.          |
 
 ### `SkuTier` {#Azure.ResourceManager.CommonTypes.SkuTier}
 
@@ -3887,9 +3887,9 @@ alias VirtualMachineScaleSetVm = Extension.ExternalChildResource<
 
 #### Properties
 
-| Name | Type       | Description |
-| ---- | ---------- | ----------- |
-| name | `NameType` |             |
+| Name | Type       | Description               |
+| ---- | ---------- | ------------------------- |
+| name | `NameType` | The name of the resource. |
 
 ### `ExternalResource` {#Azure.ResourceManager.Extension.ExternalResource}
 
@@ -3927,9 +3927,9 @@ alias Scaleset = Extension.ExternalResource<
 
 #### Properties
 
-| Name | Type       | Description |
-| ---- | ---------- | ----------- |
-| name | `NameType` |             |
+| Name | Type       | Description               |
+| ---- | ---------- | ------------------------- |
+| name | `NameType` | The name of the resource. |
 
 ### `ManagementGroup` {#Azure.ResourceManager.Extension.ManagementGroup}
 
@@ -4237,9 +4237,9 @@ model Azure.ResourceManager.Foundations.ProxyResourceUpdateModel<Resource, Prope
 
 #### Properties
 
-| Name        | Type                                                                                    | Description |
-| ----------- | --------------------------------------------------------------------------------------- | ----------- |
-| properties? | `Azure.ResourceManager.Foundations.ResourceUpdateModelProperties<Resource, Properties>` |             |
+| Name        | Type                                                                                    | Description                                         |
+| ----------- | --------------------------------------------------------------------------------------- | --------------------------------------------------- |
+| properties? | `Azure.ResourceManager.Foundations.ResourceUpdateModelProperties<Resource, Properties>` | The resource-specific properties for this resource. |
 
 ### `ResourceGroupBaseParameters` {#Azure.ResourceManager.Foundations.ResourceGroupBaseParameters}
 
@@ -4658,9 +4658,9 @@ model Employee is TrackedResource<EmployeeProperties> {
 
 #### Properties
 
-| Name              | Type                                                                                                | Description |
-| ----------------- | --------------------------------------------------------------------------------------------------- | ----------- |
-| extendedLocation? | [`ExtendedLocationOptional`](./data-types.md#Azure.ResourceManager.Legacy.ExtendedLocationOptional) |             |
+| Name              | Type                                                                                                | Description                            |
+| ----------------- | --------------------------------------------------------------------------------------------------- | -------------------------------------- |
+| extendedLocation? | [`ExtendedLocationOptional`](./data-types.md#Azure.ResourceManager.Legacy.ExtendedLocationOptional) | The extended location of the resource. |
 
 ### `GenericResource` {#Azure.ResourceManager.Legacy.GenericResource}
 

--- a/website/src/content/docs/docs/libraries/azure-resource-manager/reference/interfaces.md
+++ b/website/src/content/docs/docs/libraries/azure-resource-manager/reference/interfaces.md
@@ -780,6 +780,13 @@ op Azure.ResourceManager.ResourceListBySubscription<Resource>.listBySubscription
 **Deprecated**: Use Azure.ResourceManager.TrackedResourceOperations instead
 :::
 
+A composite interface for resources that include `ResourceInstanceOperations<Resource, Properties>`
+and `ResourceCollectionOperations<Resource>`. It includes: `GET`, `PUT`, `PATCH`, `DELETE`, ListByParent,
+ListBySubscription operations. The actual route depends on the resource model.
+This is the most common API pattern for Tracked Resources to use.
+
+Deprecated: use `Azure.ResourceManager.TrackedResourceOperations` instead.
+
 ```typespec
 interface Azure.ResourceManager.ResourceOperations<Resource, Properties, BaseParameters>
 ```

--- a/website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/decorators.md
+++ b/website/src/content/docs/docs/libraries/typespec-client-generator-core/reference/decorators.md
@@ -847,6 +847,12 @@ model MyModel {
 
 ### `@operationGroup` {#@Azure.ClientGenerator.Core.operationGroup}
 
+Define the sub client generated in the client SDK.
+If there is any `@client` definition or `@operationGroup` definition, then each `@client` is a root client and each `@operationGroup` is a sub client with hierarchy.
+This decorator cannot be used along with `@clientLocation`. This decorator cannot be used as augmentation.
+
+Deprecated: use `@client` instead. Sub clients should be represented using `@client`.
+
 ```typespec
 @Azure.ClientGenerator.Core.operationGroup(scope?: valueof string)
 ```


### PR DESCRIPTION
[microsoft/typespec#11543](https://github.com/microsoft/typespec/pull/11543) adds `missing-documentation` and `extraneous-documentation` rules to `@typespec/library-linter`. Every Azure library already runs the linter with `--warn-as-error` as part of its `build` script, so the moment that PR lands our builds break — 94 warnings across azure-core, ARM, TCGC and portal-core.

This documents the gaps so the core PR can merge cleanly.

Two categories of problems turned up, and both were hiding real content from the published reference docs:

**Doc comments starting with a tag swallowed the whole description.** `@deprecated` isn't a tag the compiler knows, so everything after it became tag content and the description vanished:

```diff
 /**
- * @deprecated Use `@client` instead. The `@operationGroup` decorator is deprecated. Sub clients should be represented using `@client`.
  * Define the sub client generated in the client SDK.
  * ...
+ *
+ * Deprecated: use `@client` instead. Sub clients should be represented using `@client`.
  */
 extern dec operationGroup(...);
```

`@operationGroup` and `ResourceOperations` now actually show their description on the website. Same story for `Azure.Core.ResourceOperationStatus`, whose only doc was behind a `@dev` tag.

**`@template` tags pointing at parameters that don't exist.** Operations inside `ResourceOperations`, `PrivateLinks` and friends documented their *interface's* template parameters, and a few models still referenced pre-rename names (`@template T` on `LocationOfCreatedResourceResponse<Resource>`). Those are now either corrected or removed.

The rest is plain missing docs on properties, enum members, template parameters and decorator parameters.

### Emitted output

Descriptions on ARM common types flow into the generated swagger, so `packages/samples/common-types` picks up a few additive `description` fields on `NetworkSecurityPerimeterConfigurationProvisioningState` and `Severity` enum values — consistent with `IssueType` and `ResourceAssociationAccessMode`, which already carry them.

Verified with `tsp compile . --warn-as-error --import @typespec/library-linter` against the linter build from the core branch: all six libraries are clean, and the full test suites for the touched packages pass unchanged.
