### PR TITLE
Bump version for hotfix: typespec-go@0.17.2

### DIFF
--- a/.chronus/changes/fix-fake-allow-reserved-path-param-regex-2026-8-26-9-35-0.md
+++ b/.chronus/changes/fix-fake-allow-reserved-path-param-regex-2026-8-26-9-35-0.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Fix fake server route regex to allow path delimiters in captures for `allowReserved` path parameters (e.g. ARM scopes and resource IDs), which are inserted into the request path unescaped and can span multiple path segments.

--- a/.chronus/changes/go-coverage-2026-7-24-16-0-36.md
+++ b/.chronus/changes/go-coverage-2026-7-24-16-0-36.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Add more Spector test coverage.

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 0.17.2
+
+### Bug Fixes
+
+- [#5321](https://github.com/Azure/typespec-azure/pull/5321) Fix fake server route regex to allow path delimiters in captures for `allowReserved` path parameters (e.g. ARM scopes and resource IDs), which are inserted into the request path unescaped and can span multiple path segments.
+
+
 ## 0.17.1
 
 ### Bug Fixes

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-go",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Go SDKs",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
Publishes a patch release of `@azure-tools/typespec-go` containing the `allowReserved` fake-server path capture fix from #5321.

This consumes the pending Go changesets and bumps the package from 0.17.1 to 0.17.2.