### PR TITLE
Bump version for hotfix: typespec-go@0.17.1

### DIFF
--- a/.chronus/changes/fix-go-fake-text-request-bodies-2026-08-20-15-13-00.md
+++ b/.chronus/changes/fix-go-fake-text-request-bodies-2026-08-20-15-13-00.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Parse text request bodies into their declared types in generated fake servers.

--- a/.chronus/changes/fix-path-param-regex-2026-7-19-21-27-28.md
+++ b/.chronus/changes/fix-path-param-regex-2026-7-19-21-27-28.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Fix fake server path param regex to exclude path delimiters

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release History
 
+## 0.17.1
+
+### Bug Fixes
+
+- [#5272](https://github.com/Azure/typespec-azure/pull/5272) Parse text request bodies into their declared types in generated fake servers.
+- [#5233](https://github.com/Azure/typespec-azure/pull/5233) Fix fake server path param regex to exclude path delimiters
+
+
 ## 0.17.0
 
 ### Features

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-go",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Go SDKs",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
Version bump for the go emitter hotfix release from `main`.

Bumps `@azure-tools/typespec-go` from 0.17.0 to 0.17.1.

### Bug Fixes
- #5272 Parse text request bodies into their declared types in generated fake servers.
- #5233 Fix fake server path parameter regex to exclude path delimiters.

Generated with Chronus targeting only `@azure-tools/typespec-go`. The `core` submodule is not included in this commit.