### PR TITLE
Refactor request handler for pageable operations

### DIFF
--- a/.chronus/changes/go-pager-refactor-1-2026-7-10-15-52-53.md
+++ b/.chronus/changes/go-pager-refactor-1-2026-7-10-15-52-53.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/azure-http-specs"
+---
+
+Enable the parameterized next link paging scenario for the Go emitter.

--- a/.chronus/changes/go-pager-refactor-1-2026-7-10-15-54-7.md
+++ b/.chronus/changes/go-pager-refactor-1-2026-7-10-15-54-7.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-go"
+---
+
+Add support for paged operations with next links that are parameterized or relative URLs.

--- a/cspell.yaml
+++ b/cspell.yaml
@@ -105,7 +105,10 @@ words:
   - regionality
   - responseasbool
   - retarget
+  - reinjectable
   - reinjected
+  - reinjecting
+  - reinjection
   - Reranker
   - rpaasoneboxacr
   - rpass

--- a/packages/azure-http-specs/specs/azure/core/page/client.tsp
+++ b/packages/azure-http-specs/specs/azure/core/page/client.tsp
@@ -2,5 +2,3 @@ import "@azure-tools/typespec-client-generator-core";
 import "./main.tsp";
 
 using Azure.ClientGenerator.Core;
-
-@@scope(_Specs_.Azure.Core.Page.withParameterizedNextLink, "!go");

--- a/packages/typespec-go/spector.config.azure.yaml
+++ b/packages/typespec-go/spector.config.azure.yaml
@@ -50,7 +50,6 @@ specs:
   "azure/core/lro/rpc": { options: { module: lrorpcgroup } }
   "azure/core/lro/standard": { options: { module: lrostdgroup } }
   "azure/core/model": { options: { module: coremodelgroup } }
-  # requires paging with re-injection support
   "azure/core/page/client.tsp": { options: { module: azurepagegroup } }
   "azure/core/scalar": { options: { module: corescalargroup } }
   # requires union support

