### PR TITLE
Resolve cross-language definition IDs through alternate types

### DIFF
--- a/.chronus/changes/resolve-alternate-type-cross-language-id-2026-08-20.md
+++ b/.chronus/changes/resolve-alternate-type-cross-language-id-2026-08-20.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-client-generator-core"
+---
+
+Resolve cross-language definition IDs through `@alternateType`.

--- a/packages/typespec-client-generator-core/src/public-utils.ts
+++ b/packages/typespec-client-generator-core/src/public-utils.ts
@@ -31,7 +31,12 @@ import {
 import { getOperationId } from "@typespec/openapi";
 import { type Version, getVersions } from "@typespec/versioning";
 import { pascalCase } from "change-case";
-import { getClientLocation, getClientNameOverride, getIsApiVersion } from "./decorators.js";
+import {
+  getAlternateType,
+  getClientLocation,
+  getClientNameOverride,
+  getIsApiVersion,
+} from "./decorators.js";
 import { normalizeExactName } from "./functions.js";
 import type {
   DecoratedType,
@@ -305,6 +310,25 @@ export function getCrossLanguageDefinitionId(
   operation?: Operation,
   appendNamespace: boolean = true,
 ): string {
+  if (
+    type.kind === "Union" ||
+    type.kind === "Model" ||
+    type.kind === "Enum" ||
+    type.kind === "Scalar" ||
+    type.kind === "ModelProperty"
+  ) {
+    const alternateType = getAlternateType(context, type);
+    if (
+      alternateType?.kind === "Union" ||
+      alternateType?.kind === "Model" ||
+      alternateType?.kind === "Enum" ||
+      alternateType?.kind === "Scalar" ||
+      alternateType?.kind === "ModelProperty"
+    ) {
+      return getCrossLanguageDefinitionId(context, alternateType, operation, appendNamespace);
+    }
+  }
+
   let retval: string = typeof type.name === "symbol" ? "anonymous" : type.name || "anonymous";
   let namespace =
     type.kind === "ModelProperty"

--- a/packages/typespec-client-generator-core/test/public-utils/get-cross-language-definition-id.test.ts
+++ b/packages/typespec-client-generator-core/test/public-utils/get-cross-language-definition-id.test.ts
@@ -1,11 +1,36 @@
+import { t } from "@typespec/compiler/testing";
 import { strictEqual } from "assert";
 import { it } from "vitest";
+import { getCrossLanguageDefinitionId } from "../../src/public-utils.js";
 import {
   AzureCoreTester,
   AzureCoreTesterWithService,
   createSdkContextForTester,
+  SimpleTester,
   SimpleTesterWithService,
 } from "../tester.js";
+
+it("resolves alternate type crossLanguageDefinitionId", async () => {
+  const { program, OriginalType, ReplacementType } = await SimpleTester.compile(t.code`
+    namespace TestService {
+      model ${t.model("ReplacementType")} {
+        value: string;
+      }
+
+      @alternateType(ReplacementType)
+      model ${t.model("OriginalType")} {
+        value: string;
+      }
+    }
+  `);
+  const context = await createSdkContextForTester(program);
+
+  strictEqual(
+    getCrossLanguageDefinitionId(context, OriginalType),
+    getCrossLanguageDefinitionId(context, ReplacementType),
+  );
+  strictEqual(getCrossLanguageDefinitionId(context, OriginalType), "TestService.ReplacementType");
+});
 
 it("parameter's crossLanguageDefinitionId", async () => {
   const { program } = await AzureCoreTesterWithService.compile(`


### PR DESCRIPTION
## Summary
- resolve cross-language definition IDs through `@alternateType`
- add regression coverage for replacement model IDs

Fixes #5248

## Validation
- `pnpm lint`
- `pnpm --filter @azure-tools/typespec-client-generator-core build`
- `pnpm --filter @azure-tools/typespec-client-generator-core exec vitest run test/public-utils/get-cross-language-definition-id.test.ts`