### PR TITLE
[publish] typespec-java 0.46.0

### DIFF
--- a/.chronus/changes/typespec-java-fluent-sample-routing-2026-08-13.md
+++ b/.chronus/changes/typespec-java-fluent-sample-routing-2026-08-13.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Fix Fluent Premium samples to use the correct service client for resource metadata suffixes (core [#11633](https://github.com/microsoft/typespec/pull/11633)).

--- a/.chronus/changes/typespec-java-preserve-sdk-properties-2026-08-13.md
+++ b/.chronus/changes/typespec-java-preserve-sdk-properties-2026-08-13.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Preserve existing properties files for applicable libraries during SDK integration (core [#11635](https://github.com/microsoft/typespec/pull/11635)).

--- a/.chronus/changes/typespec-java-remove-model-2026-08-13.md
+++ b/.chronus/changes/typespec-java-remove-model-2026-08-13.md
@@ -1,7 +1,0 @@
----
-changeKind: feature
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Sync core to microsoft/typespec commit `27b39b71b`. Support removing models from management clients with the `remove-model` emitter option (core [#11658](https://github.com/microsoft/typespec/pull/11658)).

--- a/.chronus/changes/typespec-java-response-header-javadocs-2026-08-13.md
+++ b/.chronus/changes/typespec-java-response-header-javadocs-2026-08-13.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Document response headers in protocol API Javadocs (core [#11610](https://github.com/microsoft/typespec/pull/11610)).

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -4,20 +4,20 @@
 
 ### Features
 
-- [#5218](https://github.com/Azure/typespec-azure/pull/5218) Sync core to microsoft/typespec commit `27b39b71b`. Support removing models from management clients with the `remove-model` emitter option (core [#11658](https://github.com/microsoft/typespec/pull/11658)).
+- Sync core to microsoft/typespec commit `27b39b71b`. Support removing models from management clients with the `remove-model` emitter option (core [#11658](https://github.com/microsoft/typespec/pull/11658)).
 
 ### Bug Fixes
 
-- [#5218](https://github.com/Azure/typespec-azure/pull/5218) Fix Fluent Premium samples to use the correct service client for resource metadata suffixes (core [#11633](https://github.com/microsoft/typespec/pull/11633)).
-- [#5218](https://github.com/Azure/typespec-azure/pull/5218) Preserve existing properties files for applicable libraries during SDK integration (core [#11635](https://github.com/microsoft/typespec/pull/11635)).
-- [#5218](https://github.com/Azure/typespec-azure/pull/5218) Document response headers in protocol API Javadocs (core [#11610](https://github.com/microsoft/typespec/pull/11610)).
+- Fix Fluent Premium samples to use the correct service client for resource metadata suffixes (core [#11633](https://github.com/microsoft/typespec/pull/11633)).
+- Preserve existing properties files for applicable libraries during SDK integration (core [#11635](https://github.com/microsoft/typespec/pull/11635)).
+- Document response headers in protocol API Javadocs (core [#11610](https://github.com/microsoft/typespec/pull/11610)).
 
 
 ## 0.45.13
 
 ### Features
 
-- [#5138](https://github.com/Azure/typespec-azure/pull/5138) Sync core to microsoft/typespec commit `2e1649b83`. Includes support for nested property paths and XML payloads in Azure pageable responses (core [#11504](https://github.com/microsoft/typespec/pull/11504)).
+- Sync core to microsoft/typespec commit `2e1649b83`. Includes support for nested property paths and XML payloads in Azure pageable responses (core [#11504](https://github.com/microsoft/typespec/pull/11504)).
 
 
 ## 0.45.12

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Change Log - @azure-tools/typespec-java
 
+## 0.46.0
+
+### Features
+
+- [#5218](https://github.com/Azure/typespec-azure/pull/5218) Sync core to microsoft/typespec commit `27b39b71b`. Support removing models from management clients with the `remove-model` emitter option (core [#11658](https://github.com/microsoft/typespec/pull/11658)).
+
+### Bug Fixes
+
+- [#5218](https://github.com/Azure/typespec-azure/pull/5218) Fix Fluent Premium samples to use the correct service client for resource metadata suffixes (core [#11633](https://github.com/microsoft/typespec/pull/11633)).
+- [#5218](https://github.com/Azure/typespec-azure/pull/5218) Preserve existing properties files for applicable libraries during SDK integration (core [#11635](https://github.com/microsoft/typespec/pull/11635)).
+- [#5218](https://github.com/Azure/typespec-azure/pull/5218) Document response headers in protocol API Javadocs (core [#11610](https://github.com/microsoft/typespec/pull/11610)).
+
+
 ## 0.45.13
 
 ### Features

--- a/packages/typespec-java/package.json
+++ b/packages/typespec-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.45.13",
+  "version": "0.46.0",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
## Summary

- bump `@azure-tools/typespec-java` from 0.45.13 to 0.46.0
- generate the 0.46.0 changelog from the Chronus entries merged in #5218
- consume the released change files
