### PR TITLE
Re-enable Java ARM resource identifier test

### DIFF
--- a/.chronus/changes/enable-java-arm-resource-identifier-test-2026-08-17-11-23-00.md
+++ b/.chronus/changes/enable-java-arm-resource-identifier-test-2026-08-17-11-23-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-java"
+---
+
+Re-enable the ARM resource identifier emitter test.

--- a/packages/typespec-java/core.test.patch
+++ b/packages/typespec-java/core.test.patch
@@ -16,17 +16,3 @@ index f002da96..fae8d01b 100644
      }
  
      public static byte[] getJpgBytes() {
-diff --git a/src/test/java/azure/resourcemanager/commonproperties/CommonPropertiesTests.java b/src/test/java/azure/resourcemanager/commonproperties/CommonPropertiesTests.java
---- a/src/test/java/azure/resourcemanager/commonproperties/CommonPropertiesTests.java
-+++ b/src/test/java/azure/resourcemanager/commonproperties/CommonPropertiesTests.java
-@@ -18,5 +18,6 @@ import com.azure.core.management.exception.ManagementException;
- import java.util.HashMap;
- import java.util.Map;
- import org.junit.jupiter.api.Assertions;
-+import org.junit.jupiter.api.Disabled;
- import org.junit.jupiter.api.Test;
- import org.utils.ArmUtils;
-@@ -98,2 +99,3 @@ public class CommonPropertiesTests {
-     @Test
-+    @Disabled("Requires an unreleased azure-http-specs ARM resource identifier feature")
-     public void testArmResourceIdentifiers() {

--- a/packages/typespec-java/emitter-tests/src/test/java/azure/resourcemanager/commonproperties/CommonPropertiesTests.java
+++ b/packages/typespec-java/emitter-tests/src/test/java/azure/resourcemanager/commonproperties/CommonPropertiesTests.java
@@ -18,7 +18,6 @@ import com.azure.core.management.exception.ManagementException;
 import java.util.HashMap;
 import java.util.Map;
 import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.utils.ArmUtils;
 
@@ -97,7 +96,6 @@ public class CommonPropertiesTests {
     }
 
     @Test
-    @Disabled("Requires an unreleased azure-http-specs ARM resource identifier feature")
     public void testArmResourceIdentifiers() {
         final String subscriptionId = "00000000-0000-0000-0000-000000000000";
         final String resourceGroup = "test-rg";


### PR DESCRIPTION
## Summary

- remove the obsolete patch that disables the ARM resource identifier test
- re-enable the generated Java emitter test
- add an internal TypeSpec Java change entry

## Validation

- `pnpm format`
- `pnpm lint`
- `mvn -f emitter-tests\pom.xml '-Dtest=azure.resourcemanager.commonproperties.CommonPropertiesTests#testArmResourceIdentifiers' test -q`
