### PR TITLE
Fix empty AutoRest feature file emission

### DIFF
--- a/.chronus/changes/fix-autorest-feature-files-2026-09-02.md
+++ b/.chronus/changes/fix-autorest-feature-files-2026-09-02.md
@@ -2,6 +2,7 @@
 changeKind: fix
 packages:
   - "@azure-tools/typespec-autorest"
+  - "@azure-tools/typespec-azure-resource-manager"
 ---
 
-Do not emit empty legacy feature files and apply `version-enum-strategy` to feature enums.
+Do not emit empty legacy feature files, apply `version-enum-strategy` to feature enums, and return the configured enum from the ARM feature-file accessor.

--- a/.chronus/changes/fix-autorest-feature-files-2026-09-02.md
+++ b/.chronus/changes/fix-autorest-feature-files-2026-09-02.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-autorest"
+---
+
+Do not emit empty legacy feature files and apply `version-enum-strategy` to feature enums.

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -10,8 +10,6 @@ import {
   hasUniqueItems,
 } from "@azure-tools/typespec-azure-core";
 import {
-  $featureFiles,
-  $features,
   type ArmFeatureOptions,
   getArmCommonTypeOpenAPIRef,
   getArmIdentifiers,
@@ -19,6 +17,8 @@ import {
   getCustomResourceOptions,
   getExternalTypeRef,
   getFeature,
+  getFeatureFileSet,
+  getFeatureOptions,
   getInlineAzureType,
   getResourceFeatureSet,
   isArmCommonType,
@@ -1610,7 +1610,7 @@ export async function getOpenAPIForService(
       if (
         options.versionEnumStrategy !== "include" &&
         type.kind === "Enum" &&
-        (isVersionEnum(program, type) || isFeatureEnum(serviceNamespace, type))
+        (isVersionEnum(program, type) || isFeatureEnum(program, serviceNamespace, type))
       ) {
         return true;
       }
@@ -1626,11 +1626,31 @@ export async function getOpenAPIForService(
     return false;
   }
 
-  function isFeatureEnum(serviceNamespace: Namespace, enumObj: Enum): boolean {
-    return serviceNamespace.decorators.some(
-      (decorator) =>
-        (decorator.decorator === $featureFiles || decorator.decorator === $features) &&
-        decorator.args[0]?.value === enumObj,
+  function isFeatureEnum(program: Program, serviceNamespace: Namespace, enumObj: Enum): boolean {
+    if (!getFeatureFileSet(program, serviceNamespace)) {
+      return false;
+    }
+
+    const featureSet = getResourceFeatureSet(program, serviceNamespace);
+    if (featureSet === undefined) {
+      return false;
+    }
+
+    const enumFeatureNames = new Set(
+      [...enumObj.members.values()].map((member) =>
+        getFeatureOptions(program, member).featureName.toLowerCase(),
+      ),
+    );
+    const configuredFeatureNames = new Set(
+      [...featureSet.keys()].map((featureName) => featureName.toLowerCase()),
+    );
+    if (!enumFeatureNames.has("common")) {
+      configuredFeatureNames.delete("common");
+    }
+
+    return (
+      enumFeatureNames.size === configuredFeatureNames.size &&
+      [...enumFeatureNames].every((featureName) => configuredFeatureNames.has(featureName))
     );
   }
 
@@ -3312,10 +3332,10 @@ function createFeatureDocumentProxy(
         for (const [defName, [_, defSchema]] of definitionsForFeature) {
           featureItem.document.definitions![defName] = defSchema;
         }
+        finalizeOpenApi2Document(featureItem.document, featureItem.tags);
         if (!hasOpenApiContent(featureItem.document)) {
           continue;
         }
-        finalizeOpenApi2Document(featureItem.document, featureItem.tags);
         docs.push({
           document: featureItem.document,
           operationExamples: featureExamples,

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -18,7 +18,6 @@ import {
   getExternalTypeRef,
   getFeature,
   getFeatureFileSet,
-  getFeatureOptions,
   getInlineAzureType,
   getResourceFeatureSet,
   isArmCommonType,
@@ -1627,31 +1626,7 @@ export async function getOpenAPIForService(
   }
 
   function isFeatureEnum(program: Program, serviceNamespace: Namespace, enumObj: Enum): boolean {
-    if (!getFeatureFileSet(program, serviceNamespace)) {
-      return false;
-    }
-
-    const featureSet = getResourceFeatureSet(program, serviceNamespace);
-    if (featureSet === undefined) {
-      return false;
-    }
-
-    const enumFeatureNames = new Set(
-      [...enumObj.members.values()].map((member) =>
-        getFeatureOptions(program, member).featureName.toLowerCase(),
-      ),
-    );
-    const configuredFeatureNames = new Set(
-      [...featureSet.keys()].map((featureName) => featureName.toLowerCase()),
-    );
-    if (!enumFeatureNames.has("common")) {
-      configuredFeatureNames.delete("common");
-    }
-
-    return (
-      enumFeatureNames.size === configuredFeatureNames.size &&
-      [...enumFeatureNames].every((featureName) => configuredFeatureNames.has(featureName))
-    );
+    return getFeatureFileSet(program, serviceNamespace) === enumObj;
   }
 
   function getSchemaForType(

--- a/packages/typespec-autorest/src/openapi.ts
+++ b/packages/typespec-autorest/src/openapi.ts
@@ -10,6 +10,8 @@ import {
   hasUniqueItems,
 } from "@azure-tools/typespec-azure-core";
 import {
+  $featureFiles,
+  $features,
   type ArmFeatureOptions,
   getArmCommonTypeOpenAPIRef,
   getArmIdentifiers,
@@ -1608,7 +1610,7 @@ export async function getOpenAPIForService(
       if (
         options.versionEnumStrategy !== "include" &&
         type.kind === "Enum" &&
-        isVersionEnum(program, type)
+        (isVersionEnum(program, type) || isFeatureEnum(serviceNamespace, type))
       ) {
         return true;
       }
@@ -1622,6 +1624,14 @@ export async function getOpenAPIForService(
       return true;
     }
     return false;
+  }
+
+  function isFeatureEnum(serviceNamespace: Namespace, enumObj: Enum): boolean {
+    return serviceNamespace.decorators.some(
+      (decorator) =>
+        (decorator.decorator === $featureFiles || decorator.decorator === $features) &&
+        decorator.args[0]?.value === enumObj,
+    );
   }
 
   function getSchemaForType(
@@ -3302,6 +3312,9 @@ function createFeatureDocumentProxy(
         for (const [defName, [_, defSchema]] of definitionsForFeature) {
           featureItem.document.definitions![defName] = defSchema;
         }
+        if (!hasOpenApiContent(featureItem.document)) {
+          continue;
+        }
         finalizeOpenApi2Document(featureItem.document, featureItem.tags);
         docs.push({
           document: featureItem.document,
@@ -3359,6 +3372,15 @@ function createFeatureDocumentProxy(
     const ops = operationFeatures.get(featureName)!;
     ops.add(operationId);
   }
+}
+
+function hasOpenApiContent(document: OpenAPI2Document): boolean {
+  return (
+    Object.keys(document.paths).length > 0 ||
+    Object.keys(document["x-ms-paths"] ?? {}).length > 0 ||
+    Object.keys(document.parameters ?? {}).length > 0 ||
+    Object.keys(document.definitions ?? {}).length > 0
+  );
 }
 
 function reportDuplicateOperationIds(

--- a/packages/typespec-autorest/test/arm/arm.test.ts
+++ b/packages/typespec-autorest/test/arm/arm.test.ts
@@ -602,6 +602,10 @@ it("does not emit empty feature files for versions without feature content", asy
       @added(Versions.v2)
       @route("/students")
       op getStudent(): string;
+
+      @Azure.ResourceManager.featureFile(Features.Teacher)
+      @route("/teachers")
+      op getTeacher(): string;
     `,
     {
       compilerOptions: {
@@ -618,6 +622,8 @@ it("does not emit empty feature files for versions without feature content", asy
   expectDiagnosticEmpty(ignoreDiagnostics(diagnostics, ["@typespec/http/no-service-found"]));
   ok(!outputs[resolvePath("stable", "v1", "student.json")]);
   ok(outputs[resolvePath("stable", "v2", "student.json")]);
+  ok(outputs[resolvePath("stable", "v1", "teacher.json")]);
+  ok(outputs[resolvePath("stable", "v2", "teacher.json")]);
 });
 
 it.each([

--- a/packages/typespec-autorest/test/arm/arm.test.ts
+++ b/packages/typespec-autorest/test/arm/arm.test.ts
@@ -1,6 +1,13 @@
+import { resolvePath } from "@typespec/compiler";
+import { expectDiagnosticEmpty } from "@typespec/compiler/testing";
 import { deepStrictEqual, ok, strictEqual } from "assert";
 import { expect, it } from "vitest";
-import { compileOpenAPI, CompileOpenApiWithFeatures } from "../test-host.js";
+import {
+  AzureTester,
+  compileOpenAPI,
+  CompileOpenApiWithFeatures,
+  ignoreDiagnostics,
+} from "../test-host.js";
 
 it("can share types with a library namespace", async () => {
   const openapi: any = await compileOpenAPI(
@@ -572,6 +579,98 @@ it("can split resources and operations by feature", async () => {
     "../../common-types/resource-management/v5/privatelinks.json#/definitions/PrivateLinkResourceListResult",
   );
 });
+it("does not emit empty feature files for versions without feature content", async () => {
+  const runner = await AzureTester.createInstance();
+  const [{ outputs }, diagnostics] = await runner.compileAndDiagnose(
+    `
+      @versioned(Versions)
+      @Azure.ResourceManager.featureFiles(Features)
+      @service
+      namespace Microsoft.Contoso;
+
+      enum Features {
+        Student: "student",
+        Teacher: "teacher",
+      }
+
+      enum Versions {
+        v1,
+        v2,
+      }
+
+      @Azure.ResourceManager.featureFile(Features.Student)
+      @added(Versions.v2)
+      @route("/students")
+      op getStudent(): string;
+    `,
+    {
+      compilerOptions: {
+        options: {
+          "@azure-tools/typespec-autorest": {
+            "output-splitting": "legacy-feature-files",
+            "output-file": "{emitter-output-dir}/{version-status}/{version}/{feature}.json",
+          },
+        },
+      },
+    },
+  );
+
+  expectDiagnosticEmpty(ignoreDiagnostics(diagnostics, ["@typespec/http/no-service-found"]));
+  ok(!outputs[resolvePath("stable", "v1", "student.json")]);
+  ok(outputs[resolvePath("stable", "v2", "student.json")]);
+});
+
+it.each([
+  ["omit", false],
+  ["include", true],
+] as const)(
+  "applies version enum strategy '%s' to the feature enum",
+  async (strategy, included) => {
+    const runner = await AzureTester.createInstance();
+    const [{ outputs }, diagnostics] = await runner.compileAndDiagnose(
+      `
+      @versioned(Versions)
+      @Azure.ResourceManager.featureFiles(Features)
+      @service
+      namespace Microsoft.Contoso;
+
+      enum Features {
+        Student: "student",
+        Teacher: "teacher",
+      }
+
+      enum Versions {
+        v1,
+        v2,
+      }
+
+      @route("/health")
+      op getHealth(): string;
+
+      @Azure.ResourceManager.featureFile(Features.Student)
+      @route("/students")
+      op getStudent(): string;
+    `,
+      {
+        compilerOptions: {
+          options: {
+            "@azure-tools/typespec-autorest": {
+              "output-splitting": "legacy-feature-files",
+              "output-file": "{emitter-output-dir}/{feature}.json",
+              "version-enum-strategy": strategy,
+            },
+          },
+        },
+      },
+    );
+
+    expectDiagnosticEmpty(ignoreDiagnostics(diagnostics, ["@typespec/http/no-service-found"]));
+    const common = JSON.parse(outputs["common.json"]);
+    strictEqual("Features" in common.definitions, included);
+    strictEqual("Versions" in common.definitions, included);
+  },
+);
+
 it("can represent type references within and between features", async () => {
   const { featureA, featureB, shared } = await CompileOpenApiWithFeatures(
     `

--- a/packages/typespec-azure-resource-manager/src/resource.ts
+++ b/packages/typespec-azure-resource-manager/src/resource.ts
@@ -1694,7 +1694,10 @@ export const [getResourceFeatureSet, setResourceFeatureSet] = useStateMap<
   Map<string, ArmFeatureOptions>
 >(ArmStateKeys.armFeatureSet);
 
-export const [getFeatureFileSet, setFeatureFileSet] = useStateMap<Namespace, boolean>(
+/**
+ * Gets the enum configured by `@featureFiles`, or `undefined` when feature files are not configured.
+ */
+export const [getFeatureFileSet, setFeatureFileSet] = useStateMap<Namespace, Enum>(
   ArmStateKeys.armFeatureFileSet,
 );
 
@@ -1846,7 +1849,7 @@ export const $featureFiles: FeatureFilesDecorator = (
   entity: Namespace,
   features: Enum,
 ) => {
-  setFeatureFileSet(context.program, entity, true);
+  setFeatureFileSet(context.program, entity, features);
   $features(context, entity, features);
 };
 export const $featureFileOptions: FeatureFileOptionsDecorator =

--- a/packages/typespec-azure-resource-manager/src/rules/arm-feature-file-usage-discourage.ts
+++ b/packages/typespec-azure-resource-manager/src/rules/arm-feature-file-usage-discourage.ts
@@ -13,7 +13,7 @@ export const armFeatureFileUsageDiscourage = createRule({
   create(context) {
     return {
       namespace: (namespace: Namespace) => {
-        if (getFeatureFileSet(context.program, namespace)) {
+        if (getFeatureFileSet(context.program, namespace) !== undefined) {
           context.reportDiagnostic({
             code: "arm-feature-file-usage-discourage",
             target: namespace,

--- a/packages/typespec-azure-resource-manager/test/resource.test.ts
+++ b/packages/typespec-azure-resource-manager/test/resource.test.ts
@@ -9,6 +9,7 @@ import {
   type ArmResourceDetails,
   getArmResources,
   getFeature,
+  getFeatureFileSet,
   getResourceFeature,
   getResourceFeatureSet,
 } from "../src/resource.js";
@@ -397,6 +398,15 @@ describe("ARM resource model:", () => {
     });
   });
   describe("features support", () => {
+    it("returns undefined when feature files are not configured", async () => {
+      const { program, MSTest } = await Tester.compile(t.code`
+        @armProviderNamespace("Microsoft.Test")
+        namespace ${t.namespace("MSTest")};
+      `);
+
+      strictEqual(getFeatureFileSet(program, MSTest), undefined);
+    });
+
     it("sets standard features and feature options", async () => {
       const [result, diagnostics] = await Tester.compileAndDiagnose(t.code`
 
@@ -428,6 +438,10 @@ enum Features {
       }
       `);
       expectDiagnosticEmpty(diagnostics);
+      strictEqual(
+        getFeatureFileSet(result.program, result.MSTest),
+        result.MSTest.enums.get("Features"),
+      );
       const features = getResourceFeatureSet(result.program, result.MSTest);
       expect(features).toBeDefined();
       ok(features);


### PR DESCRIPTION
## Summary
- skip legacy feature-file OpenAPI documents that contain no paths, x-ms-paths, parameters, or definitions
- apply version-enum-strategy to the feature enum as well as the API version enum
- add regression coverage for versioned empty feature files and enum include/omit behavior

## Testing
- full repository build
- repository lint and formatting
- @azure-tools/typespec-autorest coverage suite (512 tests)
- focused regression tests

Fixes #5322