### PR TITLE
Enable TypeScript client structure Spector tests

### DIFF
--- a/.chronus/changes/enable-typespec-ts-client-structure-spector-tests-2026-08-24.md
+++ b/.chronus/changes/enable-typespec-ts-client-structure-spector-tests-2026-08-24.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Enable Spector coverage for client operation groups and renamed operations.

--- a/packages/typespec-ts/spector.config.yaml
+++ b/packages/typespec-ts/spector.config.yaml
@@ -116,9 +116,8 @@ specs:
   azure/client-generator-core/response-as-bool: true
   documentation: true
 
-  # Disabled: needs tcgc upgrade https://github.com/Azure/typespec-azure/pull/3997
-  client/structure/renamed-operation: false
+  client/structure/renamed-operation: true
   client/structure/two-operation-group: false
-  client/structure/client-operation-group: false
+  client/structure/client-operation-group: true
   # Disabled: multipart not yet supported
   payload/multipart: false

--- a/packages/typespec-ts/test/azure-modular-integration/client-structure-operation-group.test.ts
+++ b/packages/typespec-ts/test/azure-modular-integration/client-structure-operation-group.test.ts
@@ -1,22 +1,26 @@
 import { assert, beforeEach, describe, it } from "vitest";
 
-// TODO: reinstate import and delete below placeholder once tests are working
-// import { FirstClient, SecondClient } from "./generated/client/structure/client-operation-group/src/index.js";
-declare type FirstClient = any;
-declare type SecondClient = any;
-declare const FirstClient: any;
-declare const SecondClient: any;
+import {
+  FirstClient,
+  SecondClient,
+} from "./generated/client/structure/client-operation-group/src/index.js";
 
