### PR TITLE
[http-client-js] Preserve parsed body in storage compat responses

### DIFF
--- a/.chronus/changes/preserve-storage-compat-parsed-body-2026-8-26-12-16-0.md
+++ b/.chronus/changes/preserve-storage-compat-parsed-body-2026-8-26-12-16-0.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-ts"
+---
+
+Preserve the original parsed response body when flattening response headers for storage compatibility.

--- a/packages/typespec-ts/static/static-helpers/storageCompatResponse.ts
+++ b/packages/typespec-ts/static/static-helpers/storageCompatResponse.ts
@@ -55,14 +55,15 @@ type StorageCompatResult<TBody, THeaders> = TBody extends undefined | void | nul
  * @param rawResponse - The raw FullOperationResponse from the HTTP pipeline.
  * @param parsedBody - The deserialized response body.
  * @param parsedHeaders - The deserialized response headers.
- * @returns The parsedBody augmented with a `_response` property.
+ * @returns A flattened copy of the body and headers augmented with a `_response` property.
  */
 export function addStorageCompatResponse<TBody, THeaders = Record<string, unknown>>(
   rawResponse: FullOperationResponse,
   parsedBody: TBody,
   parsedHeaders: THeaders,
 ): StorageCompatResult<TBody, THeaders> {
-  const base = parsedBody !== undefined && parsedBody !== null ? parsedBody : ({} as TBody);
+  const base =
+    parsedBody !== undefined && parsedBody !== null ? Object.assign({}, parsedBody) : ({} as TBody);
   return Object.assign(base as any, parsedHeaders, {
     _response: {
       rawResponse,

--- a/packages/typespec-ts/test-next/unit/static-helpers/storage-compat-response.test.ts
+++ b/packages/typespec-ts/test-next/unit/static-helpers/storage-compat-response.test.ts
@@ -49,6 +49,23 @@ describe("addStorageCompatResponse", () => {
     expect(result._response.parsedHeaders).toBe(parsedHeaders);
   });
 
+  it("should preserve parsedBody while flattening response headers", () => {
+    const rawResponse = createMockFullOperationResponse(200);
+    const parsedBody = { etag: "body-etag", value: "body-value" };
+    const parsedHeaders = { etag: "header-etag", requestId: "request-id" };
+
+    const result = addStorageCompatResponse(rawResponse, parsedBody, parsedHeaders);
+
+    expect(result.etag).toBe("header-etag");
+    expect(result.requestId).toBe("request-id");
+    expect(result._response.parsedBody).toBe(parsedBody);
+    expect(result._response.parsedBody).toEqual({
+      etag: "body-etag",
+      value: "body-value",
+    });
+    expect(result._response.parsedBody).not.toBe(result);
+  });
+
   it("should handle void (undefined) body with headers at top level", () => {
     const rawResponse = createMockFullOperationResponse(204);
     const parsedHeaders = { requestId: "req-1", version: "2024-01-01" };


### PR DESCRIPTION
Copilot agent :copilot: (on behalf of @jeremymeng): 

## Summary

- Copy the parsed response body before flattening storage compatibility response headers.
- Preserve header precedence on the top-level operation result without mutating `_response.parsedBody`.
- Add regression coverage for body/header name collisions and circular response metadata.

## Testing

- `pnpm --filter @azure-tools/typespec-ts exec vitest run --project test-next test-next/unit/static-helpers/storage-compat-response.test.ts`
- `pnpm -r --filter "@azure-tools/typespec-ts..." build`
- `pnpm change verify`

Fixes #5323