### PR TITLE
Fix silent bad codegen for unsupported string encoded arrays

### DIFF
--- a/.chronus/changes/slice-array-cleanup-2026-8-2-11-12-36.md
+++ b/.chronus/changes/slice-array-cleanup-2026-8-2-11-12-36.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-go"
+---
+
+Unsupported types for string-encoded arrays resulted in bad codegen.

--- a/packages/typespec-go/.scripts/tspcompile.js
+++ b/packages/typespec-go/.scripts/tspcompile.js
@@ -174,7 +174,6 @@ function generate(moduleName, input, outputDir, perTestOptions) {
   const fixedOptions = [outputKind, `emitter-output-dir=${fullOutputDir}`, "file-prefix=zz_"];
 
   // these options _can_ be changed per test
-  // TODO: disabled examples by default https://github.com/Azure/autorest.go/issues/1441
   const defaultOptions = [
     "generate-fakes=true",
     "inject-spans=true",

--- a/packages/typespec-go/src/codegen/core/request-handler.ts
+++ b/packages/typespec-go/src/codegen/core/request-handler.ts
@@ -632,7 +632,7 @@ function emitBody(
         text += `${indent.pop().get()}}\n`;
       }
     }
-    // TODO: spread params are JSON only https://github.com/Azure/autorest.go/issues/1455
+    // TODO: spread params are JSON only https://github.com/Azure/typespec-azure/issues/4949
     text += `${indent.get()}req.Raw().Header["Content-Type"] = []string{"application/json"}\n`;
     text += `${indent.get()}if err := runtime.MarshalAsJSON(req, body); err != nil {\n`;
     text += `${indent.push().get()}return nil, err\n`;

--- a/packages/typespec-go/src/lib.ts
+++ b/packages/typespec-go/src/lib.ts
@@ -151,7 +151,7 @@ const libDef = {
     InternalError: {
       severity: "error",
       messages: {
-        default: paramMessage`The emitter encountered an internal error during preprocessing. Please open an issue at https://github.com/Azure/autorest.go/issues and include the complete error message.\n${"stack"}`,
+        default: paramMessage`The emitter encountered an internal error during preprocessing. Please open an issue at https://github.com/Azure/typespec-azure/issues and include the complete error message.\n${"stack"}`,
       },
     },
     InvalidArgument: {

--- a/packages/typespec-go/src/tcgcadapter/adapter.ts
+++ b/packages/typespec-go/src/tcgcadapter/adapter.ts
@@ -217,7 +217,7 @@ function fixStutteringTypeNames(
     return newName;
   };
 
-  // to keep compat with autorest.go, this is off by default
+  // to keep compat with legacy behavior, this is off by default
   if (options["fix-const-stuttering"] === true) {
     for (const sdkEnum of sdkPackage.enums) {
       sdkEnum.name = renameType(sdkEnum.name);

--- a/packages/typespec-go/src/tcgcadapter/clients.ts
+++ b/packages/typespec-go/src/tcgcadapter/clients.ts
@@ -1527,7 +1527,7 @@ export class ClientAdapter {
             byVal,
           );
           if (contentType === "XML" && methodParam.type.kind === "array") {
-            // this is for compat with autorest.go
+            // this is for compat with legacy behavior
             adaptedParam.xml = new go.XMLInfo();
             adaptedParam.xml.wrapper = methodParam.type.name;
           }
@@ -1998,7 +1998,7 @@ export class ClientAdapter {
         let fieldName: string | undefined;
         let xmlInfo: go.XMLInfo | undefined;
         if (contentType === "XML" && sdkResponseType.kind === "array") {
-          // this is for compat with autorest.go
+          // this is for compat with legacy behavior
           xmlInfo = new go.XMLInfo();
           fieldName = sdkResponseType.name;
           const elementType = (<go.Slice>resultType).elementType;

--- a/packages/typespec-go/src/tcgcadapter/types.ts
+++ b/packages/typespec-go/src/tcgcadapter/types.ts
@@ -807,30 +807,30 @@ export class TypeAdapter {
     // for multipart/form data containing models, default to fields not being pointer-to-type as we
     // don't have to deal with JSON patch shenanigans. only the optional fields will be pointer-to-type.
     const isMultipartFormData = (modelType.usage & tcgc.UsageFlags.MultipartFormData) !== 0;
-    let fieldByValue = isMultipartFormData ? true : helpers.isTypePassedByValue(prop.type);
-    if (isMultipartFormData && prop.kind === "property" && prop.optional) {
-      fieldByValue = false;
+
+    let type: go.WireType;
+    if (prop.encode && prop.type.kind === "array") {
+      type = this.getSliceArray(prop.type, prop.encode);
+    } else if (prop.serializationOptions.multipart?.isFilePart) {
+      // for file parts, check if the tsp defines a fixed content type
+      // (e.g. HttpPart<File<"image/png">>). if so, bake it into the MultipartContent type.
+      const multipartOpts = prop.serializationOptions.multipart;
+      const fixedContentType =
+        multipartOpts?.contentType?.type.kind === "constant" &&
+        multipartOpts.defaultContentTypes.length === 1
+          ? multipartOpts.defaultContentTypes[0]
+          : undefined;
+      type = this.getMultipartContent(prop.type.kind === "array", fixedContentType);
+    } else {
+      type = this.getWireType(prop.type, isMultipartFormData, true);
     }
-    let type = this.getWireType(prop.type, isMultipartFormData, true);
-    if (prop.kind === "property") {
-      if (prop.serializationOptions.multipart?.isFilePart) {
-        // for file parts, check if the tsp defines a fixed content type
-        // (e.g. HttpPart<File<"image/png">>). if so, bake it into the MultipartContent type.
-        const multipartOpts = prop.serializationOptions.multipart;
-        const fixedContentType =
-          multipartOpts?.contentType?.type.kind === "constant" &&
-          multipartOpts.defaultContentTypes.length === 1
-            ? multipartOpts.defaultContentTypes[0]
-            : undefined;
-        type = this.getMultipartContent(prop.type.kind === "array", fixedContentType);
-      }
-      if (prop.visibility) {
-        // the field is read-only IFF the only visibility attribute present is Read.
-        // a field can have Read & Create set which means it's required on input and
-        // returned on output.
-        if (prop.visibility.length === 1 && prop.visibility[0] === http.Visibility.Read) {
-          annotations.readOnly = true;
-        }
+
+    if (prop.visibility) {
+      // the field is read-only IFF the only visibility attribute present is Read.
+      // a field can have Read & Create set which means it's required on input and
+      // returned on output.
+      if (prop.visibility.length === 1 && prop.visibility[0] === http.Visibility.Read) {
+        annotations.readOnly = true;
       }
     }
 
@@ -850,27 +850,13 @@ export class TypeAdapter {
       isExactName: prop.isExactName,
       access: prop.access,
     });
+
+    const fieldByValue = isMultipartFormData
+      ? !prop.optional
+      : helpers.isTypePassedByValue(prop.type);
     const field = new go.ModelField(fieldName, type, fieldByValue, serializedName, annotations);
     field.docs.summary = prop.summary;
     field.docs.description = prop.doc;
-
-    if (prop.encode && type.kind === "slice") {
-      if (type.elementType.kind === "string" || go.isConstant(type.elementType, "string")) {
-        type = new go.SliceArray(
-          type.elementType,
-          type.elementTypeByValue,
-          getSliceArrayDelimiter(prop.encode),
-        );
-        field.type = type;
-      } else {
-        this.ctx.program.reportDiagnostic({
-          code: "UnsupportedArrayEncoding",
-          severity: "warning",
-          message: `The array property ${prop.name} uses ${prop.encode} encoding with unsupported element type ${prop.type.kind === "array" ? prop.type.valueType.kind : prop.type.kind}. The encoding will be ignored.`,
-          target: prop.__raw?.node ?? tsp.NoTarget,
-        });
-      }
-    }
 
     if (prop.discriminator && modelType.discriminatorValue) {
       // the presence of modelType.discriminatorValue tells us that this
@@ -1131,6 +1117,62 @@ export class TypeAdapter {
       default:
         return valueType;
     }
+  }
+
+  /** adapts the SDK type to an encoded string array type */
+  private getSliceArray(
+    sdkType: tcgc.SdkArrayType,
+    encoding: tcgc.ArrayKnownEncoding,
+  ): go.SliceArray {
+    let keySegment: string;
+    switch (sdkType.valueType.kind) {
+      case "enum":
+        keySegment = `enum-${sdkType.valueType.name}`;
+        break;
+      default:
+        keySegment = sdkType.valueType.kind;
+    }
+
+    const keyName = `array-encoded-${keySegment}-${encoding}`;
+    let sliceArray = this.types.get(keyName);
+    if (sliceArray) {
+      return <go.SliceArray>sliceArray;
+    }
+
+    let elementType: go.SliceArrayElementType;
+    switch (sdkType.valueType.kind) {
+      case "enum":
+        switch (sdkType.valueType.valueType.kind) {
+          case "string":
+            elementType = this.getConstantType(sdkType.valueType);
+            break;
+          default:
+            throw new AdapterError(
+              "UnsupportedTsp",
+              `unsupported enum value kind ${sdkType.valueType.valueType.kind} for string encoded array`,
+              sdkType.__raw?.node,
+            );
+        }
+        break;
+      case "string":
+        elementType = this.getStringType();
+        break;
+      default:
+        throw new AdapterError(
+          "UnsupportedTsp",
+          `unsupported kind ${sdkType.valueType.kind} for string encoded array`,
+          sdkType.__raw?.node,
+        );
+    }
+
+    sliceArray = new go.SliceArray(
+      elementType,
+      this.codeModel.options["slice-elements-byval"] ?? false,
+      getSliceArrayDelimiter(encoding),
+    );
+
+    this.types.set(keyName, sliceArray);
+    return sliceArray;
   }
 
   private getUnionStruct(sdkUnion: tcgc.SdkUnionType, elementTypeByValue: boolean): go.UnionStruct {


### PR DESCRIPTION
If the array element type isn't supported, fail with a descriptive error instead of emitting incorrect code.
Refactored creating of SliceArray types to go through the type cache.
Removed references to autorest.go including the error message for filing issues when the emitter fails/crashes.