### PR TITLE
Refactor operations.ts

### DIFF
--- a/.chronus/changes/go-op-refactor-2026-7-6-15-44-32.md
+++ b/.chronus/changes/go-op-refactor-2026-7-6-15-44-32.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-go"
+---
+
+Split operations.ts into three files to better contain dependent code.

--- a/packages/typespec-go/src/codegen/core/example.ts
+++ b/packages/typespec-go/src/codegen/core/example.ts
@@ -8,7 +8,6 @@ import * as naming from "../../naming/naming.js";
 import { CodegenError } from "./errors.js";
 import * as helpers from "./helpers.js";
 import { ImportManager } from "./imports.js";
-import { fixUpMethodName } from "./operations.js";
 
 // represents the generated content for an example
 export class ExampleContent {
@@ -77,7 +76,7 @@ export function generateExamples(
         exampleText += `// Generated from example definition: ${example.filePath}\n`;
         const exampleFuncNamePrefix =
           method.examples.length > 1 ? `_${helpers.camelCase(example.name)}` : "";
-        exampleText += `func Example${client.name}_${fixUpMethodName(method)}${exampleFuncNamePrefix}() {\n`;
+        exampleText += `func Example${client.name}_${helpers.fixUpMethodName(method)}${exampleFuncNamePrefix}() {\n`;
 
         // create credential
         exampleText += `${indent.get()}cred, err := azidentity.NewDefaultAzureCredential(nil)\n`;
@@ -195,7 +194,7 @@ export function generateExamples(
         switch (method.kind) {
           case "lroMethod":
           case "lroPageableMethod":
-            exampleText += `${indent.get()}poller, err := ${clientRef}.${fixUpMethodName(method)}(ctx, ${renderedParams.join(", ")}${renderedParams.length > 0 ? ", " : ""}${methodOptionalParametersText.split("\n").join("\n" + indent.get())})\n`;
+            exampleText += `${indent.get()}poller, err := ${clientRef}.${helpers.fixUpMethodName(method)}(ctx, ${renderedParams.join(", ")}${renderedParams.length > 0 ? ", " : ""}${methodOptionalParametersText.split("\n").join("\n" + indent.get())})\n`;
             exampleText += `${indent.get()}if err != nil {\n`;
             exampleText += `${indent.push().get()}log.Fatalf("failed to finish the request: %v", err)\n`;
             exampleText += `${indent.pop().get()}}\n`;
@@ -206,13 +205,13 @@ export function generateExamples(
             exampleText += `${indent.pop().get()}}\n`;
             break;
           case "method":
-            exampleText += `${indent.get()}${checkResponse ? "res" : "_"}, err ${checkResponse ? ":=" : "="} ${clientRef}.${fixUpMethodName(method)}(ctx, ${renderedParams.join(", ")}${renderedParams.length > 0 ? ", " : ""}${methodOptionalParametersText.split("\n").join("\n" + indent.get())})\n`;
+            exampleText += `${indent.get()}${checkResponse ? "res" : "_"}, err ${checkResponse ? ":=" : "="} ${clientRef}.${helpers.fixUpMethodName(method)}(ctx, ${renderedParams.join(", ")}${renderedParams.length > 0 ? ", " : ""}${methodOptionalParametersText.split("\n").join("\n" + indent.get())})\n`;
             exampleText += `${indent.get()}if err != nil {\n`;
             exampleText += `${indent.push().get()}log.Fatalf("failed to finish the request: %v", err)\n`;
             exampleText += `${indent.pop().get()}}\n`;
             break;
           case "pageableMethod":
-            exampleText += `${indent.get()}pager := ${clientRef}.${fixUpMethodName(method)}(${renderedParams.join(", ")}${renderedParams.length > 0 ? ", " : ""}${methodOptionalParametersText.split("\n").join("\n" + indent.get())})\n`;
+            exampleText += `${indent.get()}pager := ${clientRef}.${helpers.fixUpMethodName(method)}(${renderedParams.join(", ")}${renderedParams.length > 0 ? ", " : ""}${methodOptionalParametersText.split("\n").join("\n" + indent.get())})\n`;
             break;
           default:
             method satisfies never;

--- a/packages/typespec-go/src/codegen/core/helpers.ts
+++ b/packages/typespec-go/src/codegen/core/helpers.ts
@@ -121,7 +121,7 @@ export function formatParameterTypeName(
 }
 
 // sorts parameters by their required state, ordering required before optional
-export function sortParametersByRequired(
+function sortParametersByRequired(
   a: go.ClientParameter | go.ParameterGroup,
   b: go.ClientParameter | go.ParameterGroup,
 ): number {
@@ -306,6 +306,28 @@ export function getParamName(param: go.MethodParameter): string {
   return paramName;
 }
 
+export function fixUpMethodName(method: go.MethodType): string {
+  switch (method.kind) {
+    case "lroMethod":
+    case "lroPageableMethod":
+      return `Begin${method.name}`;
+    case "pageableMethod": {
+      let N = "N";
+      let name = method.name;
+      if (method.name[0] !== method.name[0].toUpperCase()) {
+        // the method isn't exported; don't export the pager ctor
+        N = "n";
+        // ensure correct casing of the emitted function name e.g.,
+        // "listThings" -> "newListThingsPager"
+        name = name[0].toUpperCase() + name.substring(1);
+      }
+      return `${N}ew${name}Pager`;
+    }
+    case "method":
+      return method.name;
+  }
+}
+
 // converts the Go code model encoding type to the type name in the standard library
 export function formatBytesEncoding(enc: go.BytesEncoding): string {
   if (enc === "URL") {
@@ -379,6 +401,16 @@ export function formatParamValue(
   return formatValue(paramName, param.type, imports);
 }
 
+/**
+ * returns the receiver definition for a client
+ *
+ * @param receiver the receiver for which to emit the definition
+ * @returns the receiver definition
+ */
+export function getClientReceiverDefinition(receiver: go.Receiver<go.Client>): string {
+  return `(${receiver.name} ${receiver.byValue ? "" : "*"}${receiver.type.name})`;
+}
+
 export function getDelimiterForCollectionFormat(cf: go.CollectionFormat): string {
   switch (cf) {
     case "csv":
@@ -392,6 +424,28 @@ export function getDelimiterForCollectionFormat(cf: go.CollectionFormat): string
     default:
       throw new CodegenError("InternalError", `unhandled CollectionFormat ${cf}`);
   }
+}
+
+export function getMediaFormat(type: go.WireType, mediaType: "JSON" | "XML", param: string): string {
+  let marshaller: "JSON" | "XML" | "ByteArray" = mediaType;
+  let format = "";
+  if (type.kind === "encodedBytes") {
+    marshaller = "ByteArray";
+    format = `, runtime.Base64${type.encoding}Format`;
+  }
+  return `${marshaller}(${param}${format})`;
+}
+
+export function isMapOfDateTime(
+  paramType: go.WireType,
+): { format: go.TimeFormat; utc: boolean } | undefined {
+  if (paramType.kind !== "map") {
+    return undefined;
+  }
+  if (paramType.valueType.kind !== "time") {
+    return undefined;
+  }
+  return { format: paramType.valueType.format, utc: paramType.valueType.utc };
 }
 
 export function formatValue(
@@ -502,19 +556,6 @@ export function formatLiteralValue(value: go.Literal, withCast: boolean): string
       return `"${value.literal}"`;
     case "time":
       return `"${value.literal}"`;
-  }
-}
-
-// returns true if at least one of the responses has a schema
-export function hasSchemaResponse(method: go.MethodType): boolean {
-  switch (method.returns.result?.kind) {
-    case "anyResult":
-    case "modelResult":
-    case "monomorphicResult":
-    case "polymorphicResult":
-      return true;
-    default:
-      return false;
   }
 }
 
@@ -1418,7 +1459,7 @@ export function camelCase(identifier: string | Array<string>): string {
   return `${naming.uncapitalize(identifier[0])}${pascalCase(identifier.slice(1))}`;
 }
 
-export function pascalCase(identifier: string | Array<string>): string {
+function pascalCase(identifier: string | Array<string>): string {
   return identifier === undefined
     ? ""
     : typeof identifier === "string"

--- a/packages/typespec-go/src/codegen/core/index.ts
+++ b/packages/typespec-go/src/codegen/core/index.ts
@@ -1,0 +1,21 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export { generateClientFactory } from "./client-factory.js";
+export { generateCloudConfig } from "./cloud-config.js";
+export { generateConstants } from "./constants.js";
+export { generateExamples } from "./example.js";
+export { generateGoModFile } from "./gomod.js";
+export { setCustomHeaderText } from "./helpers.js";
+export { generateInterfaces } from "./interfaces.js";
+export { generateLicenseTxt } from "./license.js";
+export { generateMetadataFile } from "./metadata.js";
+export { generateModels } from "./models.js";
+export { generateOperations } from "./operations.js";
+export { generateOptions } from "./options.js";
+export { generatePolymorphicHelpers } from "./polymorphics.js";
+export { generateResponses } from "./responses.js";
+export { generateVersionInfo } from "./version.js";
+export { generateXMLAdditionalPropsHelpers } from "./xml-additional-props.js";

--- a/packages/typespec-go/src/codegen/core/operations.ts
+++ b/packages/typespec-go/src/codegen/core/operations.ts
@@ -8,6 +8,8 @@ import * as naming from "../../naming/naming.js";
 import { CodegenError } from "./errors.js";
 import * as helpers from "./helpers.js";
 import { ImportManager } from "./imports.js";
+import { createRequestHandler } from "./request-handler.js";
+import { createResponseHandler } from "./response-handler.js";
 
 // represents the generated content for an operation group
 export class OperationGroupContent {
@@ -182,10 +184,11 @@ export function generateOperations(
         opText += generateLROBeginMethod(method, options, imports, indent);
       }
       opText += generateOperation(method, options, imports, indent);
-      opText += createProtocolRequest(azureARM, method, imports, indent);
-      if (method.kind !== "lroMethod") {
-        // LRO responses are handled elsewhere, with the exception of pageable LROs
-        opText += createProtocolResponse(method, imports, indent);
+      opText += createRequestHandler(azureARM, method, imports, indent);
+      if (needsResponseHandler(method) && method.kind !== "lroMethod") {
+        // we don't emit the response handler for vanilla LROs as the Poller[T]
+        // handles that. we do need it for pageable LROs though.
+        opText += createResponseHandler(method, imports, indent);
       }
       if (
         go.isPageableMethod(method) &&
@@ -199,7 +202,7 @@ export function generateOperations(
     }
 
     for (const method of nextPageMethods) {
-      opText += createProtocolRequest(azureARM, method, imports, indent);
+      opText += createRequestHandler(azureARM, method, imports, indent);
     }
 
     // stitch it all together
@@ -504,157 +507,20 @@ function generateConstructors(
   return ctorText;
 }
 
-// use this to generate the code that will help process values returned in response headers
-function formatHeaderResponseValue(
-  method: go.SyncMethod | go.LROPageableMethod | go.PageableMethod,
-  headerResp: go.HeaderScalarResponse | go.HeaderMapResponse,
-  respObj: string,
-  zeroResp: string,
-  imports: ImportManager,
-  indent: helpers.Indentation,
-): string {
-  // dictionaries are handled slightly different so we do that first
-  if (headerResp.kind === "headerMapResponse") {
-    imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/to");
-    imports.add("strings");
-    const headerPrefix = headerResp.headerName;
-    let text = `${indent.get()}for hh := range resp.Header {\n`;
-    text += `${indent.push().get()}if len(hh) > len("${headerPrefix}") && strings.EqualFold(hh[:len("${headerPrefix}")], "${headerPrefix}") {\n`;
-    text += `${indent.push().get()}if ${respObj}.${headerResp.fieldName} == nil {\n`;
-    text += `${indent.push().get()}${respObj}.${headerResp.fieldName} = map[string]*string{}\n`;
-    text += `${indent.pop().get()}}\n`;
-    text += `${indent.get()}${respObj}.${headerResp.fieldName}[hh[len("${headerPrefix}"):]] = to.Ptr(resp.Header.Get(hh))\n`;
-    text += `${indent.pop().get()}}\n`;
-    text += `${indent.pop().get()}}\n`;
-    return text;
-  }
-
-  let text = `${indent.get()}if val := resp.Header.Get("${helpers.canonicalizeHeaderName(headerResp.headerName)}"); val != "" {\n`;
-  indent.push();
-  let name = naming.uncapitalize(headerResp.fieldName);
-  let byRef = "&";
-  switch (headerResp.type.kind) {
-    case "constant":
-    case "etag":
-      text += `${indent.get()}${respObj}.${headerResp.fieldName} = (*${go.getTypeDeclaration(headerResp.type, method.receiver.type.pkg)})(&val)\n`;
-      indent.pop();
-      text += `${indent.get()}}\n`;
-      return text;
-    case "encodedBytes":
-      // a base-64 encoded value in string format
-      imports.add("encoding/base64");
-      text += `${indent.get()}${name}, err := base64.${helpers.formatBytesEncoding(headerResp.type.encoding)}Encoding.DecodeString(val)\n`;
-      byRef = "";
-      break;
-    case "literal":
-      text += `${indent.get()}${respObj}.${headerResp.fieldName} = &val\n`;
-      indent.pop();
-      text += `${indent.get()}}\n`;
-      return text;
-    case "scalar":
-      text += emitScalarParsing(headerResp.type, "val", name, imports, indent);
-      break;
-    case "string":
-      text += `${indent.get()}${respObj}.${headerResp.fieldName} = &val\n`;
-      text += `${indent.pop().get()}}\n`;
-      return text;
-    case "time":
-      imports.add("time");
-      switch (headerResp.type.format) {
-        case "RFC1123":
-        case "RFC3339":
-        case "RFC7231":
-          text += `${indent.get()}${name}, err := time.Parse(${headerResp.type.format === "RFC3339" ? helpers.RFC3339Format : helpers.RFC1123Format}, val)\n`;
-          break;
-        case "PlainDate":
-          text += `${indent.get()}${name}, err := time.Parse(${helpers.plainDateFormat}, val)\n`;
-          break;
-        case "PlainTime":
-          text += `${indent.get()}${name}, err := time.Parse(${helpers.plainTimeFormat}, val)\n`;
-          break;
-        case "Unix":
-          imports.add("strconv");
-          imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/to");
-          text += `${indent.get()}sec, err := strconv.ParseInt(val, 10, 64)\n`;
-          name = "to.Ptr(time.Unix(sec, 0))";
-          byRef = "";
-          break;
-        default:
-          headerResp.type.format satisfies never;
-      }
-  }
-
-  // NOTE: only cases that required parsing will fall through to here
-  text += `${indent.get()}if err != nil {\n`;
-  text += `${indent.push().get()}return ${zeroResp}, err\n`;
-  text += `${indent.pop().get()}}\n`;
-  text += `${indent.get()}${respObj}.${headerResp.fieldName} = ${byRef}${name}\n`;
-  text += `${indent.pop().get()}}\n`;
-  return text;
-}
-
-/**
- * emits the code for parsing scalar types from a string.
- * note that the parsing error result is placed into a
- * local var named "err".
- *
- * @param scalar the type of scalar to parse
- * @param src the source var that contains the scalar in string format
- * @param dst the destination var that contains the result
- * @param imports the import manager currently in scope
- * @param indent the indentation helper currently in scope
- * @returns the scalar parsing code
- */
-function emitScalarParsing(
-  scalar: go.Scalar,
-  src: string,
-  dst: string,
-  imports: ImportManager,
-  indent: helpers.Indentation,
-): string {
-  imports.add("strconv");
-  switch (scalar.type) {
-    case "bool":
-      return `${indent.get()}${dst}, err := strconv.ParseBool(${src})\n`;
-    case "float32":
-      return (
-        `${indent.get()}${dst}32, err := strconv.ParseFloat(${src}, 32)\n` +
-        `${indent.get()}${dst} := float32(${dst}32)\n`
-      );
-    case "float64":
-      return `${indent.get()}${dst}, err := strconv.ParseFloat(${src}, 64)\n`;
-    case "int32":
-      return (
-        `${indent.get()}${dst}32, err := strconv.ParseInt(${src}, 10, 32)\n` +
-        `${indent.get()}${dst} := int32(${dst}32)\n`
-      );
-    case "int64":
-      return `${indent.get()}${dst}, err := strconv.ParseInt(${src}, 10, 64)\n`;
-    default:
-      throw new CodegenError("InternalError", `unhandled scalar type ${scalar.type}`);
-  }
-}
-
 /**
  * returns the zero value for the specified method.
  * note that the zero value will be different depending
  * on which API for the method is being called.
  *
  * @param method the method to determine the zero value
- * @param apiType the method's API that's being invoked
- *       lro - the exported LRO API
- *        op - the operation method. for sync methods this is the exported API. for LROs it's the internal method called by Begin*
- *   handler - the internal response handler method
  * @returns the zero value
  */
-function getZeroReturnValue(method: go.MethodType, apiType: "lro" | "op" | "handler"): string {
+function getZeroReturnValue(method: go.MethodType): string {
   let returnType = `${method.returns.name}{}`;
   if (go.isLROMethod(method)) {
-    if (apiType === "lro" || apiType === "op") {
-      // the api returns a *Poller[T]
-      // the operation returns an *http.Response
-      returnType = "nil";
-    }
+    // the api returns a *Poller[T]
+    // the operation returns an *http.Response
+    returnType = "nil";
   }
   return returnType;
 }
@@ -749,7 +615,7 @@ function emitPagerDefinition(
   indent.push();
   const reqParams = helpers.getCreateRequestParameters(method);
   if (options.generateFakes) {
-    text += `${indent.get()}ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "${method.receiver.type.name}.${fixUpMethodName(method)}")\n`;
+    text += `${indent.get()}ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "${method.receiver.type.name}.${helpers.fixUpMethodName(method)}")\n`;
   }
 
   if (method.strategy) {
@@ -872,7 +738,7 @@ function callCreateRequestWithErrCheck(
 ): string {
   const reqParams = helpers.getCreateRequestParameters(method, optionsParam);
   let text = `${indent.get()}${reqVarName}, err := client.${method.naming.requestMethod}(${reqParams})\n`;
-  const zeroResp = getZeroReturnValue(method, "op");
+  const zeroResp = getZeroReturnValue(method);
   text += `${indent.get()}${helpers.buildErrCheck(indent, "err", zeroResp)}\n`;
   return text;
 }
@@ -894,7 +760,7 @@ function callPipelineDoWithErrCheck(
   indent: helpers.Indentation,
 ): string {
   let text = `${indent.get()}${respVarName}, err := client.internal.Pipeline().Do(${reqVarName})\n`;
-  const zeroResp = getZeroReturnValue(method, "op");
+  const zeroResp = getZeroReturnValue(method);
   text += `${indent.get()}${helpers.buildErrCheck(indent, "err", zeroResp)}\n`;
   return text;
 }
@@ -908,16 +774,6 @@ function genRespErrorDoc(method: go.MethodType): string {
   return "";
 }
 
-/**
- * returns the receiver definition for a client
- *
- * @param receiver the receiver for which to emit the definition
- * @returns the receiver definition
- */
-function getClientReceiverDefinition(receiver: go.Receiver<go.Client>): string {
-  return `(${receiver.name} ${receiver.byValue ? "" : "*"}${receiver.type.name})`;
-}
-
 function generateOperation(
   method: go.MethodType,
   options: go.Options,
@@ -928,7 +784,7 @@ function generateOperation(
   const returns = generateReturnsInfo(method, "op");
   let methodName = method.name;
   if (method.kind === "pageableMethod") {
-    methodName = fixUpMethodName(method);
+    methodName = helpers.fixUpMethodName(method);
   }
   let text = "";
   const respErrDoc = genRespErrorDoc(method);
@@ -948,7 +804,7 @@ function generateOperation(
       text += helpers.formatCommentAsBulletItem(param.name, param.docs);
     }
   }
-  text += `func ${getClientReceiverDefinition(method.receiver)} ${methodName}(${params}) (${returns.join(", ")}) {\n`;
+  text += `func ${helpers.getClientReceiverDefinition(method.receiver)} ${methodName}(${params}) (${returns.join(", ")}) {\n`;
   if (method.kind === "pageableMethod") {
     text += `${indent.get()}return `;
     text += emitPagerDefinition(method, options, imports, indent);
@@ -956,7 +812,7 @@ function generateOperation(
     return text;
   }
   text += `${indent.get()}var err error\n`;
-  let operationName = `"${method.receiver.type.name}.${fixUpMethodName(method)}"`;
+  let operationName = `"${method.receiver.type.name}.${helpers.fixUpMethodName(method)}"`;
   if (options.generateFakes && options.injectSpans) {
     text += `${indent.get()}const operationName = ${operationName}\n`;
     operationName = "operationName";
@@ -980,7 +836,7 @@ function generateOperation(
     text += `${indent.get()}return client.${method.naming.responseMethod}(httpResp, ${helpers.formatStatusCodes(method.httpStatusCodes)})\n`;
   } else {
     // no response handler so we emit the status code check here
-    const zeroResp = getZeroReturnValue(method, "op");
+    const zeroResp = getZeroReturnValue(method);
     text += `${indent.get()}${helpers.buildIfBlock(indent, {
       condition: `!runtime.HasStatusCode(httpResp, ${helpers.formatStatusCodes(method.httpStatusCodes)})`,
       body: (indent) => `${indent.get()}return ${zeroResp}, runtime.NewResponseError(httpResp)\n`,
@@ -1011,1053 +867,18 @@ function generateOperation(
   return text;
 }
 
-/**
- * emits Go code to set ContentType on a MultipartContent variable if it has a fixed content type.
- * handles both direct MultipartContent and slices of MultipartContent.
- * returns the empty string if there's nothing to set.
- *
- * @param paramName the name of the multipart param
- * @param wireType the underlying type of the multipart param
- * @param indent the indentation helper currently in scope
- * @returns setter code or the empty string
- */
-function emitMultipartContentTypeSetter(
-  paramName: string,
-  wireType: go.WireType,
-  indent: helpers.Indentation,
-): string {
-  let text = "";
-  const unwrapped = helpers.recursiveUnwrapMapSlice(wireType);
-  if (unwrapped.kind !== "multipartContent" || !unwrapped.contentType) {
-    return text;
-  }
-  switch (wireType.kind) {
-    case "multipartContent":
-      text += `${indent.get()}${paramName}.ContentType = ${unwrapped.contentType.literal}\n`;
-      break;
-    case "slice":
-      text += `${indent.get()}for i := range ${paramName} {\n`;
-      text += `${indent.push().get()}${paramName}[i].ContentType = ${unwrapped.contentType.literal}\n`;
-      text += `${indent.pop().get()}}\n`;
-      break;
-  }
-  return text;
-}
-
-function createProtocolRequest(
-  azureARM: boolean,
-  method: go.MethodType | go.NextPageMethod,
-  imports: ImportManager,
-  indent: helpers.Indentation,
-): string {
-  let name = method.name;
-  if (method.kind !== "nextPageMethod") {
-    name = method.naming.requestMethod;
-  }
-
-  for (const param of method.parameters) {
-    if (param.location !== "method" || !go.isRequiredParameter(param.style)) {
-      continue;
-    }
-    imports.addForType(param.type);
-  }
-
-  const returns = ["*policy.Request", "error"];
-  let text = `${helpers.comment(name, "// ")} creates the ${method.name} request.\n`;
-  text += `func ${getClientReceiverDefinition(method.receiver)} ${name}(${helpers.getCreateRequestParametersSig(method)}) (${returns.join(", ")}) {\n`;
-
-  const hostParams = new Array<go.URIParameter>();
-  for (const parameter of method.receiver.type.parameters) {
-    if (parameter.kind === "uriParam") {
-      hostParams.push(parameter);
-    }
-  }
-
-  let hostParam: string;
-  if (azureARM) {
-    hostParam = "client.internal.Endpoint()";
-  } else if (method.receiver.type.instance?.kind === "templatedHost") {
-    imports.add("strings");
-    // we have a templated host
-    text += `${indent.get()}host := "${method.receiver.type.instance.path}"\n`;
-    // get all the host params on the client
-    for (const hostParam of hostParams) {
-      text += `${indent.get()}host = strings.ReplaceAll(host, "{${hostParam.uriPathSegment}}", ${helpers.formatValue(`client.${hostParam.name}`, hostParam.type, imports)})\n`;
-    }
-    // check for any method local host params
-    for (const param of method.parameters) {
-      if (param.location === "method" && param.kind === "uriParam") {
-        text += `${indent.get()}host = strings.ReplaceAll(host, "{${param.uriPathSegment}}", ${helpers.formatValue(helpers.getParamName(param), param.type, imports)})\n`;
-      }
-    }
-    hostParam = "host";
-  } else if (hostParams.length === 1) {
-    // simple parameterized host case
-    hostParam = "client." + hostParams[0].name;
-  } else {
-    throw new CodegenError(
-      "InternalError",
-      `no host or endpoint defined for method ${method.receiver.type.name}.${method.name}`,
-    );
-  }
-
-  const methodParamGroups = helpers.getMethodParamGroups(method);
-  const hasPathParams = methodParamGroups.pathParams.length > 0;
-
-  // storage needs the client.u to be the source-of-truth for the full path.
-  // however, swagger requires that all operations specify a path, which is at odds with storage.
-  // to work around this, storage specifies x-ms-path paths with path params but doesn't
-  // actually reference the path params (i.e. no params with which to replace the tokens).
-  // so, if a path contains tokens but there are no path params, skip emitting the path.
-  const pathStr = method.httpPath;
-  const pathContainsParms = pathStr.includes("{");
-  if (hasPathParams || (!pathContainsParms && pathStr.length > 1)) {
-    // there are path params, or the path doesn't contain tokens and is not "/" so emit it
-    text += `${indent.get()}urlPath := "${method.httpPath}"\n`;
-    hostParam = `runtime.JoinPaths(${hostParam}, urlPath)`;
-  }
-
-  // helper to build nil checks for param groups
-  const emitParamGroupCheck = function (param: go.MethodParameter): string {
-    if (!param.group) {
-      throw new CodegenError(
-        "InternalError",
-        `emitParamGroupCheck called for ungrouped parameter ${param.name}`,
-      );
-    }
-    let client = "";
-    if (param.location === "client") {
-      client = "client.";
-    }
-    const paramGroupName = naming.uncapitalize(param.group.name);
-    let optionalParamGroupCheck = `${client}${paramGroupName} != nil && `;
-    if (param.group.required) {
-      optionalParamGroupCheck = "";
-    }
-    return `${indent.get()}if ${optionalParamGroupCheck}${client}${paramGroupName}.${naming.capitalize(param.name)} != nil {\n`;
-  };
-
-  if (hasPathParams) {
-    // swagger defines path params, emit path and replace tokens
-    imports.add("strings");
-    // replace path parameters
-    for (const pp of methodParamGroups.pathParams) {
-      let paramValue: string;
-      let optionalPathSep = false;
-      if (pp.style === "literal") {
-        // literals are always scalar types and require no empty checks
-        paramValue = helpers.formatParamValue(pp, imports, indent);
-      } else if (pp.style === "required" || pp.location === "client") {
-        // NOTE: we include client params here since they behave
-        // like required params (i.e. not grouped).
-
-        // emit check to ensure path param isn't an empty string
-        if (pp.kind === "pathScalarParam") {
-          const choiceIsString = function (type: go.PathScalarParameterType): boolean {
-            return type.kind === "constant" && type.type === "string";
-          };
-          // we only need to do this for params that have an underlying type of string
-          if ((pp.type.kind === "string" || choiceIsString(pp.type)) && !pp.omitEmptyStringCheck) {
-            const paramName = helpers.getParamName(pp);
-            imports.add("errors");
-            text += `${indent.get()}if ${paramName} == "" {\n`;
-            text += `${indent.push().get()}return nil, errors.New("parameter ${paramName} cannot be empty")\n`;
-            text += `${indent.pop().get()}}\n`;
-          }
-        }
-
-        paramValue = helpers.formatParamValue(pp, imports, indent);
-
-        // for collection-based path params, we emit the empty check
-        // after calling helpers.formatParamValue as that will have the
-        // var name that contains the slice.
-        if (pp.kind === "pathCollectionParam") {
-          const paramName = helpers.getParamName(pp);
-          const joinedParamName = `${paramName}Param`;
-          text += `${indent.get()}${joinedParamName} := ${paramValue}\n`;
-          imports.add("errors");
-          text += `${indent.get()}if len(${joinedParamName}) == 0 {\n`;
-          text += `${indent.push().get()}return nil, errors.New("parameter ${paramName} cannot be empty")\n`;
-          text += `${indent.pop().get()}}\n`;
-          paramValue = joinedParamName;
-        }
-      } else if (go.isClientSideDefault(pp.style)) {
-        const defaultValue = naming.uncapitalize(pp.name) + "Default";
-        text += `${indent.get()}${defaultValue} := ${helpers.formatLiteralValue(pp.style.defaultValue, true)}\n`;
-        text += emitParamGroupCheck(pp);
-        text += `${indent.push().get()}${defaultValue} = ${helpers.getParamName(pp)}\n`;
-        text += `${indent.pop().get()}}\n`;
-        paramValue = helpers.formatValue(defaultValue, pp.type, imports);
-      } else {
-        // param isn't required, so emit a local var with
-        // the correct default value, then populate it with
-        // the optional value when set.
-        paramValue = `optional${naming.capitalize(pp.name)}`;
-        text += `${indent.get()}${paramValue} := ""\n`;
-        text += emitParamGroupCheck(pp);
-        text += `${indent.push().get()}${paramValue} = ${helpers.formatParamValue(pp, imports, indent)}\n`;
-        text += `${indent.pop().get()}}\n`;
-
-        // there are two cases for optional path params.
-        //  - /foo/bar/{optional}
-        //  - /foo/bar{/optional}
-        // for the second case, we need to include a forward slash
-        if (method.httpPath[method.httpPath.indexOf(`{${pp.pathSegment}}`) - 1] !== "/") {
-          optionalPathSep = true;
-        }
-      }
-
-      const emitPathEscape = function (): string {
-        if (pp.isEncoded) {
-          imports.add("net/url");
-          return `url.PathEscape(${paramValue})`;
-        }
-        return paramValue;
-      };
-
-      if (optionalPathSep) {
-        text += `${indent.get()}if len(${paramValue}) > 0 {\n`;
-        text += `${indent.push().get()}${paramValue} = "/"+${emitPathEscape()}\n`;
-        text += `${indent.pop().get()}}\n`;
-      } else {
-        paramValue = emitPathEscape();
-      }
-
-      text += `${indent.get()}urlPath = strings.ReplaceAll(urlPath, "{${pp.pathSegment}}", ${paramValue})\n`;
-    }
-  }
-
-  text += `${indent.get()}req, err := runtime.NewRequest(ctx, http.Method${naming.capitalize(method.httpMethod)}, ${hostParam})\n`;
-  text += `${indent.get()}if err != nil {\n`;
-  text += `${indent.push().get()}return nil, err\n`;
-  text += `${indent.pop().get()}}\n`;
-
-  // add query parameters
-  const encodedParams = methodParamGroups.encodedQueryParams;
-  const unencodedParams = methodParamGroups.unencodedQueryParams;
-
-  const emitQueryParam = function (qp: go.QueryParameter, setter: string): string {
-    let qpText: string;
-    if (qp.location === "method" && go.isClientSideDefault(qp.style)) {
-      qpText = emitClientSideDefault(
-        qp,
-        qp.style,
-        (name, val) => {
-          return `${indent.get()}reqQP.Set(${name}, ${val})`;
-        },
-        imports,
-        indent,
-      );
-    } else if (
-      go.isRequiredParameter(qp.style) ||
-      go.isLiteralParameter(qp.style) ||
-      (qp.location === "client" && go.isClientSideDefault(qp.style))
-    ) {
-      qpText = `${indent.get()}${setter}\n`;
-    } else if (qp.location === "client" && !qp.group) {
-      // global optional param
-      qpText = `${indent.get()}if client.${qp.name} != nil {\n`;
-      qpText += `${indent.push().get()}${setter}\n`;
-      qpText += `${indent.pop().get()}}\n`;
-    } else {
-      qpText = emitParamGroupCheck(qp);
-      qpText += `${indent.push().get()}${setter}\n`;
-      qpText += `${indent.pop().get()}}\n`;
-    }
-    return qpText;
-  };
-
-  // emit encoded params first
-  if (encodedParams.length > 0) {
-    text += `${indent.get()}reqQP := req.Raw().URL.Query()\n`;
-    for (const qp of encodedParams.sort((a: go.QueryParameter, b: go.QueryParameter) => {
-      return helpers.sortAscending(a.queryParameter, b.queryParameter);
-    })) {
-      let setter: string;
-      if (qp.kind === "queryCollectionParam" && qp.collectionFormat === "multi") {
-        setter = `for _, qv := range ${helpers.getParamName(qp)} {\n`;
-
-        // emit a type conversion for the qv based on the array's element type
-        let queryVal: string;
-        const arrayQP = qp.type;
-        switch (arrayQP.elementType.kind) {
-          case "constant":
-            switch (arrayQP.elementType.type) {
-              case "string":
-                queryVal = "string(qv)";
-                break;
-              default:
-                imports.add("fmt");
-                queryVal = 'fmt.Sprintf("%d", qv)';
-            }
-            break;
-          case "string":
-            queryVal = "qv";
-            break;
-          default:
-            imports.add("fmt");
-            queryVal = 'fmt.Sprintf("%v", qv)';
-        }
-
-        setter += `${indent.push().get()}reqQP.Add("${qp.queryParameter}", ${queryVal})\n`;
-        setter += `${indent.pop().get()}}`;
-      } else {
-        // cannot initialize setter to this value as helpers.formatParamValue() can change imports
-        setter = `reqQP.Set("${qp.queryParameter}", ${helpers.formatParamValue(qp, imports, indent)})`;
-      }
-      text += emitQueryParam(qp, setter);
-    }
-
-    // reqQP.Encode() encodes space chars as '+' which is application/x-www-form-urlencoded
-    // thus not applicable for URIs. the correct URI encoding for SP is %20. note that literal '+'
-    // characters are encoded by reqQP.Encode() as %2B so there's no risk of replacing them.
-    // see https://www.rfc-editor.org/rfc/rfc3986 sections 2.1, 2.2, and 3.4
-    imports.add("strings");
-    text += `${indent.get()}req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")\n`;
-  }
-
-  // tack on any unencoded params to the end
-  if (unencodedParams.length > 0) {
-    if (encodedParams.length > 0) {
-      text += `${indent.get()}unencodedParams := []string{req.Raw().URL.RawQuery}\n`;
-    } else {
-      text += `${indent.get()}unencodedParams := []string{}\n`;
-    }
-    for (const qp of unencodedParams.sort((a: go.QueryParameter, b: go.QueryParameter) => {
-      return helpers.sortAscending(a.queryParameter, b.queryParameter);
-    })) {
-      let setter: string;
-      if (qp.kind === "queryCollectionParam" && qp.collectionFormat === "multi") {
-        setter = `for _, qv := range ${helpers.getParamName(qp)} {\n`;
-        setter += `${indent.push().get()}unencodedParams = append(unencodedParams, "${qp.queryParameter}="+qv)\n`;
-        setter += `${indent.pop().get()}}`;
-      } else {
-        setter = `unencodedParams = append(unencodedParams, "${qp.queryParameter}="+${helpers.formatParamValue(qp, imports, indent)})`;
-      }
-      text += emitQueryParam(qp, setter);
-    }
-    imports.add("strings");
-    text += `${indent.get()}req.Raw().URL.RawQuery = strings.Join(unencodedParams, "&")\n`;
-  }
-
-  if (method.kind !== "nextPageMethod" && method.returns.result?.kind === "binaryResult") {
-    // skip auto-body downloading for binary stream responses
-    text += `${indent.get()}runtime.SkipBodyDownload(req)\n`;
-  }
-
-  // add specific request headers
-  const emitHeaderSet = function (headerParam: go.HeaderParameter): string {
-    if (headerParam.kind === "headerMapParam") {
-      let headerText = `${indent.get()}for k, v := range ${helpers.getParamName(headerParam)} {\n`;
-      headerText += `${indent.push().get()}if v != nil {\n`;
-      headerText += `${indent.push().get()}req.Raw().Header["${headerParam.headerName}"+k] = []string{*v}\n`;
-      headerText += `${indent.pop().get()}}\n`;
-      headerText += `${indent.pop().get()}}\n`;
-      return headerText;
-    } else if (headerParam.location === "method" && go.isClientSideDefault(headerParam.style)) {
-      return emitClientSideDefault(
-        headerParam,
-        headerParam.style,
-        (name, val) => {
-          return `${indent.get()}req.Raw().Header[${name}] = []string{${val}}`;
-        },
-        imports,
-        indent,
-      );
-    } else {
-      return `${indent.get()}req.Raw().Header["${headerParam.headerName}"] = []string{${helpers.formatParamValue(headerParam, imports, indent)}}\n`;
-    }
-  };
-
-  let contentType: string | undefined;
-  for (const param of methodParamGroups.headerParams.sort(
-    (a: go.HeaderParameter, b: go.HeaderParameter) => {
-      return helpers.sortAscending(a.headerName, b.headerName);
-    },
-  )) {
-    if (param.headerName.match(/^content-type$/i)) {
-      // canonicalize content-type as req.SetBody checks for it via its canonicalized name :(
-      param.headerName = "Content-Type";
-
-      // there's a corner case where we have a content-type param with no body
-      // param. for this case we still need to set the header inline.
-      const bodyParam = methodParamGroups.bodyParam;
-      if (bodyParam?.bodyFormat === "binary" || bodyParam?.bodyFormat === "Text") {
-        // if the content-type is from a param, then the param will be passed
-        // explicitly to runtime.SetBody() so don't emit code to set it inline.
-        // NOTE: only binary/text payloads call runtime.SetBody().
-        if (go.isClientSideDefault(param.style)) {
-          text += emitClientSideDefault(
-            param as go.HeaderScalarParameter,
-            param.style,
-            () => "",
-            imports,
-            indent,
-          );
-          continue;
-        } else if (param.style === "required") {
-          continue;
-        }
-      }
-    }
-
-    if (param.headerName === "Content-Type" && param.style === "literal") {
-      // the content-type header will be set as part of emitSetBodyWithErrCheck
-      // to handle cases where the body param is optional. we don't want to set
-      // the content-type if the body is nil.
-      // we do it like this as tsp specifies content-type while swagger does not.
-      contentType = helpers.formatParamValue(param, imports, indent);
-    } else if (
-      go.isRequiredParameter(param.style) ||
-      go.isLiteralParameter(param.style) ||
-      go.isClientSideDefault(param.style)
-    ) {
-      text += emitHeaderSet(param);
-    } else if (param.location === "client" && !param.group) {
-      // global optional param
-      text += `${indent.get()}if client.${param.name} != nil {\n`;
-      indent.push();
-      text += emitHeaderSet(param);
-      indent.pop();
-      text += `${indent.get()}}\n`;
-    } else {
-      text += emitParamGroupCheck(param);
-      indent.push();
-      text += emitHeaderSet(param);
-      indent.pop();
-      text += `${indent.get()}}\n`;
-    }
-  }
-
-  // note that these are mutually exclusive
-  const bodyParam = methodParamGroups.bodyParam;
-  const formBodyParams = methodParamGroups.formBodyParams;
-  const multipartBodyParams = methodParamGroups.multipartBodyParams;
-  const partialBodyParams = methodParamGroups.partialBodyParams;
-
-  const emitSetBodyWithErrCheck = function (setBodyParam: string, contentType?: string): string {
-    let content = "";
-    if (contentType) {
-      content += `${indent.get()}req.Raw().Header["Content-Type"] = []string{${contentType}}\n`;
-    }
-    content += `${indent.get()}if err := ${setBodyParam}; err != nil {\n`;
-    content += `${indent.push().get()}return nil, err\n`;
-    content += `${indent.pop().get()}}\n`;
-    return content;
-  };
-
-  if (bodyParam) {
-    /** returns the source value for the content type */
-    const getContentTypeValue = function (src: go.BodyParameterContentTypeKind): string {
-      switch (src.kind) {
-        case "literal":
-          return helpers.formatLiteralValue(src, false);
-        case "parameterRef": {
-          // find the param
-          for (const param of method.parameters) {
-            if (param.kind === "headerScalarParam" && param.name === src.name) {
-              if (go.isClientSideDefault(param.style)) {
-                return getClientSideDefaultVarName(param);
-              }
-              let paramName = helpers.getParamName(param);
-              if (param.type.kind === "constant") {
-                paramName = `string(${paramName})`;
-              }
-              return paramName;
-            }
-          }
-          throw new CodegenError("InternalError", `didn't find parameter reference ${src.name}`);
-        }
-      }
-    };
-
-    if (bodyParam.bodyFormat === "JSON" || bodyParam.bodyFormat === "XML") {
-      // default to the body param name
-      let body = helpers.getParamName(bodyParam);
-      if (bodyParam.type.kind === "literal") {
-        // if the value is constant, embed it directly
-        body = helpers.formatLiteralValue(bodyParam.type, true);
-      } else if (bodyParam.bodyFormat === "XML" && bodyParam.type.kind === "slice") {
-        // for XML payloads, create a wrapper type if the payload is an array
-        imports.add("encoding/xml");
-        text += `${indent.get()}type wrapper struct {\n`;
-        indent.push();
-        let tagName: string;
-        if (bodyParam.xml?.wrapper) {
-          tagName = bodyParam.xml.wrapper;
-        } else {
-          tagName = go.getTypeDeclaration(bodyParam.type, method.receiver.type.pkg);
-        }
-        text += `${indent.get()}XMLName xml.Name \`xml:"${tagName}"\`\n`;
-        const fieldName = naming.capitalize(bodyParam.name);
-        let tag = go.getTypeDeclaration(bodyParam.type.elementType, method.receiver.type.pkg);
-        if (bodyParam.type.elementType.kind === "model" && bodyParam.type.elementType.xml?.name) {
-          tag = bodyParam.type.elementType.xml.name;
-        }
-        text += `${indent.get()}${fieldName} *${go.getTypeDeclaration(bodyParam.type, method.receiver.type.pkg)} \`xml:"${tag}"\`\n`;
-        text += `${indent.pop().get()}}\n`;
-        let addr = "&";
-        if (!go.isRequiredParameter(bodyParam.style) && !bodyParam.byValue) {
-          addr = "";
-        }
-        body = `wrapper{${fieldName}: ${addr}${body}}`;
-      } else if (bodyParam.type.kind === "time") {
-        // utc datetimes are normalized to UTC before serialization. non-RFC3339
-        // formats are wrapped in the internal time type; RFC3339 relies on the
-        // default time.Time JSON marshaler so it only needs the UTC conversion.
-        const bodyVal = bodyParam.type.utc ? `${body}.UTC()` : body;
-        if (bodyParam.type.format !== "RFC3339") {
-          imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
-          body = `datetime.${bodyParam.type.format}(${bodyVal})`;
-        } else {
-          body = bodyVal;
-        }
-      } else if (isArrayOfDateTimeForMarshalling(bodyParam.type)) {
-        const timeInfo = isArrayOfDateTimeForMarshalling(bodyParam.type);
-        let elementPtr = "*";
-        if (timeInfo?.elemByVal) {
-          elementPtr = "";
-        }
-        imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
-        text += `${indent.get()}aux := make([]${elementPtr}datetime.${timeInfo?.format}, len(${body}))\n`;
-        text += `${indent.get()}for i := 0; i < len(${body}); i++ {\n`;
-        if (timeInfo?.utc && elementPtr === "*") {
-          text += `${indent.push().get()}if ${body}[i] != nil {\n`;
-          text += `${indent.push().get()}utcTime := ${body}[i].UTC()\n`;
-          text += `${indent.get()}aux[i] = (*datetime.${timeInfo?.format})(&utcTime)\n`;
-          text += `${indent.pop().get()}}\n`;
-          indent.pop();
-        } else {
-          const utcCall = timeInfo?.utc ? ".UTC()" : "";
-          text += `${indent.push().get()}aux[i] = (${elementPtr}datetime.${timeInfo?.format})(${body}[i]${utcCall})\n`;
-          indent.pop();
-        }
-        text += `${indent.get()}}\n`;
-        body = "aux";
-      } else if (isMapOfDateTime(bodyParam.type)) {
-        const timeInfo = isMapOfDateTime(bodyParam.type);
-        imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
-        text += `${indent.get()}aux := map[string]*datetime.${timeInfo?.format}{}\n`;
-        text += `${indent.get()}for k, v := range ${body} {\n`;
-        if (timeInfo?.utc) {
-          text += `${indent.push().get()}if v != nil {\n`;
-          text += `${indent.push().get()}utcTime := v.UTC()\n`;
-          text += `${indent.get()}aux[k] = (*datetime.${timeInfo?.format})(&utcTime)\n`;
-          text += `${indent.pop().get()}} else {\n`;
-          text += `${indent.push().get()}aux[k] = nil\n`;
-          text += `${indent.pop().get()}}\n`;
-          indent.pop();
-        } else {
-          text += `${indent.push().get()}aux[k] = (*datetime.${timeInfo?.format})(v)\n`;
-          indent.pop();
-        }
-        text += `${indent.get()}}\n`;
-        body = "aux";
-      }
-      let setBody = `runtime.MarshalAs${getMediaFormat(bodyParam.type, bodyParam.bodyFormat, `req, ${body}`)}`;
-      if (bodyParam.type.kind === "rawJSON") {
-        imports.add("bytes");
-        imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming");
-        setBody = `req.SetBody(streaming.NopCloser(bytes.NewReader(${body})), "application/${bodyParam.bodyFormat.toLowerCase()}")`;
-      }
-      if (go.isRequiredParameter(bodyParam.style) || go.isLiteralParameter(bodyParam.style)) {
-        text += emitSetBodyWithErrCheck(setBody, contentType);
-        text += `${indent.get()}return req, nil\n`;
-      } else {
-        text += emitParamGroupCheck(bodyParam);
-        indent.push();
-        text += emitSetBodyWithErrCheck(setBody, contentType);
-        text += `${indent.get()}return req, nil\n`;
-        indent.pop();
-        text += `${indent.get()}}\n`;
-        text += `${indent.get()}return req, nil\n`;
-      }
-    } else if (bodyParam.bodyFormat === "binary") {
-      if (go.isRequiredParameter(bodyParam.style)) {
-        text += emitSetBodyWithErrCheck(
-          `req.SetBody(${bodyParam.name}, ${getContentTypeValue(bodyParam.contentType)})`,
-          contentType,
-        );
-        text += `${indent.get()}return req, nil\n`;
-      } else {
-        text += emitParamGroupCheck(bodyParam);
-        indent.push();
-        text += emitSetBodyWithErrCheck(
-          `req.SetBody(${helpers.getParamName(bodyParam)}, ${getContentTypeValue(bodyParam.contentType)})`,
-          contentType,
-        );
-        text += `${indent.get()}return req, nil\n`;
-        indent.pop();
-        text += `${indent.get()}}\n`;
-        text += `${indent.get()}return req, nil\n`;
-      }
-    } else if (bodyParam.bodyFormat === "Text") {
-      imports.add("strings");
-      imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming");
-      if (go.isRequiredParameter(bodyParam.style)) {
-        text += `${indent.get()}body := streaming.NopCloser(strings.NewReader(${bodyParam.name}))\n`;
-        text += emitSetBodyWithErrCheck(
-          `req.SetBody(body, ${getContentTypeValue(bodyParam.contentType)})`,
-          contentType,
-        );
-        text += `${indent.get()}return req, nil\n`;
-      } else {
-        text += emitParamGroupCheck(bodyParam);
-        indent.push();
-        text += `${indent.get()}body := streaming.NopCloser(strings.NewReader(${helpers.getParamName(bodyParam)}))\n`;
-        text += emitSetBodyWithErrCheck(
-          `req.SetBody(body, ${getContentTypeValue(bodyParam.contentType)})`,
-          contentType,
-        );
-        text += `${indent.get()}return req, nil\n`;
-        indent.pop();
-        text += `${indent.get()}}\n`;
-        text += `${indent.get()}return req, nil\n`;
-      }
-    }
-  } else if (partialBodyParams.length > 0) {
-    // partial body params are discrete params that are all fields within an internal struct.
-    // define and instantiate an instance of the wire type, using the values from each param.
-    text += `${indent.get()}body := struct {\n`;
-    indent.push();
-    for (const partialBodyParam of partialBodyParams) {
-      text += `${indent.get()}${naming.capitalize(partialBodyParam.serializedName)} ${helpers.star(partialBodyParam.byValue)}${go.getTypeDeclaration(partialBodyParam.type, method.receiver.type.pkg)} \`${partialBodyParam.format.toLowerCase()}:"${partialBodyParam.serializedName}"\`\n`;
-    }
-    indent.pop();
-    text += `${indent.get()}}{\n`;
-    indent.push();
-    // required params are emitted as initializers in the struct literal
-    for (const partialBodyParam of partialBodyParams) {
-      if (go.isRequiredParameter(partialBodyParam.style)) {
-        text += `${indent.get()}${naming.capitalize(partialBodyParam.serializedName)}: ${naming.uncapitalize(partialBodyParam.name)},\n`;
-      }
-    }
-    indent.pop();
-    text += `${indent.get()}}\n`;
-    // now populate any optional params from the options type
-    for (const partialBodyParam of partialBodyParams) {
-      if (!go.isRequiredParameter(partialBodyParam.style)) {
-        text += emitParamGroupCheck(partialBodyParam);
-        text += `${indent.push().get()}body.${naming.capitalize(partialBodyParam.serializedName)} = options.${naming.capitalize(partialBodyParam.name)}\n`;
-        text += `${indent.pop().get()}}\n`;
-      }
-    }
-    // TODO: spread params are JSON only https://github.com/Azure/autorest.go/issues/1455
-    text += `${indent.get()}req.Raw().Header["Content-Type"] = []string{"application/json"}\n`;
-    text += `${indent.get()}if err := runtime.MarshalAsJSON(req, body); err != nil {\n`;
-    text += `${indent.push().get()}return nil, err\n`;
-    text += `${indent.pop().get()}}\n`;
-    text += `${indent.get()}return req, nil\n`;
-  } else if (multipartBodyParams.length > 0) {
-    // emit content type setters for direct MultipartContent params with a fixed content type.
-    // this handles the case where the param itself is a MultipartContent or a slice of them
-    // (i.e. not wrapped in a model struct with toMultipartFormData()).
-    // note that tsp only allows homogeneous content types, which is why it's safe
-    // to unwrap the first param's type and check its contentType field.
-    text += emitMultipartContentTypeSetter(
-      multipartBodyParams[0].name,
-      multipartBodyParams[0].type,
-      indent,
-    );
-    if (
-      multipartBodyParams.length === 1 &&
-      multipartBodyParams[0].type.kind === "model" &&
-      multipartBodyParams[0].type.annotations.multipartFormData
-    ) {
-      // emit content type setters for model fields that have a fixed content type.
-      // toMultipartFormData() converts the model to map[string]any but doesn't set ContentType,
-      // so we must set it on each MultipartContent field before the conversion.
-      for (const field of multipartBodyParams[0].type.fields) {
-        text += emitMultipartContentTypeSetter(
-          `${multipartBodyParams[0].name}.${field.name}`,
-          field.type,
-          indent,
-        );
-      }
-      text += `${indent.get()}formData, err := ${multipartBodyParams[0].name}.toMultipartFormData()\n`;
-      text += `${indent.get()}if err != nil {\n`;
-      text += `${indent.push().get()}return nil, err\n`;
-      text += `${indent.pop().get()}}\n`;
-    } else {
-      text += `${indent.get()}formData := map[string]any{}\n`;
-      for (const param of multipartBodyParams) {
-        const setter = `formData["${param.name}"] = ${helpers.getParamName(param)}`;
-        if (go.isRequiredParameter(param.style)) {
-          text += `${indent.get()}${setter}\n`;
-        } else {
-          text += emitParamGroupCheck(param);
-          text += `${indent.push().get()}${setter}\n`;
-          text += `${indent.pop().get()}}\n`;
-        }
-      }
-    }
-    text += `${indent.get()}if err := runtime.SetMultipartFormData(req, formData); err != nil {\n`;
-    text += `${indent.push().get()}return nil, err\n`;
-    text += `${indent.pop().get()}}\n`;
-    text += `${indent.get()}return req, nil\n`;
-  } else if (formBodyParams.length > 0) {
-    const emitFormData = function (param: go.FormBodyParameter, setter: string): string {
-      let formDataText: string;
-      if (go.isRequiredParameter(param.style)) {
-        formDataText = `${indent.get()}${setter}\n`;
-      } else {
-        formDataText = emitParamGroupCheck(param);
-        formDataText += `${indent.push().get()}${setter}\n`;
-        formDataText += `${indent.pop().get()}}\n`;
-      }
-      return formDataText;
-    };
-    imports.add("net/url");
-    imports.add("strings");
-    imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming");
-    text += `${indent.get()}formData := url.Values{}\n`;
-    // find all the form body params
-    for (const param of formBodyParams) {
-      const setter = `formData.Set("${param.formDataName}", ${helpers.formatParamValue(param, imports, indent)})`;
-      text += emitFormData(param, setter);
-    }
-    text += `${indent.get()}body := streaming.NopCloser(strings.NewReader(formData.Encode()))\n`;
-    text += emitSetBodyWithErrCheck('req.SetBody(body, "application/x-www-form-urlencoded")');
-    text += `${indent.get()}return req, nil\n`;
-  } else {
-    text += `${indent.get()}return req, nil\n`;
-  }
-  text += "}\n\n";
-  return text;
-}
-
-/**
- * returns the var name to use for a param's client-side default value
- *
- * @param param the param for which to name the var
- * @returns the var name
- */
-function getClientSideDefaultVarName(
-  param: go.HeaderCollectionParameter | go.HeaderScalarParameter | go.QueryParameter,
-): string {
-  return naming.uncapitalize(param.name) + "Default";
-}
-
-function emitClientSideDefault(
-  param: go.HeaderCollectionParameter | go.HeaderScalarParameter | go.QueryParameter,
-  csd: go.ClientSideDefault,
-  setterFormat: (name: string, val: string) => string,
-  imports: ImportManager,
-  indent: helpers.Indentation,
-): string {
-  const defaultVar = getClientSideDefaultVarName(param);
-  let text = `${indent.get()}${defaultVar} := ${helpers.formatLiteralValue(csd.defaultValue, true)}\n`;
-  text += `${indent.get()}if options != nil && options.${naming.capitalize(param.name)} != nil {\n`;
-  text += `${indent.push().get()}${defaultVar} = *options.${naming.capitalize(param.name)}\n`;
-  text += `${indent.pop().get()}}\n`;
-
-  let serializedName: string;
-  switch (param.kind) {
-    case "headerCollectionParam":
-    case "headerScalarParam":
-      serializedName = param.headerName;
-      break;
-    case "queryCollectionParam":
-    case "queryScalarParam":
-      serializedName = param.queryParameter;
-      break;
-  }
-
-  const setterFormatText = setterFormat(
-    `"${serializedName}"`,
-    helpers.formatValue(defaultVar, param.type, imports),
-  );
-  text += setterFormatText;
-  // setterFormat can return the empty string in some cases.
-  // if it does, there's no need for an extra new-line char.
-  if (setterFormatText.length > 0) {
-    text += "\n";
-  }
-  return text;
-}
-
-function getMediaFormat(type: go.WireType, mediaType: "JSON" | "XML", param: string): string {
-  let marshaller: "JSON" | "XML" | "ByteArray" = mediaType;
-  let format = "";
-  if (type.kind === "encodedBytes") {
-    marshaller = "ByteArray";
-    format = `, runtime.Base64${type.encoding}Format`;
-  }
-  return `${marshaller}(${param}${format})`;
-}
-
-function isArrayOfDateTimeForMarshalling(
-  paramType: go.WireType,
-): { format: go.TimeFormat; elemByVal: boolean; utc: boolean } | undefined {
-  if (paramType.kind !== "slice") {
-    return undefined;
-  }
-  if (paramType.elementType.kind !== "time") {
-    return undefined;
-  }
-  switch (paramType.elementType.format) {
-    case "PlainDate":
-    case "RFC1123":
-    case "RFC7231":
-    case "PlainTime":
-    case "Unix":
-      return {
-        format: paramType.elementType.format,
-        elemByVal: paramType.elementTypeByValue,
-        utc: paramType.elementType.utc,
-      };
-    case "RFC3339":
-      // RFC3339 normally uses the default time.Time marshaller, but utc slices
-      // must be normalized to UTC, which requires building the wrapper slice.
-      if (paramType.elementType.utc) {
-        return {
-          format: "RFC3339",
-          elemByVal: paramType.elementTypeByValue,
-          utc: true,
-        };
-      }
-      return undefined;
-    default:
-      return undefined;
-  }
-}
-
 // returns true if the method requires a response handler.
 // this is used to unmarshal the response body, parse response headers, or both.
 function needsResponseHandler(method: go.MethodType): boolean {
-  return helpers.hasSchemaResponse(method) || method.returns.headers.length > 0;
-}
-
-function generateResponseUnmarshaller(
-  method: go.MethodType,
-  type: go.WireType,
-  format: go.ResultFormat,
-  unmarshalTarget: string,
-  imports: ImportManager,
-  indent: helpers.Indentation,
-): string {
-  let unmarshallerText = "";
-  const zeroValue = getZeroReturnValue(method, "handler");
-  if (type.kind === "time") {
-    // use the designated time type for unmarshalling
-    imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
-    unmarshallerText += `${indent.get()}var aux *datetime.${type.format}\n`;
-    unmarshallerText += `${indent.get()}if err := runtime.UnmarshalAs${format}(resp, &aux); err != nil {\n`;
-    unmarshallerText += `${indent.push().get()}return ${zeroValue}, err\n`;
-    unmarshallerText += `${indent.pop().get()}}\n`;
-    unmarshallerText += `${indent.get()}result.${helpers.getResultFieldName(method)} = (*time.Time)(aux)\n`;
-    return unmarshallerText;
-  } else if (isArrayOfDateTime(type)) {
-    // unmarshalling arrays of date/time is a little more involved
-    const timeInfo = isArrayOfDateTime(type);
-    let elementPtr = "*";
-    if (timeInfo?.elemByVal) {
-      elementPtr = "";
-    }
-    imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
-    unmarshallerText += `${indent.get()}var aux []${elementPtr}datetime.${timeInfo?.format}\n`;
-    unmarshallerText += `${indent.get()}if err := runtime.UnmarshalAs${format}(resp, &aux); err != nil {\n`;
-    unmarshallerText += `${indent.push().get()}return ${zeroValue}, err\n`;
-    unmarshallerText += `${indent.pop().get()}}\n`;
-    unmarshallerText += `${indent.get()}cp := make([]${elementPtr}time.Time, len(aux))\n`;
-    unmarshallerText += `${indent.get()}for i := 0; i < len(aux); i++ {\n`;
-    unmarshallerText += `${indent.push().get()}cp[i] = (${elementPtr}time.Time)(aux[i])\n`;
-    unmarshallerText += `${indent.pop().get()}}\n`;
-    unmarshallerText += `${indent.get()}result.${helpers.getResultFieldName(method)} = cp\n`;
-    return unmarshallerText;
-  } else if (isMapOfDateTime(type)) {
-    const timeInfo = isMapOfDateTime(type);
-    imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
-    unmarshallerText += `${indent.get()}aux := map[string]*datetime.${timeInfo?.format}{}\n`;
-    unmarshallerText += `${indent.get()}if err := runtime.UnmarshalAs${format}(resp, &aux); err != nil {\n`;
-    unmarshallerText += `${indent.push().get()}return ${zeroValue}, err\n`;
-    unmarshallerText += `${indent.pop().get()}}\n`;
-    unmarshallerText += `${indent.get()}cp := map[string]*time.Time{}\n`;
-    unmarshallerText += `${indent.get()}for k, v := range aux {\n`;
-    unmarshallerText += `${indent.push().get()}cp[k] = (*time.Time)(v)\n`;
-    unmarshallerText += `${indent.pop().get()}}\n`;
-    unmarshallerText += `${indent.get()}result.${helpers.getResultFieldName(method)} = cp\n`;
-    return unmarshallerText;
+  switch (method.returns.result?.kind) {
+    case "anyResult":
+    case "modelResult":
+    case "monomorphicResult":
+    case "polymorphicResult":
+      return true;
+    default:
+      return method.returns.headers.length > 0;
   }
-  if (format === "JSON" || format === "XML") {
-    if (type.kind === "rawJSON") {
-      unmarshallerText += `${indent.get()}body, err := runtime.Payload(resp)\n`;
-      unmarshallerText += `${indent.get()}if err != nil {\n`;
-      unmarshallerText += `${indent.push().get()}return ${zeroValue}, err\n`;
-      unmarshallerText += `${indent.pop().get()}}\n`;
-      unmarshallerText += `${indent.get()}${unmarshalTarget} = body\n`;
-    } else {
-      unmarshallerText += `${indent.get()}if err := runtime.UnmarshalAs${getMediaFormat(type, format, `resp, &${unmarshalTarget}`)}; err != nil {\n`;
-      unmarshallerText += `${indent.push().get()}return ${zeroValue}, err\n`;
-      unmarshallerText += `${indent.pop().get()}}\n`;
-    }
-  } else if (format === "Text") {
-    unmarshallerText += `${indent.get()}body, err := runtime.Payload(resp)\n`;
-    unmarshallerText += `${indent.get()}if err != nil {\n`;
-    unmarshallerText += `${indent.push().get()}return ${zeroValue}, err\n`;
-    unmarshallerText += `${indent.pop().get()}}\n`;
-    let resultVar: string;
-    switch (type.kind) {
-      case "scalar":
-        resultVar = "parsedBody";
-        unmarshallerText += emitScalarParsing(type, "string(body)", resultVar, imports, indent);
-        unmarshallerText += `${indent.get()}${helpers.buildErrCheck(indent, "err", zeroValue)}\n`;
-        break;
-      case "string":
-        resultVar = "txt";
-        unmarshallerText += `${indent.get()}${resultVar} := string(body)\n`;
-        break;
-      default:
-        throw new CodegenError(
-          "UnsupportedTsp",
-          `unsupported text return kind ${type.kind} for method ${method.receiver.type.name}.${method.name}`,
-        );
-    }
-    unmarshallerText += `${indent.get()}${unmarshalTarget} = &${resultVar}\n`;
-  } else {
-    // the remaining formats should have been handled elsewhere
-    throw new CodegenError(
-      "InternalError",
-      `unhandled format ${format} for operation ${method.receiver.type.name}.${method.name}`,
-    );
-  }
-  return unmarshallerText;
-}
-
-function createProtocolResponse(
-  method: go.SyncMethod | go.LROPageableMethod | go.PageableMethod,
-  imports: ImportManager,
-  indent: helpers.Indentation,
-): string {
-  if (!needsResponseHandler(method)) {
-    return "";
-  }
-  const name = method.naming.responseMethod;
-  let text = `${helpers.comment(name, "// ")} handles the ${method.name} response.\n`;
-  text += `func ${getClientReceiverDefinition(method.receiver)} ${name}(resp *http.Response, successCodes ...int) (${generateReturnsInfo(method, "handler").join(", ")}) {\n`;
-
-  const resultVarName = "result";
-  text += `${indent.get()}${resultVarName} := ${method.returns.name}{}\n`;
-  text += `${indent.get()}${helpers.buildIfBlock(indent, {
-    condition: "!runtime.HasStatusCode(resp, successCodes...)",
-    body: (indent) => `${indent.get()}return ${resultVarName}, runtime.NewResponseError(resp)\n`,
-  })}\n`;
-
-  for (const header of method.returns.headers) {
-    text += formatHeaderResponseValue(
-      method,
-      header,
-      resultVarName,
-      `${method.returns.name}{}`,
-      imports,
-      indent,
-    );
-  }
-
-  const result = method.returns.result;
-  if (result) {
-    switch (result.kind) {
-      case "anyResult":
-        imports.add("fmt");
-        text += `${indent.get()}switch resp.StatusCode {\n`;
-        for (const statusCode of method.httpStatusCodes) {
-          text += `${indent.get()}case ${helpers.formatStatusCodes([statusCode])}:\n`;
-          const resultType = result.httpStatusCodeType[statusCode];
-          if (!resultType) {
-            // the operation contains a mix of schemas and non-schema responses
-            continue;
-          }
-          text += `${indent.get()}var val ${go.getTypeDeclaration(resultType, method.receiver.type.pkg)}\n`;
-          text += generateResponseUnmarshaller(
-            method,
-            resultType,
-            result.format,
-            "val",
-            imports,
-            indent,
-          );
-          text += `${indent.get()}${resultVarName}.${result.fieldName} = val\n`;
-        }
-        text += `${indent.get()}default:\n`;
-        text += `${indent.push().get()}return ${resultVarName}, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)\n`;
-        text += `${indent.pop().get()}}\n`;
-        break;
-      case "binaryResult":
-        text += `${indent.get()}${resultVarName}.${result.fieldName} = resp.Body\n`;
-        break;
-      case "headAsBooleanResult":
-        text += `${indent.get()}${resultVarName}.${result.fieldName} = resp.StatusCode >= 200 && resp.StatusCode < 300\n`;
-        break;
-      case "modelResult":
-        text += generateResponseUnmarshaller(
-          method,
-          result.modelType,
-          result.format,
-          `${resultVarName}.${helpers.getResultFieldName(method)}`,
-          imports,
-          indent,
-        );
-        break;
-      case "monomorphicResult":
-        let target = `${resultVarName}.${helpers.getResultFieldName(method)}`;
-        // when unmarshalling a wrapped XML array, unmarshal into the response envelope
-        if (result.format === "XML" && result.monomorphicType.kind === "slice") {
-          target = resultVarName;
-        }
-        text += generateResponseUnmarshaller(
-          method,
-          result.monomorphicType,
-          result.format,
-          target,
-          imports,
-          indent,
-        );
-        break;
-      case "polymorphicResult":
-        text += generateResponseUnmarshaller(
-          method,
-          result.interface,
-          result.format,
-          resultVarName,
-          imports,
-          indent,
-        );
-        break;
-      default:
-        result satisfies never;
-    }
-  }
-
-  text += `${indent.get()}return ${resultVarName}, nil\n`;
-  text += "}\n\n";
-  return text;
-}
-
-function isArrayOfDateTime(
-  paramType: go.WireType,
-): { format: go.TimeFormat; elemByVal: boolean } | undefined {
-  if (paramType.kind !== "slice") {
-    return undefined;
-  }
-  if (paramType.elementType.kind !== "time") {
-    return undefined;
-  }
-  return {
-    format: paramType.elementType.format,
-    elemByVal: paramType.elementTypeByValue,
-  };
-}
-
-function isMapOfDateTime(
-  paramType: go.WireType,
-): { format: go.TimeFormat; utc: boolean } | undefined {
-  if (paramType.kind !== "map") {
-    return undefined;
-  }
-  if (paramType.valueType.kind !== "time") {
-    return undefined;
-  }
-  return { format: paramType.valueType.format, utc: paramType.valueType.utc };
 }
 
 /**
@@ -2103,10 +924,9 @@ function getAPIParametersSig(
 // apiType describes where the return sig is used.
 //   api - for the API definition
 //    op - for the operation
-// handler - for the response handler
 function generateReturnsInfo(
   method: go.MethodType,
-  apiType: "api" | "op" | "handler",
+  apiType: "api" | "op",
 ): Array<string> {
   let returnType = method.returns.name;
   switch (method.kind) {
@@ -2120,28 +940,14 @@ function generateReturnsInfo(
             returnType = `*runtime.Poller[${returnType}]`;
           }
           break;
-        case "handler":
-          // we only have a handler for operations that return a schema
-          if (method.kind !== "lroPageableMethod") {
-            throw new CodegenError(
-              "InternalError",
-              `handler being generated for non-pageable LRO ${method.name} which is unexpected`,
-            );
-          }
-          break;
         case "op":
           returnType = "*http.Response";
           break;
       }
       break;
     case "pageableMethod":
-      switch (apiType) {
-        case "api":
-        case "op":
-          // pager operations don't return an error
-          return [`*runtime.Pager[${returnType}]`];
-      }
-      break;
+      // pager operations don't return an error
+      return [`*runtime.Pager[${returnType}]`];
   }
   return [returnType, "error"];
 }
@@ -2157,15 +963,15 @@ function generateLROBeginMethod(
   imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime");
   let text = "";
   if (method.docs.summary || method.docs.description) {
-    text += helpers.formatDocCommentWithPrefix(fixUpMethodName(method), method.docs);
+    text += helpers.formatDocCommentWithPrefix(helpers.fixUpMethodName(method), method.docs);
     text += genRespErrorDoc(method);
   }
-  const zeroResp = getZeroReturnValue(method, "lro");
+  const zeroResp = getZeroReturnValue(method);
   const methodParams = helpers.getMethodParameters(method);
   for (const param of methodParams) {
     text += helpers.formatCommentAsBulletItem(param.name, param.docs);
   }
-  text += `func ${getClientReceiverDefinition(method.receiver)} ${fixUpMethodName(method)}(${params}) (${returns.join(", ")}) {\n`;
+  text += `func ${helpers.getClientReceiverDefinition(method.receiver)} ${helpers.fixUpMethodName(method)}(${params}) (${returns.join(", ")}) {\n`;
   let pollerType = "nil";
   let pollerTypeParam = `[${method.returns.name}]`;
   if (method.kind === "lroPageableMethod") {
@@ -2274,26 +1080,4 @@ function generateLROBeginMethod(
 
   text += "}\n\n";
   return text;
-}
-
-export function fixUpMethodName(method: go.MethodType): string {
-  switch (method.kind) {
-    case "lroMethod":
-    case "lroPageableMethod":
-      return `Begin${method.name}`;
-    case "pageableMethod": {
-      let N = "N";
-      let name = method.name;
-      if (method.name[0] !== method.name[0].toUpperCase()) {
-        // the method isn't exported; don't export the pager ctor
-        N = "n";
-        // ensure correct casing of the emitted function name e.g.,
-        // "listThings" -> "newListThingsPager"
-        name = name[0].toUpperCase() + name.substring(1);
-      }
-      return `${N}ew${name}Pager`;
-    }
-    case "method":
-      return method.name;
-  }
 }

--- a/packages/typespec-go/src/codegen/core/request-handler.ts
+++ b/packages/typespec-go/src/codegen/core/request-handler.ts
@@ -1,0 +1,820 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as go from "../../codemodel/index.js";
+import * as naming from "../../naming/naming.js";
+import { CodegenError } from "./errors.js";
+import * as helpers from "./helpers.js";
+import { ImportManager } from "./imports.js";
+
+/**
+ * emits the request handler for the specified method.
+ *
+ * @param azureARM indicates whether the request is for an Azure ARM service.
+ * @param method the method for which to create the request handler.
+ * @param imports the import manager to track required imports.
+ * @param indent the indentation helper for formatting the generated code.
+ * @returns the generated request handler code as a string.
+ */
+export function createRequestHandler(
+  azureARM: boolean,
+  method: go.MethodType | go.NextPageMethod,
+  imports: ImportManager,
+  indent: helpers.Indentation,
+): string {
+  let name = method.name;
+  if (method.kind !== "nextPageMethod") {
+    name = method.naming.requestMethod;
+  }
+
+  for (const param of method.parameters) {
+    if (param.location !== "method" || !go.isRequiredParameter(param.style)) {
+      continue;
+    }
+    imports.addForType(param.type);
+  }
+
+  const returns = ["*policy.Request", "error"];
+  let text = `${helpers.comment(name, "// ")} creates the ${method.name} request.\n`;
+  text += `func ${helpers.getClientReceiverDefinition(method.receiver)} ${name}(${helpers.getCreateRequestParametersSig(method)}) (${returns.join(", ")}) {\n`;
+
+  const hostParams = new Array<go.URIParameter>();
+  for (const parameter of method.receiver.type.parameters) {
+    if (parameter.kind === "uriParam") {
+      hostParams.push(parameter);
+    }
+  }
+
+  let hostParam: string;
+  if (azureARM) {
+    hostParam = "client.internal.Endpoint()";
+  } else if (method.receiver.type.instance?.kind === "templatedHost") {
+    imports.add("strings");
+    // we have a templated host
+    text += `${indent.get()}host := "${method.receiver.type.instance.path}"\n`;
+    // get all the host params on the client
+    for (const hostParam of hostParams) {
+      text += `${indent.get()}host = strings.ReplaceAll(host, "{${hostParam.uriPathSegment}}", ${helpers.formatValue(`client.${hostParam.name}`, hostParam.type, imports)})\n`;
+    }
+    // check for any method local host params
+    for (const param of method.parameters) {
+      if (param.location === "method" && param.kind === "uriParam") {
+        text += `${indent.get()}host = strings.ReplaceAll(host, "{${param.uriPathSegment}}", ${helpers.formatValue(helpers.getParamName(param), param.type, imports)})\n`;
+      }
+    }
+    hostParam = "host";
+  } else if (hostParams.length === 1) {
+    // simple parameterized host case
+    hostParam = "client." + hostParams[0].name;
+  } else {
+    throw new CodegenError(
+      "InternalError",
+      `no host or endpoint defined for method ${method.receiver.type.name}.${method.name}`,
+    );
+  }
+
+  const methodParamGroups = helpers.getMethodParamGroups(method);
+  const hasPathParams = methodParamGroups.pathParams.length > 0;
+
+  // storage needs the client.u to be the source-of-truth for the full path.
+  // however, swagger requires that all operations specify a path, which is at odds with storage.
+  // to work around this, storage specifies x-ms-path paths with path params but doesn't
+  // actually reference the path params (i.e. no params with which to replace the tokens).
+  // so, if a path contains tokens but there are no path params, skip emitting the path.
+  const pathStr = method.httpPath;
+  const pathContainsParms = pathStr.includes("{");
+  if (hasPathParams || (!pathContainsParms && pathStr.length > 1)) {
+    // there are path params, or the path doesn't contain tokens and is not "/" so emit it
+    text += `${indent.get()}urlPath := "${method.httpPath}"\n`;
+    hostParam = `runtime.JoinPaths(${hostParam}, urlPath)`;
+  }
+
+  // helper to build nil checks for param groups
+  const emitParamGroupCheck = function (param: go.MethodParameter): string {
+    if (!param.group) {
+      throw new CodegenError(
+        "InternalError",
+        `emitParamGroupCheck called for ungrouped parameter ${param.name}`,
+      );
+    }
+    let client = "";
+    if (param.location === "client") {
+      client = "client.";
+    }
+    const paramGroupName = naming.uncapitalize(param.group.name);
+    let optionalParamGroupCheck = `${client}${paramGroupName} != nil && `;
+    if (param.group.required) {
+      optionalParamGroupCheck = "";
+    }
+    return `${indent.get()}if ${optionalParamGroupCheck}${client}${paramGroupName}.${naming.capitalize(param.name)} != nil {\n`;
+  };
+
+  if (hasPathParams) {
+    // swagger defines path params, emit path and replace tokens
+    imports.add("strings");
+    // replace path parameters
+    for (const pp of methodParamGroups.pathParams) {
+      let paramValue: string;
+      let optionalPathSep = false;
+      if (pp.style === "literal") {
+        // literals are always scalar types and require no empty checks
+        paramValue = helpers.formatParamValue(pp, imports, indent);
+      } else if (pp.style === "required" || pp.location === "client") {
+        // NOTE: we include client params here since they behave
+        // like required params (i.e. not grouped).
+
+        // emit check to ensure path param isn't an empty string
+        if (pp.kind === "pathScalarParam") {
+          const choiceIsString = function (type: go.PathScalarParameterType): boolean {
+            return type.kind === "constant" && type.type === "string";
+          };
+          // we only need to do this for params that have an underlying type of string
+          if ((pp.type.kind === "string" || choiceIsString(pp.type)) && !pp.omitEmptyStringCheck) {
+            const paramName = helpers.getParamName(pp);
+            imports.add("errors");
+            text += `${indent.get()}if ${paramName} == "" {\n`;
+            text += `${indent.push().get()}return nil, errors.New("parameter ${paramName} cannot be empty")\n`;
+            text += `${indent.pop().get()}}\n`;
+          }
+        }
+
+        paramValue = helpers.formatParamValue(pp, imports, indent);
+
+        // for collection-based path params, we emit the empty check
+        // after calling helpers.formatParamValue as that will have the
+        // var name that contains the slice.
+        if (pp.kind === "pathCollectionParam") {
+          const paramName = helpers.getParamName(pp);
+          const joinedParamName = `${paramName}Param`;
+          text += `${indent.get()}${joinedParamName} := ${paramValue}\n`;
+          imports.add("errors");
+          text += `${indent.get()}if len(${joinedParamName}) == 0 {\n`;
+          text += `${indent.push().get()}return nil, errors.New("parameter ${paramName} cannot be empty")\n`;
+          text += `${indent.pop().get()}}\n`;
+          paramValue = joinedParamName;
+        }
+      } else if (go.isClientSideDefault(pp.style)) {
+        const defaultValue = naming.uncapitalize(pp.name) + "Default";
+        text += `${indent.get()}${defaultValue} := ${helpers.formatLiteralValue(pp.style.defaultValue, true)}\n`;
+        text += emitParamGroupCheck(pp);
+        text += `${indent.push().get()}${defaultValue} = ${helpers.getParamName(pp)}\n`;
+        text += `${indent.pop().get()}}\n`;
+        paramValue = helpers.formatValue(defaultValue, pp.type, imports);
+      } else {
+        // param isn't required, so emit a local var with
+        // the correct default value, then populate it with
+        // the optional value when set.
+        paramValue = `optional${naming.capitalize(pp.name)}`;
+        text += `${indent.get()}${paramValue} := ""\n`;
+        text += emitParamGroupCheck(pp);
+        text += `${indent.push().get()}${paramValue} = ${helpers.formatParamValue(pp, imports, indent)}\n`;
+        text += `${indent.pop().get()}}\n`;
+
+        // there are two cases for optional path params.
+        //  - /foo/bar/{optional}
+        //  - /foo/bar{/optional}
+        // for the second case, we need to include a forward slash
+        if (method.httpPath[method.httpPath.indexOf(`{${pp.pathSegment}}`) - 1] !== "/") {
+          optionalPathSep = true;
+        }
+      }
+
+      const emitPathEscape = function (): string {
+        if (pp.isEncoded) {
+          imports.add("net/url");
+          return `url.PathEscape(${paramValue})`;
+        }
+        return paramValue;
+      };
+
+      if (optionalPathSep) {
+        text += `${indent.get()}if len(${paramValue}) > 0 {\n`;
+        text += `${indent.push().get()}${paramValue} = "/"+${emitPathEscape()}\n`;
+        text += `${indent.pop().get()}}\n`;
+      } else {
+        paramValue = emitPathEscape();
+      }
+
+      text += `${indent.get()}urlPath = strings.ReplaceAll(urlPath, "{${pp.pathSegment}}", ${paramValue})\n`;
+    }
+  }
+
+  text += `${indent.get()}req, err := runtime.NewRequest(ctx, http.Method${naming.capitalize(method.httpMethod)}, ${hostParam})\n`;
+  text += `${indent.get()}if err != nil {\n`;
+  text += `${indent.push().get()}return nil, err\n`;
+  text += `${indent.pop().get()}}\n`;
+
+  // add query parameters
+  const encodedParams = methodParamGroups.encodedQueryParams;
+  const unencodedParams = methodParamGroups.unencodedQueryParams;
+
+  const emitQueryParam = function (qp: go.QueryParameter, setter: string): string {
+    let qpText: string;
+    if (qp.location === "method" && go.isClientSideDefault(qp.style)) {
+      qpText = emitClientSideDefault(
+        qp,
+        qp.style,
+        (name, val) => {
+          return `${indent.get()}reqQP.Set(${name}, ${val})`;
+        },
+        imports,
+        indent,
+      );
+    } else if (
+      go.isRequiredParameter(qp.style) ||
+      go.isLiteralParameter(qp.style) ||
+      (qp.location === "client" && go.isClientSideDefault(qp.style))
+    ) {
+      qpText = `${indent.get()}${setter}\n`;
+    } else if (qp.location === "client" && !qp.group) {
+      // global optional param
+      qpText = `${indent.get()}if client.${qp.name} != nil {\n`;
+      qpText += `${indent.push().get()}${setter}\n`;
+      qpText += `${indent.pop().get()}}\n`;
+    } else {
+      qpText = emitParamGroupCheck(qp);
+      qpText += `${indent.push().get()}${setter}\n`;
+      qpText += `${indent.pop().get()}}\n`;
+    }
+    return qpText;
+  };
+
+  // emit encoded params first
+  if (encodedParams.length > 0) {
+    text += `${indent.get()}reqQP := req.Raw().URL.Query()\n`;
+    for (const qp of encodedParams.sort((a: go.QueryParameter, b: go.QueryParameter) => {
+      return helpers.sortAscending(a.queryParameter, b.queryParameter);
+    })) {
+      let setter: string;
+      if (qp.kind === "queryCollectionParam" && qp.collectionFormat === "multi") {
+        setter = `for _, qv := range ${helpers.getParamName(qp)} {\n`;
+
+        // emit a type conversion for the qv based on the array's element type
+        let queryVal: string;
+        const arrayQP = qp.type;
+        switch (arrayQP.elementType.kind) {
+          case "constant":
+            switch (arrayQP.elementType.type) {
+              case "string":
+                queryVal = "string(qv)";
+                break;
+              default:
+                imports.add("fmt");
+                queryVal = 'fmt.Sprintf("%d", qv)';
+            }
+            break;
+          case "string":
+            queryVal = "qv";
+            break;
+          default:
+            imports.add("fmt");
+            queryVal = 'fmt.Sprintf("%v", qv)';
+        }
+
+        setter += `${indent.push().get()}reqQP.Add("${qp.queryParameter}", ${queryVal})\n`;
+        setter += `${indent.pop().get()}}`;
+      } else {
+        // cannot initialize setter to this value as helpers.formatParamValue() can change imports
+        setter = `reqQP.Set("${qp.queryParameter}", ${helpers.formatParamValue(qp, imports, indent)})`;
+      }
+      text += emitQueryParam(qp, setter);
+    }
+
+    // reqQP.Encode() encodes space chars as '+' which is application/x-www-form-urlencoded
+    // thus not applicable for URIs. the correct URI encoding for SP is %20. note that literal '+'
+    // characters are encoded by reqQP.Encode() as %2B so there's no risk of replacing them.
+    // see https://www.rfc-editor.org/rfc/rfc3986 sections 2.1, 2.2, and 3.4
+    imports.add("strings");
+    text += `${indent.get()}req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")\n`;
+  }
+
+  // tack on any unencoded params to the end
+  if (unencodedParams.length > 0) {
+    if (encodedParams.length > 0) {
+      text += `${indent.get()}unencodedParams := []string{req.Raw().URL.RawQuery}\n`;
+    } else {
+      text += `${indent.get()}unencodedParams := []string{}\n`;
+    }
+    for (const qp of unencodedParams.sort((a: go.QueryParameter, b: go.QueryParameter) => {
+      return helpers.sortAscending(a.queryParameter, b.queryParameter);
+    })) {
+      let setter: string;
+      if (qp.kind === "queryCollectionParam" && qp.collectionFormat === "multi") {
+        setter = `for _, qv := range ${helpers.getParamName(qp)} {\n`;
+        setter += `${indent.push().get()}unencodedParams = append(unencodedParams, "${qp.queryParameter}="+qv)\n`;
+        setter += `${indent.pop().get()}}`;
+      } else {
+        setter = `unencodedParams = append(unencodedParams, "${qp.queryParameter}="+${helpers.formatParamValue(qp, imports, indent)})`;
+      }
+      text += emitQueryParam(qp, setter);
+    }
+    imports.add("strings");
+    text += `${indent.get()}req.Raw().URL.RawQuery = strings.Join(unencodedParams, "&")\n`;
+  }
+
+  if (method.kind !== "nextPageMethod" && method.returns.result?.kind === "binaryResult") {
+    // skip auto-body downloading for binary stream responses
+    text += `${indent.get()}runtime.SkipBodyDownload(req)\n`;
+  }
+
+  // add specific request headers
+  const emitHeaderSet = function (headerParam: go.HeaderParameter): string {
+    if (headerParam.kind === "headerMapParam") {
+      let headerText = `${indent.get()}for k, v := range ${helpers.getParamName(headerParam)} {\n`;
+      headerText += `${indent.push().get()}if v != nil {\n`;
+      headerText += `${indent.push().get()}req.Raw().Header["${headerParam.headerName}"+k] = []string{*v}\n`;
+      headerText += `${indent.pop().get()}}\n`;
+      headerText += `${indent.pop().get()}}\n`;
+      return headerText;
+    } else if (headerParam.location === "method" && go.isClientSideDefault(headerParam.style)) {
+      return emitClientSideDefault(
+        headerParam,
+        headerParam.style,
+        (name, val) => {
+          return `${indent.get()}req.Raw().Header[${name}] = []string{${val}}`;
+        },
+        imports,
+        indent,
+      );
+    } else {
+      return `${indent.get()}req.Raw().Header["${headerParam.headerName}"] = []string{${helpers.formatParamValue(headerParam, imports, indent)}}\n`;
+    }
+  };
+
+  let contentType: string | undefined;
+  for (const param of methodParamGroups.headerParams.sort(
+    (a: go.HeaderParameter, b: go.HeaderParameter) => {
+      return helpers.sortAscending(a.headerName, b.headerName);
+    },
+  )) {
+    if (param.headerName.match(/^content-type$/i)) {
+      // canonicalize content-type as req.SetBody checks for it via its canonicalized name :(
+      param.headerName = "Content-Type";
+
+      // there's a corner case where we have a content-type param with no body
+      // param. for this case we still need to set the header inline.
+      const bodyParam = methodParamGroups.bodyParam;
+      if (bodyParam?.bodyFormat === "binary" || bodyParam?.bodyFormat === "Text") {
+        // if the content-type is from a param, then the param will be passed
+        // explicitly to runtime.SetBody() so don't emit code to set it inline.
+        // NOTE: only binary/text payloads call runtime.SetBody().
+        if (go.isClientSideDefault(param.style)) {
+          text += emitClientSideDefault(
+            param as go.HeaderScalarParameter,
+            param.style,
+            () => "",
+            imports,
+            indent,
+          );
+          continue;
+        } else if (param.style === "required") {
+          continue;
+        }
+      }
+    }
+
+    if (param.headerName === "Content-Type" && param.style === "literal") {
+      // the content-type header will be set as part of emitSetBodyWithErrCheck
+      // to handle cases where the body param is optional. we don't want to set
+      // the content-type if the body is nil.
+      // we do it like this as tsp specifies content-type while swagger does not.
+      contentType = helpers.formatParamValue(param, imports, indent);
+    } else if (
+      go.isRequiredParameter(param.style) ||
+      go.isLiteralParameter(param.style) ||
+      go.isClientSideDefault(param.style)
+    ) {
+      text += emitHeaderSet(param);
+    } else if (param.location === "client" && !param.group) {
+      // global optional param
+      text += `${indent.get()}if client.${param.name} != nil {\n`;
+      indent.push();
+      text += emitHeaderSet(param);
+      indent.pop();
+      text += `${indent.get()}}\n`;
+    } else {
+      text += emitParamGroupCheck(param);
+      indent.push();
+      text += emitHeaderSet(param);
+      indent.pop();
+      text += `${indent.get()}}\n`;
+    }
+  }
+
+  // note that these are mutually exclusive
+  const bodyParam = methodParamGroups.bodyParam;
+  const formBodyParams = methodParamGroups.formBodyParams;
+  const multipartBodyParams = methodParamGroups.multipartBodyParams;
+  const partialBodyParams = methodParamGroups.partialBodyParams;
+
+  const emitSetBodyWithErrCheck = function (setBodyParam: string, contentType?: string): string {
+    let content = "";
+    if (contentType) {
+      content += `${indent.get()}req.Raw().Header["Content-Type"] = []string{${contentType}}\n`;
+    }
+    content += `${indent.get()}if err := ${setBodyParam}; err != nil {\n`;
+    content += `${indent.push().get()}return nil, err\n`;
+    content += `${indent.pop().get()}}\n`;
+    return content;
+  };
+
+  if (bodyParam) {
+    /** returns the source value for the content type */
+    const getContentTypeValue = function (src: go.BodyParameterContentTypeKind): string {
+      switch (src.kind) {
+        case "literal":
+          return helpers.formatLiteralValue(src, false);
+        case "parameterRef": {
+          // find the param
+          for (const param of method.parameters) {
+            if (param.kind === "headerScalarParam" && param.name === src.name) {
+              if (go.isClientSideDefault(param.style)) {
+                return getClientSideDefaultVarName(param);
+              }
+              let paramName = helpers.getParamName(param);
+              if (param.type.kind === "constant") {
+                paramName = `string(${paramName})`;
+              }
+              return paramName;
+            }
+          }
+          throw new CodegenError("InternalError", `didn't find parameter reference ${src.name}`);
+        }
+      }
+    };
+
+    if (bodyParam.bodyFormat === "JSON" || bodyParam.bodyFormat === "XML") {
+      // default to the body param name
+      let body = helpers.getParamName(bodyParam);
+      if (bodyParam.type.kind === "literal") {
+        // if the value is constant, embed it directly
+        body = helpers.formatLiteralValue(bodyParam.type, true);
+      } else if (bodyParam.bodyFormat === "XML" && bodyParam.type.kind === "slice") {
+        // for XML payloads, create a wrapper type if the payload is an array
+        imports.add("encoding/xml");
+        text += `${indent.get()}type wrapper struct {\n`;
+        indent.push();
+        let tagName: string;
+        if (bodyParam.xml?.wrapper) {
+          tagName = bodyParam.xml.wrapper;
+        } else {
+          tagName = go.getTypeDeclaration(bodyParam.type, method.receiver.type.pkg);
+        }
+        text += `${indent.get()}XMLName xml.Name \`xml:"${tagName}"\`\n`;
+        const fieldName = naming.capitalize(bodyParam.name);
+        let tag = go.getTypeDeclaration(bodyParam.type.elementType, method.receiver.type.pkg);
+        if (bodyParam.type.elementType.kind === "model" && bodyParam.type.elementType.xml?.name) {
+          tag = bodyParam.type.elementType.xml.name;
+        }
+        text += `${indent.get()}${fieldName} *${go.getTypeDeclaration(bodyParam.type, method.receiver.type.pkg)} \`xml:"${tag}"\`\n`;
+        text += `${indent.pop().get()}}\n`;
+        let addr = "&";
+        if (!go.isRequiredParameter(bodyParam.style) && !bodyParam.byValue) {
+          addr = "";
+        }
+        body = `wrapper{${fieldName}: ${addr}${body}}`;
+      } else if (bodyParam.type.kind === "time") {
+        // utc datetimes are normalized to UTC before serialization. non-RFC3339
+        // formats are wrapped in the internal time type; RFC3339 relies on the
+        // default time.Time JSON marshaler so it only needs the UTC conversion.
+        const bodyVal = bodyParam.type.utc ? `${body}.UTC()` : body;
+        if (bodyParam.type.format !== "RFC3339") {
+          imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
+          body = `datetime.${bodyParam.type.format}(${bodyVal})`;
+        } else {
+          body = bodyVal;
+        }
+      } else if (isArrayOfDateTimeForMarshalling(bodyParam.type)) {
+        const timeInfo = isArrayOfDateTimeForMarshalling(bodyParam.type);
+        let elementPtr = "*";
+        if (timeInfo?.elemByVal) {
+          elementPtr = "";
+        }
+        imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
+        text += `${indent.get()}aux := make([]${elementPtr}datetime.${timeInfo?.format}, len(${body}))\n`;
+        text += `${indent.get()}for i := 0; i < len(${body}); i++ {\n`;
+        if (timeInfo?.utc && elementPtr === "*") {
+          text += `${indent.push().get()}if ${body}[i] != nil {\n`;
+          text += `${indent.push().get()}utcTime := ${body}[i].UTC()\n`;
+          text += `${indent.get()}aux[i] = (*datetime.${timeInfo?.format})(&utcTime)\n`;
+          text += `${indent.pop().get()}}\n`;
+          indent.pop();
+        } else {
+          const utcCall = timeInfo?.utc ? ".UTC()" : "";
+          text += `${indent.push().get()}aux[i] = (${elementPtr}datetime.${timeInfo?.format})(${body}[i]${utcCall})\n`;
+          indent.pop();
+        }
+        text += `${indent.get()}}\n`;
+        body = "aux";
+      } else if (helpers.isMapOfDateTime(bodyParam.type)) {
+        const timeInfo = helpers.isMapOfDateTime(bodyParam.type);
+        imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
+        text += `${indent.get()}aux := map[string]*datetime.${timeInfo?.format}{}\n`;
+        text += `${indent.get()}for k, v := range ${body} {\n`;
+        if (timeInfo?.utc) {
+          text += `${indent.push().get()}if v != nil {\n`;
+          text += `${indent.push().get()}utcTime := v.UTC()\n`;
+          text += `${indent.get()}aux[k] = (*datetime.${timeInfo?.format})(&utcTime)\n`;
+          text += `${indent.pop().get()}} else {\n`;
+          text += `${indent.push().get()}aux[k] = nil\n`;
+          text += `${indent.pop().get()}}\n`;
+          indent.pop();
+        } else {
+          text += `${indent.push().get()}aux[k] = (*datetime.${timeInfo?.format})(v)\n`;
+          indent.pop();
+        }
+        text += `${indent.get()}}\n`;
+        body = "aux";
+      }
+      let setBody = `runtime.MarshalAs${helpers.getMediaFormat(bodyParam.type, bodyParam.bodyFormat, `req, ${body}`)}`;
+      if (bodyParam.type.kind === "rawJSON") {
+        imports.add("bytes");
+        imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming");
+        setBody = `req.SetBody(streaming.NopCloser(bytes.NewReader(${body})), "application/${bodyParam.bodyFormat.toLowerCase()}")`;
+      }
+      if (go.isRequiredParameter(bodyParam.style) || go.isLiteralParameter(bodyParam.style)) {
+        text += emitSetBodyWithErrCheck(setBody, contentType);
+        text += `${indent.get()}return req, nil\n`;
+      } else {
+        text += emitParamGroupCheck(bodyParam);
+        indent.push();
+        text += emitSetBodyWithErrCheck(setBody, contentType);
+        text += `${indent.get()}return req, nil\n`;
+        indent.pop();
+        text += `${indent.get()}}\n`;
+        text += `${indent.get()}return req, nil\n`;
+      }
+    } else if (bodyParam.bodyFormat === "binary") {
+      if (go.isRequiredParameter(bodyParam.style)) {
+        text += emitSetBodyWithErrCheck(
+          `req.SetBody(${bodyParam.name}, ${getContentTypeValue(bodyParam.contentType)})`,
+          contentType,
+        );
+        text += `${indent.get()}return req, nil\n`;
+      } else {
+        text += emitParamGroupCheck(bodyParam);
+        indent.push();
+        text += emitSetBodyWithErrCheck(
+          `req.SetBody(${helpers.getParamName(bodyParam)}, ${getContentTypeValue(bodyParam.contentType)})`,
+          contentType,
+        );
+        text += `${indent.get()}return req, nil\n`;
+        indent.pop();
+        text += `${indent.get()}}\n`;
+        text += `${indent.get()}return req, nil\n`;
+      }
+    } else if (bodyParam.bodyFormat === "Text") {
+      imports.add("strings");
+      imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming");
+      if (go.isRequiredParameter(bodyParam.style)) {
+        text += `${indent.get()}body := streaming.NopCloser(strings.NewReader(${bodyParam.name}))\n`;
+        text += emitSetBodyWithErrCheck(
+          `req.SetBody(body, ${getContentTypeValue(bodyParam.contentType)})`,
+          contentType,
+        );
+        text += `${indent.get()}return req, nil\n`;
+      } else {
+        text += emitParamGroupCheck(bodyParam);
+        indent.push();
+        text += `${indent.get()}body := streaming.NopCloser(strings.NewReader(${helpers.getParamName(bodyParam)}))\n`;
+        text += emitSetBodyWithErrCheck(
+          `req.SetBody(body, ${getContentTypeValue(bodyParam.contentType)})`,
+          contentType,
+        );
+        text += `${indent.get()}return req, nil\n`;
+        indent.pop();
+        text += `${indent.get()}}\n`;
+        text += `${indent.get()}return req, nil\n`;
+      }
+    }
+  } else if (partialBodyParams.length > 0) {
+    // partial body params are discrete params that are all fields within an internal struct.
+    // define and instantiate an instance of the wire type, using the values from each param.
+    text += `${indent.get()}body := struct {\n`;
+    indent.push();
+    for (const partialBodyParam of partialBodyParams) {
+      text += `${indent.get()}${naming.capitalize(partialBodyParam.serializedName)} ${helpers.star(partialBodyParam.byValue)}${go.getTypeDeclaration(partialBodyParam.type, method.receiver.type.pkg)} \`${partialBodyParam.format.toLowerCase()}:"${partialBodyParam.serializedName}"\`\n`;
+    }
+    indent.pop();
+    text += `${indent.get()}}{\n`;
+    indent.push();
+    // required params are emitted as initializers in the struct literal
+    for (const partialBodyParam of partialBodyParams) {
+      if (go.isRequiredParameter(partialBodyParam.style)) {
+        text += `${indent.get()}${naming.capitalize(partialBodyParam.serializedName)}: ${naming.uncapitalize(partialBodyParam.name)},\n`;
+      }
+    }
+    indent.pop();
+    text += `${indent.get()}}\n`;
+    // now populate any optional params from the options type
+    for (const partialBodyParam of partialBodyParams) {
+      if (!go.isRequiredParameter(partialBodyParam.style)) {
+        text += emitParamGroupCheck(partialBodyParam);
+        text += `${indent.push().get()}body.${naming.capitalize(partialBodyParam.serializedName)} = options.${naming.capitalize(partialBodyParam.name)}\n`;
+        text += `${indent.pop().get()}}\n`;
+      }
+    }
+    // TODO: spread params are JSON only https://github.com/Azure/autorest.go/issues/1455
+    text += `${indent.get()}req.Raw().Header["Content-Type"] = []string{"application/json"}\n`;
+    text += `${indent.get()}if err := runtime.MarshalAsJSON(req, body); err != nil {\n`;
+    text += `${indent.push().get()}return nil, err\n`;
+    text += `${indent.pop().get()}}\n`;
+    text += `${indent.get()}return req, nil\n`;
+  } else if (multipartBodyParams.length > 0) {
+    // emit content type setters for direct MultipartContent params with a fixed content type.
+    // this handles the case where the param itself is a MultipartContent or a slice of them
+    // (i.e. not wrapped in a model struct with toMultipartFormData()).
+    // note that tsp only allows homogeneous content types, which is why it's safe
+    // to unwrap the first param's type and check its contentType field.
+    text += emitMultipartContentTypeSetter(
+      multipartBodyParams[0].name,
+      multipartBodyParams[0].type,
+      indent,
+    );
+    if (
+      multipartBodyParams.length === 1 &&
+      multipartBodyParams[0].type.kind === "model" &&
+      multipartBodyParams[0].type.annotations.multipartFormData
+    ) {
+      // emit content type setters for model fields that have a fixed content type.
+      // toMultipartFormData() converts the model to map[string]any but doesn't set ContentType,
+      // so we must set it on each MultipartContent field before the conversion.
+      for (const field of multipartBodyParams[0].type.fields) {
+        text += emitMultipartContentTypeSetter(
+          `${multipartBodyParams[0].name}.${field.name}`,
+          field.type,
+          indent,
+        );
+      }
+      text += `${indent.get()}formData, err := ${multipartBodyParams[0].name}.toMultipartFormData()\n`;
+      text += `${indent.get()}if err != nil {\n`;
+      text += `${indent.push().get()}return nil, err\n`;
+      text += `${indent.pop().get()}}\n`;
+    } else {
+      text += `${indent.get()}formData := map[string]any{}\n`;
+      for (const param of multipartBodyParams) {
+        const setter = `formData["${param.name}"] = ${helpers.getParamName(param)}`;
+        if (go.isRequiredParameter(param.style)) {
+          text += `${indent.get()}${setter}\n`;
+        } else {
+          text += emitParamGroupCheck(param);
+          text += `${indent.push().get()}${setter}\n`;
+          text += `${indent.pop().get()}}\n`;
+        }
+      }
+    }
+    text += `${indent.get()}if err := runtime.SetMultipartFormData(req, formData); err != nil {\n`;
+    text += `${indent.push().get()}return nil, err\n`;
+    text += `${indent.pop().get()}}\n`;
+    text += `${indent.get()}return req, nil\n`;
+  } else if (formBodyParams.length > 0) {
+    const emitFormData = function (param: go.FormBodyParameter, setter: string): string {
+      let formDataText: string;
+      if (go.isRequiredParameter(param.style)) {
+        formDataText = `${indent.get()}${setter}\n`;
+      } else {
+        formDataText = emitParamGroupCheck(param);
+        formDataText += `${indent.push().get()}${setter}\n`;
+        formDataText += `${indent.pop().get()}}\n`;
+      }
+      return formDataText;
+    };
+    imports.add("net/url");
+    imports.add("strings");
+    imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/streaming");
+    text += `${indent.get()}formData := url.Values{}\n`;
+    // find all the form body params
+    for (const param of formBodyParams) {
+      const setter = `formData.Set("${param.formDataName}", ${helpers.formatParamValue(param, imports, indent)})`;
+      text += emitFormData(param, setter);
+    }
+    text += `${indent.get()}body := streaming.NopCloser(strings.NewReader(formData.Encode()))\n`;
+    text += emitSetBodyWithErrCheck('req.SetBody(body, "application/x-www-form-urlencoded")');
+    text += `${indent.get()}return req, nil\n`;
+  } else {
+    text += `${indent.get()}return req, nil\n`;
+  }
+  text += "}\n\n";
+  return text;
+}
+
+function emitClientSideDefault(
+  param: go.HeaderCollectionParameter | go.HeaderScalarParameter | go.QueryParameter,
+  csd: go.ClientSideDefault,
+  setterFormat: (name: string, val: string) => string,
+  imports: ImportManager,
+  indent: helpers.Indentation,
+): string {
+  const defaultVar = getClientSideDefaultVarName(param);
+  let text = `${indent.get()}${defaultVar} := ${helpers.formatLiteralValue(csd.defaultValue, true)}\n`;
+  text += `${indent.get()}if options != nil && options.${naming.capitalize(param.name)} != nil {\n`;
+  text += `${indent.push().get()}${defaultVar} = *options.${naming.capitalize(param.name)}\n`;
+  text += `${indent.pop().get()}}\n`;
+
+  let serializedName: string;
+  switch (param.kind) {
+    case "headerCollectionParam":
+    case "headerScalarParam":
+      serializedName = param.headerName;
+      break;
+    case "queryCollectionParam":
+    case "queryScalarParam":
+      serializedName = param.queryParameter;
+      break;
+  }
+
+  const setterFormatText = setterFormat(
+    `"${serializedName}"`,
+    helpers.formatValue(defaultVar, param.type, imports),
+  );
+  text += setterFormatText;
+  // setterFormat can return the empty string in some cases.
+  // if it does, there's no need for an extra new-line char.
+  if (setterFormatText.length > 0) {
+    text += "\n";
+  }
+  return text;
+}
+
+/**
+ * emits Go code to set ContentType on a MultipartContent variable if it has a fixed content type.
+ * handles both direct MultipartContent and slices of MultipartContent.
+ * returns the empty string if there's nothing to set.
+ *
+ * @param paramName the name of the multipart param
+ * @param wireType the underlying type of the multipart param
+ * @param indent the indentation helper currently in scope
+ * @returns setter code or the empty string
+ */
+function emitMultipartContentTypeSetter(
+  paramName: string,
+  wireType: go.WireType,
+  indent: helpers.Indentation,
+): string {
+  let text = "";
+  const unwrapped = helpers.recursiveUnwrapMapSlice(wireType);
+  if (unwrapped.kind !== "multipartContent" || !unwrapped.contentType) {
+    return text;
+  }
+  switch (wireType.kind) {
+    case "multipartContent":
+      text += `${indent.get()}${paramName}.ContentType = ${unwrapped.contentType.literal}\n`;
+      break;
+    case "slice":
+      text += `${indent.get()}for i := range ${paramName} {\n`;
+      text += `${indent.push().get()}${paramName}[i].ContentType = ${unwrapped.contentType.literal}\n`;
+      text += `${indent.pop().get()}}\n`;
+      break;
+  }
+  return text;
+}
+
+/**
+ * returns the var name to use for a param's client-side default value
+ *
+ * @param param the param for which to name the var
+ * @returns the var name
+ */
+function getClientSideDefaultVarName(
+  param: go.HeaderCollectionParameter | go.HeaderScalarParameter | go.QueryParameter,
+): string {
+  return naming.uncapitalize(param.name) + "Default";
+}
+
+function isArrayOfDateTimeForMarshalling(
+  paramType: go.WireType,
+): { format: go.TimeFormat; elemByVal: boolean; utc: boolean } | undefined {
+  if (paramType.kind !== "slice") {
+    return undefined;
+  }
+  if (paramType.elementType.kind !== "time") {
+    return undefined;
+  }
+  switch (paramType.elementType.format) {
+    case "PlainDate":
+    case "RFC1123":
+    case "RFC7231":
+    case "PlainTime":
+    case "Unix":
+      return {
+        format: paramType.elementType.format,
+        elemByVal: paramType.elementTypeByValue,
+        utc: paramType.elementType.utc,
+      };
+    case "RFC3339":
+      // RFC3339 normally uses the default time.Time marshaller, but utc slices
+      // must be normalized to UTC, which requires building the wrapper slice.
+      if (paramType.elementType.utc) {
+        return {
+          format: "RFC3339",
+          elemByVal: paramType.elementTypeByValue,
+          utc: true,
+        };
+      }
+      return undefined;
+    default:
+      return undefined;
+  }
+}

--- a/packages/typespec-go/src/codegen/core/response-handler.ts
+++ b/packages/typespec-go/src/codegen/core/response-handler.ts
@@ -1,0 +1,365 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as go from "../../codemodel/index.js";
+import * as naming from "../../naming/naming.js";
+import { CodegenError } from "./errors.js";
+import * as helpers from "./helpers.js";
+import { ImportManager } from "./imports.js";
+
+/**
+ * emits the response handler for the specified method.
+ * @param method the method for which to create the response handler.
+ * @param imports the import manager to track required imports.
+ * @param indent the indentation helper for formatting the generated code.
+ * @returns the generated response handler code as a string.
+ */
+export function createResponseHandler(
+  method: go.SyncMethod | go.LROPageableMethod | go.PageableMethod,
+  imports: ImportManager,
+  indent: helpers.Indentation,
+): string {
+  const name = method.naming.responseMethod;
+  let text = `${helpers.comment(name, "// ")} handles the ${method.name} response.\n`;
+  text += `func ${helpers.getClientReceiverDefinition(method.receiver)} ${name}(resp *http.Response, successCodes ...int) (${method.returns.name}, error) {\n`;
+
+  const resultVarName = "result";
+  text += `${indent.get()}${resultVarName} := ${method.returns.name}{}\n`;
+  text += `${indent.get()}${helpers.buildIfBlock(indent, {
+    condition: "!runtime.HasStatusCode(resp, successCodes...)",
+    body: (indent) => `${indent.get()}return ${resultVarName}, runtime.NewResponseError(resp)\n`,
+  })}\n`;
+
+  for (const header of method.returns.headers) {
+    text += formatHeaderResponseValue(
+      method,
+      header,
+      resultVarName,
+      `${method.returns.name}{}`,
+      imports,
+      indent,
+    );
+  }
+
+  const result = method.returns.result;
+  if (result) {
+    switch (result.kind) {
+      case "anyResult":
+        imports.add("fmt");
+        text += `${indent.get()}switch resp.StatusCode {\n`;
+        for (const statusCode of method.httpStatusCodes) {
+          text += `${indent.get()}case ${helpers.formatStatusCodes([statusCode])}:\n`;
+          const resultType = result.httpStatusCodeType[statusCode];
+          if (!resultType) {
+            // the operation contains a mix of schemas and non-schema responses
+            continue;
+          }
+          text += `${indent.get()}var val ${go.getTypeDeclaration(resultType, method.receiver.type.pkg)}\n`;
+          text += generateResponseUnmarshaller(
+            method,
+            resultType,
+            result.format,
+            "val",
+            imports,
+            indent,
+          );
+          text += `${indent.get()}${resultVarName}.${result.fieldName} = val\n`;
+        }
+        text += `${indent.get()}default:\n`;
+        text += `${indent.push().get()}return ${resultVarName}, fmt.Errorf("unhandled HTTP status code %d", resp.StatusCode)\n`;
+        text += `${indent.pop().get()}}\n`;
+        break;
+      case "binaryResult":
+        text += `${indent.get()}${resultVarName}.${result.fieldName} = resp.Body\n`;
+        break;
+      case "headAsBooleanResult":
+        text += `${indent.get()}${resultVarName}.${result.fieldName} = resp.StatusCode >= 200 && resp.StatusCode < 300\n`;
+        break;
+      case "modelResult":
+        text += generateResponseUnmarshaller(
+          method,
+          result.modelType,
+          result.format,
+          `${resultVarName}.${helpers.getResultFieldName(method)}`,
+          imports,
+          indent,
+        );
+        break;
+      case "monomorphicResult":
+        let target = `${resultVarName}.${helpers.getResultFieldName(method)}`;
+        // when unmarshalling a wrapped XML array, unmarshal into the response envelope
+        if (result.format === "XML" && result.monomorphicType.kind === "slice") {
+          target = resultVarName;
+        }
+        text += generateResponseUnmarshaller(
+          method,
+          result.monomorphicType,
+          result.format,
+          target,
+          imports,
+          indent,
+        );
+        break;
+      case "polymorphicResult":
+        text += generateResponseUnmarshaller(
+          method,
+          result.interface,
+          result.format,
+          resultVarName,
+          imports,
+          indent,
+        );
+        break;
+      default:
+        result satisfies never;
+    }
+  }
+
+  text += `${indent.get()}return ${resultVarName}, nil\n`;
+  text += "}\n\n";
+  return text;
+}
+
+function generateResponseUnmarshaller(
+  method: go.MethodType,
+  type: go.WireType,
+  format: go.ResultFormat,
+  unmarshalTarget: string,
+  imports: ImportManager,
+  indent: helpers.Indentation,
+): string {
+  let unmarshallerText = "";
+  const zeroValue = `${method.returns.name}{}`;
+  if (type.kind === "time") {
+    // use the designated time type for unmarshalling
+    imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
+    unmarshallerText += `${indent.get()}var aux *datetime.${type.format}\n`;
+    unmarshallerText += `${indent.get()}if err := runtime.UnmarshalAs${format}(resp, &aux); err != nil {\n`;
+    unmarshallerText += `${indent.push().get()}return ${zeroValue}, err\n`;
+    unmarshallerText += `${indent.pop().get()}}\n`;
+    unmarshallerText += `${indent.get()}${unmarshalTarget} = (*time.Time)(aux)\n`;
+    return unmarshallerText;
+  } else if (isArrayOfDateTime(type)) {
+    // unmarshalling arrays of date/time is a little more involved
+    const timeInfo = isArrayOfDateTime(type);
+    let elementPtr = "*";
+    if (timeInfo?.elemByVal) {
+      elementPtr = "";
+    }
+    imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
+    unmarshallerText += `${indent.get()}var aux []${elementPtr}datetime.${timeInfo?.format}\n`;
+    unmarshallerText += `${indent.get()}if err := runtime.UnmarshalAs${format}(resp, &aux); err != nil {\n`;
+    unmarshallerText += `${indent.push().get()}return ${zeroValue}, err\n`;
+    unmarshallerText += `${indent.pop().get()}}\n`;
+    unmarshallerText += `${indent.get()}cp := make([]${elementPtr}time.Time, len(aux))\n`;
+    unmarshallerText += `${indent.get()}for i := 0; i < len(aux); i++ {\n`;
+    unmarshallerText += `${indent.push().get()}cp[i] = (${elementPtr}time.Time)(aux[i])\n`;
+    unmarshallerText += `${indent.pop().get()}}\n`;
+    unmarshallerText += `${indent.get()}${unmarshalTarget} = cp\n`;
+    return unmarshallerText;
+  } else if (helpers.isMapOfDateTime(type)) {
+    const timeInfo = helpers.isMapOfDateTime(type);
+    imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
+    unmarshallerText += `${indent.get()}aux := map[string]*datetime.${timeInfo?.format}{}\n`;
+    unmarshallerText += `${indent.get()}if err := runtime.UnmarshalAs${format}(resp, &aux); err != nil {\n`;
+    unmarshallerText += `${indent.push().get()}return ${zeroValue}, err\n`;
+    unmarshallerText += `${indent.pop().get()}}\n`;
+    unmarshallerText += `${indent.get()}cp := map[string]*time.Time{}\n`;
+    unmarshallerText += `${indent.get()}for k, v := range aux {\n`;
+    unmarshallerText += `${indent.push().get()}cp[k] = (*time.Time)(v)\n`;
+    unmarshallerText += `${indent.pop().get()}}\n`;
+    unmarshallerText += `${indent.get()}${unmarshalTarget} = cp\n`;
+    return unmarshallerText;
+  }
+  if (format === "JSON" || format === "XML") {
+    if (type.kind === "rawJSON") {
+      unmarshallerText += `${indent.get()}body, err := runtime.Payload(resp)\n`;
+      unmarshallerText += `${indent.get()}if err != nil {\n`;
+      unmarshallerText += `${indent.push().get()}return ${zeroValue}, err\n`;
+      unmarshallerText += `${indent.pop().get()}}\n`;
+      unmarshallerText += `${indent.get()}${unmarshalTarget} = body\n`;
+    } else {
+      unmarshallerText += `${indent.get()}if err := runtime.UnmarshalAs${helpers.getMediaFormat(type, format, `resp, &${unmarshalTarget}`)}; err != nil {\n`;
+      unmarshallerText += `${indent.push().get()}return ${zeroValue}, err\n`;
+      unmarshallerText += `${indent.pop().get()}}\n`;
+    }
+  } else if (format === "Text") {
+    unmarshallerText += `${indent.get()}body, err := runtime.Payload(resp)\n`;
+    unmarshallerText += `${indent.get()}if err != nil {\n`;
+    unmarshallerText += `${indent.push().get()}return ${zeroValue}, err\n`;
+    unmarshallerText += `${indent.pop().get()}}\n`;
+    let resultVar: string;
+    switch (type.kind) {
+      case "scalar":
+        resultVar = "parsedBody";
+        unmarshallerText += emitScalarParsing(type, "string(body)", resultVar, imports, indent);
+        unmarshallerText += `${indent.get()}${helpers.buildErrCheck(indent, "err", zeroValue)}\n`;
+        break;
+      case "string":
+        resultVar = "txt";
+        unmarshallerText += `${indent.get()}${resultVar} := string(body)\n`;
+        break;
+      default:
+        throw new CodegenError(
+          "UnsupportedTsp",
+          `unsupported text return kind ${type.kind} for method ${method.receiver.type.name}.${method.name}`,
+        );
+    }
+    unmarshallerText += `${indent.get()}${unmarshalTarget} = &${resultVar}\n`;
+  } else {
+    // the remaining formats should have been handled elsewhere
+    throw new CodegenError(
+      "InternalError",
+      `unhandled format ${format} for operation ${method.receiver.type.name}.${method.name}`,
+    );
+  }
+  return unmarshallerText;
+}
+
+// use this to generate the code that will help process values returned in response headers
+function formatHeaderResponseValue(
+  method: go.SyncMethod | go.LROPageableMethod | go.PageableMethod,
+  headerResp: go.HeaderScalarResponse | go.HeaderMapResponse,
+  respObj: string,
+  zeroResp: string,
+  imports: ImportManager,
+  indent: helpers.Indentation,
+): string {
+  // dictionaries are handled slightly different so we do that first
+  if (headerResp.kind === "headerMapResponse") {
+    imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/to");
+    imports.add("strings");
+    const headerPrefix = headerResp.headerName;
+    let text = `${indent.get()}for hh := range resp.Header {\n`;
+    text += `${indent.push().get()}if len(hh) > len("${headerPrefix}") && strings.EqualFold(hh[:len("${headerPrefix}")], "${headerPrefix}") {\n`;
+    text += `${indent.push().get()}if ${respObj}.${headerResp.fieldName} == nil {\n`;
+    text += `${indent.push().get()}${respObj}.${headerResp.fieldName} = map[string]*string{}\n`;
+    text += `${indent.pop().get()}}\n`;
+    text += `${indent.get()}${respObj}.${headerResp.fieldName}[hh[len("${headerPrefix}"):]] = to.Ptr(resp.Header.Get(hh))\n`;
+    text += `${indent.pop().get()}}\n`;
+    text += `${indent.pop().get()}}\n`;
+    return text;
+  }
+
+  let text = `${indent.get()}if val := resp.Header.Get("${helpers.canonicalizeHeaderName(headerResp.headerName)}"); val != "" {\n`;
+  indent.push();
+  let name = naming.uncapitalize(headerResp.fieldName);
+  let byRef = "&";
+  switch (headerResp.type.kind) {
+    case "constant":
+    case "etag":
+      text += `${indent.get()}${respObj}.${headerResp.fieldName} = (*${go.getTypeDeclaration(headerResp.type, method.receiver.type.pkg)})(&val)\n`;
+      indent.pop();
+      text += `${indent.get()}}\n`;
+      return text;
+    case "encodedBytes":
+      // a base-64 encoded value in string format
+      imports.add("encoding/base64");
+      text += `${indent.get()}${name}, err := base64.${helpers.formatBytesEncoding(headerResp.type.encoding)}Encoding.DecodeString(val)\n`;
+      byRef = "";
+      break;
+    case "literal":
+      text += `${indent.get()}${respObj}.${headerResp.fieldName} = &val\n`;
+      indent.pop();
+      text += `${indent.get()}}\n`;
+      return text;
+    case "scalar":
+      text += emitScalarParsing(headerResp.type, "val", name, imports, indent);
+      break;
+    case "string":
+      text += `${indent.get()}${respObj}.${headerResp.fieldName} = &val\n`;
+      text += `${indent.pop().get()}}\n`;
+      return text;
+    case "time":
+      imports.add("time");
+      switch (headerResp.type.format) {
+        case "RFC1123":
+        case "RFC3339":
+        case "RFC7231":
+          text += `${indent.get()}${name}, err := time.Parse(${headerResp.type.format === "RFC3339" ? helpers.RFC3339Format : helpers.RFC1123Format}, val)\n`;
+          break;
+        case "PlainDate":
+          text += `${indent.get()}${name}, err := time.Parse(${helpers.plainDateFormat}, val)\n`;
+          break;
+        case "PlainTime":
+          text += `${indent.get()}${name}, err := time.Parse(${helpers.plainTimeFormat}, val)\n`;
+          break;
+        case "Unix":
+          imports.add("strconv");
+          imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/to");
+          text += `${indent.get()}sec, err := strconv.ParseInt(val, 10, 64)\n`;
+          name = "to.Ptr(time.Unix(sec, 0))";
+          byRef = "";
+          break;
+        default:
+          headerResp.type.format satisfies never;
+      }
+  }
+
+  // NOTE: only cases that required parsing will fall through to here
+  text += `${indent.get()}if err != nil {\n`;
+  text += `${indent.push().get()}return ${zeroResp}, err\n`;
+  text += `${indent.pop().get()}}\n`;
+  text += `${indent.get()}${respObj}.${headerResp.fieldName} = ${byRef}${name}\n`;
+  text += `${indent.pop().get()}}\n`;
+  return text;
+}
+
+/**
+ * emits the code for parsing scalar types from a string.
+ * note that the parsing error result is placed into a
+ * local var named "err".
+ *
+ * @param scalar the type of scalar to parse
+ * @param src the source var that contains the scalar in string format
+ * @param dst the destination var that contains the result
+ * @param imports the import manager currently in scope
+ * @param indent the indentation helper currently in scope
+ * @returns the scalar parsing code
+ */
+function emitScalarParsing(
+  scalar: go.Scalar,
+  src: string,
+  dst: string,
+  imports: ImportManager,
+  indent: helpers.Indentation,
+): string {
+  imports.add("strconv");
+  switch (scalar.type) {
+    case "bool":
+      return `${indent.get()}${dst}, err := strconv.ParseBool(${src})\n`;
+    case "float32":
+      return (
+        `${indent.get()}${dst}32, err := strconv.ParseFloat(${src}, 32)\n` +
+        `${indent.get()}${dst} := float32(${dst}32)\n`
+      );
+    case "float64":
+      return `${indent.get()}${dst}, err := strconv.ParseFloat(${src}, 64)\n`;
+    case "int32":
+      return (
+        `${indent.get()}${dst}32, err := strconv.ParseInt(${src}, 10, 32)\n` +
+        `${indent.get()}${dst} := int32(${dst}32)\n`
+      );
+    case "int64":
+      return `${indent.get()}${dst}, err := strconv.ParseInt(${src}, 10, 64)\n`;
+    default:
+      throw new CodegenError("InternalError", `unhandled scalar type ${scalar.type}`);
+  }
+}
+
+function isArrayOfDateTime(
+  paramType: go.WireType,
+): { format: go.TimeFormat; elemByVal: boolean } | undefined {
+  if (paramType.kind !== "slice") {
+    return undefined;
+  }
+  if (paramType.elementType.kind !== "time") {
+    return undefined;
+  }
+  return {
+    format: paramType.elementType.format,
+    elemByVal: paramType.elementTypeByValue,
+  };
+}

--- a/packages/typespec-go/src/codegen/emitter.ts
+++ b/packages/typespec-go/src/codegen/emitter.ts
@@ -4,24 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 
 import * as go from "../codemodel/index.js";
-import { generateClientFactory } from "./core/client-factory.js";
-import { generateCloudConfig } from "./core/cloud-config.js";
-import { generateConstants } from "./core/constants.js";
-import { generateExamples } from "./core/example.js";
-import { generateGoModFile } from "./core/gomod.js";
-import { setCustomHeaderText } from "./core/helpers.js";
-import { generateInterfaces } from "./core/interfaces.js";
-import { generateLicenseTxt } from "./core/license.js";
-import { generateMetadataFile } from "./core/metadata.js";
-import { generateModels } from "./core/models.js";
-import { generateOperations } from "./core/operations.js";
-import { generateOptions } from "./core/options.js";
-import { generatePolymorphicHelpers } from "./core/polymorphics.js";
-import { generateResponses } from "./core/responses.js";
-import { generateVersionInfo } from "./core/version.js";
-import { generateXMLAdditionalPropsHelpers } from "./core/xml-additional-props.js";
-import { generateServerFactory } from "./fake/factory.js";
-import { generateServers } from "./fake/servers.js";
+import * as core from "./core/index.js";
+import * as fake from "./fake/index.js";
 
 /** abstractions over various file handling facilities */
 export interface FsFacilities {
@@ -53,7 +37,7 @@ export class Emitter {
       this.filePrefix = "";
     }
     if (this.codeModel.options.headerText) {
-      setCustomHeaderText(this.codeModel.options.headerText);
+      core.setCustomHeaderText(this.codeModel.options.headerText);
     }
 
     switch (this.codeModel.root.kind) {
@@ -80,7 +64,11 @@ export class Emitter {
       if (await this.fs.exists(goModFile)) {
         existingGoMod = await this.fs.read(goModFile);
       }
-      const gomod = generateGoModFile(this.codeModel.root, this.codeModel.options, existingGoMod);
+      const gomod = core.generateGoModFile(
+        this.codeModel.root,
+        this.codeModel.options,
+        existingGoMod,
+      );
       if (gomod.length > 0) {
         await this.fs.write(goModFile, gomod);
       }
@@ -91,7 +79,7 @@ export class Emitter {
         pkg: go.PackageContent,
         write: (name: string, content: string, subdir?: string) => Promise<void>,
       ): Promise<void> => {
-        const clientFactory = generateClientFactory(
+        const clientFactory = core.generateClientFactory(
           pkg,
           this.codeModel.type,
           this.codeModel.options,
@@ -100,22 +88,26 @@ export class Emitter {
           await write("client_factory.go", clientFactory);
         }
 
-        const constants = generateConstants(pkg);
+        const constants = core.generateConstants(pkg);
         if (constants.length > 0) {
           await write("constants.go", constants);
         }
 
-        const interfaces = generateInterfaces(pkg);
+        const interfaces = core.generateInterfaces(pkg);
         if (interfaces.length > 0) {
           await write("interfaces.go", interfaces);
         }
 
-        const operations = generateOperations(pkg, this.codeModel.type, this.codeModel.options);
+        const operations = core.generateOperations(
+          pkg,
+          this.codeModel.type,
+          this.codeModel.options,
+        );
         for (const op of operations) {
           await write(`${snakeClientFileName(op.name)}.go`, op.content);
         }
 
-        const models = generateModels(pkg, this.codeModel.options, emitter);
+        const models = core.generateModels(pkg, this.codeModel.options, emitter);
         if (models.models.length > 0) {
           await write("models.go", models.models);
         }
@@ -123,17 +115,17 @@ export class Emitter {
           await write("models_serde.go", models.serDe);
         }
 
-        const options = generateOptions(pkg);
+        const options = core.generateOptions(pkg);
         if (options.length > 0) {
           await write("options.go", options);
         }
 
-        const polymorphics = generatePolymorphicHelpers(pkg);
+        const polymorphics = core.generatePolymorphicHelpers(pkg);
         if (polymorphics.length > 0) {
           await write("polymorphic_helpers.go", polymorphics);
         }
 
-        const responses = generateResponses(pkg, this.codeModel.options);
+        const responses = core.generateResponses(pkg, this.codeModel.options);
         if (responses.responses.length > 0) {
           await write("responses.go", responses.responses);
         }
@@ -141,28 +133,28 @@ export class Emitter {
           await write("responses_serde.go", responses.serDe);
         }
 
-        const xmlAddlProps = generateXMLAdditionalPropsHelpers(pkg);
+        const xmlAddlProps = core.generateXMLAdditionalPropsHelpers(pkg);
         if (xmlAddlProps.length > 0) {
           await write("xml_helper.go", xmlAddlProps);
         }
 
         if (this.codeModel.options.generateFakes) {
           const fakePkg = new go.FakePackage(pkg);
-          const serverContent = generateServers(fakePkg, this.codeModel.type);
+          const serverContent = fake.generateServers(fakePkg, this.codeModel.type);
           if (serverContent.servers.length > 0) {
             for (const op of serverContent.servers) {
               const fileName = `${snakeClientFileName(op.name, "server")}.go`;
               await write(fileName, op.content, fakePkg.kind);
             }
 
-            const serverFactory = generateServerFactory(fakePkg, this.codeModel.type);
+            const serverFactory = fake.generateServerFactory(fakePkg, this.codeModel.type);
             if (serverFactory.length > 0) {
               await write("server_factory.go", serverFactory, fakePkg.kind);
             }
 
             await write("internal.go", serverContent.internals, fakePkg.kind);
 
-            const polymorphics = generatePolymorphicHelpers(fakePkg);
+            const polymorphics = core.generatePolymorphicHelpers(fakePkg);
             if (polymorphics.length > 0) {
               await write("polymorphic_helpers.go", polymorphics, fakePkg.kind);
             }
@@ -174,7 +166,7 @@ export class Emitter {
     // only one version.go file per module
     if (this.codeModel.root.kind === "module") {
       // don't overwrite an existing version.go file
-      const versionGo = generateVersionInfo(this.codeModel.root);
+      const versionGo = core.generateVersionInfo(this.codeModel.root);
       const versionGoFileName = `${this.filePrefix}version.go`;
       if (versionGo.length > 0 && !(await this.fs.exists(versionGoFileName))) {
         await this.fs.write(versionGoFileName, versionGo);
@@ -187,7 +179,7 @@ export class Emitter {
     if (this.codeModel.root.kind !== "module") {
       return;
     }
-    const cloudConfig = generateCloudConfig(this.codeModel.root, this.codeModel.type);
+    const cloudConfig = core.generateCloudConfig(this.codeModel.root, this.codeModel.type);
     if (cloudConfig.length > 0) {
       await this.fs.write(`${this.filePrefix}cloud_config.go`, cloudConfig);
     }
@@ -204,7 +196,7 @@ export class Emitter {
         pkg: go.PackageContent,
         write: (name: string, content: string) => Promise<void>,
       ): Promise<void> => {
-        const examples = generateExamples(
+        const examples = core.generateExamples(
           new go.TestPackage(pkg),
           this.codeModel.type,
           this.codeModel.options,
@@ -223,7 +215,7 @@ export class Emitter {
     }
 
     // don't overwrite an existing LICENSE.txt file
-    const licenseTxt = generateLicenseTxt(this.codeModel.options);
+    const licenseTxt = core.generateLicenseTxt(this.codeModel.options);
     const licenseTxtFileName = "LICENSE.txt";
     if (licenseTxt && !(await this.fs.exists(licenseTxtFileName))) {
       await this.fs.write(licenseTxtFileName, licenseTxt);
@@ -236,7 +228,7 @@ export class Emitter {
       return;
     }
 
-    const metadata = generateMetadataFile(this.codeModel);
+    const metadata = core.generateMetadataFile(this.codeModel);
     if (metadata.length > 0) {
       await this.fs.write("testdata/_metadata.json", metadata);
     }

--- a/packages/typespec-go/src/codegen/fake/index.ts
+++ b/packages/typespec-go/src/codegen/fake/index.ts
@@ -1,0 +1,7 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+export { generateServerFactory } from "./factory.js";
+export { generateServers } from "./servers.js";

--- a/packages/typespec-go/src/codegen/fake/servers.ts
+++ b/packages/typespec-go/src/codegen/fake/servers.ts
@@ -8,7 +8,6 @@ import * as naming from "../../naming/naming.js";
 import { CodegenError } from "../core/errors.js";
 import * as helpers from "../core/helpers.js";
 import { ImportManager } from "../core/imports.js";
-import { fixUpMethodName } from "../core/operations.js";
 import { generateServerInternal, RequiredHelpers } from "./internal.js";
 
 // contains the generated content for all servers and the required helpers
@@ -117,7 +116,7 @@ export function generateServers(pkg: go.FakePackage, target: go.CodeModelType): 
           break;
       }
 
-      const operationName = fixUpMethodName(method);
+      const operationName = helpers.fixUpMethodName(method);
       content += `${indent.get()}// ${operationName} is the fake for method ${client.name}.${operationName}\n`;
       const successCodes = new Array<string>();
       if (method.returns.result?.kind === "anyResult") {
@@ -181,11 +180,11 @@ export function generateServers(pkg: go.FakePackage, target: go.CodeModelType): 
               respType = `azfake.PagerResponder[${go.getTypeDeclaration(method.returns, pkg)}]`;
             }
             requiredHelpers.tracker = true;
-            content += `${indent.get()}${naming.uncapitalize(fixUpMethodName(method))}: newTracker[azfake.PollerResponder[${respType}]](),\n`;
+            content += `${indent.get()}${naming.uncapitalize(helpers.fixUpMethodName(method))}: newTracker[azfake.PollerResponder[${respType}]](),\n`;
             break;
           case "pageableMethod":
             requiredHelpers.tracker = true;
-            content += `${indent.get()}${naming.uncapitalize(fixUpMethodName(method))}: newTracker[azfake.PagerResponder[${respType}]](),\n`;
+            content += `${indent.get()}${naming.uncapitalize(helpers.fixUpMethodName(method))}: newTracker[azfake.PagerResponder[${respType}]](),\n`;
             break;
         }
       }
@@ -219,11 +218,11 @@ export function generateServers(pkg: go.FakePackage, target: go.CodeModelType): 
             respType = `azfake.PagerResponder[${go.getTypeDeclaration(method.returns, pkg)}]`;
           }
           requiredHelpers.tracker = true;
-          content += `${indent.get()}${naming.uncapitalize(fixUpMethodName(method))} *tracker[azfake.PollerResponder[${respType}]]\n`;
+          content += `${indent.get()}${naming.uncapitalize(helpers.fixUpMethodName(method))} *tracker[azfake.PollerResponder[${respType}]]\n`;
           break;
         case "pageableMethod":
           requiredHelpers.tracker = true;
-          content += `${indent.get()}${naming.uncapitalize(fixUpMethodName(method))} *tracker[azfake.PagerResponder[${go.getTypeDeclaration(method.returns, pkg)}]]\n`;
+          content += `${indent.get()}${naming.uncapitalize(helpers.fixUpMethodName(method))} *tracker[azfake.PagerResponder[${go.getTypeDeclaration(method.returns, pkg)}]]\n`;
           break;
       }
     }
@@ -400,7 +399,7 @@ function generateServerTransportMethodDispatch(
   content += `${indent.get()}switch method {\n`;
 
   for (const method of finalMethods) {
-    const operationName = fixUpMethodName(method);
+    const operationName = helpers.fixUpMethodName(method);
     content += `${indent.get()}case "${client.name}.${operationName}":\n`;
     content += `${indent.push().get()}res.resp, res.err = ${receiverName}.dispatch${operationName}(req)\n`;
     indent.pop();
@@ -454,9 +453,9 @@ function generateServerTransportMethods(
 
   let content = "";
   for (const method of finalMethods) {
-    content += `func (${receiverName} *${serverTransport}) dispatch${fixUpMethodName(method)}(req *http.Request) (*http.Response, error) {\n`;
-    content += `${indent.get()}if ${receiverName}.srv.${fixUpMethodName(method)} == nil {\n`;
-    content += `${indent.push().get()}return nil, &nonRetriableError{errors.New("fake for method ${fixUpMethodName(method)} not implemented")}\n`;
+    content += `func (${receiverName} *${serverTransport}) dispatch${helpers.fixUpMethodName(method)}(req *http.Request) (*http.Response, error) {\n`;
+    content += `${indent.get()}if ${receiverName}.srv.${helpers.fixUpMethodName(method)} == nil {\n`;
+    content += `${indent.push().get()}return nil, &nonRetriableError{errors.New("fake for method ${helpers.fixUpMethodName(method)} not implemented")}\n`;
     content += `${indent.pop().get()}}\n`;
 
     switch (method.kind) {
@@ -919,7 +918,7 @@ function dispatchForOperationBody(
     );
   }
 
-  const apiCall = `:= ${receiverName}.srv.${fixUpMethodName(method)}(${populateApiParams(pkg, method, result.params, imports)})`;
+  const apiCall = `:= ${receiverName}.srv.${helpers.fixUpMethodName(method)}(${populateApiParams(pkg, method, result.params, imports)})`;
   if (method.kind === "pageableMethod") {
     content += `resp ${apiCall}\n`;
     return content;
@@ -966,7 +965,7 @@ function dispatchForLROBody(
   imports: ImportManager,
   indent: helpers.Indentation,
 ): string {
-  const operationName = fixUpMethodName(method);
+  const operationName = helpers.fixUpMethodName(method);
   const localVarName = naming.uncapitalize(operationName);
   const operationStateMachine = `${receiverName}.${naming.uncapitalize(operationName)}`;
   let content = `${indent.get()}${localVarName} := ${operationStateMachine}.get(req)\n`;
@@ -1013,7 +1012,7 @@ function dispatchForPagerBody(
   imports: ImportManager,
   indent: helpers.Indentation,
 ): string {
-  const operationName = fixUpMethodName(method);
+  const operationName = helpers.fixUpMethodName(method);
   const localVarName = naming.uncapitalize(operationName);
   const operationStateMachine = `${receiverName}.${naming.uncapitalize(operationName)}`;
   let content = `${indent.get()}${localVarName} := ${operationStateMachine}.get(req)\n`;


### PR DESCRIPTION
Split monolithic file into three files so it's easier to reason about. Added barrel files to clarify external APIs used by the emitter. Moved shared functions to helpers.ts.
Simplified a few bits of code to avoid more shared helpers.

No functional changes.