### PR TITLE
Bump typespec-java pinned http-client-java core commit

### DIFF
--- a/.chronus/changes/bump-http-client-java-core-commit-2026-08-31-14-40-00.md
+++ b/.chronus/changes/bump-http-client-java-core-commit-2026-08-31-14-40-00.md
@@ -1,0 +1,7 @@
+---
+changeKind: dependencies
+packages:
+  - "@azure-tools/typespec-java"
+---
+
+Bump the pinned `http-client-java` core commit in `core-commit.json` to pick up the fix for Javadoc corruption from literal `*/` in parameter descriptions.

--- a/packages/typespec-java/core-commit.json
+++ b/packages/typespec-java/core-commit.json
@@ -1,1 +1,1 @@
-{ "sha": "27b39b71bf5c67f560ec6035900ae5621226ac8d" }
+{ "sha": "0bd0c174228cf559ec7d4c9edec904294b59b9bc" }


### PR DESCRIPTION
## Summary

`packages/typespec-java` pins the `http-client-java` sources it consumes from the `core` (microsoft/typespec) submodule via `core-commit.json`, independent of whatever commit the submodule itself is checked out to. This meant a fix landed in `core` was not actually being picked up.

Bumps `core-commit.json`'s `sha` from `27b39b71bf5c67f560ec6035900ae5621226ac8d` to `0bd0c174228cf559ec7d4c9edec904294b59b9bc`, which includes [microsoft/typespec#11766](https://github.com/microsoft/typespec/pull/11766) "Fix Javadoc corruption from literal `*/` in parameter description". That fix resolves the `Regen & Spector Tests` CI failure seen on #5305 (unrelated PR — the failure was a real compile error in generated Java, not flakiness).

## Verification

- `pnpm turbo run --filter "@azure-tools/typespec-java^..." build`
- `pnpm run regenerate` (in `packages/typespec-java`) — all specs regenerate successfully
- `mvn compile -f emitter-tests/pom.xml` — generated Java compiles cleanly (previously failed with `';' expected` / `<identifier> expected` errors in `FileClient.java`)
- `pnpm run test:java:e2e` — Spector e2e tests pass (BUILD SUCCESS)
- `pnpm lint` passes
