### PR TITLE
Update Black to 26.3.1 to avoid security risk

### DIFF
--- a/.chronus/changes/pr-5240-2026-7-18-10-11-56.md
+++ b/.chronus/changes/pr-5240-2026-7-18-10-11-56.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-python"
+---
+
+Update Black to 26.3.1 to avoid security risk

--- a/packages/typespec-python/dev_requirements.txt
+++ b/packages/typespec-python/dev_requirements.txt
@@ -8,7 +8,7 @@ colorama==0.4.6
 debugpy==1.8.2
 pytest==9.0.3
 coverage==7.6.1
-black==24.4.0
+black==26.3.1
 ptvsd==4.3.2
 types-PyYAML==6.0.12.8
 

--- a/packages/typespec-python/tests/requirements/lint.txt
+++ b/packages/typespec-python/tests/requirements/lint.txt
@@ -1,4 +1,4 @@
 # Linting dependencies
 -r base.txt
 pylint==4.0.4
-black==24.4.0
+black==26.3.1


### PR DESCRIPTION
Alerted by: https://github.com/Azure/typespec-azure/security/dependabot/313 and https://github.com/Azure/typespec-azure/security/dependabot/314