### PR TITLE
Code model improvements

### DIFF
--- a/.chronus/changes/types-cleanup-2026-8-1-15-13-26.md
+++ b/.chronus/changes/types-cleanup-2026-8-1-15-13-26.md
@@ -1,0 +1,7 @@
+---
+changeKind: internal
+packages:
+  - "@azure-tools/typespec-go"
+---
+
+Code model improvements.

--- a/packages/typespec-go/src/codegen/core/example.ts
+++ b/packages/typespec-go/src/codegen/core/example.ts
@@ -332,7 +332,7 @@ function getExampleValue(
       } else if (example.type.kind === "etag") {
         imports?.add(example.type.module);
         exampleText = `${go.getTypeDeclaration(example.type, pkg)}("${escapeString(example.value)}")`;
-      } else if (example.type.kind === "scalar" && example.type.type === "byte") {
+      } else if (go.isScalar(example.type, "byte")) {
         exampleText = `io.NopCloser(bytes.NewReader([]byte("${escapeString(example.value)}")))`;
       } else if (example.type.kind === "readSeekCloser") {
         imports?.add("bytes");
@@ -398,15 +398,9 @@ function getExampleValue(
         exampleText += `${indent}\t${field}: ${getExampleValue(pkg, example.value[field], indent + "\t", imports, isFieldByValue && !isFieldPolymorphic).slice(indent.length + 1)},\n`;
       }
       if (example.additionalProperties) {
-        const additionalPropertiesField = example.type.fields.find(
-          (f) => f.annotations.isAdditionalProperties,
+        const additionalPropertiesField = example.type.fields.find((f) =>
+          go.isAdditionalProperties(f),
         )!;
-        if (additionalPropertiesField.type.kind !== "map") {
-          throw new CodegenError(
-            "InternalError",
-            `additional properties field type should be map type`,
-          );
-        }
         const isAdditionalPropertiesFieldByValue =
           additionalPropertiesField.type.valueTypeByValue ?? false;
         const isAdditionalPropertiesPolymorphic =

--- a/packages/typespec-go/src/codegen/core/helpers.ts
+++ b/packages/typespec-go/src/codegen/core/helpers.ts
@@ -478,18 +478,6 @@ export function getMediaFormat(
   return `${marshaller}(${param}${format})`;
 }
 
-export function isMapOfDateTime(
-  paramType: go.WireType,
-): { format: go.TimeFormat; utc: boolean } | undefined {
-  if (paramType.kind !== "map") {
-    return undefined;
-  }
-  if (paramType.valueType.kind !== "time") {
-    return undefined;
-  }
-  return { format: paramType.valueType.format, utc: paramType.valueType.utc };
-}
-
 /**
  * Emits the code for parsing scalar types from a string.
  * The parsing error result is placed into a local var named "err".

--- a/packages/typespec-go/src/codegen/core/models.ts
+++ b/packages/typespec-go/src/codegen/core/models.ts
@@ -495,7 +495,7 @@ function generateModelDefs(
 function needsXMLDictionaryHelper(modelType: go.Model): boolean {
   for (const field of modelType.fields) {
     // additional properties uses an internal wrapper type with its own serde impl
-    if (field.type.kind === "map" && !field.annotations.isAdditionalProperties) {
+    if (field.type.kind === "map" && !go.isAdditionalProperties(field)) {
       return true;
     }
   }
@@ -635,7 +635,7 @@ function generateJSONMarshallerBody(
   let marshaller = "";
   let addlProps: go.Map | undefined;
   for (const field of modelDef.Model.fields) {
-    if (field.type.kind === "map" && field.annotations.isAdditionalProperties) {
+    if (go.isAdditionalProperties(field)) {
       addlProps = field.type;
       continue;
     }
@@ -653,7 +653,7 @@ function generateJSONMarshallerBody(
       marshaller += `${indent.push().get()}return runtime.EncodeByteArray(${receiver}.${field.name}, runtime.Base64${field.type.encoding}Format)\n`;
       marshaller += `${indent.pop().get()}})\n`;
       modelDef.SerDe.needsJSONPopulateByteArray = true;
-    } else if (field.type.kind === "slice" && field.type.elementType.kind === "encodedBytes") {
+    } else if (go.isSlice(field.type, "encodedBytes")) {
       imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime");
       marshaller += `${indent.get()}populateByteArray(objectMap, "${field.serializedName}", ${receiver}.${field.name}, func() any {\n`;
       marshaller += `${indent.push().get()}encodedValue := make([]string, len(${receiver}.${field.name}))\n`;
@@ -663,7 +663,7 @@ function generateJSONMarshallerBody(
       marshaller += `${indent.get()}return encodedValue\n`;
       marshaller += `${indent.pop().get()}})\n`;
       modelDef.SerDe.needsJSONPopulateByteArray = true;
-    } else if (field.type.kind === "slice" && field.type.elementType.kind === "time") {
+    } else if (go.isSlice(field.type, "time")) {
       const source = `${receiver}.${field.name}`;
       const elementType = field.type.elementType;
       let elementPtr = "*";
@@ -708,8 +708,17 @@ function generateJSONMarshallerBody(
         marshaller += `${indent.pop().get()}}\n`;
       }
       if (
-        field.type.kind === "scalar" &&
-        (field.type.type.startsWith("uint") || field.type.type.startsWith("int")) &&
+        go.isScalar(
+          field.type,
+          "uint8",
+          "uint16",
+          "uint32",
+          "uint64",
+          "int8",
+          "int16",
+          "int32",
+          "int64",
+        ) &&
         field.type.encodeAsString
       ) {
         imports.add("strconv");
@@ -725,11 +734,7 @@ function generateJSONMarshallerBody(
         marshaller += `${indent.push().get()}return strconv.${isSigned ? "FormatInt" : "FormatUint"}(${fieldExpr}, 10)\n`;
         marshaller += `${indent.pop().get()}})\n`;
         modelDef.SerDe.needsJSONPopulateAsString = true;
-      } else if (
-        field.type.kind === "scalar" &&
-        field.type.type === "bool" &&
-        field.type.encodeAsString
-      ) {
+      } else if (go.isScalar(field.type, "bool") && field.type.encodeAsString) {
         imports.add("strconv");
         marshaller += `${indent.get()}populateAsString(objectMap, "${field.serializedName}", ${receiver}.${field.name}, func() string {\n`;
         marshaller += `${indent.push().get()}return strconv.FormatBool(*${receiver}.${field.name})\n`;
@@ -877,7 +882,7 @@ function generateJSONUnmarshallerBody(
     let addlProps: go.Map | undefined;
     unmarshalBody += `${indent.get()}switch key {\n`;
     for (const field of modelDef.Model.fields) {
-      if (field.type.kind === "map" && field.annotations.isAdditionalProperties) {
+      if (go.isAdditionalProperties(field)) {
         addlProps = field.type;
         continue;
       }
@@ -894,7 +899,7 @@ function generateJSONUnmarshallerBody(
         unmarshalBody += `${indent.get()}err = unpopulateTime[datetime.${field.type.format}](val, "${field.name}", &${receiver}.${field.name})\n`;
         modelDef.SerDe.needsJSONUnpopulateTime = true;
         needsErrCheck = true;
-      } else if (field.type.kind === "slice" && field.type.elementType.kind === "time") {
+      } else if (go.isSlice(field.type, "time")) {
         imports.add("time");
         imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
         let elementPtr = "*";
@@ -914,7 +919,7 @@ function generateJSONUnmarshallerBody(
         unmarshalBody += `${indent.push().get()}err = runtime.DecodeByteArray(string(val), &${receiver}.${field.name}, runtime.Base64${field.type.encoding}Format)\n`;
         unmarshalBody += `${indent.pop().get()}}\n`;
         needsErrCheck = true;
-      } else if (field.type.kind === "slice" && field.type.elementType.kind === "encodedBytes") {
+      } else if (go.isSlice(field.type, "encodedBytes")) {
         imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime");
         unmarshalBody += `${indent.get()}var encodedValue []string\n`;
         unmarshalBody += `${indent.get()}err = unpopulate(val, "${field.name}", &encodedValue)\n`;
@@ -932,11 +937,7 @@ function generateJSONUnmarshallerBody(
         unmarshalBody += `${indent.get()}if string(val) != "null" {\n`;
         unmarshalBody += `${indent.push().get()}${receiver}.${field.name} = val\n`;
         unmarshalBody += `${indent.pop().get()}}\n`;
-      } else if (
-        field.type.kind === "scalar" &&
-        field.type.type === "bool" &&
-        field.type.encodeAsString
-      ) {
+      } else if (go.isScalar(field.type, "bool") && field.type.encodeAsString) {
         imports.add("strconv");
         imports.add("strings");
         imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/to");
@@ -951,8 +952,17 @@ function generateJSONUnmarshallerBody(
         modelDef.SerDe.needsJSONUnpopulateFromString = true;
         needsErrCheck = true;
       } else if (
-        field.type.kind === "scalar" &&
-        (field.type.type.startsWith("uint") || field.type.type.startsWith("int")) &&
+        go.isScalar(
+          field.type,
+          "uint8",
+          "uint16",
+          "uint32",
+          "uint64",
+          "int8",
+          "int16",
+          "int32",
+          "int64",
+        ) &&
         field.type.encodeAsString
       ) {
         const scalarType = field.type.type;
@@ -1075,9 +1085,9 @@ function generateDiscriminatorUnmarshaller(
   // these are the simple, non-nested cases (e.g. InterfaceType, []InterfaceType, map[string]InterfaceType)
   if (field.type.kind === "interface") {
     return `${indent.get()}${receiver}.${propertyName}, err = unmarshal${field.type.name}(val)\n`;
-  } else if (field.type.kind === "slice" && field.type.elementType.kind === "interface") {
+  } else if (go.isSlice(field.type, "interface")) {
     return `${indent.get()}${receiver}.${propertyName}, err = unmarshal${field.type.elementType.name}Array(val)\n`;
-  } else if (field.type.kind === "map" && field.type.valueType.kind === "interface") {
+  } else if (go.isMap(field.type, "interface")) {
     return `${indent.get()}${receiver}.${propertyName}, err = unmarshal${field.type.valueType.name}Map(val)\n`;
   }
 
@@ -1256,7 +1266,7 @@ function generateXMLMarshaller(
       text += `${indent.get()}if ${receiver}.${field.name} != nil {\n`;
       text += `${indent.push().get()}aux.${field.name} = &${receiver}.${field.name}\n`;
       text += `${indent.pop().get()}}\n`;
-    } else if (field.annotations.isAdditionalProperties || field.type.kind === "map") {
+    } else if (go.isAdditionalProperties(field) || field.type.kind === "map") {
       text += `${indent.get()}aux.${field.name} = (additionalProperties)(${receiver}.${field.name})\n`;
     } else if (field.type.kind === "encodedBytes") {
       imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime");
@@ -1298,7 +1308,7 @@ function generateXMLUnmarshaller(
       text += `${indent.get()}if aux.${field.name} != nil && !(*time.Time)(aux.${field.name}).IsZero() {\n`;
       text += `${indent.push().get()}${receiver}.${field.name} = (*time.Time)(aux.${field.name})\n`;
       text += `${indent.pop().get()}}\n`;
-    } else if (field.annotations.isAdditionalProperties || field.type.kind === "map") {
+    } else if (go.isAdditionalProperties(field) || field.type.kind === "map") {
       text += `${indent.get()}${receiver}.${field.name} = (map[string]*string)(aux.${field.name})\n`;
     } else if (field.type.kind === "encodedBytes") {
       imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime");
@@ -1339,7 +1349,7 @@ function generateAliasType(
     if (field.type.kind === "time") {
       imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
       text += `${indent.get()}${field.name} *datetime.${field.type.format} \`xml:"${sn}"\`\n`;
-    } else if (field.annotations.isAdditionalProperties || field.type.kind === "map") {
+    } else if (go.isAdditionalProperties(field) || field.type.kind === "map") {
       text += `${indent.get()}${field.name} additionalProperties \`xml:"${sn}"\`\n`;
     } else if (field.type.kind === "slice") {
       text += `${indent.get()}${field.name} *${go.getTypeDeclaration(field.type, modelType.pkg)} \`xml:"${sn}"\`\n`;
@@ -1466,7 +1476,7 @@ class ModelDef {
       }
       let tag = "";
       // only emit tags for XML; JSON uses custom marshallers/unmarshallers
-      if (this.Format === "XML" && !field.annotations.isAdditionalProperties) {
+      if (this.Format === "XML" && !go.isAdditionalProperties(field)) {
         tag = ` \`xml:"${serialization}"\``;
       }
       text += `${indent.get()}${field.name} ${helpers.star(field.byValue)}${typeName}${tag}\n`;

--- a/packages/typespec-go/src/codegen/core/request-handler.ts
+++ b/packages/typespec-go/src/codegen/core/request-handler.ts
@@ -132,8 +132,7 @@ export function createRequestHandler(
         if (pp.kind === "pathScalarParam") {
           // we only need to do this for params that have an underlying type of string
           if (
-            (pp.type.kind === "string" ||
-              (pp.type.kind === "constant" && pp.type.type === "string")) &&
+            (pp.type.kind === "string" || go.isConstant(pp.type, "string")) &&
             !pp.omitEmptyStringCheck
           ) {
             text += helpers.emitEmptyPathParamCheck(pp, "method", imports, indent);
@@ -502,43 +501,43 @@ function emitBody(
         } else {
           body = bodyVal;
         }
-      } else if (isArrayOfDateTimeForMarshalling(bodyParam.type)) {
-        const timeInfo = isArrayOfDateTimeForMarshalling(bodyParam.type);
-        let elementPtr = "*";
-        if (timeInfo?.elemByVal) {
-          elementPtr = "";
-        }
+      } else if (
+        go.isSlice(bodyParam.type, "time") &&
+        isSliceOfTimeForMarshalling(bodyParam.type)
+      ) {
+        const timeType = bodyParam.type.elementType;
+        const elementPtr = bodyParam.type.elementTypeByValue ? "" : "*";
         imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
-        text += `${indent.get()}aux := make([]${elementPtr}datetime.${timeInfo?.format}, len(${body}))\n`;
+        text += `${indent.get()}aux := make([]${elementPtr}datetime.${timeType.format}, len(${body}))\n`;
         text += `${indent.get()}for i := 0; i < len(${body}); i++ {\n`;
-        if (timeInfo?.utc && elementPtr === "*") {
+        if (timeType.utc && elementPtr === "*") {
           text += `${indent.push().get()}if ${body}[i] != nil {\n`;
           text += `${indent.push().get()}utcTime := ${body}[i].UTC()\n`;
-          text += `${indent.get()}aux[i] = (*datetime.${timeInfo?.format})(&utcTime)\n`;
+          text += `${indent.get()}aux[i] = (*datetime.${timeType.format})(&utcTime)\n`;
           text += `${indent.pop().get()}}\n`;
           indent.pop();
         } else {
-          const utcCall = timeInfo?.utc ? ".UTC()" : "";
-          text += `${indent.push().get()}aux[i] = (${elementPtr}datetime.${timeInfo?.format})(${body}[i]${utcCall})\n`;
+          const utcCall = timeType.utc ? ".UTC()" : "";
+          text += `${indent.push().get()}aux[i] = (${elementPtr}datetime.${timeType.format})(${body}[i]${utcCall})\n`;
           indent.pop();
         }
         text += `${indent.get()}}\n`;
         body = "aux";
-      } else if (helpers.isMapOfDateTime(bodyParam.type)) {
-        const timeInfo = helpers.isMapOfDateTime(bodyParam.type);
+      } else if (go.isMap(bodyParam.type, "time")) {
+        const timeType = bodyParam.type.valueType;
         imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
-        text += `${indent.get()}aux := map[string]*datetime.${timeInfo?.format}{}\n`;
+        text += `${indent.get()}aux := map[string]*datetime.${timeType.format}{}\n`;
         text += `${indent.get()}for k, v := range ${body} {\n`;
-        if (timeInfo?.utc) {
+        if (timeType.utc) {
           text += `${indent.push().get()}if v != nil {\n`;
           text += `${indent.push().get()}utcTime := v.UTC()\n`;
-          text += `${indent.get()}aux[k] = (*datetime.${timeInfo?.format})(&utcTime)\n`;
+          text += `${indent.get()}aux[k] = (*datetime.${timeType.format})(&utcTime)\n`;
           text += `${indent.pop().get()}} else {\n`;
           text += `${indent.push().get()}aux[k] = nil\n`;
           text += `${indent.pop().get()}}\n`;
           indent.pop();
         } else {
-          text += `${indent.push().get()}aux[k] = (*datetime.${timeInfo?.format})(v)\n`;
+          text += `${indent.push().get()}aux[k] = (*datetime.${timeType.format})(v)\n`;
           indent.pop();
         }
         text += `${indent.get()}}\n`;
@@ -983,45 +982,31 @@ function getContentTypeValue(
 }
 
 /**
- * returns info for custom marshaling of slices of time.Time.
- * returns undefined if the type isn't a slice of time.Time or
- * if no custom marshaling is required.
+ * returns true if the given slice of time.Time requires custom marshalling.
  *
- * @param paramType the type to inspect
- * @returns custom marshaling info or undefined
+ * the caller narrows to go.Slice<go.Time> (via go.isSlice) before calling this; this only
+ * decides marshalling based on the element's TimeFormat/utc. keep it a plain boolean rather
+ * than widening the param back to go.WireType and returning a `type is go.Slice<go.Time>`
+ * predicate: a false result (e.g. RFC3339 non-utc, which uses the default marshaller) does
+ * not mean the value isn't a slice of time.Time, so a predicate would unsoundly narrow those
+ * out of any later slice-of-time checks.
+ *
+ * @param type the slice of time.Time to inspect
+ * @returns true if the slice needs custom marshalling
  */
-function isArrayOfDateTimeForMarshalling(
-  paramType: go.WireType,
-): { format: go.TimeFormat; elemByVal: boolean; utc: boolean } | undefined {
-  if (paramType.kind !== "slice") {
-    return undefined;
-  }
-  if (paramType.elementType.kind !== "time") {
-    return undefined;
-  }
-  switch (paramType.elementType.format) {
+function isSliceOfTimeForMarshalling(type: go.Slice<go.Time>): boolean {
+  switch (type.elementType.format) {
     case "PlainDate":
     case "RFC1123":
     case "RFC7231":
     case "PlainTime":
     case "Unix":
-      return {
-        format: paramType.elementType.format,
-        elemByVal: paramType.elementTypeByValue,
-        utc: paramType.elementType.utc,
-      };
+      return true;
     case "RFC3339":
       // RFC3339 normally uses the default time.Time marshaller, but utc slices
       // must be normalized to UTC, which requires building the wrapper slice.
-      if (paramType.elementType.utc) {
-        return {
-          format: "RFC3339",
-          elemByVal: paramType.elementTypeByValue,
-          utc: true,
-        };
-      }
-      return undefined;
+      return type.elementType.utc;
     default:
-      return undefined;
+      return false;
   }
 }

--- a/packages/typespec-go/src/codegen/core/response-handler.ts
+++ b/packages/typespec-go/src/codegen/core/response-handler.ts
@@ -141,15 +141,12 @@ function generateResponseUnmarshaller(
     unmarshallerText += `${indent.pop().get()}}\n`;
     unmarshallerText += `${indent.get()}${unmarshalTarget} = (*time.Time)(aux)\n`;
     return unmarshallerText;
-  } else if (isArrayOfDateTime(type)) {
+  } else if (go.isSlice(type, "time")) {
     // unmarshalling arrays of date/time is a little more involved
-    const timeInfo = isArrayOfDateTime(type);
-    let elementPtr = "*";
-    if (timeInfo?.elemByVal) {
-      elementPtr = "";
-    }
+    const timeType = type.elementType;
+    const elementPtr = type.elementTypeByValue ? "" : "*";
     imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
-    unmarshallerText += `${indent.get()}var aux []${elementPtr}datetime.${timeInfo?.format}\n`;
+    unmarshallerText += `${indent.get()}var aux []${elementPtr}datetime.${timeType.format}\n`;
     unmarshallerText += `${indent.get()}if err := runtime.UnmarshalAs${format}(resp, &aux); err != nil {\n`;
     unmarshallerText += `${indent.push().get()}return ${zeroValue}, err\n`;
     unmarshallerText += `${indent.pop().get()}}\n`;
@@ -159,10 +156,10 @@ function generateResponseUnmarshaller(
     unmarshallerText += `${indent.pop().get()}}\n`;
     unmarshallerText += `${indent.get()}${unmarshalTarget} = cp\n`;
     return unmarshallerText;
-  } else if (helpers.isMapOfDateTime(type)) {
-    const timeInfo = helpers.isMapOfDateTime(type);
+  } else if (go.isMap(type, "time")) {
+    const timeType = type.valueType;
     imports.add("github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime/datetime");
-    unmarshallerText += `${indent.get()}aux := map[string]*datetime.${timeInfo?.format}{}\n`;
+    unmarshallerText += `${indent.get()}aux := map[string]*datetime.${timeType.format}{}\n`;
     unmarshallerText += `${indent.get()}if err := runtime.UnmarshalAs${format}(resp, &aux); err != nil {\n`;
     unmarshallerText += `${indent.push().get()}return ${zeroValue}, err\n`;
     unmarshallerText += `${indent.pop().get()}}\n`;
@@ -296,19 +293,4 @@ function formatHeaderResponseValue(
   text += `${indent.get()}${respObj}.${headerResp.fieldName} = ${byRef}${name}\n`;
   text += `${indent.pop().get()}}\n`;
   return text;
-}
-
-function isArrayOfDateTime(
-  paramType: go.WireType,
-): { format: go.TimeFormat; elemByVal: boolean } | undefined {
-  if (paramType.kind !== "slice") {
-    return undefined;
-  }
-  if (paramType.elementType.kind !== "time") {
-    return undefined;
-  }
-  return {
-    format: paramType.elementType.format,
-    elemByVal: paramType.elementTypeByValue,
-  };
 }

--- a/packages/typespec-go/src/codegen/fake/servers.ts
+++ b/packages/typespec-go/src/codegen/fake/servers.ts
@@ -1249,11 +1249,7 @@ function parseHeaderPathQueryParams(
     // skips url.PathEscape for them), so they're passed through verbatim.
     if (go.isPathParameter(param)) {
       let paramVar = createLocalVariableName(param, "Unescaped");
-      if (
-        go.isRequiredParameter(param.style) &&
-        param.type.kind === "constant" &&
-        param.type.type === "string"
-      ) {
+      if (go.isRequiredParameter(param.style) && go.isConstant(param.type, "string")) {
         // for string-based enums, we perform the conversion as part of unescaping
         paramVar = createLocalVariableName(param, "Param");
         if (param.isEncoded) {
@@ -1271,8 +1267,7 @@ function parseHeaderPathQueryParams(
       } else {
         const isStringParam =
           go.isRequiredParameter(param.style) &&
-          (param.type.kind === "string" ||
-            (param.type.kind === "slice" && param.type.elementType.kind === "string"));
+          (param.type.kind === "string" || go.isSlice(param.type, "string"));
         if (isStringParam) {
           // by convention, if the value is in its "final form" (i.e. no parsing required)
           // then its var is to have the "Param" suffix. the only case is string, everything
@@ -1392,7 +1387,7 @@ function parseHeaderPathQueryParams(
         requiredHelpers.splitHelper = true;
         content += `${indent.get()}${createLocalVariableName(param, "Param")} := splitHelper(${paramValue}, "${helpers.getDelimiterForCollectionFormat(param.collectionFormat)}")\n`;
       }
-    } else if (param.type.kind === "scalar" && param.type.type === "bool") {
+    } else if (go.isScalar(param.type, "bool")) {
       imports.add("strconv");
       let from = `strconv.ParseBool(${paramValue})`;
       if (!go.isRequiredParameter(param.style)) {
@@ -1440,13 +1435,7 @@ function parseHeaderPathQueryParams(
         content += `${indent.get()}return time.Unix(p, 0), nil\n${indent.pop().get()}})\n`;
         content += `${indent.get()}if err != nil {\n${indent.push().get()}return nil, err\n${indent.pop().get()}}\n`;
       }
-    } else if (
-      param.type.kind === "scalar" &&
-      (param.type.type === "float32" ||
-        param.type.type === "float64" ||
-        param.type.type === "int32" ||
-        param.type.type === "int64")
-    ) {
+    } else if (go.isScalar(param.type, "float32", "float64", "int32", "int64")) {
       let parser: string;
       if (!go.isRequiredParameter(param.style)) {
         requiredHelpers.parseOptional = true;
@@ -1484,7 +1473,7 @@ function parseHeaderPathQueryParams(
       content += `${indent.push().get()}if ${localVar} == nil {\n${indent.push().get()}${localVar} = map[string]*string{}\n${indent.pop().get()}}\n`;
       content += `${indent.get()}${localVar}[hh[len("${headerPrefix}"):]] = to.Ptr(getHeaderValue(req.Header, hh))\n`;
       content += `${indent.pop().get()}}\n${indent.pop().get()}}\n`;
-    } else if (param.type.kind === "constant" && param.type.type !== "string") {
+    } else if (go.isConstant(param.type, "bool", "float32", "float64", "int32", "int64")) {
       let parseHelper: string;
       if (!go.isRequiredParameter(param.style)) {
         requiredHelpers.parseOptional = true;
@@ -1731,8 +1720,7 @@ function getFinalParamValue(
       }
     } else if (
       (go.isHeaderParameter(param) || go.isQueryParameter(param)) &&
-      param.type.kind === "constant" &&
-      param.type.type === "string"
+      go.isConstant(param.type, "string")
     ) {
       // query params from req.URL.Query() are already decoded, so like headers we cast required, string-based enums inline
       return `${go.getTypeDeclaration(param.type, pkg)}(${paramValue})`;

--- a/packages/typespec-go/src/codemodel/type.ts
+++ b/packages/typespec-go/src/codemodel/type.ts
@@ -62,7 +62,7 @@ export interface ArmClientOptions extends QualifiedType {
 }
 
 /** a const type definition used for enums */
-export interface Constant {
+export interface Constant<T extends ConstantType = ConstantType> {
   kind: "constant";
 
   /** the const type name */
@@ -75,7 +75,7 @@ export interface Constant {
   pkg: PackageContent;
 
   /** the underlying type of the const */
-  type: ConstantType;
+  type: T;
 
   /** the possible values for this const */
   values: Array<ConstantValue>;
@@ -183,18 +183,35 @@ export interface Literal<T extends LiteralType = LiteralType> {
 export type LiteralType = Constant | ConstantDef | EncodedBytes | Scalar | String | Time;
 
 /** a Go map type. note that the key is always a string */
-export interface Map {
+export interface Map<T extends MapValueType = MapValueType> {
   kind: "map";
 
   /** the type of values in the map */
-  valueType: MapValueType;
+  valueType: T;
 
   /** indicates if the map's value type is pointer-to-type or not */
   valueTypeByValue: boolean;
 }
 
 /** the set of map value types */
-export type MapValueType = WireType;
+export type MapValueType =
+  | Any
+  | Constant
+  | EncodedBytes
+  | Interface
+  | Map
+  | Model
+  | MultipartContent
+  | PolymorphicModel
+  | RawJSON
+  | ReadCloser
+  | ReadSeekCloser
+  | Scalar
+  | Slice
+  | SliceArray
+  | String
+  | Time
+  | UnionStruct;
 
 /** a field within a model */
 export interface ModelField extends StructField {
@@ -275,11 +292,11 @@ export interface RawJSON {
 }
 
 /** a Go scalar type */
-export interface Scalar {
+export interface Scalar<T extends ScalarType = ScalarType> {
   kind: "scalar";
 
   /** the type of scalar */
-  type: ScalarType;
+  type: T;
 
   /** indicates the value is sent/received as a string */
   encodeAsString: boolean;
@@ -312,11 +329,11 @@ export type ScalarType =
   | "uint64";
 
 /** a Go slice */
-export interface Slice {
+export interface Slice<T extends SliceElementType = SliceElementType> {
   kind: "slice";
 
   /** the element type for this slice */
-  elementType: SliceElementType;
+  elementType: T;
 
   /** indicates if the slice's element type is pointer-to-type or not */
   elementTypeByValue: boolean;
@@ -337,13 +354,30 @@ export interface SliceArray {
 }
 
 /** the set of slice array delimiters */
-export type SliceArrayDelimiter = "comma" | "space" | "pipe" | "newline";
+export type SliceArrayDelimiter = "comma" | "newline" | "pipe" | "space";
 
 /** the supported element types for arrays represented as delimited strings */
-export type SliceArrayElementType = String | Constant;
+export type SliceArrayElementType = Constant | String;
 
 /** the set of slice element types */
-export type SliceElementType = WireType;
+export type SliceElementType =
+  | Any
+  | Constant
+  | EncodedBytes
+  | Interface
+  | Map
+  | Model
+  | MultipartContent
+  | PolymorphicModel
+  | RawJSON
+  | ReadCloser
+  | ReadSeekCloser
+  | Scalar
+  | Slice
+  | SliceArray
+  | String
+  | Time
+  | UnionStruct;
 
 /** a Go string */
 export interface String {
@@ -552,6 +586,22 @@ export function getTypeDeclaration(type: Client | Type, scope: PackageType): str
   }
 }
 
+/** narrows the field to the model's JSON additional properties bucket, whose type is always a map */
+export function isAdditionalProperties(field: ModelField): field is ModelField & { type: Map } {
+  return field.annotations.isAdditionalProperties;
+}
+
+/** narrows type to a constant with one of the specified underlying types (any constant when no types are given) */
+export function isConstant<T extends ConstantType = ConstantType>(
+  type: WireType,
+  ...kinds: Array<T>
+): type is Constant<T> {
+  if (type.kind !== "constant") {
+    return false;
+  }
+  return kinds.length === 0 || (kinds as Array<ConstantType>).includes(type.type);
+}
+
 /** narrows type to a LiteralType within the conditional block */
 export function isLiteralValueType(type: WireType): type is LiteralType {
   switch (type.kind) {
@@ -564,6 +614,39 @@ export function isLiteralValueType(type: WireType): type is LiteralType {
     default:
       return false;
   }
+}
+
+/** narrows type to a map with one of the specified value type kinds (any map when no kinds are given) */
+export function isMap<T extends MapValueType["kind"] = MapValueType["kind"]>(
+  type: WireType,
+  ...kinds: Array<T>
+): type is Map<Extract<MapValueType, { kind: T }>> {
+  if (type.kind !== "map") {
+    return false;
+  }
+  return kinds.length === 0 || (kinds as Array<string>).includes(type.valueType.kind);
+}
+
+/** narrows type to a scalar with one of the specified underlying types (any scalar when no types are given) */
+export function isScalar<T extends ScalarType = ScalarType>(
+  type: WireType,
+  ...kinds: Array<T>
+): type is Scalar<T> {
+  if (type.kind !== "scalar") {
+    return false;
+  }
+  return kinds.length === 0 || (kinds as Array<ScalarType>).includes(type.type);
+}
+
+/** narrows type to a slice with one of the specified element type kinds (any slice when no kinds are given) */
+export function isSlice<T extends SliceElementType["kind"] = SliceElementType["kind"]>(
+  type: WireType,
+  ...kinds: Array<T>
+): type is Slice<Extract<SliceElementType, { kind: T }>> {
+  if (type.kind !== "slice") {
+    return false;
+  }
+  return kinds.length === 0 || (kinds as Array<string>).includes(type.elementType.kind);
 }
 
 /** narrows type to a UnionVariantType within the conditional block */
@@ -677,8 +760,8 @@ export class ArmClientOptions extends QualifiedType implements ArmClientOptions 
   }
 }
 
-export class Constant implements Constant {
-  constructor(pkg: PackageContent, name: string, type: ConstantType, valuesFuncName: string) {
+export class Constant<T extends ConstantType = ConstantType> implements Constant<T> {
+  constructor(pkg: PackageContent, name: string, type: T, valuesFuncName: string) {
     this.kind = "constant";
     this.name = name;
     this.pkg = pkg;
@@ -743,8 +826,8 @@ export class Literal<T> implements Literal<T> {
   }
 }
 
-export class Map implements Map {
-  constructor(valueType: MapValueType, valueTypeByValue: boolean) {
+export class Map<T extends MapValueType = MapValueType> implements Map<T> {
+  constructor(valueType: T, valueTypeByValue: boolean) {
     this.kind = "map";
     this.valueType = valueType;
     this.valueTypeByValue = valueTypeByValue;
@@ -837,16 +920,16 @@ export class ReadSeekCloser extends QualifiedType implements ReadSeekCloser {
   }
 }
 
-export class Scalar implements Scalar {
-  constructor(type: ScalarType, encodeAsString: boolean) {
+export class Scalar<T extends ScalarType = ScalarType> implements Scalar<T> {
+  constructor(type: T, encodeAsString: boolean) {
     this.kind = "scalar";
     this.type = type;
     this.encodeAsString = encodeAsString;
   }
 }
 
-export class Slice implements Slice {
-  constructor(elementType: SliceElementType, elementTypeByValue: boolean) {
+export class Slice<T extends SliceElementType = SliceElementType> implements Slice<T> {
+  constructor(elementType: T, elementTypeByValue: boolean) {
     this.kind = "slice";
     this.elementType = elementType;
     this.elementTypeByValue = elementTypeByValue;

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -2467,21 +2467,14 @@ export class ClientAdapter {
           if (exampleType.additionalPropertiesValue) {
             ret.additionalProperties = {};
             for (const [k, v] of Object.entries(exampleType.additionalPropertiesValue)) {
-              const filed = concreteType.fields.find((f) => f.annotations.isAdditionalProperties);
-              if (!filed) {
+              const field = concreteType.fields.find((f) => go.isAdditionalProperties(f));
+              if (!field) {
                 throw new AdapterError(
                   "InternalError",
                   `additional properties field not found in model '${concreteType.name}'.`,
                 );
               }
-              if (filed.type.kind === "map") {
-                ret.additionalProperties[k] = this.adaptExampleType(v, filed.type.valueType);
-              } else {
-                throw new AdapterError(
-                  "InternalError",
-                  `additional properties field type should be map type, but got '${filed.type.kind}' in model '${concreteType.name}'`,
-                );
-              }
+              ret.additionalProperties[k] = this.adaptExampleType(v, field.type.valueType);
             }
           }
           return ret;

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -2102,7 +2102,11 @@ export class ClientAdapter {
       case "unknown":
         return this.ta.codeModel.options["rawjson-as-bytes"] ? "RawJSON" : "Interface";
       default:
-        throw new Error(`unhandled monomorphic response type kind ${type.kind}`);
+        throw new AdapterError(
+          "UnsupportedTsp",
+          `unsupported kind ${type.kind} for monomorphic response`,
+          type.__raw?.node,
+        );
     }
   }
 

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -147,7 +147,7 @@ export class TypeAdapter {
       if (content.addlProps) {
         const annotations = new go.ModelFieldAnnotations(false, false, true, false);
         const addlPropsType = new go.Map(
-          this.getWireType(content.addlProps, false, false),
+          this.getMapValueType(content.addlProps, false, false),
           helpers.isTypePassedByValue(content.addlProps),
         );
         const addlProps = new go.ModelField(
@@ -254,10 +254,19 @@ export class TypeAdapter {
         if (arrayType) {
           return arrayType;
         }
-        arrayType = new go.Slice(
-          this.getWireType(elementType, elementTypeByValue, substituteDiscriminator),
-          myElementTypeByValue,
+        const goElementType = this.getWireType(
+          type.valueType,
+          elementTypeByValue,
+          substituteDiscriminator,
         );
+        switch (goElementType.kind) {
+          case "constantDef":
+          case "constantValue":
+          case "etag":
+          case "literal":
+            throw new Error("todo elementType");
+        }
+        arrayType = new go.Slice(goElementType, myElementTypeByValue);
         this.types.set(keyName, arrayType);
         return arrayType;
       }
@@ -288,7 +297,7 @@ export class TypeAdapter {
           return mapType;
         }
         mapType = new go.Map(
-          this.getWireType(type.valueType, elementTypeByValue, substituteDiscriminator),
+          this.getMapValueType(type.valueType, elementTypeByValue, substituteDiscriminator),
           valueTypeByValue,
         );
         this.types.set(keyName, mapType);
@@ -842,10 +851,7 @@ export class TypeAdapter {
     field.docs.description = prop.doc;
 
     if (prop.encode && type.kind === "slice") {
-      if (
-        type.elementType.kind === "string" ||
-        (type.elementType.kind === "constant" && type.elementType.type === "string")
-      ) {
+      if (type.elementType.kind === "string" || go.isConstant(type.elementType, "string")) {
         type = new go.SliceArray(
           type.elementType,
           type.elementTypeByValue,
@@ -1098,6 +1104,29 @@ export class TypeAdapter {
     }
 
     // TODO: tcgc doesn't support duration as a literal value
+  }
+
+  /** adapts the SDK type to a Go map value type */
+  private getMapValueType(
+    sdkType: tcgc.SdkType,
+    elementTypeByValue: boolean,
+    substituteDiscriminator: boolean,
+  ): go.MapValueType {
+    const valueType = this.getWireType(sdkType, elementTypeByValue, substituteDiscriminator);
+    switch (valueType.kind) {
+      case "constantDef":
+      case "constantValue":
+      case "etag":
+      case "multipartContent":
+      case "literal":
+        throw new AdapterError(
+          "UnsupportedTsp",
+          `unsupported kind ${valueType.kind} for map value type`,
+          sdkType.__raw?.node,
+        );
+      default:
+        return valueType;
+    }
   }
 
   private getUnionStruct(sdkUnion: tcgc.SdkUnionType, elementTypeByValue: boolean): go.UnionStruct {

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -264,7 +264,11 @@ export class TypeAdapter {
           case "constantValue":
           case "etag":
           case "literal":
-            throw new Error("todo elementType");
+            throw new AdapterError(
+              "UnsupportedTsp",
+              `unsupported kind ${goElementType.kind} for slice element type`,
+              type.valueType.__raw?.node,
+            );
         }
         arrayType = new go.Slice(goElementType, myElementTypeByValue);
         this.types.set(keyName, arrayType);


### PR DESCRIPTION
Added generic type params to Constant, Map, Scalar, and Slice for their underlying types along with type guards to simplify narrowing. Replaced some duplicate helpers with the new ones.
Constrained slice element/map value types to applicable types instead of the wider WireType.
Added type guard for additional properties model fields which simplified checks at the call site.

No functional changes.