--- a/packages/typespec-go/src/codegen/core/gomod.ts
+++ b/packages/typespec-go/src/codegen/core/gomod.ts
@@ -25,7 +25,7 @@ export function generateGoModFile(
 
   // here we specify the minimum version of azcore as required by the code generator.
   // the version can be overwritten by passing the --azcore-version switch during generation.
-  let version = "1.22.0";
+  let version = "1.23.0";
   if (options.azcoreVersion) {
     // when matching versions, we need to handle beta, non-beta, and pseudo versions
     // 1.2.3-beta.1, 1.2.3, 0.22.1-0.20220315231014-ed309e73db6b

--- a/packages/typespec-go/src/codegen/core/helpers.ts
+++ b/packages/typespec-go/src/codegen/core/helpers.ts
@@ -182,6 +182,7 @@ export function sortClientParameters(
 // returns the parameters for the internal request creator method.
 // e.g. "i int, s string"
 export function getCreateRequestParametersSig(method: go.MethodType | go.NextPageMethod): string {
+  // NOTE: keep in sync with getCreateRequestParameters
   const methodParams = getMethodParameters(method);
   const params = new Array<string>();
   params.push("ctx context.Context");
@@ -198,6 +199,13 @@ export function getCreateRequestParametersSig(method: go.MethodType | go.NextPag
     }
     params.push(`${paramName} ${formatParameterTypeName(method.receiver.type.pkg, methodParam)}`);
   }
+  if (
+    (method.kind === "lroPageableMethod" || method.kind === "pageableMethod") &&
+    method.strategy?.kind === "nextLink"
+  ) {
+    // inject the nextLink param right before the options param
+    params.splice(-1, 0, "nextLink string");
+  }
   return params.join(", ");
 }
 
@@ -209,7 +217,11 @@ export function getCreateRequestParametersSig(method: go.MethodType | go.NextPag
  * @param optionsParam optional custom param name for the method options param
  * @returns the text for the parameters
  */
-export function getCreateRequestParameters(method: go.MethodType, optionsParam?: string): string {
+export function getCreateRequestParameters(
+  method: go.MethodType,
+  nextLinkParam?: string,
+  optionsParam?: string,
+): string {
   // NOTE: keep in sync with getCreateRequestParametersSig
   const methodParams = getMethodParameters(method);
   const params = new Array<string>();
@@ -222,6 +234,10 @@ export function getCreateRequestParameters(method: go.MethodType, optionsParam?:
     } else {
       params.push(methodParam.name);
     }
+  }
+  if (nextLinkParam) {
+    // inject the nextLink param right before the options param
+    params.splice(-1, 0, nextLinkParam);
   }
   return params.join(", ");
 }
@@ -426,7 +442,11 @@ export function getDelimiterForCollectionFormat(cf: go.CollectionFormat): string
   }
 }
 
-export function getMediaFormat(type: go.WireType, mediaType: "JSON" | "XML", param: string): string {
+export function getMediaFormat(
+  type: go.WireType,
+  mediaType: "JSON" | "XML",
+  param: string,
+): string {
   let marshaller: "JSON" | "XML" | "ByteArray" = mediaType;
   let format = "";
   if (type.kind === "encodedBytes") {

--- a/packages/typespec-go/src/codegen/core/operations.ts
+++ b/packages/typespec-go/src/codegen/core/operations.ts
@@ -515,9 +515,12 @@ function generateConstructors(
  * @param method the method to determine the zero value
  * @returns the zero value
  */
-function getZeroReturnValue(method: go.MethodType): string {
+function getZeroReturnValue(method: go.MethodType, forFetcher: boolean): string {
+  // NOTE: we need more context when attempting to determine the zero value for pageable LROs:
+  //  - in the fetcher, return the response envelope type
+  //  - outside the fetcher return nil
   let returnType = `${method.returns.name}{}`;
-  if (go.isLROMethod(method)) {
+  if (go.isLROMethod(method) && !forFetcher) {
     // the api returns a *Poller[T]
     // the operation returns an *http.Response
     returnType = "nil";
@@ -573,7 +576,10 @@ function emitPagerDefinition(
   indent: helpers.Indentation,
 ): string {
   imports.add("context");
+  // BEGIN runtime.NewPager
   let text = `runtime.NewPager(runtime.PagingHandler[${method.returns.name}]{\n`;
+
+  // BEGIN More func
   text += `${indent.push().get()}More: func(page ${method.returns.name}) bool {\n`;
   indent.push();
   if (method.strategy) {
@@ -609,15 +615,18 @@ function emitPagerDefinition(
     // there is no advancer for single-page pagers
     text += `${indent.get()}return false\n`;
   }
-  text += `${indent.pop().get()}},\n`; // end More func
+  text += `${indent.pop().get()}},\n`;
+  // END More func
 
+  // BEGIN Fetcher func
   text += `${indent.get()}Fetcher: func(ctx context.Context, page *${method.returns.name}) (${method.returns.name}, error) {\n`;
   indent.push();
-  const reqParams = helpers.getCreateRequestParameters(method);
   if (options.generateFakes) {
     text += `${indent.get()}ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "${method.receiver.type.name}.${helpers.fixUpMethodName(method)}")\n`;
   }
 
+  let nextLinkParam: string | undefined;
+  let optionsParam: string | undefined;
   if (method.strategy) {
     switch (method.strategy.kind) {
       case "continuationToken": {
@@ -651,117 +660,40 @@ function emitPagerDefinition(
             `${indent.get()}${optionsCopy}.${ms.requestToken.name} = page.${respToken}\n`,
         })}\n`;
 
-        text += callCreateRequestWithErrCheck(method, "req", indent, `&${optionsCopy}`);
-        text += callPipelineDoWithErrCheck(method, "req", "resp", indent);
-        text += `${indent.get()}return client.${method.naming.responseMethod}(resp, ${helpers.formatStatusCodes(method.httpStatusCodes)})\n`;
+        optionsParam = `&${optionsCopy}`;
         break;
       }
       case "nextLink": {
         const nextLinkPath = helpers.buildNextLinkPath(method.strategy);
-        let nextLinkVar: string;
         if (method.kind === "pageableMethod") {
           text += `${indent.get()}nextLink := ""\n`;
-          nextLinkVar = "nextLink";
+          nextLinkParam = "nextLink";
           text += `${indent.get()}if page != nil {\n`;
           text += `${indent.push().get()}nextLink = *page.${nextLinkPath}\n`;
           text += `${indent.pop().get()}}\n`;
         } else {
-          nextLinkVar = `*page.${nextLinkPath}`;
+          nextLinkParam = `*page.${nextLinkPath}`;
         }
-        text += `${indent.get()}resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), ${nextLinkVar}, func(ctx context.Context) (*policy.Request, error) {\n`;
-        text += `${indent.push().get()}return client.${method.naming.requestMethod}(${reqParams})\n`;
-        text += `${indent.pop().get()}}, `;
-        // nextPageMethod might be absent in some cases, see https://github.com/Azure/autorest/issues/4393
-        if (method.strategy.method) {
-          const nextOpParams = helpers
-            .getCreateRequestParametersSig(method.strategy.method)
-            .split(",");
-          // keep the parameter names from the name/type tuples and find nextLink param
-          for (let i = 0; i < nextOpParams.length; ++i) {
-            const paramName = nextOpParams[i].trim().split(" ")[0];
-            const paramType = nextOpParams[i].trim().split(" ")[1];
-            if (paramName.startsWith("next") && paramType === "string") {
-              nextOpParams[i] = "encodedNextLink";
-            } else {
-              nextOpParams[i] = paramName;
-            }
-          }
-          // add a definition for the nextReq func that uses the nextLinkOperation
-          indent.push();
-          text += `&runtime.FetcherForNextLinkOptions{\n`;
-          text += `${indent.get()}NextReq: func(ctx context.Context, encodedNextLink string) (*policy.Request, error) {\n`;
-          text += `${indent.push().get()}return client.${method.strategy.method.name}(${nextOpParams.join(", ")})\n`;
-          text += `${indent.pop().get()}},\n`;
-          text += `${indent.pop().get()}})\n`;
-        } else if (method.nextLinkVerb !== "get") {
-          text += `&runtime.FetcherForNextLinkOptions{\n`;
-          text += `${indent.push().get()}HTTPVerb: http.Method${naming.capitalize(method.nextLinkVerb)},\n`;
-          text += `${indent.pop().get()}})\n`;
-        } else {
-          text += "nil)\n";
-        }
-        text += `${indent.get()}if err != nil {\n`;
-        text += `${indent.push().get()}return ${method.returns.name}{}, err\n`;
-        text += `${indent.pop().get()}}\n`;
-        text += `${indent.get()}return client.${method.naming.responseMethod}(resp, ${helpers.formatStatusCodes(method.httpStatusCodes)})\n`;
       }
     }
-  } else {
-    // this is the singular page case, no fetcher helper required
-    text += callCreateRequestWithErrCheck(method, "req", indent);
-    text += callPipelineDoWithErrCheck(method, "req", "resp", indent);
-    text += `${indent.get()}return client.${method.naming.responseMethod}(resp, ${helpers.formatStatusCodes(method.httpStatusCodes)})\n`;
   }
-  text += `${indent.pop().get()}},\n`; // end Fetcher func
+
+  const reqParams = helpers.getCreateRequestParameters(method, nextLinkParam, optionsParam);
+  text += `${indent.get()}req, err := client.${method.naming.requestMethod}(${reqParams})\n`;
+  text += `${indent.get()}${helpers.buildErrCheck(indent, "err", getZeroReturnValue(method, true))}\n`;
+
+  text += `${indent.get()}resp, err := client.internal.Pipeline().Do(req)\n`;
+  text += `${indent.get()}${helpers.buildErrCheck(indent, "err", getZeroReturnValue(method, true))}\n`;
+  text += `${indent.get()}return client.${method.naming.responseMethod}(resp, ${helpers.formatStatusCodes(method.httpStatusCodes)})\n`;
+  text += `${indent.pop().get()}},\n`;
+  // END Fetcher func
+
   if (options.injectSpans) {
     text += `${indent.get()}Tracer: client.internal.Tracer(),\n`;
   }
-  text += `${indent.pop().get()}})\n`; // end runtime.NewPager
-  return text;
-}
+  text += `${indent.pop().get()}})\n`;
+  // END runtime.NewPager
 
-/**
- * emits the call to the *CreateRequest method for an SDK method.
- * if the call returns an error, the error is propagated to the caller.
- *
- * @param method the method to call its *CreateRequest method
- * @param reqVarName the var name of the resultant *policy.Request
- * @param indent the indentation helper currently in scope
- * @param optionsParam optional custom param name for the method options param
- * @returns the call to *CreateRequest with an error check
- */
-function callCreateRequestWithErrCheck(
-  method: go.MethodType,
-  reqVarName: string,
-  indent: helpers.Indentation,
-  optionsParam?: string,
-): string {
-  const reqParams = helpers.getCreateRequestParameters(method, optionsParam);
-  let text = `${indent.get()}${reqVarName}, err := client.${method.naming.requestMethod}(${reqParams})\n`;
-  const zeroResp = getZeroReturnValue(method);
-  text += `${indent.get()}${helpers.buildErrCheck(indent, "err", zeroResp)}\n`;
-  return text;
-}
-
-/**
- * emits the call to the pipeline's Do() method on the internal client.
- * if the call returns an error, the error is propagated to the caller.
- *
- * @param method the method that's making the call
- * @param reqVarName the var name of the *policy.Request
- * @param respVarName the var name of the *http.Response
- * @param indent the indentation helper currently in scope
- * @returns the call to Do() with an error check
- */
-function callPipelineDoWithErrCheck(
-  method: go.MethodType,
-  reqVarName: string,
-  respVarName: string,
-  indent: helpers.Indentation,
-): string {
-  let text = `${indent.get()}${respVarName}, err := client.internal.Pipeline().Do(${reqVarName})\n`;
-  const zeroResp = getZeroReturnValue(method);
-  text += `${indent.get()}${helpers.buildErrCheck(indent, "err", zeroResp)}\n`;
   return text;
 }
 
@@ -825,8 +757,15 @@ function generateOperation(
     text += `${indent.get()}defer func() { endSpan(err) }()\n`;
   }
 
-  text += callCreateRequestWithErrCheck(method, "req", indent);
-  text += callPipelineDoWithErrCheck(method, "req", "httpResp", indent);
+  const reqParams = helpers.getCreateRequestParameters(
+    method,
+    method.kind === "lroPageableMethod" ? `""` : undefined,
+  );
+  text += `${indent.get()}req, err := client.${method.naming.requestMethod}(${reqParams})\n`;
+  text += `${indent.get()}${helpers.buildErrCheck(indent, "err", getZeroReturnValue(method, false))}\n`;
+
+  text += `${indent.get()}httpResp, err := client.internal.Pipeline().Do(req)\n`;
+  text += `${indent.get()}${helpers.buildErrCheck(indent, "err", getZeroReturnValue(method, false))}\n`;
 
   // NOTE: for an LRO's op method we never invoke the response handler.
   // for vanilla LRO's we don't emit one, only for pageable LROs and in
@@ -836,7 +775,7 @@ function generateOperation(
     text += `${indent.get()}return client.${method.naming.responseMethod}(httpResp, ${helpers.formatStatusCodes(method.httpStatusCodes)})\n`;
   } else {
     // no response handler so we emit the status code check here
-    const zeroResp = getZeroReturnValue(method);
+    const zeroResp = getZeroReturnValue(method, false);
     text += `${indent.get()}${helpers.buildIfBlock(indent, {
       condition: `!runtime.HasStatusCode(httpResp, ${helpers.formatStatusCodes(method.httpStatusCodes)})`,
       body: (indent) => `${indent.get()}return ${zeroResp}, runtime.NewResponseError(httpResp)\n`,
@@ -855,7 +794,10 @@ function generateOperation(
         default:
           // we should never get here as the remaining kinds are all modeled results
           // thus should have been handled by the needsResponseHandler check earlier
-          throw new CodegenError("InternalError", `unexpected method result kind ${method.returns.result.kind}`);
+          throw new CodegenError(
+            "InternalError",
+            `unexpected method result kind ${method.returns.result.kind}`,
+          );
       }
     } else {
       // no result type, just response envelope
@@ -924,10 +866,7 @@ function getAPIParametersSig(
 // apiType describes where the return sig is used.
 //   api - for the API definition
 //    op - for the operation
-function generateReturnsInfo(
-  method: go.MethodType,
-  apiType: "api" | "op",
-): Array<string> {
+function generateReturnsInfo(method: go.MethodType, apiType: "api" | "op"): Array<string> {
   let returnType = method.returns.name;
   switch (method.kind) {
     case "lroMethod":
@@ -966,7 +905,7 @@ function generateLROBeginMethod(
     text += helpers.formatDocCommentWithPrefix(helpers.fixUpMethodName(method), method.docs);
     text += genRespErrorDoc(method);
   }
-  const zeroResp = getZeroReturnValue(method);
+  const zeroResp = getZeroReturnValue(method, false);
   const methodParams = helpers.getMethodParameters(method);
   for (const param of methodParams) {
     text += helpers.formatCommentAsBulletItem(param.name, param.docs);

--- a/packages/typespec-go/src/codegen/core/request-handler.ts
+++ b/packages/typespec-go/src/codegen/core/request-handler.ts
@@ -41,6 +41,18 @@ export function createRequestHandler(
   text += `func ${helpers.getClientReceiverDefinition(method.receiver)} ${name}(${helpers.getCreateRequestParametersSig(method)}) (${returns.join(", ")}) {\n`;
 
   // BEGIN create request
+  // pageable methods that use nextLink require special handling (e.g. reinjectable query params)
+  const forNextLinkPager =
+    (method.kind === "pageableMethod" || method.kind === "lroPageableMethod") &&
+    method.strategy?.kind === "nextLink";
+  if (forNextLinkPager) {
+    text += `${indent.get()}firstPage := nextLink == ""\n`;
+    text += `${indent.get()}var req *policy.Request\n`;
+    text += `${indent.get()}var err error\n`;
+    text += `${indent.get()}if firstPage {\n`;
+    indent.push();
+  }
+
   const hostParams = new Array<go.URIParameter>();
   for (const parameter of method.receiver.type.parameters) {
     if (parameter.kind === "uriParam") {
@@ -86,10 +98,11 @@ export function createRequestHandler(
   // so, if a path contains tokens but there are no path params, skip emitting the path.
   const pathStr = method.httpPath;
   const pathContainsParms = pathStr.includes("{");
+  let opEndpoint = hostParam;
   if (hasPathParams || (!pathContainsParms && pathStr.length > 1)) {
     // there are path params, or the path doesn't contain tokens and is not "/" so emit it
     text += `${indent.get()}urlPath := "${method.httpPath}"\n`;
-    hostParam = `runtime.JoinPaths(${hostParam}, urlPath)`;
+    opEndpoint = `runtime.JoinPaths(${hostParam}, urlPath)`;
   }
 
   if (hasPathParams) {
@@ -175,7 +188,12 @@ export function createRequestHandler(
     }
   }
 
-  text += `${indent.get()}req, err := runtime.NewRequest(ctx, http.Method${naming.capitalize(method.httpMethod)}, ${hostParam})\n`;
+  text += `${indent.get()}req, err ${forNextLinkPager ? "=" : ":="} runtime.NewRequest(ctx, http.Method${naming.capitalize(method.httpMethod)}, ${opEndpoint})\n`;
+  if (forNextLinkPager) {
+    text += `${indent.pop().get()}} else {\n`;
+    text += `${indent.push().get()}req, err = runtime.NewRequestForNextLink(ctx, http.Method${naming.capitalize(method.nextLinkVerb)}, ${hostParam}, nextLink)\n`;
+    text += `${indent.pop().get()}}\n`;
+  }
   text += `${indent.get()}if err != nil {\n`;
   text += `${indent.push().get()}return nil, err\n`;
   text += `${indent.pop().get()}}\n`;
@@ -185,9 +203,41 @@ export function createRequestHandler(
   const encodedParams = methodParamGroups.encodedQueryParams;
   const unencodedParams = methodParamGroups.unencodedQueryParams;
 
+  // check for any params that require reinjection
+  const reinjectedParams = new Array<go.QueryParameter>();
+  if (forNextLinkPager && method.strategy?.kind === "nextLink") {
+    reinjectedParams.push(...method.strategy.reinjectedParams);
+  }
+
+  // tracks if we're inside an "if firstPage {}" block so we can close it at the end
+  let inIfFirstPage = false;
+
   // emit encoded params first
   if (encodedParams.length > 0) {
+    // determine the query params for reinjection.
+    // default to "all" to cover the non-pager case.
+    let forReinjection: "all" | "none" | "some" = "all";
+    if (forNextLinkPager) {
+      if (reinjectedParams.length === 0) {
+        forReinjection = "none";
+      } else if (reinjectedParams.length < encodedParams.length) {
+        forReinjection = "some";
+      }
+    }
+
+    if (forReinjection === "none") {
+      // no params to be reinjected, shove everything into "if firstPage {}" block
+      text += `${indent.get()}if firstPage {\n`;
+      indent.push();
+      inIfFirstPage = true;
+    }
+
     text += `${indent.get()}reqQP := req.Raw().URL.Query()\n`;
+
+    // this will accumulate any non-reinjected params code
+    let nonReinjectedParamsText = "";
+
+    // we emit all reinjected params in the loop, and collect the code for non-reinjected params
     for (const qp of encodedParams.sort((a: go.QueryParameter, b: go.QueryParameter) => {
       return helpers.sortAscending(a.queryParameter, b.queryParameter);
     })) {
@@ -223,7 +273,26 @@ export function createRequestHandler(
         // cannot initialize setter to this value as helpers.formatParamValue() can change imports
         setter = `reqQP.Set("${qp.queryParameter}", ${helpers.formatParamValue(qp, imports, indent)})`;
       }
-      text += emitQueryParam(qp, imports, indent, setter);
+
+      const qpText = emitQueryParam(qp, imports, indent, setter);
+
+      // if we're not reinjecting any params, or this param is for reinjection
+      // then emit it now, else collect it for the non-reinjected case.
+      if (forReinjection !== "some" || reinjectedParams.includes(qp)) {
+        text += qpText;
+      } else {
+        nonReinjectedParamsText += qpText;
+      }
+    }
+
+    if (forReinjection === "some") {
+      if (nonReinjectedParamsText.length === 0) {
+        throw new CodegenError("InternalError", "missing query parameters for reinjection");
+      }
+      // the indentation for nonReinjectedParamsText won't line up but gofmt fixes it
+      text += `${indent.get()}if firstPage {\n`;
+      text += nonReinjectedParamsText;
+      text += `${indent.get()}}\n`;
     }
 
     // reqQP.Encode() encodes space chars as '+' which is application/x-www-form-urlencoded
@@ -232,9 +301,26 @@ export function createRequestHandler(
     // see https://www.rfc-editor.org/rfc/rfc3986 sections 2.1, 2.2, and 3.4
     imports.add("strings");
     text += `${indent.get()}req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")\n`;
+
+    // don't close it yet if there are header/body params as those don't get reinjected
+    const bodyParam = methodParamGroups.bodyParam;
+    const formBodyParams = methodParamGroups.formBodyParams;
+    const multipartBodyParams = methodParamGroups.multipartBodyParams;
+    const partialBodyParams = methodParamGroups.partialBodyParams;
+    const hasBodyParam =
+      bodyParam ||
+      formBodyParams.length > 0 ||
+      multipartBodyParams.length > 0 ||
+      partialBodyParams.length > 0;
+    if (forReinjection === "none" && methodParamGroups.headerParams.length === 0 && !hasBodyParam) {
+      // closing brace for the "if firstPage {}" block
+      text += `${indent.pop().get()}}\n`;
+      inIfFirstPage = false;
+    }
   }
 
   // tack on any unencoded params to the end
+  // TODO: this was from OpenAPI support as tsp can't describe this at present. remove?
   if (unencodedParams.length > 0) {
     if (encodedParams.length > 0) {
       text += `${indent.get()}unencodedParams := []string{req.Raw().URL.RawQuery}\n`;
@@ -265,6 +351,13 @@ export function createRequestHandler(
   }
 
   // BEGIN specific request headers
+  if (forNextLinkPager && methodParamGroups.headerParams.length > 0 && !inIfFirstPage) {
+    // header params are never reinjected
+    text += `${indent.get()}if firstPage {\n`;
+    indent.push();
+    inIfFirstPage = true;
+  }
+
   let contentType: string | undefined;
   for (const param of methodParamGroups.headerParams.sort(
     (a: go.HeaderParameter, b: go.HeaderParameter) => {
@@ -327,12 +420,41 @@ export function createRequestHandler(
   // END specific request headers
 
   // BEGIN set body
+  const body = emitBody(method, methodParamGroups, imports, indent, contentType);
+  if (body) {
+    if (forNextLinkPager && !inIfFirstPage) {
+      // body params are never reinjected
+      text += `${indent.get()}if firstPage {\n`;
+      indent.push();
+      inIfFirstPage = true;
+    }
+    text += `${indent.get()}${body}`;
+  }
+  // END set body
+
+  if (inIfFirstPage) {
+    text += `${indent.pop().get()}}\n`;
+  }
+
+  text += `${indent.get()}return req, nil\n`;
+  text += "}\n\n";
+  return text;
+}
+
+function emitBody(
+  method: go.MethodType | go.NextPageMethod,
+  methodParamGroups: helpers.MethodParamGroups,
+  imports: ImportManager,
+  indent: helpers.Indentation,
+  contentType?: string,
+): string | undefined {
   // note that these are mutually exclusive
   const bodyParam = methodParamGroups.bodyParam;
   const formBodyParams = methodParamGroups.formBodyParams;
   const multipartBodyParams = methodParamGroups.multipartBodyParams;
   const partialBodyParams = methodParamGroups.partialBodyParams;
 
+  let text = "";
   if (bodyParam) {
     if (bodyParam.bodyFormat === "JSON" || bodyParam.bodyFormat === "XML") {
       // default to the body param name
@@ -417,6 +539,7 @@ export function createRequestHandler(
         text += `${indent.get()}}\n`;
         body = "aux";
       }
+
       let setBody = `runtime.MarshalAs${helpers.getMediaFormat(bodyParam.type, bodyParam.bodyFormat, `req, ${body}`)}`;
       if (bodyParam.type.kind === "rawJSON") {
         imports.add("bytes");
@@ -425,7 +548,6 @@ export function createRequestHandler(
       }
       if (go.isRequiredParameter(bodyParam.style) || go.isLiteralParameter(bodyParam.style)) {
         text += emitSetBodyWithErrCheck(setBody, indent, contentType);
-        text += `${indent.get()}return req, nil\n`;
       } else {
         text += emitParamGroupCheck(bodyParam, indent);
         indent.push();
@@ -433,7 +555,6 @@ export function createRequestHandler(
         text += `${indent.get()}return req, nil\n`;
         indent.pop();
         text += `${indent.get()}}\n`;
-        text += `${indent.get()}return req, nil\n`;
       }
     } else if (bodyParam.bodyFormat === "binary") {
       if (go.isRequiredParameter(bodyParam.style)) {
@@ -442,7 +563,6 @@ export function createRequestHandler(
           indent,
           contentType,
         );
-        text += `${indent.get()}return req, nil\n`;
       } else {
         text += emitParamGroupCheck(bodyParam, indent);
         indent.push();
@@ -454,7 +574,6 @@ export function createRequestHandler(
         text += `${indent.get()}return req, nil\n`;
         indent.pop();
         text += `${indent.get()}}\n`;
-        text += `${indent.get()}return req, nil\n`;
       }
     } else if (bodyParam.bodyFormat === "Text") {
       imports.add("strings");
@@ -466,7 +585,6 @@ export function createRequestHandler(
           indent,
           contentType,
         );
-        text += `${indent.get()}return req, nil\n`;
       } else {
         text += emitParamGroupCheck(bodyParam, indent);
         indent.push();
@@ -479,9 +597,9 @@ export function createRequestHandler(
         text += `${indent.get()}return req, nil\n`;
         indent.pop();
         text += `${indent.get()}}\n`;
-        text += `${indent.get()}return req, nil\n`;
       }
     }
+    return text;
   } else if (partialBodyParams.length > 0) {
     // partial body params are discrete params that are all fields within an internal struct.
     // define and instantiate an instance of the wire type, using the values from each param.
@@ -514,7 +632,7 @@ export function createRequestHandler(
     text += `${indent.get()}if err := runtime.MarshalAsJSON(req, body); err != nil {\n`;
     text += `${indent.push().get()}return nil, err\n`;
     text += `${indent.pop().get()}}\n`;
-    text += `${indent.get()}return req, nil\n`;
+    return text;
   } else if (multipartBodyParams.length > 0) {
     // emit content type setters for direct MultipartContent params with a fixed content type.
     // this handles the case where the param itself is a MultipartContent or a slice of them
@@ -561,7 +679,7 @@ export function createRequestHandler(
     text += `${indent.get()}if err := runtime.SetMultipartFormData(req, formData); err != nil {\n`;
     text += `${indent.push().get()}return nil, err\n`;
     text += `${indent.pop().get()}}\n`;
-    text += `${indent.get()}return req, nil\n`;
+    return text;
   } else if (formBodyParams.length > 0) {
     imports.add("net/url");
     imports.add("strings");
@@ -583,15 +701,11 @@ export function createRequestHandler(
       'req.SetBody(body, "application/x-www-form-urlencoded")',
       indent,
     );
-    text += `${indent.get()}return req, nil\n`;
+    return text;
   } else {
     // no body
-    text += `${indent.get()}return req, nil\n`;
+    return undefined;
   }
-  // END set body
-
-  text += "}\n\n";
-  return text;
 }
 
 /**
@@ -836,7 +950,10 @@ function getClientSideDefaultVarName(
  * @param src the source containing the value
  * @returns the code containing the Content-Type value
  */
-function getContentTypeValue(method: go.MethodType | go.NextPageMethod, src: go.BodyParameterContentTypeKind): string {
+function getContentTypeValue(
+  method: go.MethodType | go.NextPageMethod,
+  src: go.BodyParameterContentTypeKind,
+): string {
   switch (src.kind) {
     case "literal":
       return helpers.formatLiteralValue(src, false);

--- a/packages/typespec-go/src/codemodel/client.ts
+++ b/packages/typespec-go/src/codemodel/client.ts
@@ -276,6 +276,9 @@ export interface PageableStrategyNextLink {
    */
   nextLinkPath: Array<type.ModelField>;
 
+  /** query parameters to add to the next link request. can be empty */
+  reinjectedParams: Array<param.QueryParameter>;
+
   /** the custom method used to fetch the next link */
   method?: NextPageMethod;
 }
@@ -553,6 +556,7 @@ export class PageableStrategyNextLink implements PageableStrategyNextLink {
   constructor(nextLinkPath: Array<type.ModelField>) {
     this.kind = "nextLink";
     this.nextLinkPath = nextLinkPath;
+    this.reinjectedParams = new Array<param.QueryParameter>();
   }
 }
 

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -634,16 +634,6 @@ export class ClientAdapter {
         );
         break;
       case "paging":
-        if (
-          sdkMethod.pagingMetadata.nextLinkReInjectedParametersSegments !== undefined &&
-          sdkMethod.pagingMetadata.nextLinkReInjectedParametersSegments.length > 0
-        ) {
-          throw new AdapterError(
-            "UnsupportedTsp",
-            `paging with re-injected parameters is not supported`,
-            sdkMethod.__raw?.node,
-          );
-        }
         method = new go.PageableMethod(
           methodName,
           goClient,
@@ -736,9 +726,11 @@ export class ClientAdapter {
     if (sdkMethod.pagingMetadata.nextLinkOperation) {
       throw new AdapterError("UnsupportedTsp", "next page operation NYI", sdkMethod.__raw?.node);
     } else if (sdkMethod.pagingMetadata.nextLinkSegments) {
-      return new go.PageableStrategyNextLink(
+      const strategy = new go.PageableStrategyNextLink(
         buildNextLinkPath(sdkMethod.pagingMetadata.nextLinkSegments),
       );
+      strategy.reinjectedParams = this.adaptPageableMethodReinjectionParams(sdkMethod, paramsMap);
+      return strategy;
     } else if (
       sdkMethod.pagingMetadata.continuationTokenParameterSegments &&
       sdkMethod.pagingMetadata.continuationTokenResponseSegments
@@ -755,6 +747,13 @@ export class ClientAdapter {
             throw new AdapterError(
               "InternalError",
               `missing continuation token request parameter name ${tokenReq.name} for operation ${sdkMethod.name}`,
+              sdkMethod.__raw?.node,
+            );
+          }
+          if (tokenParam.kind === "queryCollectionParam") {
+            throw new AdapterError(
+              "InternalError",
+              `unexpected collection continuation token request parameter ${tokenReq.name} for operation ${sdkMethod.name}`,
               sdkMethod.__raw?.node,
             );
           }
@@ -802,6 +801,50 @@ export class ClientAdapter {
 
     // operation is pageable but doesn't yet support fetching subsequent pages
     return undefined;
+  }
+
+  /**
+   * converts the method parameters that must be added to next link requests.
+   *
+   * @param method the tcgc pageable method
+   * @param paramsMap maps tcgc method parameters to Go parameters
+   * @returns the query parameters to add to next link requests
+   */
+  private adaptPageableMethodReinjectionParams(
+    method:
+      | tcgc.SdkLroPagingServiceMethod<tcgc.SdkHttpOperation>
+      | tcgc.SdkPagingServiceMethod<tcgc.SdkHttpOperation>,
+    paramsMap: ParamsMapForPageable,
+  ): Array<go.QueryParameter> {
+    if (!method.pagingMetadata.nextLinkReInjectedParametersSegments) {
+      return [];
+    }
+
+    const paramsForReinjection = new Array<go.QueryParameter>();
+    for (const reinjectedParamSegment of method.pagingMetadata
+      .nextLinkReInjectedParametersSegments) {
+      for (const reinjectedParam of reinjectedParamSegment) {
+        if (reinjectedParam.kind !== "method") {
+          throw new AdapterError(
+            "InternalError",
+            `unexpected next link re-injection parameter kind ${reinjectedParam.kind}`,
+            reinjectedParam.__raw?.node,
+          );
+        }
+        const goParam = paramsMap.get(reinjectedParam);
+        if (!goParam) {
+          throw new AdapterError(
+            "InternalError",
+            `missing re-injection parameter name ${reinjectedParam.name} for operation ${method.name}`,
+            method.__raw?.node,
+          );
+        } else if (goParam.kind === "headerScalarParam") {
+          continue;
+        }
+        paramsForReinjection.push(goParam);
+      }
+    }
+    return paramsForReinjection;
   }
 
   private populateMethod(
@@ -1194,6 +1237,7 @@ export class ClientAdapter {
         if (method.kind !== "nextPageMethod" && go.isPageableMethod(method)) {
           switch (adaptedParam.kind) {
             case "headerScalarParam":
+            case "queryCollectionParam":
             case "queryScalarParam":
               pageableParamsMap.set(param, adaptedParam);
           }
@@ -2464,7 +2508,7 @@ interface ParameterStyleInfo {
  */
 type ParamsMapForPageable = Map<
   tcgc.SdkMethodParameter,
-  go.HeaderScalarParameter | go.QueryScalarParameter
+  go.HeaderScalarParameter | go.QueryParameter
 >;
 
 /**

--- a/packages/typespec-go/test/azure-http-specs/azure/core/azurepagegroup/custom_client_test.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/core/azurepagegroup/custom_client_test.go
@@ -77,8 +77,8 @@ func TestPageClient_NewListWithParametersPager(t *testing.T) {
 	require.EqualValues(t, 1, pages)
 }
 
-/*func TestPageClient_NewWithParameterizedNextLinkPager(t *testing.T) {
-	client, err := azurepagegroup.NewPageClient("http://localhost:3000", nil)
+func TestPageClient_NewWithParameterizedNextLinkPager(t *testing.T) {
+	client, err := azurepagegroup.NewPageClientWithNoCredential("http://localhost:3000", nil)
 	require.NoError(t, err)
 	pager := client.NewWithParameterizedNextLinkPager("name", &azurepagegroup.PageClientWithParameterizedNextLinkOptions{
 		IncludePending: to.Ptr(true),
@@ -108,10 +108,9 @@ func TestPageClient_NewListWithParametersPager(t *testing.T) {
 		}
 	}
 	require.EqualValues(t, 2, pages)
-}*/
+}
 
-// TODO: runtime.FetcherForNextLink doesn't support relative next link URLs
-/*func TestPageClient_NewWithRelativeNextLinkPager(t *testing.T) {
+func TestPageClient_NewWithRelativeNextLinkPager(t *testing.T) {
 	client, err := azurepagegroup.NewPageClientWithNoCredential("http://localhost:3000", nil)
 	require.NoError(t, err)
 	pager := client.NewWithRelativeNextLinkPager(nil)
@@ -142,4 +141,4 @@ func TestPageClient_NewListWithParametersPager(t *testing.T) {
 		}
 	}
 	require.EqualValues(t, 2, pages)
-}*/
+}

--- a/packages/typespec-go/test/unittest/scenarios/pageable-lro.md
+++ b/packages/typespec-go/test/unittest/scenarios/pageable-lro.md
@@ -102,9 +102,11 @@ func (client *PageableLROsClient) BeginListPrivateEndPoints(ctx context.Context,
 			return page.NextLink != nil && len(*page.NextLink) > 0
 		},
 		Fetcher: func(ctx context.Context, page *PageableLROsClientListPrivateEndPointsResponse) (PageableLROsClientListPrivateEndPointsResponse, error) {
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), *page.NextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listPrivateEndPointsCreateRequest(ctx, apiVersion, resourceGroupName, resourceName, options)
-			}, nil)
+			req, err := client.listPrivateEndPointsCreateRequest(ctx, apiVersion, resourceGroupName, resourceName, *page.NextLink, options)
+			if err != nil {
+				return PageableLROsClientListPrivateEndPointsResponse{}, err
+			}
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return PageableLROsClientListPrivateEndPointsResponse{}, err
 			}
@@ -130,7 +132,7 @@ func (client *PageableLROsClient) BeginListPrivateEndPoints(ctx context.Context,
 // ListPrivateEndPoints - A long-running resource action.
 func (client *PageableLROsClient) listPrivateEndPoints(ctx context.Context, apiVersion string, resourceGroupName string, resourceName string, options *PageableLROsClientBeginListPrivateEndPointsOptions) (*http.Response, error) {
 	var err error
-	req, err := client.listPrivateEndPointsCreateRequest(ctx, apiVersion, resourceGroupName, resourceName, options)
+	req, err := client.listPrivateEndPointsCreateRequest(ctx, apiVersion, resourceGroupName, resourceName, "", options)
 	if err != nil {
 		return nil, err
 	}
@@ -145,28 +147,37 @@ func (client *PageableLROsClient) listPrivateEndPoints(ctx context.Context, apiV
 }
 
 // listPrivateEndPointsCreateRequest creates the ListPrivateEndPoints request.
-func (client *PageableLROsClient) listPrivateEndPointsCreateRequest(ctx context.Context, apiVersion string, resourceGroupName string, resourceName string, _ *PageableLROsClientBeginListPrivateEndPointsOptions) (*policy.Request, error) {
-	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/PageableLROs/resourceSegment/{resourceName}"
-	if client.subscriptionID == "" {
-		return nil, errors.New("parameter client.subscriptionID cannot be empty")
+func (client *PageableLROsClient) listPrivateEndPointsCreateRequest(ctx context.Context, apiVersion string, resourceGroupName string, resourceName string, nextLink string, _ *PageableLROsClientBeginListPrivateEndPointsOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/PageableLROs/resourceSegment/{resourceName}"
+		if client.subscriptionID == "" {
+			return nil, errors.New("parameter client.subscriptionID cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
+		if resourceGroupName == "" {
+			return nil, errors.New("parameter resourceGroupName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
+		if resourceName == "" {
+			return nil, errors.New("parameter resourceName cannot be empty")
+		}
+		urlPath = strings.ReplaceAll(urlPath, "{resourceName}", url.PathEscape(resourceName))
+		req, err = runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
 	}
-	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
-	if resourceGroupName == "" {
-		return nil, errors.New("parameter resourceGroupName cannot be empty")
-	}
-	urlPath = strings.ReplaceAll(urlPath, "{resourceGroupName}", url.PathEscape(resourceGroupName))
-	if resourceName == "" {
-		return nil, errors.New("parameter resourceName cannot be empty")
-	}
-	urlPath = strings.ReplaceAll(urlPath, "{resourceName}", url.PathEscape(resourceName))
-	req, err := runtime.NewRequest(ctx, http.MethodPost, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", apiVersion)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", apiVersion)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 

--- a/packages/typespec-go/test/unittest/scenarios/tenant-resource.md
+++ b/packages/typespec-go/test/unittest/scenarios/tenant-resource.md
@@ -285,9 +285,11 @@ func (client *TenantItemsClient) NewListPager(apiVersion string, options *Tenant
 			if page != nil {
 				nextLink = *page.NextLink
 			}
-			resp, err := runtime.FetcherForNextLink(ctx, client.internal.Pipeline(), nextLink, func(ctx context.Context) (*policy.Request, error) {
-				return client.listCreateRequest(ctx, apiVersion, options)
-			}, nil)
+			req, err := client.listCreateRequest(ctx, apiVersion, nextLink, options)
+			if err != nil {
+				return TenantItemsClientListResponse{}, err
+			}
+			resp, err := client.internal.Pipeline().Do(req)
 			if err != nil {
 				return TenantItemsClientListResponse{}, err
 			}
@@ -297,16 +299,25 @@ func (client *TenantItemsClient) NewListPager(apiVersion string, options *Tenant
 }
 
 // listCreateRequest creates the List request.
-func (client *TenantItemsClient) listCreateRequest(ctx context.Context, apiVersion string, _ *TenantItemsClientListOptions) (*policy.Request, error) {
-	urlPath := "/providers/Microsoft.Test/tenantItems"
-	req, err := runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+func (client *TenantItemsClient) listCreateRequest(ctx context.Context, apiVersion string, nextLink string, _ *TenantItemsClientListOptions) (*policy.Request, error) {
+	firstPage := nextLink == ""
+	var req *policy.Request
+	var err error
+	if firstPage {
+		urlPath := "/providers/Microsoft.Test/tenantItems"
+		req, err = runtime.NewRequest(ctx, http.MethodGet, runtime.JoinPaths(client.internal.Endpoint(), urlPath))
+	} else {
+		req, err = runtime.NewRequestForNextLink(ctx, http.MethodGet, client.internal.Endpoint(), nextLink)
+	}
 	if err != nil {
 		return nil, err
 	}
-	reqQP := req.Raw().URL.Query()
-	reqQP.Set("api-version", apiVersion)
-	req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
-	req.Raw().Header["Accept"] = []string{"application/json"}
+	if firstPage {
+		reqQP := req.Raw().URL.Query()
+		reqQP.Set("api-version", apiVersion)
+		req.Raw().URL.RawQuery = strings.ReplaceAll(reqQP.Encode(), "+", "%20")
+		req.Raw().Header["Accept"] = []string{"application/json"}
+	}
 	return req, nil
 }
 


### PR DESCRIPTION
This adds support for parameterized next links and paging with a relative next link.
Fetchers now call their request handlers instead of FetcherForNextLink. Request handlers now have a nextLink parameter that's used to predicate construction of the first request, what parameters to reinject, and passed to NewRequestForNextLink on subsequent pages (request handlers for non-pageable operations are not affected).

Fixes https://github.com/Azure/typespec-azure/issues/4994
Fixes https://github.com/Azure/typespec-azure/issues/4993