### PR TITLE
Bump typespec-java to 0.46.2 for hotfix

### DIFF
--- a/.chronus/changes/typespec-java-model-maximum-overloads-2026-09-01.md
+++ b/.chronus/changes/typespec-java-model-maximum-overloads-2026-09-01.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Sync core to microsoft/typespec commit `a32575719`. Add model maximum overloads to Java clients and preserve internal protocol method names (core [#11803](https://github.com/microsoft/typespec/pull/11803)).

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug Fixes
 
-- [#5362](https://github.com/Azure/typespec-azure/pull/5362) Sync core to microsoft/typespec commit `a32575719`. Add model maximum overloads to Java clients and preserve internal protocol method names (core [#11803](https://github.com/microsoft/typespec/pull/11803)).
+- Sync core to microsoft/typespec commit `a32575719`. Add model maximum overloads to Java clients and preserve internal protocol method names (core [#11803](https://github.com/microsoft/typespec/pull/11803)).
 
 
 ## 0.46.1

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-java
 
+## 0.46.2
+
+### Bug Fixes
+
+- [#5362](https://github.com/Azure/typespec-azure/pull/5362) Sync core to microsoft/typespec commit `a32575719`. Add model maximum overloads to Java clients and preserve internal protocol method names (core [#11803](https://github.com/microsoft/typespec/pull/11803)).
+
+
 ## 0.46.1
 
 ### Bug Fixes

--- a/packages/typespec-java/package.json
+++ b/packages/typespec-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.46.1",
+  "version": "0.46.2",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
## Summary

- bump `@azure-tools/typespec-java` from `0.46.1` to `0.46.2`
- publish the model maximum overload and internal protocol method fixes from Azure/typespec-azure#5362
- consume the corresponding Chronus change entry

## Validation

- `pnpm -w format`
- `pnpm -w lint`
