### PR TITLE
Scope package size report to this repo's packages and colorize deltas

### DIFF
--- a/.github/workflows/package-size.yml
+++ b/.github/workflows/package-size.yml
@@ -1,7 +1,9 @@
 name: Package Size
 
-# Measures the published npm tarball size of every publishable package and reports the
-# change introduced by the PR. This workflow only has a read-only token (it may run for
+# Measures the published npm tarball size of every publishable package in `packages/` and
+# reports the change introduced by the PR. Packages from the `core/` submodule are not
+# measured: they are published from `microsoft/typespec`, not from this repo.
+# This workflow only has a read-only token (it may run for
 # fork PRs); the actual PR comment is posted by the `package-size-comment.yml` workflow
 # which runs with `pull-requests: write` after this one completes.
 # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
@@ -13,7 +15,6 @@ on:
       - release/*
     paths:
       - "packages/**"
-      - "core/packages/**"
       - "eng/scripts/bundle-size/**"
       - ".github/workflows/package-size.yml"
 

--- a/eng/scripts/bundle-size/compare.test.ts
+++ b/eng/scripts/bundle-size/compare.test.ts
@@ -1,0 +1,64 @@
+import { resolve } from "path";
+import { describe, expect, it } from "vitest";
+import { repoRoot } from "../helpers.js";
+import { renderMarkdown } from "./compare.ts";
+import type { SizeReport } from "./measure.ts";
+import { colored, isRepoPackage, type WorkspacePackage } from "./utils.ts";
+
+const pkg = (size: number, unpackedSize: number) => ({ version: "1.0.0", size, unpackedSize });
+
+describe("renderMarkdown", () => {
+  it("colors a size increase in red and a decrease in green", () => {
+    const base: SizeReport = { grew: pkg(1000, 4000), shrank: pkg(2000, 8000) };
+    const head: SizeReport = { grew: pkg(1100, 4400), shrank: pkg(1800, 7200) };
+
+    const markdown = renderMarkdown(base, head);
+
+    expect(markdown).toContain(colored("+100 B (+10.0%)", "increase"));
+    expect(markdown).toContain(colored("-200 B (-10.0%)", "decrease"));
+  });
+
+  it("reports the overall packed delta in the summary line", () => {
+    const base: SizeReport = { a: pkg(1000, 4000), b: pkg(1000, 4000) };
+    const head: SizeReport = { a: pkg(1200, 4000), b: pkg(1000, 4000) };
+
+    expect(renderMarkdown(base, head)).toContain(
+      `1 package changed size, ${colored("+200 B (+10.0%)", "increase")} packed overall.`,
+    );
+  });
+
+  it("double-escapes the percent sign so it survives GitHub's markdown pass", () => {
+    const markdown = renderMarkdown({ a: pkg(1000, 4000) }, { a: pkg(1100, 4400) });
+    expect(markdown).toContain("(+10.0\\\\%)");
+    expect(markdown).not.toMatch(/[^\\]%/);
+  });
+
+  it("renders an unchanged package without any color markup", () => {
+    const markdown = renderMarkdown({ a: pkg(1000, 4000) }, { a: pkg(1000, 4000) });
+    expect(markdown).toContain("✅ No package size changes compared to the base branch.");
+    expect(markdown).not.toContain("\\textcolor");
+  });
+
+  it("flags added and removed packages", () => {
+    const markdown = renderMarkdown({ gone: pkg(1000, 4000) }, { added: pkg(500, 2000) });
+    expect(markdown).toContain("`added` 🆕");
+    expect(markdown).toContain("`gone` 🗑️");
+  });
+});
+
+describe("isRepoPackage", () => {
+  const makePackage = (path: string): WorkspacePackage => ({
+    name: "pkg",
+    version: "1.0.0",
+    path: resolve(repoRoot, path),
+    private: false,
+  });
+
+  it.each(["packages/typespec-azure-core", "packages/typespec-ts"])("includes %s", (path) => {
+    expect(isRepoPackage(makePackage(path))).toBe(true);
+  });
+
+  it.each(["core/packages/compiler", "core", "packages", "website"])("excludes %s", (path) => {
+    expect(isRepoPackage(makePackage(path))).toBe(false);
+  });
+});

--- a/eng/scripts/bundle-size/compare.test.ts
+++ b/eng/scripts/bundle-size/compare.test.ts
@@ -3,46 +3,101 @@ import { describe, expect, it } from "vitest";
 import { repoRoot } from "../helpers.js";
 import { renderMarkdown } from "./compare.ts";
 import type { SizeReport } from "./measure.ts";
-import { colored, isRepoPackage, type WorkspacePackage } from "./utils.ts";
+import type { WorkspacePackage } from "./utils.ts";
+import { changeIndicator, isNotableSizeChange, isRepoPackage, LEGEND } from "./utils.ts";
 
 const pkg = (size: number, unpackedSize: number) => ({ version: "1.0.0", size, unpackedSize });
 
 describe("renderMarkdown", () => {
-  it("colors a size increase in red and a decrease in green", () => {
-    const base: SizeReport = { grew: pkg(1000, 4000), shrank: pkg(2000, 8000) };
-    const head: SizeReport = { grew: pkg(1100, 4400), shrank: pkg(1800, 7200) };
+  it("marks a notable increase with 🔴 and a notable decrease with 🟢", () => {
+    const base: SizeReport = { grew: pkg(10000, 40000), shrank: pkg(10000, 40000) };
+    const head: SizeReport = { grew: pkg(11000, 44000), shrank: pkg(9000, 36000) };
 
     const markdown = renderMarkdown(base, head);
 
-    expect(markdown).toContain(colored("+100 B (+10.0%)", "increase"));
-    expect(markdown).toContain(colored("-200 B (-10.0%)", "decrease"));
+    expect(markdown).toContain("+1000 B (+10.0%) 🔴");
+    expect(markdown).toContain("-1000 B (-10.0%) 🟢");
+  });
+
+  it("leaves sub-threshold noise unmarked and out of the top table", () => {
+    // 100 B on a ~1 MB package: under the byte floor and only 0.0% - not worth flagging.
+    const markdown = renderMarkdown(
+      { a: pkg(1_000_000, 4_000_000) },
+      { a: pkg(1_000_100, 4_000_000) },
+    );
+
+    expect(markdown).toContain("✅ No notable package size changes compared to the base branch.");
+    expect(markdown).toContain("1 package(s) with no notable change");
+    // The trailing pipe proves the cell ends right after the percentage, with no marker.
+    expect(markdown).toContain("+100 B (+0.0%) |");
+  });
+
+  it("groups away a jar-timestamp style wobble (packed moves, unpacked identical)", () => {
+    // What `@azure-tools/typespec-java` does on every run: its Maven jar carries wall-clock
+    // build timestamps, so the bytes differ but the length does not.
+    const markdown = renderMarkdown(
+      { "@azure-tools/typespec-java": pkg(14_166_651, 15_760_257) },
+      { "@azure-tools/typespec-java": pkg(14_166_605, 15_760_257) },
+    );
+
+    expect(markdown).toContain("✅ No notable package size changes compared to the base branch.");
+    expect(markdown).toContain("-46 B (-0.0%) |");
+  });
+
+  it("leaves a large percentage of a tiny package unmarked when the byte delta is trivial", () => {
+    // 10 B on a 300 B package is 3.3%, but 10 B is noise in absolute terms.
+    const markdown = renderMarkdown({ a: pkg(300, 900) }, { a: pkg(310, 900) });
+
+    expect(markdown).toContain("+10 B (+3.3%) |");
+    expect(markdown).toContain("✅ No notable package size changes compared to the base branch.");
   });
 
   it("reports the overall packed delta in the summary line", () => {
-    const base: SizeReport = { a: pkg(1000, 4000), b: pkg(1000, 4000) };
-    const head: SizeReport = { a: pkg(1200, 4000), b: pkg(1000, 4000) };
+    const base: SizeReport = { a: pkg(10000, 40000), b: pkg(10000, 40000) };
+    const head: SizeReport = { a: pkg(11000, 40000), b: pkg(10000, 40000) };
 
     expect(renderMarkdown(base, head)).toContain(
-      `1 package changed size, ${colored("+200 B (+10.0%)", "increase")} packed overall.`,
+      "1 package changed size, +1000 B (+5.0%) 🔴 packed overall.",
     );
   });
 
-  it("double-escapes the percent sign so it survives GitHub's markdown pass", () => {
-    const markdown = renderMarkdown({ a: pkg(1000, 4000) }, { a: pkg(1100, 4400) });
-    expect(markdown).toContain("(+10.0\\\\%)");
-    expect(markdown).not.toMatch(/[^\\]%/);
-  });
-
-  it("renders an unchanged package without any color markup", () => {
+  it("renders an unchanged package without any marker", () => {
     const markdown = renderMarkdown({ a: pkg(1000, 4000) }, { a: pkg(1000, 4000) });
-    expect(markdown).toContain("✅ No package size changes compared to the base branch.");
-    expect(markdown).not.toContain("\\textcolor");
+    expect(markdown).toContain("✅ No notable package size changes compared to the base branch.");
+    expect(markdown).toContain("| `a` | 1000 B → 1000 B | — | 3.91 KB → 3.91 KB | — |");
   });
 
-  it("flags added and removed packages", () => {
+  it("flags added and removed packages with a status label instead of a marker", () => {
     const markdown = renderMarkdown({ gone: pkg(1000, 4000) }, { added: pkg(500, 2000) });
     expect(markdown).toContain("`added` 🆕");
     expect(markdown).toContain("`gone` 🗑️");
+    expect(markdown).toContain("+500 B (new) |");
+    expect(markdown).toContain("-1000 B (-100.0%) |");
+  });
+
+  it("always explains the markers in the legend", () => {
+    const markdown = renderMarkdown({ a: pkg(1000, 4000) }, { a: pkg(1000, 4000) });
+    expect(markdown).toContain(LEGEND);
+  });
+});
+
+describe("isNotableSizeChange", () => {
+  it("requires both the byte and the percentage threshold to be crossed", () => {
+    expect(isNotableSizeChange(1000, 10000)).toBe(true); // 1000 B, 10%
+    expect(isNotableSizeChange(100, 10000)).toBe(false); // under the byte floor
+    expect(isNotableSizeChange(1000, 10_000_000)).toBe(false); // under the percentage floor
+  });
+
+  it("always treats a brand new package as notable", () => {
+    expect(isNotableSizeChange(1, 0)).toBe(true);
+    expect(isNotableSizeChange(0, 0)).toBe(false);
+  });
+});
+
+describe("changeIndicator", () => {
+  it("returns an empty string rather than a neutral marker for noise", () => {
+    expect(changeIndicator(10, 10000)).toBe("");
+    expect(changeIndicator(0, 10000)).toBe("");
   });
 });
 

--- a/eng/scripts/bundle-size/compare.ts
+++ b/eng/scripts/bundle-size/compare.ts
@@ -11,7 +11,14 @@ import { appendFile, mkdir, readFile, writeFile } from "fs/promises";
 import { dirname } from "path";
 import { pathToFileURL } from "url";
 import type { PackageSize, SizeReport } from "./measure.ts";
-import { colored, formatBytes, formatDelta, formatPercent, trendOf } from "./utils.ts";
+import {
+  changeIndicator,
+  formatBytes,
+  formatDelta,
+  formatPercent,
+  isNotableSizeChange,
+  LEGEND,
+} from "./utils.ts";
 
 /** Hidden marker so the comment workflow can find & update its own comment. */
 export const COMMENT_MARKER = "<!-- bundle-size-report -->";
