### PR TITLE
Bump version for hotfix: typespec-go@0.17.3

### DIFF
--- a/.chronus/changes/empty-path-param-check-2026-7-27-8-53-35.md
+++ b/.chronus/changes/empty-path-param-check-2026-7-27-8-53-35.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-go"
----
-
-Revert removal of empty client path parameter checks during request construction.

--- a/packages/typespec-go/CHANGELOG.md
+++ b/packages/typespec-go/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Release History
 
+## 0.17.3
+
+### Bug Fixes
+
+- [#5333](https://github.com/Azure/typespec-azure/pull/5333) Revert removal of empty client path parameter checks during request construction.
+
+
 ## 0.17.2
 
 ### Bug Fixes

--- a/packages/typespec-go/package.json
+++ b/packages/typespec-go/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-go",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "author": "Microsoft Corporation",
   "description": "TypeSpec emitter for Go SDKs",
   "homepage": "https://azure.github.io/typespec-azure",


### PR DESCRIPTION
Publishes a patch release of `@azure-tools/typespec-go` containing the restored empty client path-parameter validation from #5333.

This consumes the pending Go changeset and bumps the package from 0.17.2 to 0.17.3.