### PR TITLE
Path params in fakes honors encoded setting

### DIFF
--- a/.chronus/changes/fake-path-params-2026-8-1-10-34-22.md
+++ b/.chronus/changes/fake-path-params-2026-8-1-10-34-22.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-go"
+---
+
+Fixed handling of reserved characters in path params for fakes.

--- a/packages/typespec-go/src/codegen/fake/servers.ts
+++ b/packages/typespec-go/src/codegen/fake/servers.ts
@@ -1244,9 +1244,10 @@ function parseHeaderPathQueryParams(
     // contains the unescaped value.
     let paramValue = getRawParamValue(param);
 
-    // path params are escaped, so we need to unescape them first.
+    // encoded path params are escaped, so we need to unescape them first.
+    // non-encoded path params are already in their final form (the client
+    // skips url.PathEscape for them), so they're passed through verbatim.
     if (go.isPathParameter(param)) {
-      imports.add("net/url");
       let paramVar = createLocalVariableName(param, "Unescaped");
       if (
         go.isRequiredParameter(param.style) &&
@@ -1254,27 +1255,42 @@ function parseHeaderPathQueryParams(
         param.type.type === "string"
       ) {
         // for string-based enums, we perform the conversion as part of unescaping
-        requiredHelpers.parseWithCast = true;
         paramVar = createLocalVariableName(param, "Param");
-        content += `${indent.get()}${paramVar}, err := parseWithCast(${paramValue}, func (v string) (${go.getTypeDeclaration(param.type, pkg)}, error) {\n`;
-        content += `${indent.push().get()}p, unescapeErr := url.PathUnescape(v)\n`;
-        content += `${indent.get()}if unescapeErr != nil {\n${indent.push().get()}return "", unescapeErr\n${indent.pop().get()}}\n`;
-        content += `${indent.get()}return ${go.getTypeDeclaration(param.type, pkg)}(p), nil\n${indent.pop().get()}})\n`;
+        if (param.isEncoded) {
+          imports.add("net/url");
+          requiredHelpers.parseWithCast = true;
+          content += `${indent.get()}${paramVar}, err := parseWithCast(${paramValue}, func (v string) (${go.getTypeDeclaration(param.type, pkg)}, error) {\n`;
+          content += `${indent.push().get()}p, unescapeErr := url.PathUnescape(v)\n`;
+          content += `${indent.get()}if unescapeErr != nil {\n${indent.push().get()}return "", unescapeErr\n${indent.pop().get()}}\n`;
+          content += `${indent.get()}return ${go.getTypeDeclaration(param.type, pkg)}(p), nil\n${indent.pop().get()}})\n`;
+          content += `${indent.get()}if err != nil {\n${indent.push().get()}return nil, err\n${indent.pop().get()}}\n`;
+        } else {
+          content += `${indent.get()}${paramVar} := ${go.getTypeDeclaration(param.type, pkg)}(${paramValue})\n`;
+        }
+        paramValue = paramVar;
       } else {
-        if (
+        const isStringParam =
           go.isRequiredParameter(param.style) &&
           (param.type.kind === "string" ||
-            (param.type.kind === "slice" && param.type.elementType.kind === "string"))
-        ) {
+            (param.type.kind === "slice" && param.type.elementType.kind === "string"));
+        if (isStringParam) {
           // by convention, if the value is in its "final form" (i.e. no parsing required)
           // then its var is to have the "Param" suffix. the only case is string, everything
           // else requires some amount of parsing/conversion.
           paramVar = createLocalVariableName(param, "Param");
         }
-        content += `${indent.get()}${paramVar}, err := url.PathUnescape(${paramValue})\n`;
+        if (param.isEncoded) {
+          imports.add("net/url");
+          content += `${indent.get()}${paramVar}, err := url.PathUnescape(${paramValue})\n`;
+          content += `${indent.get()}if err != nil {\n${indent.push().get()}return nil, err\n${indent.pop().get()}}\n`;
+          paramValue = paramVar;
+        } else if (isStringParam) {
+          content += `${indent.get()}${paramVar} := ${paramValue}\n`;
+          paramValue = paramVar;
+        }
+        // otherwise (non-encoded, non-string) the raw matched value is passed
+        // directly to the parsing code below.
       }
-      content += `${indent.get()}if err != nil {\n${indent.push().get()}return nil, err\n${indent.pop().get()}}\n`;
-      paramValue = paramVar;
     }
 
     // parse params as required

--- a/packages/typespec-go/test/local/fakeserver/server_test.go
+++ b/packages/typespec-go/test/local/fakeserver/server_test.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"fakeserver"
 	"fakeserver/fake"
+	"math"
+	"strconv"
 	"testing"
 	"time"
 
@@ -156,6 +158,90 @@ func TestDoubleDecodeQueryParamPlusAndSpace(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, tt.path, receivedPath, "path param mismatch")
 			require.Equal(t, tt.query, receivedQuery, "query param mismatch")
+		})
+	}
+}
+
+// TestReservedCharactersFake verifies that a path parameter allowing reserved characters
+// (RFC 6570 reserved expansion) round-trips verbatim through the fake server. The client
+// skips url.PathEscape for these values, so the fake must not call url.PathUnescape,
+// otherwise reserved characters such as '/' and any '%' sequences would be corrupted.
+func TestReservedCharactersFake(t *testing.T) {
+	for _, pathValue := range []string{
+		"subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test-rg",
+		"a/b:c@d!e$f&g'h(i)j*k+l,m;n=o.p_q~r-s",
+		"single-segment",
+	} {
+		t.Run(pathValue, func(t *testing.T) {
+			var receivedPath string
+			client, err := fakeserver.NewClientWithNoCredential("https://fake.endpoint", &fakeserver.ClientOptions{
+				ClientOptions: policy.ClientOptions{
+					Transport: fake.NewServerTransport(&fake.Server{
+						ReservedCharacters: func(_ context.Context, pathParam string, _ *fakeserver.ClientReservedCharactersOptions) (resp azfake.Responder[fakeserver.ClientReservedCharactersResponse], errResp azfake.ErrorResponder) {
+							receivedPath = pathParam
+							resp.SetResponse(http.StatusNoContent, fakeserver.ClientReservedCharactersResponse{}, nil)
+							return
+						},
+					}),
+				},
+			})
+			require.NoError(t, err)
+
+			_, err = client.ReservedCharacters(context.Background(), pathValue, nil)
+			require.NoError(t, err)
+			require.Equal(t, pathValue, receivedPath, "reserved-character path param did not round-trip")
+		})
+	}
+}
+
+// TestIntPathFake verifies that a non-string (int32) path parameter is parsed correctly
+// by the fake server rather than being treated as a string.
+func TestIntPathFake(t *testing.T) {
+	for _, value := range []int32{0, 42, -7, math.MaxInt32, math.MinInt32} {
+		t.Run(strconv.FormatInt(int64(value), 10), func(t *testing.T) {
+			var received int32
+			client, err := fakeserver.NewClientWithNoCredential("https://fake.endpoint", &fakeserver.ClientOptions{
+				ClientOptions: policy.ClientOptions{
+					Transport: fake.NewServerTransport(&fake.Server{
+						IntPath: func(_ context.Context, v int32, _ *fakeserver.ClientIntPathOptions) (resp azfake.Responder[fakeserver.ClientIntPathResponse], errResp azfake.ErrorResponder) {
+							received = v
+							resp.SetResponse(http.StatusNoContent, fakeserver.ClientIntPathResponse{}, nil)
+							return
+						},
+					}),
+				},
+			})
+			require.NoError(t, err)
+
+			_, err = client.IntPath(context.Background(), value, nil)
+			require.NoError(t, err)
+			require.Equal(t, value, received, "int path param did not round-trip")
+		})
+	}
+}
+
+// TestIntEnumPathFake verifies that a path parameter whose type is an int-based enum is
+// parsed and cast to the enum type by the fake server.
+func TestIntEnumPathFake(t *testing.T) {
+	for _, value := range fakeserver.PossibleIntEnumValues() {
+		t.Run(strconv.FormatInt(int64(value), 10), func(t *testing.T) {
+			var received fakeserver.IntEnum
+			client, err := fakeserver.NewClientWithNoCredential("https://fake.endpoint", &fakeserver.ClientOptions{
+				ClientOptions: policy.ClientOptions{
+					Transport: fake.NewServerTransport(&fake.Server{
+						IntEnumPath: func(_ context.Context, v fakeserver.IntEnum, _ *fakeserver.ClientIntEnumPathOptions) (resp azfake.Responder[fakeserver.ClientIntEnumPathResponse], errResp azfake.ErrorResponder) {
+							received = v
+							resp.SetResponse(http.StatusNoContent, fakeserver.ClientIntEnumPathResponse{}, nil)
+							return
+						},
+					}),
+				},
+			})
+			require.NoError(t, err)
+
+			_, err = client.IntEnumPath(context.Background(), value, nil)
+			require.NoError(t, err)
+			require.Equal(t, value, received, "int-enum path param did not round-trip")
 		})
 	}
 }

