### PR TITLE
[Test] Add Spector coverage for body-root and status-code-range scenarios

### DIFF
--- a/.chronus/changes/add-typespec-ts-body-root-status-code-range-spector-tests-2026-08-26.md
+++ b/.chronus/changes/add-typespec-ts-body-root-status-code-range-spector-tests-2026-08-26.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Add Spector coverage for body-root parameters and status-code-range responses.

--- a/packages/typespec-ts/spector.config.yaml
+++ b/packages/typespec-ts/spector.config.yaml
@@ -17,7 +17,9 @@ specs:
   azure/core/lro/standard: true
   azure/client-generator-core/access: true
   azure/client-generator-core/usage: true
+  parameters/body-root: true
   parameters/body-optionality: true
+  response/status-code-range: true
   type/model/usage: true
   client/structure/default: true
   client/structure/multi-client: true

--- a/packages/typespec-ts/test/azure-modular-integration/generated/parameters/body-root/.gitignore
+++ b/packages/typespec-ts/test/azure-modular-integration/generated/parameters/body-root/.gitignore
@@ -1,0 +1,6 @@
+/**
+!/src
+/src/**
+!/src/index.d.ts
+!/.gitignore
+!/tspconfig.yaml

--- a/packages/typespec-ts/test/azure-modular-integration/generated/parameters/body-root/src/index.d.ts
+++ b/packages/typespec-ts/test/azure-modular-integration/generated/parameters/body-root/src/index.d.ts
@@ -1,0 +1,32 @@
+import { ClientOptions } from '@azure-rest/core-client';
+import { isRestError } from '@azure/core-rest-pipeline';
+import { OperationOptions } from '@azure-rest/core-client';
+import { Pipeline } from '@azure/core-rest-pipeline';
+import { RestError } from '@azure/core-rest-pipeline';
+
+export declare class BodyRootClient {
+    private _client;
+    readonly pipeline: Pipeline;
+    constructor(options?: BodyRootClientOptionalParams);
+    nested(body: {
+        bodyRootParameters: BodyRootModel;
+    }, options?: NestedOptionalParams): Promise<void>;
+}
+
+export declare interface BodyRootClientOptionalParams extends ClientOptions {
+}
+
+export declare interface BodyRootModel {
+    category?: string;
+    linkType?: string;
+    wasSuccessful?: boolean;
+}
+
+export { isRestError }
+
+export declare interface NestedOptionalParams extends OperationOptions {
+}
+
+export { RestError }
+
+export { }

--- a/packages/typespec-ts/test/azure-modular-integration/generated/parameters/body-root/tspconfig.yaml
+++ b/packages/typespec-ts/test/azure-modular-integration/generated/parameters/body-root/tspconfig.yaml
@@ -1,0 +1,7 @@
+emit:
+  - "@azure-tools/typespec-ts"
+options:
+  "@azure-tools/typespec-ts":
+    emitter-output-dir: "{project-root}"
+    package-details:
+      name: "@msinternal/parameters-body-root"

--- a/packages/typespec-ts/test/azure-modular-integration/generated/response/status-code-range/.gitignore
+++ b/packages/typespec-ts/test/azure-modular-integration/generated/response/status-code-range/.gitignore
@@ -1,0 +1,6 @@
+/**
+!/src
+/src/**
+!/src/index.d.ts
+!/.gitignore
+!/tspconfig.yaml

--- a/packages/typespec-ts/test/azure-modular-integration/generated/response/status-code-range/src/index.d.ts
+++ b/packages/typespec-ts/test/azure-modular-integration/generated/response/status-code-range/src/index.d.ts
@@ -1,0 +1,46 @@
+import { ClientOptions } from '@azure-rest/core-client';
+import { isRestError } from '@azure/core-rest-pipeline';
+import { OperationOptions } from '@azure-rest/core-client';
+import { Pipeline } from '@azure/core-rest-pipeline';
+import { RestError } from '@azure/core-rest-pipeline';
+
+export declare interface DefaultError {
+    code: string;
+}
+
+export declare interface ErrorInRange {
+    code: string;
+    message: string;
+}
+
+export declare interface ErrorResponseStatusCode404OptionalParams extends OperationOptions {
+}
+
+export declare interface ErrorResponseStatusCodeInRangeOptionalParams extends OperationOptions {
+}
+
+export { isRestError }
+
+export declare interface NotFoundError {
+    code: string;
+    resourceId: string;
+}
+
+export { RestError }
+
+export declare interface Standard4XXError {
+    code: string;
+}
+
+export declare class StatusCodeRangeClient {
+    private _client;
+    readonly pipeline: Pipeline;
+    constructor(options?: StatusCodeRangeClientOptionalParams);
+    errorResponseStatusCode404(options?: ErrorResponseStatusCode404OptionalParams): Promise<void>;
+    errorResponseStatusCodeInRange(options?: ErrorResponseStatusCodeInRangeOptionalParams): Promise<void>;
+}
+
+export declare interface StatusCodeRangeClientOptionalParams extends ClientOptions {
+}
+
+export { }

--- a/packages/typespec-ts/test/azure-modular-integration/generated/response/status-code-range/tspconfig.yaml
+++ b/packages/typespec-ts/test/azure-modular-integration/generated/response/status-code-range/tspconfig.yaml
@@ -1,0 +1,7 @@
+emit:
+  - "@azure-tools/typespec-ts"
+options:
+  "@azure-tools/typespec-ts":
+    emitter-output-dir: "{project-root}"
+    package-details:
+      name: "@msinternal/response-status-code-range"

--- a/packages/typespec-ts/test/azure-modular-integration/parameters-body-root.test.ts
+++ b/packages/typespec-ts/test/azure-modular-integration/parameters-body-root.test.ts
@@ -1,0 +1,29 @@
+import { assert, beforeEach, describe, it } from "vitest";
+
+import { BodyRootClient } from "./generated/parameters/body-root/src/index.js";
+
+describe("BodyRoot Client", () => {
+  let client: BodyRootClient;
+
+  beforeEach(() => {
+    client = new BodyRootClient({
+      endpoint: "http://localhost:3002",
+      allowInsecureConnection: true,
+      retryOptions: {
+        maxRetries: 0,
+      },
+    });
+  });
+
+  it("sends a nested body root parameter", async () => {
+    const result = await client.nested({
+      bodyRootParameters: {
+        category: "widget",
+        linkType: "hard",
+        wasSuccessful: true,
+      },
+    });
+
+    assert.isUndefined(result);
+  });
+});

--- a/packages/typespec-ts/test/azure-modular-integration/response-status-code-range.test.ts
+++ b/packages/typespec-ts/test/azure-modular-integration/response-status-code-range.test.ts
@@ -1,0 +1,54 @@
+import { assert, beforeEach, describe, it } from "vitest";
+
+import {
+  isRestError,
+  StatusCodeRangeClient,
+} from "./generated/response/status-code-range/src/index.js";
+
+describe("StatusCodeRange Client", () => {
+  let client: StatusCodeRangeClient;
+
+  beforeEach(() => {
+    client = new StatusCodeRangeClient({
+      endpoint: "http://localhost:3002",
+      allowInsecureConnection: true,
+      retryOptions: {
+        maxRetries: 0,
+      },
+    });
+  });
+
+  it("deserializes an error response with status code 404", async () => {
+    try {
+      await client.errorResponseStatusCode404();
+      assert.fail("Expected a 404 response");
+    } catch (error) {
+      assert.isTrue(isRestError(error));
+      if (!isRestError(error)) {
+        throw error;
+      }
+      assert.strictEqual(error.statusCode, 404);
+      assert.deepStrictEqual(error.details, {
+        code: "not-found",
+        resourceId: "resource1",
+      });
+    }
+  });
+
+  it("deserializes an error response with a status code in range", async () => {
+    try {
+      await client.errorResponseStatusCodeInRange();
+      assert.fail("Expected a 494 response");
+    } catch (error) {
+      assert.isTrue(isRestError(error));
+      if (!isRestError(error)) {
+        throw error;
+      }
+      assert.strictEqual(error.statusCode, 494);
+      assert.deepStrictEqual(error.details, {
+        code: "request-header-too-large",
+        message: "Request header too large",
+      });
+    }
+  });
+});


### PR DESCRIPTION
## Skill evaluation

This PR copies the changes from [JialinHuang803/typespec-azure#7](https://github.com/JialinHuang803/typespec-azure/pull/7) unchanged onto the latest upstream `main` so the full Azure repository CI can validate the output of the `typespec-ts-add-spector-test` skill and the task instructions in [fork issue #4](https://github.com/JialinHuang803/typespec-azure/issues/4).

No failures reported by Copilot were fixed while transferring the changes.

## Spector test results

### `Service_MultipleServices_ServiceA_Operations`

- ❌ Failed: `opA` — `ServiceAClient` incorrectly exposes Service B operation groups.

### `Service_MultipleServices_ServiceA_SubNamespace`

- ❌ Failed: `subOpA` — `ServiceAClient` incorrectly exposes Service B subnamespace operations.

### `Azure_ResourceManager_Resources_ExtensionsResources` — `azure-arm-resources.test.ts`

- ❌ Failed: `createOrUpdate` — tenant scope generates `//providers/...`.
- ❌ Failed: `delete` — tenant scope generates `//providers/...`.
- ❌ Failed: `get` — tenant scope generates `//providers/...`.
- ❌ Failed: `listByScope` — tenant scope generates `//providers/...`.
- ❌ Failed: `update` — tenant scope generates `//providers/...`.

### `Response_StatusCodeRange` — `response-status-code-range.test.ts`

- ✅ Added: `errorResponseStatusCode404`
- ✅ Added: `errorResponseStatusCodeInRange`

### `Parameters_BodyRoot` — `parameters-body-root.test.ts`

- ✅ Added: `nested`

## Changes

- Enabled the supported `response/status-code-range` and `parameters/body-root` Spector specs.
- Added focused integration tests for error-model deserialization and nested body-root serialization.
- Added generated package configuration and declaration baselines.