### PR TITLE
[Swagger Linter Migration] NonApplicationJsonType (origin)

### DIFF
--- a/packages/typespec-lintdiff/src/rules/non-application-json-type.ts
+++ b/packages/typespec-lintdiff/src/rules/non-application-json-type.ts
@@ -1,8 +1,8 @@
-import { createRule } from "@typespec/compiler";
-import type { ModelProperty, Operation } from "@typespec/compiler";
-import { getHttpOperation } from "@typespec/http";
-import type { HttpPayloadBody } from "@typespec/http";
 import { isArmProviderNamespace } from "@azure-tools/typespec-azure-resource-manager";
+import type { Interface, ModelProperty, Operation, Program } from "@typespec/compiler";
+import { createRule, getLocationContext } from "@typespec/compiler";
+import type { HttpPayloadBody } from "@typespec/http";
+import { getHttpOperation } from "@typespec/http";
 
 export const nonApplicationJsonTypeRule = createRule({
   name: "non-application-json-type",
@@ -49,22 +49,34 @@ function reportInvalidBody(
     }
 
     context.reportDiagnostic({
-      target: getDiagnosticTarget(operation, body),
+      target: getDiagnosticTarget(context.program, operation, body),
     });
   }
 }
 
 function getDiagnosticTarget(
+  program: Program,
   operation: Operation,
   body: HttpPayloadBody,
-): ModelProperty | Operation {
-  if (body.contentTypeProperty !== undefined) {
+): Interface | ModelProperty | Operation {
+  if (
+    body.contentTypeProperty !== undefined &&
+    getLocationContext(program, body.contentTypeProperty).type === "project"
+  ) {
     return body.contentTypeProperty;
   }
 
-  if ("property" in body && body.property !== undefined) {
+  if (
+    "property" in body &&
+    body.property !== undefined &&
+    getLocationContext(program, body.property).type === "project"
+  ) {
     return body.property;
   }
 
-  return operation;
+  if (getLocationContext(program, operation).type === "project") {
+    return operation;
+  }
+
+  return operation.interface ?? operation;
 }

--- a/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/migration.md
+++ b/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/migration.md
@@ -1,0 +1,199 @@
+# NonApplicationJsonType migration investigation
+
+## Conclusion
+
+The migrated TypeSpec rule
+`tsp-lintdiff-local-linter/non-application-json-type` is functionally equivalent
+to the Swagger `NonApplicationJsonType` rule for authorable TypeSpec ARM
+operations after this change.
+
+**TypeSpec rule update required:** yes. The rule already discovered implicit
+scalar response content types, but diagnostics targeted a body property
+instantiated from the ARM library. The compiler does not surface project lint
+diagnostics on that library target. The rule now uses an authored content-type
+or body property when available and otherwise reports on the authored
+operation. A scalar-response regression fixture covers the corrected branch.
+
+## Reports and populations
+
+| Evidence                                                              | Revision and population                                                                                                                                                                             | `NonApplicationJsonType` row                                                                                                                              |
+| --------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| [`docs/coverage_old.md`](../../../docs/coverage_old.md)               | Snapshot committed at `6a418911dbe5d35992fb5845cf4460d45643fec8`; source gist does not record its specs or generator revision; 450 compiled projects and 210 validator rules                        | Below 80%: validator fired in 4 projects, local lint fired in 3, no official coverage, 75%                                                                |
+| [`specs/coverage-breakdown.md`](../../../specs/coverage-breakdown.md) | Checked-in baseline generated `2026-08-10T09:38:18.108Z` at specs commit `f6b53f105b95da05276530a0754a1c71b4f16397`; 462 of 468 projects compiled successfully                                      | Production: validator 3 projects, TypeSpec 3 projects, overlap 3, no one-sided projects; 20 validator and 19 TypeSpec diagnostics                         |
+| Fresh full validation recorded by this note                           | Full `specs:typespec` run generated `2026-08-24T10:31:51.884Z` at the same specs commit with harness revision `fa05821e966c8b326d82e401b5158215490721a9`; 462 of 468 projects compiled successfully | Production: validator 3 projects, raw TypeSpec 4 projects, overlap 3, validator-only 0, raw TypeSpec-only 1; 20 validator and 21 raw TypeSpec diagnostics |
+
+The old report credits aggregate project coverage across a different,
+unrecorded snapshot. It does not retain per-project diagnostics, so its fourth
+validator project cannot be reconstructed by subtracting the totals. The
+checked-in lint-diff report requires observed same-project diagnostics over the
+pinned successful-project population and preserves the project sets and raw
+results.
+
+The fresh full run is validation evidence for this rule change. As required for
+rule-development PRs, its generated files under `specs/` were restored instead
+of committed; the complete rule row, project sets, counts, and representative
+source evidence are preserved below. It evaluated ARM rules against the
+dataset-selected latest Swagger API version. TypeSpec linting observed the
+unprojected service, so the raw TypeSpec result also includes declarations
+removed from the selected version. The six compile failures were excluded from
+both sides:
+
+- `specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices`
+- `specification/monitor/resource-manager/Microsoft.Insights/Insights/TenantActionGroups`
+- `specification/network/resource-manager/Microsoft.Network/Network/Network`
+- `specification/quota/resource-manager/Microsoft.Quota/Quota`
+- `specification/resources/resource-manager/Microsoft.Resources/deployments`
+- `specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker`
+
+None can be assessed for this rule; this is retained uncertainty about the
+excluded population, not evidence of a semantic mismatch.
+
+## Aligned project comparison
+
+The selected-latest-version TypeSpec population excludes the Container Apps
+diagnostic described below because its operation is removed in the selected
+`2026-01-01` service version.
+
+| Project                                                                        | Validator | Raw TypeSpec | Selected-version TypeSpec |
+| ------------------------------------------------------------------------------ | --------: | -----------: | ------------------------: |
+| `specification/automation/Automation.Management`                               |         8 |            8 |                         8 |
+| `specification/marketplace/resource-manager/Microsoft.Marketplace/Marketplace` |         2 |            2 |                         2 |
+| `specification/web/resource-manager/Microsoft.Web/AppService`                  |        10 |           10 |                        10 |
+| `specification/app/resource-manager/Microsoft.App/ContainerApps`               |         0 |            1 |                         0 |
+
+Aligned sets:
+
+- Validator projects: Automation, Marketplace, and App Service.
+- Selected-version TypeSpec projects: Automation, Marketplace, and App Service.
+- Same-project overlap: all 3 projects.
+- Validator-only projects: none.
+- Selected-version TypeSpec-only projects: none.
+
+## Diagnostic cardinality
+
+| Identity                                         | Swagger | Raw TypeSpec | Selected-version TypeSpec |
+| ------------------------------------------------ | ------: | -----------: | ------------------------: |
+| Raw diagnostics                                  |      20 |           21 |                        20 |
+| Validator `project + Swagger file + JSON path`   |      20 |          N/A |                       N/A |
+| Validator `project + JSON path`                  |      20 |          N/A |                       N/A |
+| TypeSpec `project + source file + line + column` |     N/A |           21 |                        20 |
+
+All three aligned projects have equal counts. The raw TypeSpec population has a
+single positive difference and no validator excess; after latest-version
+attribution both positive and negative differences are zero. These identities
+remain representation-specific and count equality is supporting evidence, not
+the definition of functional equivalence.
+
+## Rule and fixture evidence
+
+The Swagger spectral rule evaluates every root-level and operation-level
+`produces` or `consumes` array entry under both `paths` and `x-ms-paths`. Each
+entry must contain the `application/json` pattern. The TypeSpec rule evaluates
+the resolved request body and every response body for each ARM HTTP operation,
+using the HTTP library's content-type resolution. It reports each non-matching
+content type on an authored content-type property, authored body property, or
+operation.
+
+Focused fixtures establish:
+
+- explicit `application/octet-stream` response: violation;
+- implicit scalar `text/plain` response: violation;
+- explicit `text/plain` request: violation;
+- explicit `application/merge-patch+json` request: violation;
+- JSON-only request and response bodies: compliant.
+
+Root-level Swagger `produces` and `consumes` regressions are not separately
+authorable because the current OpenAPI2 emitter controls those global arrays.
+The operation fixtures cover the authorable semantic source of the emitted
+entries.
+
+### Gap example: library-instantiated scalar response target
+
+- **Classification:** count-only
+- **Status:** fixed
+- **Project/API version:** `specification/automation/Automation.Management` / `2024-10-23`
+- **Source:** `AutomationAccount.tsp`, operation `generateUri`
+
+**TypeSpec source**
+
+```typespec
+@action("webhooks/generateUri")
+generateUri is ArmResourceActionSync<
+  AutomationAccount,
+  void,
+  ArmResponse<string>
+>;
+```
+
+**Emitted OpenAPI or validator behavior**
+
+```json
+"produces": [
+  "text/plain",
+  "application/json"
+]
+```
+
+| Engine            | Observed result                                                                                                                                                                  |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Swagger validator | Reports `produces[0]` because `text/plain` does not contain `application/json`.                                                                                                  |
+| TypeSpec lint     | Before the fix, attempted to report on the ARM-library-instantiated body property and emitted no project diagnostic. After the fix, reports on authored operation `generateUri`. |
+
+**Explanation:** HTTP content-type resolution correctly identifies
+`text/plain`. The semantic miss was the diagnostic target: template expansion
+left the body property in library context, where project lint diagnostics are
+not surfaced. `getLocationContext` now preserves authored property targets and
+falls back to the authored operation for library-instantiated bodies.
+
+**Disposition:** production rule fix plus
+`scalar-response-content-type` regression fixture.
+
+### Gap example: operation removed from selected version
+
+- **Classification:** TypeSpec-only
+- **Status:** population mismatch
+- **Project/API version:** `specification/app/resource-manager/Microsoft.App/ContainerApps` / `2026-01-01`
+- **Source:** `Revision.tsp`, operation `invokeFunctionsHost`
+
+**TypeSpec source**
+
+```typespec
+@removed(Versions.v2026_01_01)
+@armResourceOperations
+interface FunctionsExtension {
+  @action("invoke")
+  invokeFunctionsHost is FunctionExtensionOps.ActionSync<Revision, void, ArmResponse<string>>;
+}
+```
+
+**Selected-version metadata**
+
+```json
+{
+  "apiVersion": "2026-01-01",
+  "serviceCount": 1
+}
+```
+
+| Engine            | Observed result                                                                                       |
+| ----------------- | ----------------------------------------------------------------------------------------------------- |
+| Swagger validator | No diagnostic because the removed operation is absent from selected `2026-01-01` Swagger.             |
+| TypeSpec lint     | One raw unprojected diagnostic at `Revision.tsp:130`; zero after attribution to the selected version. |
+
+**Explanation:** the ordinary TypeSpec lint run includes declarations from
+older service versions, while the retained Swagger corpus contains only the
+dataset-selected version. There is no selected-version Swagger operation to
+compare.
+
+**Disposition:** exclude this one diagnostic only from the aligned behavioral
+population; preserve it in the raw TypeSpec count.
+
+## Final judgment
+
+The focused fixtures cover every authorable request/response content-type
+surface, all selected-version validator projects overlap, no aligned one-sided
+projects remain, and the only raw TypeSpec-only project is explained by version
+projection. The migrated TypeSpec rule is therefore functionally equal to the
+related Swagger rule. Raw count equality is not required, though the aligned
+counts are equal in this corpus. Remaining uncertainty is limited to the six
+projects that did not compile.

--- a/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/rule.md
+++ b/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/rule.md
@@ -11,6 +11,8 @@ tspLints:
 
 **Applies to:** Resource Manager (ARM)
 
+**Original Swagger rule:** [`NonApplicationJsonType`](https://github.com/Azure/azure-openapi-validator/blob/main/packages/rulesets/src/spectral/az-arm.ts)
+
 Operations must only consume/produce application/json content type.
 
 ## Semantic coverage notes
@@ -18,6 +20,7 @@ Operations must only consume/produce application/json content type.
 The authorable matrix in this repo includes:
 
 - ARM action response with explicit `application/octet-stream` => invalid
+- ARM action response with an implicit scalar `text/plain` content type => invalid
 - ARM action request with explicit `text/plain` => invalid
 - ARM PATCH action request with explicit `application/merge-patch+json` => invalid
 - Standard JSON-only request/response shapes => valid
@@ -27,9 +30,10 @@ Unrepresentable or blocked upstream shapes:
 - Root-level `consumes` / `produces` entries are emitter-controlled in current TypeSpec OpenAPI2 output, so the upstream global-array regressions cannot be authored directly here.
 - `multipart/form-data` request bodies are suppression-dependent because current TypeSpec and autorest validation emit unrelated diagnostics first.
 
-| ID                      | Violation | Description                                  |
-| ----------------------- | --------- | -------------------------------------------- |
-| `json-only-content-type` | false    | ARM action uses only `application/json` content types |
-| `non-json-content-type` | true      | ARM action produces `application/octet-stream` |
-| `non-json-request-content-type` | true | ARM action consumes `text/plain` |
-| `patch-merge-patch-content-type` | true | ARM PATCH action consumes `application/merge-patch+json` |
+| ID                               | Violation | Description                                                 |
+| -------------------------------- | --------- | ----------------------------------------------------------- |
+| `json-only-content-type`         | false     | ARM action uses only `application/json` content types       |
+| `non-json-content-type`          | true      | ARM action produces `application/octet-stream`              |
+| `scalar-response-content-type`   | true      | ARM action returns a scalar body that produces `text/plain` |
+| `non-json-request-content-type`  | true      | ARM action consumes `text/plain`                            |
+| `patch-merge-patch-content-type` | true      | ARM PATCH action consumes `application/merge-patch+json`    |

--- a/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/scalar-response-content-type/expect.json
+++ b/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/scalar-response-content-type/expect.json
@@ -1,0 +1,3 @@
+{
+  "violation": true
+}

--- a/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/scalar-response-content-type/main.tsp
+++ b/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/scalar-response-content-type/main.tsp
@@ -1,0 +1,48 @@
+import "../../lib/imports.tsp";
+
+using TypeSpec.Http;
+using TypeSpec.Rest;
+using TypeSpec.Versioning;
+using Azure.ResourceManager;
+
+@armProviderNamespace
+@service(#{ title: "Test Service" })
+@versioned(Versions)
+@armCommonTypesVersion(CommonTypes.Versions.v5)
+namespace Microsoft.TestService;
+
+enum Versions {
+  @useDependency(Azure.ResourceManager.CommonTypes.Versions.v5)
+  v2024_01_01: "2024-01-01",
+}
+
+model Widget is TrackedResource<WidgetProperties> {
+  @key("widgetName")
+  @segment("widgets")
+  @doc("The name of the widget")
+  @path
+  name: string;
+}
+
+model WidgetProperties {
+  @doc("Description")
+  description?: string;
+
+  @doc("Resource provisioning state")
+  @visibility(Lifecycle.Read)
+  provisioningState?: ResourceProvisioningState;
+}
+
+interface Operations extends Azure.ResourceManager.Operations {}
+
+@armResourceOperations
+interface Widgets {
+  get is ArmResourceRead<Widget>;
+  createOrUpdate is ArmResourceCreateOrReplaceAsync<Widget>;
+  delete is ArmResourceDeleteWithoutOkAsync<Widget>;
+
+  @doc("Generate a plain-text token")
+  @post
+  @armResourceAction(Widget)
+  generateToken is ArmResourceActionSync<Widget, void, ArmResponse<string>>;
+}

--- a/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/scalar-response-content-type/output.json
+++ b/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/scalar-response-content-type/output.json
@@ -1,0 +1,327 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Test Service",
+    "version": "2024-01-01",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": ["https"],
+  "host": "management.azure.com",
+  "produces": ["application/json"],
+  "consumes": ["application/json"],
+  "security": [
+    {
+      "azure_auth": ["user_impersonation"]
+    }
+  ],
+  "securityDefinitions": {
+    "azure_auth": {
+      "type": "oauth2",
+      "description": "Azure Active Directory OAuth2 Flow.",
+      "flow": "implicit",
+      "authorizationUrl": "https://login.microsoftonline.com/common/oauth2/authorize",
+      "scopes": {
+        "user_impersonation": "impersonate your user account"
+      }
+    }
+  },
+  "tags": [
+    {
+      "name": "Operations"
+    },
+    {
+      "name": "Widgets"
+    }
+  ],
+  "paths": {
+    "/providers/Microsoft.TestService/operations": {
+      "get": {
+        "operationId": "Operations_List",
+        "tags": ["Operations"],
+        "description": "List the operations for the provider",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/OperationListResult"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-pageable": {
+          "nextLinkName": "nextLink"
+        }
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.TestService/widgets/{widgetName}": {
+      "get": {
+        "operationId": "Widgets_Get",
+        "tags": ["Widgets"],
+        "description": "Get a Widget",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "widgetName",
+            "in": "path",
+            "description": "The name of the widget",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "$ref": "#/definitions/Widget"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      },
+      "put": {
+        "operationId": "Widgets_CreateOrUpdate",
+        "tags": ["Widgets"],
+        "description": "Create a Widget",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "widgetName",
+            "in": "path",
+            "description": "The name of the widget",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "resource",
+            "in": "body",
+            "description": "Resource create parameters.",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/Widget"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Resource 'Widget' update operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Widget"
+            }
+          },
+          "201": {
+            "description": "Resource 'Widget' create operation succeeded",
+            "schema": {
+              "$ref": "#/definitions/Widget"
+            },
+            "headers": {
+              "Azure-AsyncOperation": {
+                "type": "string",
+                "description": "A link to the status monitor"
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "azure-async-operation"
+        },
+        "x-ms-long-running-operation": true
+      },
+      "delete": {
+        "operationId": "Widgets_Delete",
+        "tags": ["Widgets"],
+        "description": "Delete a Widget",
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "widgetName",
+            "in": "path",
+            "description": "The name of the widget",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "202": {
+            "description": "Resource deletion accepted.",
+            "headers": {
+              "Location": {
+                "type": "string",
+                "description": "The Location header contains the URL where the status of the long running operation can be checked."
+              },
+              "Retry-After": {
+                "type": "integer",
+                "format": "int32",
+                "description": "The Retry-After header can indicate how long the client should wait before polling the operation status."
+              }
+            }
+          },
+          "204": {
+            "description": "Resource does not exist."
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        },
+        "x-ms-long-running-operation-options": {
+          "final-state-via": "location"
+        },
+        "x-ms-long-running-operation": true
+      }
+    },
+    "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.TestService/widgets/{widgetName}/generateToken": {
+      "post": {
+        "operationId": "Widgets_GenerateToken",
+        "tags": ["Widgets"],
+        "description": "Generate a plain-text token",
+        "produces": ["text/plain", "application/json"],
+        "parameters": [
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ApiVersionParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/SubscriptionIdParameter"
+          },
+          {
+            "$ref": "../../../../../common-types/resource-management/v5/types.json#/parameters/ResourceGroupNameParameter"
+          },
+          {
+            "name": "widgetName",
+            "in": "path",
+            "description": "The name of the widget",
+            "required": true,
+            "type": "string"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Azure operation completed successfully.",
+            "schema": {
+              "type": "string"
+            }
+          },
+          "default": {
+            "description": "An unexpected error response.",
+            "schema": {
+              "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/ErrorResponse"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Azure.ResourceManager.ResourceProvisioningState": {
+      "type": "string",
+      "description": "The provisioning state of a resource type.",
+      "enum": ["Succeeded", "Failed", "Canceled"],
+      "x-ms-enum": {
+        "name": "ResourceProvisioningState",
+        "modelAsString": true,
+        "values": [
+          {
+            "name": "Succeeded",
+            "value": "Succeeded",
+            "description": "Resource has been created."
+          },
+          {
+            "name": "Failed",
+            "value": "Failed",
+            "description": "Resource creation failed."
+          },
+          {
+            "name": "Canceled",
+            "value": "Canceled",
+            "description": "Resource creation was canceled."
+          }
+        ]
+      }
+    },
+    "Widget": {
+      "type": "object",
+      "description": "Concrete tracked resource types can be created by aliasing this type using a specific property type.",
+      "properties": {
+        "properties": {
+          "$ref": "#/definitions/WidgetProperties",
+          "description": "The resource-specific properties for this resource."
+        }
+      },
+      "allOf": [
+        {
+          "$ref": "../../../../../common-types/resource-management/v5/types.json#/definitions/TrackedResource"
+        }
+      ]
+    },
+    "WidgetProperties": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Description"
+        },
+        "provisioningState": {
+          "$ref": "#/definitions/Azure.ResourceManager.ResourceProvisioningState",
+          "description": "Resource provisioning state",
+          "readOnly": true
+        }
+      }
+    }
+  },
+  "parameters": {}
+}

--- a/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/scalar-response-content-type/tsp-diagnostics.json
+++ b/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/scalar-response-content-type/tsp-diagnostics.json
@@ -1,0 +1,97 @@
+[
+  {
+    "code": "@azure-tools/typespec-azure-resource-manager/arm-resource-name-pattern",
+    "severity": "warning",
+    "message": "The resource name parameter should be defined with a 'pattern' restriction.  Please use 'ResourceNameParameter' to specify the name parameter with options to override default pattern RegEx expression."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/latest-version-of-common-types-must-be-used",
+    "severity": "warning",
+    "message": "Use the latest ARM common-types version 'v6' instead of 'v5'."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/top-level-resources-list-by-resource-group",
+    "severity": "warning",
+    "message": "Top-level resource 'Widget' should define a list by resource group operation."
+  },
+  {
+    "code": "@azure-tools/typespec-azure-core/documentation-required",
+    "severity": "warning",
+    "message": "The Model named 'WidgetProperties' should have a documentation or description, use doc comment /** */ to provide it."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/description-must-not-be-node-name",
+    "severity": "warning",
+    "message": "Description must not match the name of the node it describes. Node name:'description' Description:'Description'"
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/tracked-resource-patch-operation",
+    "severity": "warning",
+    "message": "Tracked resource 'Widget' must have patch operation that at least supports the update of tags."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/xms-examples-required",
+    "severity": "warning",
+    "message": "Please provide x-ms-examples describing minimum/maximum property set for response/request payloads for operations."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/path-parameter-schema",
+    "severity": "warning",
+    "message": "Path parameter should specify a maximum length (maxLength) and characters allowed (pattern)."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/path-parameter-schema",
+    "severity": "warning",
+    "message": "Path parameter should specify a maximum length (maxLength) and characters allowed (pattern)."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/xms-examples-required",
+    "severity": "warning",
+    "message": "Please provide x-ms-examples describing minimum/maximum property set for response/request payloads for operations."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/path-parameter-schema",
+    "severity": "warning",
+    "message": "Path parameter should specify a maximum length (maxLength) and characters allowed (pattern)."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/path-parameter-schema",
+    "severity": "warning",
+    "message": "Path parameter should specify a maximum length (maxLength) and characters allowed (pattern)."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/path-parameter-schema",
+    "severity": "warning",
+    "message": "Path parameter should specify a maximum length (maxLength) and characters allowed (pattern)."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/xms-examples-required",
+    "severity": "warning",
+    "message": "Please provide x-ms-examples describing minimum/maximum property set for response/request payloads for operations."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/path-parameter-schema",
+    "severity": "warning",
+    "message": "Path parameter should specify a maximum length (maxLength) and characters allowed (pattern)."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/path-parameter-schema",
+    "severity": "warning",
+    "message": "Path parameter should specify a maximum length (maxLength) and characters allowed (pattern)."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/non-application-json-type",
+    "severity": "warning",
+    "message": "Only content-type 'application/json' is supported by ARM"
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/xms-examples-required",
+    "severity": "warning",
+    "message": "Please provide x-ms-examples describing minimum/maximum property set for response/request payloads for operations."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/path-parameter-schema",
+    "severity": "warning",
+    "message": "Path parameter should specify a maximum length (maxLength) and characters allowed (pattern)."
+  }
+]

--- a/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/scalar-response-content-type/validator-diagnostics.json
+++ b/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/scalar-response-content-type/validator-diagnostics.json
@@ -1,0 +1,14 @@
+[
+  {
+    "code": "NonApplicationJsonType",
+    "message": "Only content-type 'application/json' is supported by ARM",
+    "path": [
+      "paths",
+      "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.TestService/widgets/{widgetName}/generateToken",
+      "post",
+      "produces",
+      "0"
+    ],
+    "severity": 0
+  }
+]


### PR DESCRIPTION
## Original Swagger linter

[`NonApplicationJsonType`](https://github.com/Azure/azure-openapi-validator/blob/main/packages/rulesets/src/spectral/az-arm.ts)

The original rule performs these checks:

- [x] Every root-level `consumes` entry contains the `application/json` pattern.
- [x] Every root-level `produces` entry contains the `application/json` pattern.
- [x] Every operation-level `consumes` entry under both `paths` and `x-ms-paths` contains the pattern.
- [x] Every operation-level `produces` entry under both `paths` and `x-ms-paths` contains the pattern.

## How the Swagger linter works

The Spectral rule traverses root and operation `consumes`/`produces` arrays in emitted OpenAPI 2 documents and reports the individual array entry whose media type does not contain `application/json`. It therefore validates emitted occurrences rather than authored semantic declarations. Root-level arrays are controlled by the current TypeSpec OpenAPI2 emitter and are not independently authorable in fixtures; operation request and response bodies are the authorable source of those media types.

## How the migrated TypeSpec linter works

The TypeSpec rule visits ARM operations, resolves each operation with `getHttpOperation`, and checks the resolved request body and every response body through `HttpPayloadBody.contentTypes`. Valid JSON content types are skipped; each nonmatching content type is reported on an authored content-type property or body property when available.

This change fixes implicit scalar responses such as Automation's `ArmResponse<string>`, which resolves to `text/plain`. The body property can originate from an ARM library template, and reporting on that library target does not surface a project lint warning. `getLocationContext` now selects project-authored properties and otherwise falls back to the authored operation or interface. This raises Automation from 7 to 8 TypeSpec diagnostics, matching its 8 Swagger findings.

The raw TypeSpec run remains intentionally unprojected. The migration evidence separately attributes declarations removed from the Swagger-selected latest API version instead of suppressing valid diagnostics in the production rule.

## Migration evidence

See [`migration.md`](https://github.com/Azure/typespec-azure/blob/feature/lintdiff-non-application-json-type/packages/typespec-lintdiff/test/fixtures/NonApplicationJsonType/migration.md) for focused fixture results, full-corpus project overlap and counts, the Container Apps version-projection explanation, the six excluded compile failures, code-backed gap examples, and the remaining uncertainty.