-describe.skip("Client Structure Operation Group Rest Client", () => {
+describe("Client Structure Operation Group Rest Client", () => {
   let client1: FirstClient;
   let client2: SecondClient;
 
   beforeEach(() => {
     client1 = new FirstClient("http://localhost:3002", "client-operation-group", {
       allowInsecureConnection: true,
+      retryOptions: {
+        maxRetries: 0,
+      },
     });
     client2 = new SecondClient("http://localhost:3002", "client-operation-group", {
       allowInsecureConnection: true,
+      retryOptions: {
+        maxRetries: 0,
+      },
     });
   });
 
@@ -26,17 +30,17 @@ describe.skip("Client Structure Operation Group Rest Client", () => {
   });
 
   it("should call operation two correctly", async () => {
-    const result = await client1.two();
+    const result = await client1.group3.two();
     assert.strictEqual(result, undefined);
   });
 
   it("should call operation three correctly", async () => {
-    const result = await client1.three();
+    const result = await client1.group3.three();
     assert.strictEqual(result, undefined);
   });
 
   it("should call operation four correctly", async () => {
-    const result = await client1.four();
+    const result = await client1.group4.four();
     assert.strictEqual(result, undefined);
   });
 
@@ -46,7 +50,7 @@ describe.skip("Client Structure Operation Group Rest Client", () => {
   });
 
   it("should call operation six correctly", async () => {
-    const result = await client2.six();
+    const result = await client2.group5.six();
     assert.strictEqual(result, undefined);
   });
 });

--- a/packages/typespec-ts/test/azure-modular-integration/client-structure-renamed.test.ts
+++ b/packages/typespec-ts/test/azure-modular-integration/client-structure-renamed.test.ts
@@ -1,16 +1,16 @@
 import { assert, beforeEach, describe, it } from "vitest";
 
-// TODO: reinstate import and delete below placeholder once tests are working
-// import { RenamedOperationClient } from "./generated/client/structure/renamed-operation/src/index.js";
-declare type RenamedOperationClient = any;
-declare const RenamedOperationClient: any;
+import { RenamedOperationClient } from "./generated/client/structure/renamed-operation/src/index.js";
 
-describe.skip("Client Structure Renamed-Operation Rest Client", () => {
+describe("Client Structure Renamed-Operation Rest Client", () => {
   let client: RenamedOperationClient;
 
   beforeEach(() => {
     client = new RenamedOperationClient("http://localhost:3002", "renamed-operation", {
       allowInsecureConnection: true,
+      retryOptions: {
+        maxRetries: 0,
+      },
     });
   });
 
@@ -20,7 +20,7 @@ describe.skip("Client Structure Renamed-Operation Rest Client", () => {
   });
 
   it("should call operation two correctly", async () => {
-    const result = await client.renamedTwo();
+    const result = await client.group.renamedTwo();
     assert.strictEqual(result, undefined);
   });
 
@@ -30,7 +30,7 @@ describe.skip("Client Structure Renamed-Operation Rest Client", () => {
   });
 
   it("should call operation four correctly", async () => {
-    const result = await client.renamedFour();
+    const result = await client.group.renamedFour();
     assert.strictEqual(result, undefined);
   });
 
@@ -40,7 +40,7 @@ describe.skip("Client Structure Renamed-Operation Rest Client", () => {
   });
 
   it("should call operation six correctly", async () => {
-    const result = await client.renamedSix();
+    const result = await client.group.renamedSix();
     assert.strictEqual(result, undefined);
   });
 });

--- a/packages/typespec-ts/test/azure-modular-integration/generated/client/structure/client-operation-group/src/index.d.ts
+++ b/packages/typespec-ts/test/azure-modular-integration/generated/client/structure/client-operation-group/src/index.d.ts
@@ -1,6 +1,8 @@
 import { ClientOptions } from '@azure-rest/core-client';
+import { isRestError } from '@azure/core-rest-pipeline';
 import { OperationOptions } from '@azure-rest/core-client';
 import { Pipeline } from '@azure/core-rest-pipeline';
+import { RestError } from '@azure/core-rest-pipeline';
 
 export declare type ClientType = "default" | "multi-client" | "renamed-operation" | "two-operation-group" | "client-operation-group";
 
@@ -8,10 +10,9 @@ export declare class FirstClient {
     private _client;
     readonly pipeline: Pipeline;
     constructor(endpointParam: string, clientParam: ClientType, options?: FirstClientOptionalParams);
-    four(options?: FourOptionalParams): Promise<void>;
-    three(options?: ThreeOptionalParams): Promise<void>;
-    two(options?: TwoOptionalParams): Promise<void>;
     one(options?: OneOptionalParams): Promise<void>;
+    readonly group4: Group4Operations;
+    readonly group3: Group3Operations;
 }
 
 export declare interface FirstClientOptionalParams extends ClientOptions {
@@ -20,30 +21,47 @@ export declare interface FirstClientOptionalParams extends ClientOptions {
 export declare interface FiveOptionalParams extends OperationOptions {
 }
 
-export declare interface FourOptionalParams extends OperationOptions {
+export declare interface Group3Operations {
+    three: (options?: Group3ThreeOptionalParams) => Promise<void>;
+    two: (options?: Group3TwoOptionalParams) => Promise<void>;
 }
+
+export declare interface Group3ThreeOptionalParams extends OperationOptions {
+}
+
+export declare interface Group3TwoOptionalParams extends OperationOptions {
+}
+
+export declare interface Group4FourOptionalParams extends OperationOptions {
+}
+
+export declare interface Group4Operations {
+    four: (options?: Group4FourOptionalParams) => Promise<void>;
+}
+
+export declare interface Group5Operations {
+    six: (options?: Group5SixOptionalParams) => Promise<void>;
+}
+
+export declare interface Group5SixOptionalParams extends OperationOptions {
+}
+
+export { isRestError }
 
 export declare interface OneOptionalParams extends OperationOptions {
 }
+
+export { RestError }
 
 export declare class SecondClient {
     private _client;
     readonly pipeline: Pipeline;
     constructor(endpointParam: string, clientParam: ClientType, options?: SecondClientOptionalParams);
-    six(options?: SixOptionalParams): Promise<void>;
     five(options?: FiveOptionalParams): Promise<void>;
+    readonly group5: Group5Operations;
 }
 
 export declare interface SecondClientOptionalParams extends ClientOptions {
-}
-
-export declare interface SixOptionalParams extends OperationOptions {
-}
-
-export declare interface ThreeOptionalParams extends OperationOptions {
-}
-
-export declare interface TwoOptionalParams extends OperationOptions {
 }
 
 export { }

--- a/packages/typespec-ts/test/azure-modular-integration/generated/client/structure/client-operation-group/tspconfig.yaml
+++ b/packages/typespec-ts/test/azure-modular-integration/generated/client/structure/client-operation-group/tspconfig.yaml
@@ -3,10 +3,5 @@ emit:
 options:
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{project-root}"
-    generate-test: false
-    add-credentials: false
-    flavor: azure
     package-details:
-      name: "@msinternal/client-operation-group"
-      description: "Client Structure OperaitonGroup Test Service"
-      version: "1.0.0"
+      name: "@msinternal/client-structure-client-operation-group"

--- a/packages/typespec-ts/test/azure-modular-integration/generated/client/structure/renamed-operation/src/index.d.ts
+++ b/packages/typespec-ts/test/azure-modular-integration/generated/client/structure/renamed-operation/src/index.d.ts
@@ -1,13 +1,29 @@
 import { ClientOptions } from '@azure-rest/core-client';
+import { isRestError } from '@azure/core-rest-pipeline';
 import { OperationOptions } from '@azure-rest/core-client';
 import { Pipeline } from '@azure/core-rest-pipeline';
+import { RestError } from '@azure/core-rest-pipeline';
 
 export declare type ClientType = "default" | "multi-client" | "renamed-operation" | "two-operation-group" | "client-operation-group";
 
-export declare interface RenamedFiveOptionalParams extends OperationOptions {
+export declare interface GroupOperations {
+    renamedSix: (options?: GroupRenamedSixOptionalParams) => Promise<void>;
+    renamedFour: (options?: GroupRenamedFourOptionalParams) => Promise<void>;
+    renamedTwo: (options?: GroupRenamedTwoOptionalParams) => Promise<void>;
 }
 
-export declare interface RenamedFourOptionalParams extends OperationOptions {
+export declare interface GroupRenamedFourOptionalParams extends OperationOptions {
+}
+
+export declare interface GroupRenamedSixOptionalParams extends OperationOptions {
+}
+
+export declare interface GroupRenamedTwoOptionalParams extends OperationOptions {
+}
+
+export { isRestError }
+
+export declare interface RenamedFiveOptionalParams extends OperationOptions {
 }
 
 export declare interface RenamedOneOptionalParams extends OperationOptions {
@@ -17,24 +33,18 @@ export declare class RenamedOperationClient {
     private _client;
     readonly pipeline: Pipeline;
     constructor(endpointParam: string, clientParam: ClientType, options?: RenamedOperationClientOptionalParams);
-    renamedSix(options?: RenamedSixOptionalParams): Promise<void>;
-    renamedFour(options?: RenamedFourOptionalParams): Promise<void>;
-    renamedTwo(options?: RenamedTwoOptionalParams): Promise<void>;
     renamedFive(options?: RenamedFiveOptionalParams): Promise<void>;
     renamedThree(options?: RenamedThreeOptionalParams): Promise<void>;
     renamedOne(options?: RenamedOneOptionalParams): Promise<void>;
+    readonly group: GroupOperations;
 }
 
 export declare interface RenamedOperationClientOptionalParams extends ClientOptions {
 }
 
-export declare interface RenamedSixOptionalParams extends OperationOptions {
-}
-
 export declare interface RenamedThreeOptionalParams extends OperationOptions {
 }
 
-export declare interface RenamedTwoOptionalParams extends OperationOptions {
-}
+export { RestError }
 
 export { }

--- a/packages/typespec-ts/test/azure-modular-integration/generated/client/structure/renamed-operation/tspconfig.yaml
+++ b/packages/typespec-ts/test/azure-modular-integration/generated/client/structure/renamed-operation/tspconfig.yaml
@@ -3,10 +3,5 @@ emit:
 options:
   "@azure-tools/typespec-ts":
     emitter-output-dir: "{project-root}"
-    generate-test: false
-    add-credentials: false
-    flavor: azure
     package-details:
-      name: "@msinternal/client-structure-renamed"
-      description: "Client Structure RenamedOperaiton Test Service"
-      version: "1.0.0"
+      name: "@msinternal/client-structure-renamed-operation"


### PR DESCRIPTION
## Summary

- enable the client operation-group and renamed-operation Spector cases for typespec-ts
- replace skipped placeholder tests with generated client usage for all 12 scenarios
- regenerate the tracked declaration baselines with current emitter configuration

## Validation

- 12 focused Spector integration tests passed
- pnpm format
- pnpm lint
- pnpm change verify