### PR TITLE
Empty path param check for client params

### DIFF
--- a/.chronus/changes/empty-path-param-check-2026-7-27-8-53-35.md
+++ b/.chronus/changes/empty-path-param-check-2026-7-27-8-53-35.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-go"
+---
+
+Revert removal of empty client path parameter checks during request construction.

--- a/packages/typespec-go/src/codegen/core/helpers.ts
+++ b/packages/typespec-go/src/codegen/core/helpers.ts
@@ -91,17 +91,19 @@ export function canonicalizeHeaderName(name: string): string {
  * emits code to verify that a path parameter is not empty
  *
  * @param param the path parameter to check
+ * @param paramIn where the path parameter check is being emitted
  * @param imports the import manager currently in scope
  * @param indent the indentation helper currently in scope
  * @returns the code to check the path parameter for emptiness
  */
 export function emitEmptyPathParamCheck(
   param: go.PathParameter,
+  paramIn: "ctor" | "method",
   imports: ImportManager,
   indent: Indentation,
 ): string {
   imports.add("errors");
-  let text = `${indent.get()}if ${param.name} == "" {\n`;
+  let text = `${indent.get()}if ${paramIn === "ctor" ? param.name : getParamName(param)} == "" {\n`;
   text += `${indent.push().get()}return nil, errors.New("parameter ${param.name} cannot be empty")\n`;
   text += `${indent.pop().get()}}\n`;
   return text;
@@ -540,7 +542,13 @@ export function emitScalarParsing(
  * @param indent the indentation helper currently in scope
  * @returns the time parsing code
  */
-export function emitTimeParsing(srcVar: string, time: go.Time, dstVar: string, imports: ImportManager, indent: Indentation): string {
+export function emitTimeParsing(
+  srcVar: string,
+  time: go.Time,
+  dstVar: string,
+  imports: ImportManager,
+  indent: Indentation,
+): string {
   imports.add("time");
   let text: string;
   switch (time.format) {

--- a/packages/typespec-go/src/codegen/core/operations.ts
+++ b/packages/typespec-go/src/codegen/core/operations.ts
@@ -312,7 +312,7 @@ function generateConstructors(
         // emit empty path param checks
         if (param.kind === "pathScalarParam") {
           if (!param.isApiVersion) {
-            bodyText += helpers.emitEmptyPathParamCheck(param, imports, indent);
+            bodyText += helpers.emitEmptyPathParamCheck(param, "ctor", imports, indent);
           }
         }
 
@@ -424,7 +424,7 @@ function generateConstructors(
                 // emit empty path param checks
                 if (param.kind === "pathScalarParam") {
                   if (!param.isApiVersion) {
-                    prolog += helpers.emitEmptyPathParamCheck(param, imports, indent);
+                    prolog += helpers.emitEmptyPathParamCheck(param, "ctor", imports, indent);
                   }
                 }
               }

--- a/packages/typespec-go/src/codegen/core/request-handler.ts
+++ b/packages/typespec-go/src/codegen/core/request-handler.ts
@@ -115,16 +115,20 @@ export function createRequestHandler(
       if (pp.style === "literal") {
         // literals are always scalar types and require no empty checks
         paramValue = helpers.formatParamValue(pp, imports, indent);
-      } else if (pp.location === "client") {
-        // required/optional client params have already been resolved
-        // in the constructor, so we can just use the client param value here.
-        // NOTE: we must check this before style === "required"
+      } else if (pp.location === "client" && pp.kind === "pathScalarParam" && pp.isApiVersion) {
+        // path API version params have already been resolved in the constructor
+        // and will never be a factory method param so we can just use the value
         paramValue = helpers.getParamName(pp);
-      } else if (pp.style === "required") {
+      } else if (pp.style === "required" || pp.location === "client") {
         // NOTE: we include client params here since they behave
         // like required params (i.e. not grouped).
 
         // emit check to ensure path param isn't an empty string
+        // NOTE: we _must_ include the empty path param check for client
+        // path params even though they were already validated in the
+        // ctor. this is to handle the case of client accessor methods
+        // that take a path param since we can't validate it there as those
+        // methods don't return an error
         if (pp.kind === "pathScalarParam") {
           // we only need to do this for params that have an underlying type of string
           if (
@@ -132,7 +136,7 @@ export function createRequestHandler(
               (pp.type.kind === "constant" && pp.type.type === "string")) &&
             !pp.omitEmptyStringCheck
           ) {
-            text += helpers.emitEmptyPathParamCheck(pp, imports, indent);
+            text += helpers.emitEmptyPathParamCheck(pp, "method", imports, indent);
           }
         }
 

--- a/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/locationresources_client_test.go
+++ b/packages/typespec-go/test/azure-http-specs/azure/resource-manager/resources/locationresources_client_test.go
@@ -121,3 +121,13 @@ func TestLocationResourcesClient_Update(t *testing.T) {
 		Type: to.Ptr("Azure.ResourceManager.Resources/locationResources"),
 	}, resp.LocationResource)
 }
+
+func TestLocationResourcesClient_CreateOrUpdate_emptySubscriptionID(t *testing.T) {
+	resp, err := clientFactory.NewLocationResourcesClient("").CreateOrUpdate(context.Background(), "eastus", "resource", resources.LocationResource{
+		Properties: &resources.LocationResourceProperties{
+			Description: to.Ptr("valid"),
+		},
+	}, nil)
+	require.ErrorContains(t, err, "parameter subscriptionID cannot be empty")
+	require.Zero(t, resp)
+}

--- a/packages/typespec-go/test/unittest/scenarios/arm-lro.md
+++ b/packages/typespec-go/test/unittest/scenarios/arm-lro.md
@@ -184,6 +184,9 @@ func (client *LROClient) okResponseWithAsyncHeader(ctx context.Context, apiVersi
 // okResponseWithAsyncHeaderCreateRequest creates the OkResponseWithAsyncHeader request.
 func (client *LROClient) okResponseWithAsyncHeaderCreateRequest(ctx context.Context, apiVersion string, resourceGroupName string, lroModelName string, resource TestLROModel, _ *LROClientBeginOkResponseWithAsyncHeaderOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/LROModels/{LROModelName}"
+	if client.subscriptionID == "" {
+		return nil, errors.New("parameter subscriptionID cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -246,6 +249,9 @@ func (client *LROClient) scalarResult(ctx context.Context, apiVersion string, re
 // scalarResultCreateRequest creates the ScalarResult request.
 func (client *LROClient) scalarResultCreateRequest(ctx context.Context, apiVersion string, resourceGroupName string, lroModelName string, body ActionRequest, _ *LROClientBeginScalarResultOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/LROModels/{LROModelName}/scalarResult"
+	if client.subscriptionID == "" {
+		return nil, errors.New("parameter subscriptionID cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")

--- a/packages/typespec-go/test/unittest/scenarios/body-root.md
+++ b/packages/typespec-go/test/unittest/scenarios/body-root.md
@@ -246,6 +246,9 @@ func (client *BodyRootsClient) Action(ctx context.Context, apiVersion string, re
 // actionCreateRequest creates the Action request.
 func (client *BodyRootsClient) actionCreateRequest(ctx context.Context, apiVersion string, resourceGroupName string, bodyRootName string, action ActionRequest, _ *BodyRootsClientActionOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/bodyRoots/{bodyRootName}/action"
+	if client.subscriptionID == "" {
+		return nil, errors.New("parameter subscriptionID cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -291,6 +294,9 @@ func (client *BodyRootsClient) Get(ctx context.Context, apiVersion string, resou
 // getCreateRequest creates the Get request.
 func (client *BodyRootsClient) getCreateRequest(ctx context.Context, apiVersion string, resourceGroupName string, bodyRootName string, _ *BodyRootsClientGetOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/bodyRoots/{bodyRootName}"
+	if client.subscriptionID == "" {
+		return nil, errors.New("parameter subscriptionID cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -345,6 +351,9 @@ func (client *BodyRootsClient) Put(ctx context.Context, apiVersion string, resou
 // putCreateRequest creates the Put request.
 func (client *BodyRootsClient) putCreateRequest(ctx context.Context, apiVersion string, resourceGroupName string, bodyRootName string, resource BodyRoot, _ *BodyRootsClientPutOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/bodyRoots/{bodyRootName}"
+	if client.subscriptionID == "" {
+		return nil, errors.New("parameter subscriptionID cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")

--- a/packages/typespec-go/test/unittest/scenarios/pageable-lro.md
+++ b/packages/typespec-go/test/unittest/scenarios/pageable-lro.md
@@ -156,6 +156,9 @@ func (client *PageableLROsClient) listPrivateEndPointsCreateRequest(ctx context.
 	var err error
 	if firstPage {
 		urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/PageableLROs/resourceSegment/{resourceName}"
+		if client.subscriptionID == "" {
+			return nil, errors.New("parameter subscriptionID cannot be empty")
+		}
 		urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 		if resourceGroupName == "" {
 			return nil, errors.New("parameter resourceGroupName cannot be empty")

--- a/packages/typespec-go/test/unittest/scenarios/streaming-response.md
+++ b/packages/typespec-go/test/unittest/scenarios/streaming-response.md
@@ -200,6 +200,9 @@ func (client *ConfigurationsClient) GetContent(ctx context.Context, apiVersion s
 // getContentCreateRequest creates the GetContent request.
 func (client *ConfigurationsClient) getContentCreateRequest(ctx context.Context, apiVersion string, resourceGroupName string, configurationName string, _ *ConfigurationsClientGetContentOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/configurations/{configurationName}"
+	if client.subscriptionID == "" {
+		return nil, errors.New("parameter subscriptionID cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -254,6 +257,9 @@ func (client *ConfigurationsClient) GetStreamingContent(ctx context.Context, api
 // getStreamingContentCreateRequest creates the GetStreamingContent request.
 func (client *ConfigurationsClient) getStreamingContentCreateRequest(ctx context.Context, apiVersion string, resourceGroupName string, configurationName string, _ *ConfigurationsClientGetStreamingContentOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/configurations/{configurationName}/content"
+	if client.subscriptionID == "" {
+		return nil, errors.New("parameter subscriptionID cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -310,6 +316,9 @@ func (client *ConfigurationsClient) GetTextContent(ctx context.Context, apiVersi
 // getTextContentCreateRequest creates the GetTextContent request.
 func (client *ConfigurationsClient) getTextContentCreateRequest(ctx context.Context, apiVersion string, resourceGroupName string, configurationName string, _ *ConfigurationsClientGetTextContentOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/configurations/{configurationName}/textContent"
+	if client.subscriptionID == "" {
+		return nil, errors.New("parameter subscriptionID cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")
@@ -370,6 +379,9 @@ func (client *ConfigurationsClient) PutStreamingContent(ctx context.Context, api
 // putStreamingContentCreateRequest creates the PutStreamingContent request.
 func (client *ConfigurationsClient) putStreamingContentCreateRequest(ctx context.Context, apiVersion string, resourceGroupName string, configurationName string, body io.ReadSeekCloser, _ *ConfigurationsClientPutStreamingContentOptions) (*policy.Request, error) {
 	urlPath := "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Test/configurations/{configurationName}/putContent"
+	if client.subscriptionID == "" {
+		return nil, errors.New("parameter subscriptionID cannot be empty")
+	}
 	urlPath = strings.ReplaceAll(urlPath, "{subscriptionId}", url.PathEscape(client.subscriptionID))
 	if resourceGroupName == "" {
 		return nil, errors.New("parameter resourceGroupName cannot be empty")


### PR DESCRIPTION
This adds back the empty path param check for client path params to the request builder method. The reason is that client accessor methods don't return an error, so if a client accessor method contains a path param we can only validate it's not empty during request creation.
Fixes regression introduced in 7c0c271.