### PR TITLE
Bump typespec-java to 0.46.1 for hotfix

### DIFF
--- a/.chronus/changes/enable-java-arm-resource-identifier-test-2026-08-17-11-23-00.md
+++ b/.chronus/changes/enable-java-arm-resource-identifier-test-2026-08-17-11-23-00.md
@@ -1,7 +1,0 @@
----
-changeKind: internal
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Re-enable the ARM resource identifier emitter test.

--- a/.chronus/changes/fix-typespec-java-remove-model-2026-08-17.md
+++ b/.chronus/changes/fix-typespec-java-remove-model-2026-08-17.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Sync core to microsoft/typespec commit `5b9cd21d2`. Includes fixes for management `remove-model` generation (core [#11698](https://github.com/microsoft/typespec/pull/11698)), Javadocs containing `*/` (core [#11766](https://github.com/microsoft/typespec/pull/11766)), and response headers following a constant header (core [#11793](https://github.com/microsoft/typespec/pull/11793)).

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- [#5239](https://github.com/Azure/typespec-azure/pull/5239) Sync core to microsoft/typespec commit `5b9cd21d2`. Includes fixes for management `remove-model` generation (core [#11698](https://github.com/microsoft/typespec/pull/11698)), Javadocs containing `*/` (core [#11766](https://github.com/microsoft/typespec/pull/11766)), and response headers following a constant header (core [#11793](https://github.com/microsoft/typespec/pull/11793)).
+- Sync core to microsoft/typespec commit `5b9cd21d2`. Includes fixes for management `remove-model` generation (core [#11698](https://github.com/microsoft/typespec/pull/11698)), Javadocs containing `*/` (core [#11766](https://github.com/microsoft/typespec/pull/11766)), and response headers following a constant header (core [#11793](https://github.com/microsoft/typespec/pull/11793)).
 
 
 ## 0.46.0

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-java
 
+## 0.46.1
+
+### Bug Fixes
+
+- [#5239](https://github.com/Azure/typespec-azure/pull/5239) Sync core to microsoft/typespec commit `5b9cd21d2`. Includes fixes for management `remove-model` generation (core [#11698](https://github.com/microsoft/typespec/pull/11698)), Javadocs containing `*/` (core [#11766](https://github.com/microsoft/typespec/pull/11766)), and response headers following a constant header (core [#11793](https://github.com/microsoft/typespec/pull/11793)).
+
+
 ## 0.46.0
 
 ### Features

--- a/packages/typespec-java/package.json
+++ b/packages/typespec-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.46.0",
+  "version": "0.46.1",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
## Summary

- bump `@azure-tools/typespec-java` from `0.46.0` to `0.46.1`
- publish the Java fixes synced in #5239

## Included fixes

- management `remove-model` generation (`microsoft/typespec#11698`)
- Javadocs containing `*/` (`microsoft/typespec#11766`)
- response headers following a constant header (`microsoft/typespec#11793`)