--- a/packages/typespec-go/test/tsp/FakeServer/main.tsp
+++ b/packages/typespec-go/test/tsp/FakeServer/main.tsp
@@ -31,3 +31,37 @@ op getInteger(): {
 @post
 @route("/double-decode/{path}")
 op doubleDecode(@path path: string, @query query: string): void;
+
+/**
+ * A path parameter that allows reserved characters (RFC 6570 reserved
+ * expansion). The client skips url.PathEscape for these values, so the
+ * fake must pass them through verbatim without url.PathUnescape.
+ */
+@get
+@route("/reserved-chars/{+path}")
+op reservedCharacters(@path path: string): void;
+
+/**
+ * A non-string (int32) path parameter, used to verify the fake parses
+ * the numeric path value rather than treating it as a string.
+ */
+@get
+@route("/int-path/{value}")
+op intPath(@path value: int32): void;
+
+/**
+ * An enum backed by integer values.
+ */
+enum IntEnum {
+  One: 1,
+  Two: 2,
+  Three: 3,
+}
+
+/**
+ * A path parameter whose type is an int-based enum, used to verify the
+ * fake parses the numeric path value and casts it to the enum type.
+ */
+@get
+@route("/int-enum-path/{value}")
+op intEnumPath(@path value: IntEnum): void;

--- a/packages/typespec-go/test/unittest/scenarios/fake-allow-reserved-path-param.md
+++ b/packages/typespec-go/test/unittest/scenarios/fake-allow-reserved-path-param.md
@@ -55,7 +55,6 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/fake/server"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"net/http"
-	"net/url"
 	"regexp"
 	"slices"
 	"testmodule"
@@ -131,10 +130,7 @@ func (e *ExtensionTopicsServerTransport) dispatchGet(req *http.Request) (*http.R
 		return nil, fmt.Errorf("failed to parse path %s", req.URL.Path)
 	}
 	qp := req.URL.Query()
-	scopeParam, err := url.PathUnescape(matches[regex.SubexpIndex("scope")])
-	if err != nil {
-		return nil, err
-	}
+	scopeParam := matches[regex.SubexpIndex("scope")]
 	respr, errRespr := e.srv.Get(req.Context(), qp.Get("api-version"), scopeParam, nil)
 	if respErr := server.GetError(errRespr, req); respErr != nil {
 		return nil, respErr


### PR DESCRIPTION
Only unescape path params that don't allow reserved characters. Added a few more runtime tests.