### PR TITLE
Label management C# emitter in coverage dashboard

### DIFF
--- a/website/src/pages/can-i-use/http.astro
+++ b/website/src/pages/can-i-use/http.astro
@@ -27,6 +27,7 @@ const options: CoverageFromAzureStorageOptions = {
     "@azure-tools/typespec-python": "Python",
     "@azure-tools/typespec-go": "Go",
     "@azure-typespec/http-client-csharp": "C#",
+    "@azure-typespec/http-client-csharp-mgmt": "C#",
     "@azure-tools/typespec-ts": "JavaScript",
     "@azure-tools/typespec-java": "Java",
     "@azure-tools/typespec-cpp": "C++",


### PR DESCRIPTION
## Summary

- map `@azure-typespec/http-client-csharp-mgmt` to the `C#` dashboard display name
- ensure the Azure Management Plane table uses the same language label as the data-plane C# emitter
- allow the display-name grouping from microsoft/typespec#11709 to aggregate both C# emitters into one overview card

## Validation

- Verified the combined changes against live coverage data: the management-plane table header displays `C#`, the raw management emitter package name is absent, and the overview contains one aggregated C# card.
