### PR TITLE
fix(typespec-go): support scalar metadata headers

### DIFF
--- a/.chronus/changes/fix-go-scalar-metadata-headers-2026-08-13-15-05-00.md
+++ b/.chronus/changes/fix-go-scalar-metadata-headers-2026-08-13-15-05-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-go"
+---
+
+Generate scalar `x-ms-meta` request and response headers without treating them as metadata maps.

--- a/packages/typespec-go/spector.config.http.yaml
+++ b/packages/typespec-go/spector.config.http.yaml
@@ -23,6 +23,7 @@ specs:
   "parameters/query": { options: { module: querygroup } }
   "parameters/spread": { options: { module: spreadgroup } }
   "payload/content-negotiation": { options: { module: contentneggroup } }
+  "payload/head": { options: { module: headgroup } }
   "payload/json-merge-patch": { options: { module: jmergepatchgroup } }
   "payload/media-type": { options: { module: mediatypegroup } }
   "payload/multipart": { options: { module: multipartgroup } }
@@ -61,8 +62,6 @@ specs:
   # --- Not generated yet (tracked skips) ---
   # emitter bug: @encode(string) on boolean is ignored; bool is serialized as a JSON boolean instead of a string, so the mock rejects the body
   "encode/boolean": false
-  # emitter error: unexpected kind string for HeaderMapResponse metadata (HEAD op returning response headers)
-  "payload/head": false
   # TODO: https://github.com/Azure/autorest.go/issues/1606
   "response/status-code-range": false
   # TODO: https://github.com/Azure/autorest.go/issues/1730