@@ -61,8 +68,8 @@ function unpackedCell(size: PackageSize | undefined): string {
 
 export function renderMarkdown(base: SizeReport, head: SizeReport): string {
   const rows = buildRows(base, head);
-  const changed = rows.filter((r) => r.packedDelta !== 0 || r.unpackedDelta !== 0);
-  const unchanged = rows.filter((r) => r.packedDelta === 0 && r.unpackedDelta === 0);
+  const notable = rows.filter(isNotableRow);
+  const rest = rows.filter((row) => !isNotableRow(row));
 
   const lines: string[] = [];
   lines.push(COMMENT_MARKER);
@@ -74,46 +81,64 @@ export function renderMarkdown(base: SizeReport, head: SizeReport): string {
     return lines.join("\n");
   }
 
-  if (changed.length === 0) {
-    lines.push("✅ No package size changes compared to the base branch.");
+  if (notable.length === 0) {
+    lines.push("✅ No notable package size changes compared to the base branch.");
   } else {
     const totalBase = sum(rows, (r) => r.base?.size ?? 0);
     const totalHead = sum(rows, (r) => r.head?.size ?? 0);
     lines.push(
-      `${changed.length} package${changed.length === 1 ? "" : "s"} changed size, ` +
+      `${notable.length} package${notable.length === 1 ? "" : "s"} changed size, ` +
         `${deltaCell(totalHead - totalBase, totalBase, totalHead)} packed overall.`,
     );
     lines.push("");
-    lines.push(...renderTable(changed));
+    lines.push(...renderTable(notable));
   }
   lines.push("");
 
-  if (unchanged.length > 0) {
+  if (rest.length > 0) {
     lines.push("<details>");
-    lines.push(`<summary>${unchanged.length} unchanged package(s)</summary>`);
+    lines.push(`<summary>${rest.length} package(s) with no notable change</summary>`);
     lines.push("");
-    lines.push(...renderTable(unchanged));
+    lines.push(...renderTable(rest));
     lines.push("</details>");
     lines.push("");
   }
 
   lines.push(
     "<sub>Packed = gzipped `.tgz` published to npm. Unpacked = total extracted size. " +
-      "🆕 added, 🗑️ removed. Packages from the `core/` submodule are not included.</sub>",
+      "🆕 added, 🗑️ removed. Packages from the `core/` submodule are not included.<br>" +
+      LEGEND +
+      "</sub>",
   );
   return lines.join("\n");
+}
+
+/**
+ * Whether a package moved enough to be worth a reviewer's attention.
+ *
+ * Anything below the thresholds is grouped away: rebuilding the same sources does not always
+ * produce a byte-identical tarball. `@azure-tools/typespec-java`, for instance, ships a Maven
+ * jar whose zip entries carry wall-clock build timestamps, so the head and base builds compress
+ * to slightly different sizes even when nothing about the package changed.
+ */
+function isNotableRow(row: Row): boolean {
+  return (
+    isNotableSizeChange(row.packedDelta, row.base?.size ?? 0) ||
+    isNotableSizeChange(row.unpackedDelta, row.base?.unpackedSize ?? 0)
+  );
 }
 
 function sum(rows: Row[], select: (row: Row) => number): number {
   return rows.reduce((total, row) => total + select(row), 0);
 }
 
-/** A colored, signed delta with its percentage, e.g. a red "+1.02 KB (+0.1%)". */
-function deltaCell(delta: number, base: number, head: number): string {
+/** A signed delta with its percentage and, when notable, a 🔴/🟢 marker. */
+function deltaCell(delta: number, base: number, head: number, marker = true): string {
   if (delta === 0) {
     return "—";
   }
-  return colored(`${formatDelta(delta)} (${formatPercent(base, head)})`, trendOf(delta));
+  const indicator = marker ? changeIndicator(delta, base) : "";
+  return `${formatDelta(delta)} (${formatPercent(base, head)}) ${indicator}`.trim();
 }
 
 function renderTable(rows: Row[]): string[] {
@@ -123,11 +148,19 @@ function renderTable(rows: Row[]): string[] {
   for (const row of rows) {
     const packed = `${sizeCell(row.base)} → ${sizeCell(row.head)}`;
     const unpacked = `${unpackedCell(row.base)} → ${unpackedCell(row.head)}`;
-    const packedDelta = deltaCell(row.packedDelta, row.base?.size ?? 0, row.head?.size ?? 0);
+    // An added or removed package is already called out by 🆕/🗑️; a marker would just be noise.
+    const marker = Boolean(row.base && row.head);
+    const packedDelta = deltaCell(
+      row.packedDelta,
+      row.base?.size ?? 0,
+      row.head?.size ?? 0,
+      marker,
+    );
     const unpackedDelta = deltaCell(
       row.unpackedDelta,
       row.base?.unpackedSize ?? 0,
       row.head?.unpackedSize ?? 0,
+      marker,
     );
     lines.push(
       `| \`${row.name}\`${statusLabel(row)} | ${packed} | ${packedDelta} | ${unpacked} | ${unpackedDelta} |`,

--- a/eng/scripts/bundle-size/compare.ts
+++ b/eng/scripts/bundle-size/compare.ts
@@ -9,8 +9,9 @@
 
 import { appendFile, mkdir, readFile, writeFile } from "fs/promises";
 import { dirname } from "path";
+import { pathToFileURL } from "url";
 import type { PackageSize, SizeReport } from "./measure.ts";
-import { formatBytes, formatDelta, formatPercent } from "./utils.ts";
+import { colored, formatBytes, formatDelta, formatPercent, trendOf } from "./utils.ts";
 
 /** Hidden marker so the comment workflow can find & update its own comment. */
 export const COMMENT_MARKER = "<!-- bundle-size-report -->";
@@ -74,10 +75,13 @@ export function renderMarkdown(base: SizeReport, head: SizeReport): string {
   }
 
   if (changed.length === 0) {
-    lines.push("No package size changes detected compared to the base branch. ✅");
+    lines.push("✅ No package size changes compared to the base branch.");
   } else {
+    const totalBase = sum(rows, (r) => r.base?.size ?? 0);
+    const totalHead = sum(rows, (r) => r.head?.size ?? 0);
     lines.push(
-      `${changed.length} package${changed.length === 1 ? "" : "s"} changed size compared to the base branch.`,
+      `${changed.length} package${changed.length === 1 ? "" : "s"} changed size, ` +
+        `${deltaCell(totalHead - totalBase, totalBase, totalHead)} packed overall.`,
     );
     lines.push("");
     lines.push(...renderTable(changed));
@@ -94,9 +98,22 @@ export function renderMarkdown(base: SizeReport, head: SizeReport): string {
   }
 
   lines.push(
-    "<sub>Packed = gzipped `.tgz` published to npm. Unpacked = total extracted size. 🆕 added, 🗑️ removed.</sub>",
+    "<sub>Packed = gzipped `.tgz` published to npm. Unpacked = total extracted size. " +
+      "🆕 added, 🗑️ removed. Packages from the `core/` submodule are not included.</sub>",
   );
   return lines.join("\n");
+}
+
+function sum(rows: Row[], select: (row: Row) => number): number {
+  return rows.reduce((total, row) => total + select(row), 0);
+}
+
+/** A colored, signed delta with its percentage, e.g. a red "+1.02 KB (+0.1%)". */
+function deltaCell(delta: number, base: number, head: number): string {
+  if (delta === 0) {
+    return "—";
+  }
+  return colored(`${formatDelta(delta)} (${formatPercent(base, head)})`, trendOf(delta));
 }
 
 function renderTable(rows: Row[]): string[] {
@@ -106,14 +123,12 @@ function renderTable(rows: Row[]): string[] {
   for (const row of rows) {
     const packed = `${sizeCell(row.base)} → ${sizeCell(row.head)}`;
     const unpacked = `${unpackedCell(row.base)} → ${unpackedCell(row.head)}`;
-    const packedDelta =
-      row.packedDelta === 0
-        ? "—"
-        : `${formatDelta(row.packedDelta)} (${formatPercent(row.base?.size ?? 0, row.head?.size ?? 0)})`;
-    const unpackedDelta =
-      row.unpackedDelta === 0
-        ? "—"
-        : `${formatDelta(row.unpackedDelta)} (${formatPercent(row.base?.unpackedSize ?? 0, row.head?.unpackedSize ?? 0)})`;
+    const packedDelta = deltaCell(row.packedDelta, row.base?.size ?? 0, row.head?.size ?? 0);
+    const unpackedDelta = deltaCell(
+      row.unpackedDelta,
+      row.base?.unpackedSize ?? 0,
+      row.head?.unpackedSize ?? 0,
+    );
     lines.push(
       `| \`${row.name}\`${statusLabel(row)} | ${packed} | ${packedDelta} | ${unpacked} | ${unpackedDelta} |`,
     );
@@ -151,4 +166,7 @@ async function main() {
   console.log(markdown);
 }
 
-await main();
+// Only run as a CLI, so the rendering helpers above can be imported from tests.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  await main();
+}

--- a/eng/scripts/bundle-size/measure.ts
+++ b/eng/scripts/bundle-size/measure.ts
@@ -1,6 +1,7 @@
-// Measure the published npm package (tarball) size of every publishable workspace
-// package. For each package we run `npm pack --dry-run --json` inside the package
-// directory and record the packed (gzipped) size and the unpacked size.
+// Measure the published npm package (tarball) size of every publishable package owned by
+// this repo (the `core/` submodule is excluded, it publishes from `microsoft/typespec`).
+// For each package we run `npm pack --dry-run --json` inside the package directory and
+// record the packed (gzipped) size and the unpacked size.
 //
 // Usage:
 //   tsx eng/scripts/bundle-size/measure.ts --out <file.json>
@@ -10,7 +11,7 @@
 import { execFileSync } from "child_process";
 import { mkdir, writeFile } from "fs/promises";
 import { dirname } from "path";
-import { listPackages } from "./utils.ts";
+import { isRepoPackage, listPackages } from "./utils.ts";
 
 export interface PackageSize {
   version: string;
@@ -56,8 +57,10 @@ export async function measureAllPackages(): Promise<SizeReport> {
 
   for (const pkg of packages) {
     const name = pkg.name;
-    if (!name || pkg.private) {
-      continue; // Skip unnamed or private (non-publishable) packages.
+    // Skip unnamed or private (non-publishable) packages, and everything from the `core/`
+    // submodule, which is published from `microsoft/typespec` rather than from this repo.
+    if (!name || pkg.private || !isRepoPackage(pkg)) {
+      continue;
     }
     try {
       const result = measurePackage(pkg.path);

--- a/eng/scripts/bundle-size/utils.ts
+++ b/eng/scripts/bundle-size/utils.ts
@@ -1,7 +1,11 @@
 // Shared helpers for the bundle-size scripts.
 
 import { execFileSync } from "child_process";
+import { isAbsolute, relative, resolve } from "path";
 import { repoRoot } from "../helpers.js";
+
+/** This repo's own `packages/` folder, as opposed to the `core/` submodule workspace. */
+const packagesRoot = resolve(repoRoot, "packages");
 
 export interface WorkspacePackage {
   name: string;
@@ -28,6 +32,48 @@ export function listPackages(): WorkspacePackage[] {
   return parsed
     .filter((pkg): pkg is WorkspacePackage => Boolean(pkg.name && pkg.path))
     .map((pkg) => ({ ...pkg, private: pkg.private ?? false }));
+}
+
+/**
+ * True when the package lives in this repo's `packages/` folder, false for anything coming
+ * from the nested `core/` submodule workspace.
+ *
+ * Core packages are published from `microsoft/typespec`, so a PR here can never change their
+ * published size. They are also measured unreliably: unlike our packages they do not declare
+ * a `files` field, so their tarballs include build artifacts such as `.turbo/turbo-build.log`
+ * (which embeds the compiler version banner and CLI spinner frames) and `temp/`, making every
+ * core package look like it changed by a handful of bytes on every run.
+ */
+export function isRepoPackage(pkg: WorkspacePackage): boolean {
+  const rel = relative(packagesRoot, pkg.path);
+  return rel !== "" && !rel.startsWith("..") && !isAbsolute(rel);
+}
+
+/**
+ * Colors for size trends, picked to stay legible on both the light and dark GitHub themes.
+ */
+const trendColors = {
+  increase: "#e5534b",
+  decrease: "#2da44e",
+  neutral: "#8b949e",
+} as const;
+
+export type SizeTrend = keyof typeof trendColors;
+
+/** Pick the trend for a delta: growing is bad (red), shrinking is good (green). */
+export function trendOf(delta: number): SizeTrend {
+  return delta > 0 ? "increase" : delta < 0 ? "decrease" : "neutral";
+}
+
+/**
+ * Render `text` in color. GitHub renders `$...$` in comments as inline math, which is the only
+ * way to get colored text inside a markdown table.
+ */
+export function colored(text: string, trend: SizeTrend): string {
+  // `%` starts a comment in TeX so it has to reach the math renderer as `\%`. GitHub's markdown
+  // pass eats one level of backslash escaping first, hence the doubled backslash here.
+  const escaped = text.replace(/%/g, "\\\\%");
+  return `$\\textcolor{${trendColors[trend]}}{\\textsf{${escaped}}}$`;
 }
 
 /** Format a byte count as a human readable string (B, KB, MB). */

--- a/eng/scripts/bundle-size/utils.ts
+++ b/eng/scripts/bundle-size/utils.ts
@@ -50,31 +50,36 @@ export function isRepoPackage(pkg: WorkspacePackage): boolean {
 }
 
 /**
- * Colors for size trends, picked to stay legible on both the light and dark GitHub themes.
+ * A size change is only worth flagging when it is both big enough in absolute terms and big
+ * enough relative to the package. Anything smaller is build noise (timestamps, compiler banners
+ * captured in generated files, gzip jitter) rather than something a reviewer should act on.
  */
-const trendColors = {
-  increase: "#e5534b",
-  decrease: "#2da44e",
-  neutral: "#8b949e",
-} as const;
+const MIN_NOTABLE_BYTES = 512;
+const MIN_NOTABLE_PERCENT = 0.5;
 
-export type SizeTrend = keyof typeof trendColors;
-
-/** Pick the trend for a delta: growing is bad (red), shrinking is good (green). */
-export function trendOf(delta: number): SizeTrend {
-  return delta > 0 ? "increase" : delta < 0 ? "decrease" : "neutral";
+/** Mirrors `isNotableMetricChange` in the benchmark comment: both thresholds must be crossed. */
+export function isNotableSizeChange(
+  delta: number,
+  base: number,
+  minBytes: number = MIN_NOTABLE_BYTES,
+  minPercent: number = MIN_NOTABLE_PERCENT,
+): boolean {
+  if (base === 0) {
+    return delta !== 0; // A brand new package is always worth pointing out.
+  }
+  return Math.abs(delta) >= minBytes && Math.abs((delta / base) * 100) >= minPercent;
 }
 
-/**
- * Render `text` in color. GitHub renders `$...$` in comments as inline math, which is the only
- * way to get colored text inside a markdown table.
- */
-export function colored(text: string, trend: SizeTrend): string {
-  // `%` starts a comment in TeX so it has to reach the math renderer as `\%`. GitHub's markdown
-  // pass eats one level of backslash escaping first, hence the doubled backslash here.
-  const escaped = text.replace(/%/g, "\\\\%");
-  return `$\\textcolor{${trendColors[trend]}}{\\textsf{${escaped}}}$`;
+/** 🔴 grew, 🟢 shrank, nothing when the change is below the notability thresholds. */
+export function changeIndicator(delta: number, base: number): string {
+  if (!isNotableSizeChange(delta, base)) {
+    return "";
+  }
+  return delta > 0 ? "🔴" : "🟢";
 }
+
+/** Explains the indicators and the threshold behind them. */
+export const LEGEND = `🔴 grew · 🟢 shrank — only changes of at least ${MIN_NOTABLE_BYTES} B *and* ${MIN_NOTABLE_PERCENT}% are marked.`;
 
 /** Format a byte count as a human readable string (B, KB, MB). */
 export function formatBytes(bytes: number): string {


### PR DESCRIPTION
The package size check reports noise. On [#5182](https://github.com/Azure/typespec-azure/pull/5182#issuecomment-5217948687) — a core submodule bump — it claimed **25 packages changed size**, most by a handful of bytes. Two independent causes, both fixed here.

**It measured the `core/` submodule.** Those packages are published from `microsoft/typespec`; no PR here can change their published size. They're also measured unreliably — 11 of them ship `.turbo/turbo-build.log`, which captures the compiler version banner and CLI spinner frames, so their tarball size shifts on every build (filed as microsoft/typespec#11589). Measurement is now scoped to this repo's `packages/`, taking the report from 45 packages down to the 13 we actually publish.

**Rebuilding isn't byte-reproducible, so every package wobbled.** `@azure-tools/typespec-java` is the clearest case: it ships a Maven jar whose zip entries carry wall-clock build timestamps. The workflow builds head and base minutes apart, so those bytes differ while the jar's *length* doesn't — the packed size moves a few dozen bytes and the unpacked delta is exactly zero. The report duly announced it as a change.

Deltas now need to clear both a byte floor and a percentage floor to count, mirroring `isNotableMetricChange` in `packages/benchmark/src/compare.ts`. Sub-threshold rows drop into the collapsed section instead of leading the comment:

> 2 packages changed size, +19.99 KB (+0.1%) packed overall.

| Package | Packed (base → head) | Δ Packed | Unpacked (base → head) | Δ Unpacked |
| --- | --- | --- | --- | --- |
| `@azure-tools/typespec-metadata` 🆕 | — → 15.91 KB | +15.91 KB (new) | — → 62.26 KB | +62.26 KB (new) |
| `@azure-tools/typespec-azure-core` | 123.69 KB → 127.87 KB | +4.18 KB (+3.4%) 🔴 | 689.86 KB → 695.48 KB | +5.63 KB (+0.8%) 🔴 |

<details>
<summary>2 package(s) with no notable change</summary>

| Package | Packed (base → head) | Δ Packed | Unpacked (base → head) | Δ Unpacked |
| --- | --- | --- | --- | --- |
| `@azure-tools/typespec-ts` | 524.72 KB → 524.66 KB | -58 B (-0.0%) | 2.53 MB → 2.53 MB | — |
| `@azure-tools/typespec-java` | 13.51 MB → 13.51 MB | -46 B (-0.0%) | 15.03 MB → 15.03 MB | — |
</details>

The 🔴/🟢 markers match the benchmark comment's existing convention. I first tried real colored text via GitHub inline math, but it renders in MathJax's fonts rather than GitHub's, and it's a pattern almost no size bot uses — `preactjs/compressed-size-action`, `size-limit-action`, Codecov, BundleMon and the Next.js bot all signal direction with emoji instead.

`compare.ts` no longer runs `main()` on import, so the rendering is covered by tests.
