### PR TITLE
Minor release: @azure-tools/typespec-go@0.17.0

### DIFF
--- a/.chronus/changes/add-spector-test-case-except-union-2026-7-10-9-47-57.md
+++ b/.chronus/changes/add-spector-test-case-except-union-2026-7-10-9-47-57.md
@@ -1,8 +1,0 @@
----
-# Change versionKind to one of: internal, fix, dependencies, feature, deprecation, breaking
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-go"
----
-
-add spector test cases except union cases

--- a/.chronus/changes/add-tests-2026-7-18-16-31-0.md
+++ b/.chronus/changes/add-tests-2026-7-18-16-31-0.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Add missing tests.

--- a/.chronus/changes/arm-coverage-2026-7-18-12-36-27.md
+++ b/.chronus/changes/arm-coverage-2026-7-18-12-36-27.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Add tests for new ARM scenarios.

--- a/.chronus/changes/emit-content-type-2026-7-19-15-11-30.md
+++ b/.chronus/changes/emit-content-type-2026-7-19-15-11-30.md
@@ -1,7 +1,0 @@
----
-changeKind: feature
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Add emit-content-type-header emitter option.

--- a/.chronus/changes/fix-go-boolean-string-encoding-2026-08-13-15-04-00.md
+++ b/.chronus/changes/fix-go-boolean-string-encoding-2026-08-13-15-04-00.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Honor `@encode(string)` when serializing and deserializing boolean model properties.

--- a/.chronus/changes/fix-go-extensible-enum-request-body-2026-08-17-14-00-00.md
+++ b/.chronus/changes/fix-go-extensible-enum-request-body-2026-08-17-14-00-00.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Format text request body values as strings before creating readers.

--- a/.chronus/changes/fix-go-fake-path-api-version-2026-08-17.md
+++ b/.chronus/changes/fix-go-fake-path-api-version-2026-08-17.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Generate fake servers for operations with path-based API versions and additional path parameters.

--- a/.chronus/changes/fix-go-path-api-version-override-2026-08-04-14-45-00.md
+++ b/.chronus/changes/fix-go-path-api-version-override-2026-08-04-14-45-00.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Honor `ClientOptions.APIVersion` for API versions emitted in operation paths.

--- a/.chronus/changes/fix-go-scalar-metadata-headers-2026-08-13-15-05-00.md
+++ b/.chronus/changes/fix-go-scalar-metadata-headers-2026-08-13-15-05-00.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Generate scalar `x-ms-meta` request and response headers without treating them as metadata maps.

--- a/.chronus/changes/fix-test-2026-7-18-14-3-56.md
+++ b/.chronus/changes/fix-test-2026-7-18-14-3-56.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Fix broken test.

--- a/.chronus/changes/go-pager-refactor-1-2026-7-10-15-54-7.md
+++ b/.chronus/changes/go-pager-refactor-1-2026-7-10-15-54-7.md
@@ -1,7 +1,0 @@
----
-changeKind: feature
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Add support for paged operations with next links that are parameterized or relative URLs.

--- a/.chronus/changes/go-tsp-unions-2026-7-17-13-46-11.md
+++ b/.chronus/changes/go-tsp-unions-2026-7-17-13-46-11.md
@@ -1,7 +1,0 @@
----
-changeKind: feature
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Added support for tsp non-discriminated unions.

--- a/.chronus/changes/remove-traits-tests-2026-7-17-15-19-8.md
+++ b/.chronus/changes/remove-traits-tests-2026-7-17-15-19-8.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Remove bad tests.

--- a/.chronus/changes/typespec-go-array-property-encoding-2026-08-04.md
+++ b/.chronus/changes/typespec-go-array-property-encoding-2026-08-04.md
@@ -1,7 +1,0 @@
----
-changeKind: feature
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Support array encoding decorators.

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Release History
 
+## 0.17.0
+
+### Features
+
+- [#5261](https://github.com/Azure/typespec-azure/pull/5261) Add emit-content-type-header emitter option.
+- [#5198](https://github.com/Azure/typespec-azure/pull/5198) Add support for paged operations with next links that are parameterized or relative URLs.
+- [#5245](https://github.com/Azure/typespec-azure/pull/5245) Added support for tsp non-discriminated unions.
+- [#5152](https://github.com/Azure/typespec-azure/pull/5152) Support array encoding decorators.
+
+### Bug Fixes
+
+- [#5189](https://github.com/Azure/typespec-azure/pull/5189) add spector test cases except union cases
+- [#5219](https://github.com/Azure/typespec-azure/pull/5219) Honor `@encode(string)` when serializing and deserializing boolean model properties.
+- [#5238](https://github.com/Azure/typespec-azure/pull/5238) Format text request body values as strings before creating readers.
+- [#5235](https://github.com/Azure/typespec-azure/pull/5235) Generate fake servers for operations with path-based API versions and additional path parameters.
+- [#5151](https://github.com/Azure/typespec-azure/pull/5151) Honor `ClientOptions.APIVersion` for API versions emitted in operation paths.
+- [#5220](https://github.com/Azure/typespec-azure/pull/5220) Generate scalar `x-ms-meta` request and response headers without treating them as metadata maps.
+
+
 ## 0.16.0
 
 ### Features

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -11,7 +11,6 @@
 
 ### Bug Fixes
 
-- [#5189](https://github.com/Azure/typespec-azure/pull/5189) add spector test cases except union cases
 - [#5219](https://github.com/Azure/typespec-azure/pull/5219) Honor `@encode(string)` when serializing and deserializing boolean model properties.
 - [#5238](https://github.com/Azure/typespec-azure/pull/5238) Format text request body values as strings before creating readers.
 - [#5235](https://github.com/Azure/typespec-azure/pull/5235) Generate fake servers for operations with path-based API versions and additional path parameters.

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-go",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Go SDKs",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
Releases `@azure-tools/typespec-go` 0.17.0 from `main`.

### Features

- Add the `emit-content-type-header` emitter option (#5261).
- Support paged operations with parameterized or relative next-link URLs (#5198).
- Support non-discriminated TypeSpec unions (#5245).
- Support array encoding decorators (#5152).

### Bug fixes

- Honor `@encode(string)` for boolean model properties (#5219).
- Format text request body values as strings before creating readers (#5238).
- Generate fake servers for path-based API versions with additional path parameters (#5235).
- Honor `ClientOptions.APIVersion` for operation-path API versions (#5151).
- Generate scalar `x-ms-meta` headers without treating them as metadata maps (#5220).

Includes four internal-only changes. Generated with Chronus for `@azure-tools/typespec-go` only; the `core` submodule and other package versions are unchanged.