--- a/packages/typespec-go/src/codemodel/param.ts
+++ b/packages/typespec-go/src/codemodel/param.ts
@@ -104,7 +104,8 @@ export interface HeaderCollectionParameter extends HttpParameterBase {
 
 /**
  * parameter map collection that goes in a HTTP header.
- * NOTE: this is a specialized parameter type to support storage.
+ * NOTE: this is a specialized parameter type to support storage
+ * x-ms-meta headers and should _not_ be used for any other cases.
  */
 export interface HeaderMapParameter extends HttpParameterBase {
   kind: "headerMapParam";

--- a/packages/typespec-go/src/codemodel/result.ts
+++ b/packages/typespec-go/src/codemodel/result.ts
@@ -62,7 +62,9 @@ export interface HeadAsBooleanResult {
 
 /**
  * a collection of header responses.
- * NOTE: this is a specialized type to support storage.
+ * NOTE: this is a specialized type to support storage
+ * x-ms-meta and x-ms-or headers and should _not_ be used
+ * for any other cases.
  */
 export interface HeaderMapResponse {
   kind: "headerMapResponse";

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -1539,19 +1539,15 @@ export class ClientAdapter {
           opParam.__raw?.node,
         );
       case "header":
-        if (opParam.serializedName === "x-ms-meta") {
-          const type = this.ta.getWireType(methodParam.type, true, false);
-          if (type.kind !== "map") {
-            throw new AdapterError(
-              "InternalError",
-              `unexpected kind ${type.kind} for HeaderMapParameter ${methodParam.name}`,
-              opParam.__raw?.node,
-            );
-          }
+        const headerMapType =
+          opParam.serializedName === "x-ms-meta"
+            ? this.ta.getWireType(methodParam.type, true, false)
+            : undefined;
+        if (headerMapType?.kind === "map") {
           adaptedParam = new go.HeaderMapParameter(
             paramName,
             `${opParam.serializedName}-`,
-            type,
+            headerMapType,
             paramStyle,
             byVal,
             location,
@@ -1777,20 +1773,14 @@ export class ClientAdapter {
           }
 
           let headerResp: go.HeaderScalarResponse | go.HeaderMapResponse;
-          if (
-            httpHeader.serializedName === "x-ms-meta" ||
-            httpHeader.serializedName === "x-ms-or"
-          ) {
-            const type = this.ta.getWireType(httpHeader.type, true, false);
-            if (type.kind !== "map") {
-              throw new AdapterError(
-                "InternalError",
-                `unexpected kind ${type.kind} for HeaderMapResponse ${httpHeader.name}`,
-              );
-            }
+          const headerMapType =
+            httpHeader.serializedName === "x-ms-meta" || httpHeader.serializedName === "x-ms-or"
+              ? this.ta.getWireType(httpHeader.type, true, false)
+              : undefined;
+          if (headerMapType?.kind === "map") {
             headerResp = new go.HeaderMapResponse(
               helpers.getEffectiveName(httpHeader),
-              type,
+              headerMapType,
               `${httpHeader.serializedName}-`,
             );
           } else {

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -1539,15 +1539,19 @@ export class ClientAdapter {
           opParam.__raw?.node,
         );
       case "header":
-        const headerMapType =
-          opParam.serializedName === "x-ms-meta"
-            ? this.ta.getWireType(methodParam.type, true, false)
-            : undefined;
-        if (headerMapType?.kind === "map") {
+        const type = this.ta.getWireType(methodParam.type, true, false);
+        if (type.kind === "map") {
+          if (opParam.serializedName !== "x-ms-meta") {
+            throw new AdapterError(
+              "InternalError",
+              `unexpected kind ${type.kind} for header ${opParam.serializedName}`,
+              opParam.__raw?.node,
+            );
+          }
           adaptedParam = new go.HeaderMapParameter(
             paramName,
             `${opParam.serializedName}-`,
-            headerMapType,
+            type,
             paramStyle,
             byVal,
             location,
@@ -1772,15 +1776,21 @@ export class ClientAdapter {
             continue;
           }
 
+          const type = this.ta.getWireType(httpHeader.type, true, false);
           let headerResp: go.HeaderScalarResponse | go.HeaderMapResponse;
-          const headerMapType =
-            httpHeader.serializedName === "x-ms-meta" || httpHeader.serializedName === "x-ms-or"
-              ? this.ta.getWireType(httpHeader.type, true, false)
-              : undefined;
-          if (headerMapType?.kind === "map") {
+          if (type.kind === "map") {
+            if (
+              httpHeader.serializedName !== "x-ms-meta" &&
+              httpHeader.serializedName !== "x-ms-or"
+            ) {
+              throw new AdapterError(
+                "InternalError",
+                `unexpected kind ${type.kind} for header ${httpHeader.serializedName}`,
+              );
+            }
             headerResp = new go.HeaderMapResponse(
               helpers.getEffectiveName(httpHeader),
-              headerMapType,
+              type,
               `${httpHeader.serializedName}-`,
             );
           } else {

--- a/packages/typespec-go/test/http-specs/payload/headgroup/head_client_test.go
+++ b/packages/typespec-go/test/http-specs/payload/headgroup/head_client_test.go
@@ -1,0 +1,24 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License. See License.txt in the project root for license information.
+
+package headgroup_test
+
+import (
+	"context"
+	"headgroup"
+	"testing"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
+	"github.com/stretchr/testify/require"
+)
+
+func TestHeadClient_ContentTypeHeaderInResponse(t *testing.T) {
+	client, err := headgroup.NewHeadClientWithNoCredential("http://localhost:3000", nil)
+	require.NoError(t, err)
+
+	resp, err := client.ContentTypeHeaderInResponse(context.Background(), nil)
+	require.NoError(t, err)
+	require.True(t, resp.Success)
+	require.Equal(t, to.Ptr("text/plain; charset=utf-8"), resp.ContentType)
+	require.Equal(t, to.Ptr("hello"), resp.Metadata)
+}

--- a/packages/typespec-go/test/unittest/scenarios/canonical-headers.md
+++ b/packages/typespec-go/test/unittest/scenarios/canonical-headers.md
@@ -1,7 +1,8 @@
 # Header names passed to `Get` and `Set` use Go canonical MIME casing
 
 Header names passed to `http.Header.Get` and `http.Header.Set` are canonicalized at generation
-time. Direct map access preserves the TypeSpec-provided header name.
+time. Direct map access preserves the TypeSpec-provided header name. Scalar `x-ms-meta` headers
+remain scalar instead of being treated as metadata maps.
 
 ## Emitter configuration
 
@@ -19,10 +20,14 @@ model HeaderResponse {
   @statusCode statusCode: 200;
   @header("x-response-header") responseHeader: string;
   @header("X-MS-FOO") uppercaseHeader: string;
+  @header("x-ms-meta") metadata: string;
 }
 
 @get
-op read(@header("x-request-header") requestHeader: string): HeaderResponse;
+op read(
+  @header("x-request-header") requestHeader: string,
+  @header("x-ms-meta") requestMetadata: string,
+): HeaderResponse;
 ```
 
 ## The generated client canonicalizes response header names but preserves direct map access
@@ -75,10 +80,10 @@ func NewHeadersClientWithNoCredential(endpoint string, options *HeadersClientOpt
 // Read -
 // If the operation fails it returns an *azcore.ResponseError type.
 //   - options - HeadersClientReadOptions contains the optional parameters for the HeadersClient.Read method.
-func (client *HeadersClient) Read(ctx context.Context, requestHeader string, options *HeadersClientReadOptions) (HeadersClientReadResponse, error) {
+func (client *HeadersClient) Read(ctx context.Context, requestHeader string, requestMetadata string, options *HeadersClientReadOptions) (HeadersClientReadResponse, error) {
 	var err error
 	ctx = context.WithValue(ctx, runtime.CtxAPINameKey{}, "HeadersClient.Read")
-	req, err := client.readCreateRequest(ctx, requestHeader, options)
+	req, err := client.readCreateRequest(ctx, requestHeader, requestMetadata, options)
 	if err != nil {
 		return HeadersClientReadResponse{}, err
 	}
@@ -90,11 +95,12 @@ func (client *HeadersClient) Read(ctx context.Context, requestHeader string, opt
 }
 
 // readCreateRequest creates the Read request.
-func (client *HeadersClient) readCreateRequest(ctx context.Context, requestHeader string, _ *HeadersClientReadOptions) (*policy.Request, error) {
+func (client *HeadersClient) readCreateRequest(ctx context.Context, requestHeader string, requestMetadata string, _ *HeadersClientReadOptions) (*policy.Request, error) {
 	req, err := runtime.NewRequest(ctx, http.MethodGet, client.endpoint)
 	if err != nil {
 		return nil, err
 	}
+	req.Raw().Header["x-ms-meta"] = []string{requestMetadata}
 	req.Raw().Header["x-request-header"] = []string{requestHeader}
 	return req, nil
 }
@@ -104,6 +110,9 @@ func (client *HeadersClient) readHandleResponse(resp *http.Response, successCode
 	result := HeadersClientReadResponse{}
 	if !runtime.HasStatusCode(resp, successCodes...) {
 		return result, runtime.NewResponseError(resp)
+	}
+	if val := resp.Header.Get("X-Ms-Meta"); val != "" {
+		result.Metadata = &val
 	}
 	if val := resp.Header.Get("X-Response-Header"); val != "" {
 		result.ResponseHeader = &val
@@ -140,7 +149,7 @@ import (
 type HeadersServer struct {
 	// Read is the fake for method HeadersClient.Read
 	// HTTP status codes to indicate success: http.StatusOK
-	Read func(ctx context.Context, requestHeader string, options *testmodule.HeadersClientReadOptions) (resp azfake.Responder[testmodule.HeadersClientReadResponse], errResp azfake.ErrorResponder)
+	Read func(ctx context.Context, requestHeader string, requestMetadata string, options *testmodule.HeadersClientReadOptions) (resp azfake.Responder[testmodule.HeadersClientReadResponse], errResp azfake.ErrorResponder)
 }
 
 // NewHeadersServerTransport creates a new instance of HeadersServerTransport with the provided implementation.
@@ -199,7 +208,7 @@ func (h *HeadersServerTransport) dispatchRead(req *http.Request) (*http.Response
 	if h.srv.Read == nil {
 		return nil, &nonRetriableError{errors.New("fake for method Read not implemented")}
 	}
-	respr, errRespr := h.srv.Read(req.Context(), getHeaderValue(req.Header, "x-request-header"), nil)
+	respr, errRespr := h.srv.Read(req.Context(), getHeaderValue(req.Header, "x-request-header"), getHeaderValue(req.Header, "x-ms-meta"), nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr
 	}
@@ -210,6 +219,9 @@ func (h *HeadersServerTransport) dispatchRead(req *http.Request) (*http.Response
 	resp, err := server.NewResponse(respContent, req, nil)
 	if err != nil {
 		return nil, err
+	}
+	if val := server.GetResponse(respr).Metadata; val != nil {
+		resp.Header.Set("X-Ms-Meta", *val)
 	}
 	if val := server.GetResponse(respr).ResponseHeader; val != nil {
 		resp.Header.Set("X-Response-Header", *val)


### PR DESCRIPTION
## Summary

- classify `x-ms-meta` and `x-ms-or` headers as metadata maps only when their wire type is a map
- generate scalar `x-ms-meta` request and response headers through the normal scalar path
- enable the `payload/head` Spector case and assert its `Content-Type`, `x-ms-meta`, and HEAD success response values

## Testing

- `vitest run test/unittest/scenario-suites/canonical-headers.test.ts`
- `node .scripts/tspcompile.js --filter=headgroup`
- `go test -v ./...` against the Spector server

Fixes #5180