### PR TITLE
[Swagger Linter Migration] OperationIdNounVerb (origin)

### DIFF
--- a/packages/typespec-lintdiff/src/rules/operation-id-noun-verb.ts
+++ b/packages/typespec-lintdiff/src/rules/operation-id-noun-verb.ts
@@ -1,5 +1,22 @@
-import { createRule, paramMessage } from "@typespec/compiler";
-import { resolveOperationId } from "@typespec/openapi";
+import {
+  createTCGCContext,
+  getClientLocation,
+  getClientNameOverride,
+  type TCGCContext,
+} from "@azure-tools/typespec-client-generator-core";
+import {
+  createRule,
+  isGlobalNamespace,
+  isService,
+  isTemplateDeclarationOrInstance,
+  paramMessage,
+  type Interface,
+  type Namespace,
+  type Operation,
+  type Program,
+} from "@typespec/compiler";
+import { capitalize } from "@typespec/compiler/casing";
+import { getOperationId } from "@typespec/openapi";
 
 export const operationIdNounVerbRule = createRule({
   name: "operation-id-noun-verb",
@@ -7,13 +24,30 @@ export const operationIdNounVerbRule = createRule({
     "OperationIds should follow the Noun_Verb convention without repeating the noun after the underscore.",
   severity: "warning",
   messages: {
-    default:
-      paramMessage`Per the Noun_Verb convention for Operation Ids, the noun '${"noun"}' should not appear after the underscore.`,
+    default: paramMessage`Per the Noun_Verb convention for Operation Ids, the noun '${"noun"}' should not appear after the underscore.`,
   },
   create(context) {
+    const tcgcContext = createTCGCContext(context.program, "@azure-tools/typespec-autorest", {
+      mutateNamespace: false,
+    });
+    let emittedOperations: Set<Operation> | undefined;
+
+    function getEmittedOperations(): Set<Operation> {
+      if (emittedOperations === undefined) {
+        emittedOperations = new Set(
+          tcgcContext.getClients().flatMap((client) => tcgcContext.getOperationsForClient(client)),
+        );
+      }
+      return emittedOperations;
+    }
+
     return {
       operation: (operation) => {
-        const operationId = resolveOperationId(context.program, operation);
+        if (isTemplateDeclarationOrInstance(operation) || !getEmittedOperations().has(operation)) {
+          return;
+        }
+
+        const operationId = resolveAutorestOperationId(context.program, operation, tcgcContext);
         if (operationId.length === 0 || !operationId.includes("_")) {
           return;
         }
@@ -24,14 +58,11 @@ export const operationIdNounVerbRule = createRule({
         }
 
         const singularizedNoun =
-          nounPart.endsWith("s") && nounPart.length > 1
-            ? nounPart.slice(0, -1)
-            : undefined;
+          nounPart.endsWith("s") && nounPart.length > 1 ? nounPart.slice(0, -1) : undefined;
 
         if (
           verbPart.includes(nounPart) ||
-          (singularizedNoun !== undefined &&
-            verbPart.includes(singularizedNoun))
+          (singularizedNoun !== undefined && verbPart.includes(singularizedNoun))
         ) {
           context.reportDiagnostic({
             target: operation,
@@ -44,3 +75,58 @@ export const operationIdNounVerbRule = createRule({
     };
   },
 });
+
+function resolveAutorestOperationId(
+  program: Program,
+  operation: Operation,
+  tcgcContext: TCGCContext,
+): string {
+  const explicitOperationId = getOperationId(program, operation);
+  if (explicitOperationId) {
+    return explicitOperationId;
+  }
+
+  const operationName = getClientName(tcgcContext, operation);
+  const clientLocation = getClientLocation(tcgcContext, operation);
+
+  if (clientLocation) {
+    if (typeof clientLocation === "string") {
+      return standardizeOperationId(`${clientLocation}_${operationName}`);
+    }
+    if (clientLocation.kind === "Interface") {
+      return standardizeOperationId(
+        `${getClientName(tcgcContext, clientLocation)}_${operationName}`,
+      );
+    }
+    if (isGlobalNamespace(program, clientLocation) || isService(program, clientLocation)) {
+      return standardizeOperationId(operationName);
+    }
+    return standardizeOperationId(`${getClientName(tcgcContext, clientLocation)}_${operationName}`);
+  }
+
+  let operationId: string;
+  if (operation.interface) {
+    operationId = `${getClientName(tcgcContext, operation.interface)}_${operationName}`;
+  } else if (
+    operation.namespace === undefined ||
+    isGlobalNamespace(program, operation.namespace) ||
+    isService(program, operation.namespace)
+  ) {
+    operationId = operationName;
+  } else {
+    operationId = `${getClientName(tcgcContext, operation.namespace)}_${operationName}`;
+  }
+
+  return standardizeOperationId(operationId);
+}
+
+function standardizeOperationId(operationId: string): string {
+  return operationId
+    .split("_")
+    .map((part) => capitalize(part))
+    .join("_");
+}
+
+function getClientName(tcgcContext: TCGCContext, type: Operation | Interface | Namespace): string {
+  return getClientNameOverride(tcgcContext, type) ?? type.name;
+}

--- a/packages/typespec-lintdiff/src/rules/operation-id-noun-verb.ts
+++ b/packages/typespec-lintdiff/src/rules/operation-id-noun-verb.ts
@@ -24,7 +24,7 @@ export const operationIdNounVerbRule = createRule({
     "OperationIds should follow the Noun_Verb convention without repeating the noun after the underscore.",
   severity: "warning",
   messages: {
-    default: paramMessage`Per the Noun_Verb convention for Operation Ids, the noun '${"noun"}' should not appear after the underscore.`,
+    default: paramMessage`Per the Noun_Verb convention for Operation Ids, the noun '${"noun"}' should not appear after the underscore. Note: If you have already shipped an SDK on top of this spec, fixing this warning may introduce a breaking change.`,
   },
   create(context) {
     const tcgcContext = createTCGCContext(context.program, "@azure-tools/typespec-autorest", {

--- a/packages/typespec-lintdiff/src/rules/operation-id-noun-verb.ts
+++ b/packages/typespec-lintdiff/src/rules/operation-id-noun-verb.ts
@@ -52,7 +52,7 @@ export const operationIdNounVerbRule = createRule({
           return;
         }
 
-        const [nounPart, verbPart = ""] = operationId.split("_", 2);
+        const [nounPart, verbPart = ""] = operationId.split("_");
         if (nounPart.length === 0 || verbPart.length === 0) {
           return;
         }

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/explicit-operation-id/expect.json
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/explicit-operation-id/expect.json
@@ -1,0 +1,3 @@
+{
+  "violation": true
+}

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/explicit-operation-id/main.tsp
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/explicit-operation-id/main.tsp
@@ -1,0 +1,32 @@
+import "@typespec/http";
+import "@typespec/openapi";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-autorest";
+
+using TypeSpec.Http;
+using TypeSpec.OpenAPI;
+using TypeSpec.Versioning;
+
+@service(#{ title: "Test Service" })
+@versioned(Versions)
+namespace TestService;
+
+enum Versions {
+  v2024_01_01: "2024-01-01",
+}
+
+@doc("A certificate resource")
+model Certificate {
+  @doc("The certificate name")
+  name: string;
+}
+
+@operationId("Certificates_GetCertificate")
+@route("/certificates/{name}")
+@doc("Get a certificate")
+@get
+op getCertificate(
+  @path @doc("Certificate name") name: string,
+  @query("api-version") @doc("API version") apiVersion: string,
+): Certificate;

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/explicit-operation-id/output.json
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/explicit-operation-id/output.json
@@ -1,0 +1,71 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Test Service",
+    "version": "2024-01-01",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "tags": [],
+  "paths": {
+    "/certificates/{name}": {
+      "get": {
+        "operationId": "Certificates_GetCertificate",
+        "description": "Get a certificate",
+        "parameters": [
+          {
+            "name": "name",
+            "in": "path",
+            "description": "Certificate name",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "API version",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "apiVersion"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "$ref": "#/definitions/Certificate"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Certificate": {
+      "type": "object",
+      "description": "A certificate resource",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The certificate name"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    }
+  },
+  "parameters": {}
+}

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/explicit-operation-id/tsp-diagnostics.json
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/explicit-operation-id/tsp-diagnostics.json
@@ -2,7 +2,7 @@
   {
     "code": "tsp-lintdiff-local-linter/operation-id-noun-verb",
     "severity": "warning",
-    "message": "Per the Noun_Verb convention for Operation Ids, the noun 'Certificates' should not appear after the underscore."
+    "message": "Per the Noun_Verb convention for Operation Ids, the noun 'Certificates' should not appear after the underscore. Note: If you have already shipped an SDK on top of this spec, fixing this warning may introduce a breaking change."
   },
   {
     "code": "tsp-lintdiff-local-linter/path-parameter-schema",

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/explicit-operation-id/tsp-diagnostics.json
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/explicit-operation-id/tsp-diagnostics.json
@@ -1,0 +1,17 @@
+[
+  {
+    "code": "tsp-lintdiff-local-linter/operation-id-noun-verb",
+    "severity": "warning",
+    "message": "Per the Noun_Verb convention for Operation Ids, the noun 'Certificates' should not appear after the underscore."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/path-parameter-schema",
+    "severity": "warning",
+    "message": "Path parameter should specify a maximum length (maxLength) and characters allowed (pattern)."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/xms-examples-required",
+    "severity": "warning",
+    "message": "Please provide x-ms-examples describing minimum/maximum property set for response/request payloads for operations."
+  }
+]

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/explicit-operation-id/validator-diagnostics.json
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/explicit-operation-id/validator-diagnostics.json
@@ -1,0 +1,13 @@
+[
+  {
+    "code": "OperationIdNounVerb",
+    "message": "Per the Noun_Verb convention for Operation Ids, the noun 'Certificates' should not appear after the underscore. Note: If you have already shipped an SDK on top of this spec, fixing this warning may introduce a breaking change.",
+    "path": [
+      "paths",
+      "/certificates/{name}",
+      "get",
+      "operationId"
+    ],
+    "severity": 0
+  }
+]

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/migration.md
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/migration.md
@@ -1,0 +1,197 @@
+# OperationIdNounVerb migration
+
+## Conclusion
+
+The migrated TypeSpec rule is functionally equivalent to the Swagger `OperationIdNounVerb` rule for assessable projects after resolving operation IDs through the same AutoRest/TCGC naming inputs used by generated OpenAPI. The final full corpus has 100% same-project coverage: 34 validator projects, 34 TypeSpec projects, 34 overlapping projects, 111 assessable validator diagnostics, and 111 assessable TypeSpec diagnostics.
+
+The TypeSpec rule **did require a production update**. The previous implementation used `@typespec/openapi` `resolveOperationId`, which missed AutoRest client-location/name behavior and reported operations that TCGC marks as override customizations even though those override operations are not emitted as OpenAPI operations. The updated rule resolves AutoRest-style operation IDs from TCGC client names and client locations and only checks operations present in the TCGC client operation set.
+
+## Required TypeSpec changes
+
+- Updated `packages/typespec-lintdiff/src/rules/operation-id-noun-verb.ts` to resolve operation IDs with `@azure-tools/typespec-client-generator-core` client names and client locations instead of the generic OpenAPI helper.
+- Skipped template declarations and TCGC-omitted override customization operations.
+- Added fixtures for explicit `@operationId` and namespace-derived operation IDs.
+- Marked the fixture coverage as `lint`, opted the rule into `projectionScope: http-reachable`, and refreshed snapshots.
+
+## Source rule
+
+- Linter code: [`OperationIdNounVerb`](https://github.com/Azure/azure-openapi-validator/blob/1198225afecbb818c3050d4d2a91da92e14e56ce/packages/rulesets/src/spectral/functions/operation-id-noun-verb.ts)
+- Linter doc: [`operation-id-noun-verb.md`](https://github.com/Azure/azure-openapi-validator/blob/1198225afecbb818c3050d4d2a91da92e14e56ce/docs/operation-id-noun-verb.md)
+
+The Spectral rule ignores empty, non-string, and no-underscore operation IDs. For an ID with an underscore, it takes the first segment as the noun and the second segment as the verb, then reports when the verb matches the noun. When the noun ends in `s`, the validator uses a permissive regex equivalent to allowing the singularized noun as well. It reports at the emitted Swagger `operationId` JSON path.
+
+## Official TypeSpec coverage check
+
+Classification: **gap**.
+
+No official Azure.Core or Azure.ResourceManager rule fully enforces this Swagger behavior. `@azure-tools/typespec-azure-core/no-openapi` warns on explicit `@operationId`, but it does not inspect generated operation IDs and therefore does not catch generated `Noun_VerbWithNoun` values. The ARM RPC coverage document has no `OperationIdNounVerb`, `operationId`, or `Noun_Verb` lint mapping, and ARM templates generate operation IDs but do not reject noun repetition after the underscore.
+
+## Report reconciliation
+
+| Report                                        | Snapshot evidence                                                                                               | Row/category              | Validator projects |                            TypeSpec projects | Official projects | Same-project overlap |      Validator-only |       TypeSpec-only |              Raw diagnostics |
+| --------------------------------------------- | --------------------------------------------------------------------------------------------------------------- | ------------------------- | -----------------: | -------------------------------------------: | ----------------: | -------------------: | ------------------: | ------------------: | ---------------------------: |
+| `docs/coverage_old.md`                        | external gist snapshot; 450 compiled projects, 210 validator rules                                              | 80-99% coverage           |                 33 | 0 local column not separated from lint count |                 0 |           not listed | not reconstructable | not reconstructable |                   not listed |
+| `specs/coverage-breakdown.md` before this fix | specs commit `f6b53f105b95da05276530a0754a1c71b4f16397`; full 462/468 projects                                  | Partial observed coverage |                 34 |                                           54 |                 0 |                   27 |                   7 |                  27 | 111 validator / 263 TypeSpec |
+| Final full corpus                             | specs commit `f6b53f105b95da05276530a0754a1c71b4f16397`; generated `2026-09-03T10:45:20.082Z`; 462/468 projects | 100% observed coverage    |                 34 |                                           34 |                 0 |                   34 |                   0 |                   0 | 111 validator / 111 TypeSpec |
+
+The cross-report differences are caused by different snapshots and coverage definitions. The old report is aggregate-only and cannot identify unmatched projects. The lintdiff report compares mapped TypeSpec diagnostics in the same successfully compiled projects and excludes TypeSpec compile failures from behavioral coverage.
+
+## Final corpus evidence
+
+- Specs commit: `f6b53f105b95da05276530a0754a1c71b4f16397`
+- Run scope: full, 468 dataset projects, 462 successful, 6 failed
+- Analysis timestamp: `2026-09-03T10:45:20.082Z`
+- Duration: 1,330,656 ms
+- Validator projects: 34
+- TypeSpec projects: 34
+- Same-project overlap: 34
+- Validator-only projects: none
+- TypeSpec-only projects: none
+- Assessable diagnostics: 111 validator / 111 TypeSpec
+- Raw diagnostic shards before failed-project exclusion: 265 validator / 122 TypeSpec
+- Excluded by compile failures: 154 validator diagnostics and 11 TypeSpec diagnostics from failed projects
+- Deduplicated assessable identities: 111 validator project+file+JSON-path identities, 111 validator project+JSON-path identities, 111 TypeSpec project+source-location identities
+
+Compile-failed projects excluded from the behavioral comparison:
+
+- `specification/deviceprovisioningservices/resource-manager/Microsoft.Devices/DeviceProvisioningServices`
+- `specification/monitor/resource-manager/Microsoft.Insights/Insights/TenantActionGroups`
+- `specification/network/resource-manager/Microsoft.Network/Network/Network`
+- `specification/quota/resource-manager/Microsoft.Quota/Quota`
+- `specification/resources/resource-manager/Microsoft.Resources/deployments`
+- `specification/servicelinker/resource-manager/Microsoft.ServiceLinker/ServiceLinker`
+
+## Emission matrix
+
+| Authored TypeSpec shape                                             | Emitter/helper branch                                        | Selected OpenAPI field                       | Expected Swagger result               | Expected TypeSpec lint result | Fixture/evidence            |
+| ------------------------------------------------------------------- | ------------------------------------------------------------ | -------------------------------------------- | ------------------------------------- | ----------------------------- | --------------------------- |
+| Interface operation `Paths.listPaths`                               | interface + operation client names, standardized by AutoRest | `operationId: "Paths_ListPaths"`             | violation (`Paths` repeats after `_`) | violation                     | `noun-in-verb`              |
+| Interface operation `Paths.listPath`                                | interface + operation client names, standardized by AutoRest | `operationId: "Paths_ListPath"`              | violation (singularized `Path`)       | violation                     | `singularized-noun-in-verb` |
+| Interface operation `Paths.list`                                    | interface + operation client names, standardized by AutoRest | `operationId: "Paths_List"`                  | no violation                          | no diagnostic                 | `noun-not-in-verb`          |
+| Service-root operation `getWidget`                                  | service/root operation name only                             | `operationId: "GetWidget"`                   | ignored, no underscore                | no diagnostic                 | `no-underscore`             |
+| Explicit `@operationId("Certificates_GetCertificate")`              | explicit OpenAPI operation ID                                | `operationId: "Certificates_GetCertificate"` | violation                             | violation                     | `explicit-operation-id`     |
+| Nested namespace operation `Admins.listAdmins`                      | namespace + operation client names, standardized by AutoRest | `operationId: "Admins_ListAdmins"`           | violation                             | violation                     | `namespace-operation`       |
+| TCGC override customization operation in `namespace Customizations` | omitted override operation                                   | no emitted OpenAPI operation                 | no validator diagnostic               | no diagnostic after fix       | Search example below        |
+
+## Gap example: TCGC override customizations omitted from OpenAPI
+
+- **Classification:** TypeSpec-only
+- **Status:** fixed
+- **Project/API version:** `specification/search/resource-manager/Microsoft.Search/Search` / `2026-09-01-preview`
+- **Source:** `client.tsp` customization operations in `namespace Customizations`
+
+**TypeSpec source**
+
+```typespec
+namespace Customizations;
+
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-operation" "Client-only override, not an ARM resource operation."
+#suppress "@azure-tools/typespec-azure-resource-manager/arm-resource-invalid-action-verb" "Client-only override: retains existing action verb."
+@autoRoute
+@action("servicesCheckNameAvailability")
+op servicesCheckNameAvailabilityCustomization(...): ArmResponse<CheckNameAvailabilityOutput> | CloudError;
+
+@@Azure.ClientGenerator.Core.override(
+  ServicesOperationGroup.checkNameAvailability,
+  servicesCheckNameAvailabilityCustomization,
+  "go,csharp"
+);
+```
+
+**Emitted OpenAPI or validator behavior**
+
+```json
+{
+  "operationId": "Services_CheckNameAvailability"
+}
+```
+
+| Engine            | Observed result                                                                                                                                                                 |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Swagger validator | No diagnostic: the selected 2026-09-01-preview OpenAPI contains `Services_CheckNameAvailability`, not a `Customizations_*Customization` operation ID.                           |
+| TypeSpec lint     | Before this fix, diagnostics were reported for `Customizations_*Customization` override operations. After the fix, Search has no `operation-id-noun-verb` TypeSpec diagnostics. |
+
+**Explanation:** TCGC marks override operations as omitted from the generated client/OpenAPI operation set. The previous rule visited all TypeSpec operations and used generic OpenAPI naming, so it diagnosed authoring helpers that do not correspond to Swagger `operationId` fields. Restricting checks to TCGC client operations matches the Swagger population.
+
+**Disposition:** production rule fix.
+
+## Gap example: AutoRest client-location/name resolution
+
+- **Classification:** TypeSpec-only
+- **Status:** fixed
+- **Project/API version:** `specification/app/resource-manager/Microsoft.App/ContainerApps` / `2026-01-01`
+- **Source:** `Certificate.tsp` operations with back-compatible client-name/client-location customizations
+
+**TypeSpec source**
+
+```typespec
+interface Certificates {
+  @tag("ManagedEnvironments")
+  @summary("Get the specified Certificate.")
+  getCertificates is CertificateOperationGroupOps.Read<Certificate>;
+}
+
+@@clientName(Certificates.listCertificates, "List");
+@@clientName(Certificates.deleteCertificates, "Delete");
+@@clientName(Certificates.updateCertificates, "Update");
+```
+
+**Emitted OpenAPI or validator behavior**
+
+```json
+{
+  "operationId": "ManagedCertificates_List"
+}
+```
+
+| Engine            | Observed result                                                                                                                                                                                          |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Swagger validator | No diagnostic for the previously TypeSpec-only `Certificates_*Certificates` source names in the selected stable OpenAPI.                                                                                 |
+| TypeSpec lint     | Before this fix, the rule reported source names such as `Certificates_GetCertificates`. After resolving AutoRest/TCGC operation IDs, ContainerApps has no `operation-id-noun-verb` TypeSpec diagnostics. |
+
+**Explanation:** Generated OpenAPI operation IDs are affected by TCGC client names and locations. Generic `resolveOperationId` does not account for those transformations. The rule now uses TCGC client naming and standardizes operation-id parts like AutoRest.
+
+**Disposition:** production rule fix.
+
+## Gap example: failed-project exclusion
+
+- **Classification:** count-only
+- **Status:** population mismatch
+- **Project/API version:** `specification/network/resource-manager/Microsoft.Network/Network/Network` / selected corpus version
+- **Source:** final corpus compile status
+
+**TypeSpec source**
+
+```text
+The project did not compile in the final corpus run and is listed in comparison-results.json unassessedProjects.
+```
+
+**Emitted OpenAPI or validator behavior**
+
+```text
+Validator shard still contains OperationIdNounVerb diagnostics for this project, but lintdiff excludes failed TypeSpec projects from the behavioral comparison.
+```
+
+| Engine            | Observed result                                                             |
+| ----------------- | --------------------------------------------------------------------------- |
+| Swagger validator | Raw shard includes diagnostics from the retained Swagger files.             |
+| TypeSpec lint     | Compile failure prevents reliable TypeSpec lint assessment for the project. |
+
+**Explanation:** Failed TypeSpec projects are retained as compile-failure evidence but excluded from same-project behavioral coverage. This explains why raw validator shard counts (265) are higher than assessable validator diagnostics (111).
+
+**Disposition:** comparison population exclusion, not a rule change.
+
+## Focused fixture validation
+
+`mise exec -- pnpm --dir packages/typespec-lintdiff validate OperationIdNounVerb` passed with six cases:
+
+- `noun-in-verb`: validator violation and direct TypeSpec lint diagnostic
+- `singularized-noun-in-verb`: validator violation and direct TypeSpec lint diagnostic
+- `explicit-operation-id`: validator violation and direct TypeSpec lint diagnostic
+- `namespace-operation`: validator violation and direct TypeSpec lint diagnostic
+- `noun-not-in-verb`: validator clean; no mapped TypeSpec diagnostic
+- `no-underscore`: validator clean; no mapped TypeSpec diagnostic
+
+## Final equivalence statement
+
+Functional equivalence is established for the assessable corpus and focused fixture matrix. The rule now checks the emitted AutoRest operation ID population rather than every TypeSpec operation declaration. Raw counts are equal for assessable diagnostics, but equality is supporting evidence only; the conclusion rests on the closed fixture matrix, elimination of one-sided project sets, and code-backed fixes for the earlier TypeSpec-only causes. Remaining uncertainty is limited to projects that failed TypeSpec compilation in the corpus and therefore cannot be safely compared by this rule PR.

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/namespace-operation/expect.json
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/namespace-operation/expect.json
@@ -1,0 +1,3 @@
+{
+  "violation": true
+}

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/namespace-operation/main.tsp
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/namespace-operation/main.tsp
@@ -1,0 +1,28 @@
+import "@typespec/http";
+import "@typespec/rest";
+import "@typespec/versioning";
+import "@azure-tools/typespec-autorest";
+
+using TypeSpec.Http;
+using TypeSpec.Versioning;
+
+@service(#{ title: "Test Service" })
+@versioned(Versions)
+namespace TestService;
+
+enum Versions {
+  v2024_01_01: "2024-01-01",
+}
+
+namespace Admins {
+  @doc("An admin resource")
+  model Admin {
+    @doc("The admin name")
+    name: string;
+  }
+
+  @route("/admins")
+  @doc("List admins")
+  @get
+  op listAdmins(@query("api-version") @doc("API version") apiVersion: string): Admin[];
+}

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/namespace-operation/output.json
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/namespace-operation/output.json
@@ -1,0 +1,67 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "Test Service",
+    "version": "2024-01-01",
+    "x-typespec-generated": [
+      {
+        "emitter": "@azure-tools/typespec-autorest"
+      }
+    ]
+  },
+  "schemes": [
+    "https"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "tags": [],
+  "paths": {
+    "/admins": {
+      "get": {
+        "operationId": "Admins_ListAdmins",
+        "description": "List admins",
+        "parameters": [
+          {
+            "name": "api-version",
+            "in": "query",
+            "description": "API version",
+            "required": true,
+            "type": "string",
+            "x-ms-client-name": "apiVersion"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The request has succeeded.",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/Admins.Admin"
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions": {
+    "Admins.Admin": {
+      "type": "object",
+      "description": "An admin resource",
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The admin name"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    }
+  },
+  "parameters": {}
+}

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/namespace-operation/tsp-diagnostics.json
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/namespace-operation/tsp-diagnostics.json
@@ -2,7 +2,7 @@
   {
     "code": "tsp-lintdiff-local-linter/operation-id-noun-verb",
     "severity": "warning",
-    "message": "Per the Noun_Verb convention for Operation Ids, the noun 'Admins' should not appear after the underscore."
+    "message": "Per the Noun_Verb convention for Operation Ids, the noun 'Admins' should not appear after the underscore. Note: If you have already shipped an SDK on top of this spec, fixing this warning may introduce a breaking change."
   },
   {
     "code": "tsp-lintdiff-local-linter/xms-examples-required",

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/namespace-operation/tsp-diagnostics.json
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/namespace-operation/tsp-diagnostics.json
@@ -1,0 +1,12 @@
+[
+  {
+    "code": "tsp-lintdiff-local-linter/operation-id-noun-verb",
+    "severity": "warning",
+    "message": "Per the Noun_Verb convention for Operation Ids, the noun 'Admins' should not appear after the underscore."
+  },
+  {
+    "code": "tsp-lintdiff-local-linter/xms-examples-required",
+    "severity": "warning",
+    "message": "Please provide x-ms-examples describing minimum/maximum property set for response/request payloads for operations."
+  }
+]

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/namespace-operation/validator-diagnostics.json
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/namespace-operation/validator-diagnostics.json
@@ -1,0 +1,13 @@
+[
+  {
+    "code": "OperationIdNounVerb",
+    "message": "Per the Noun_Verb convention for Operation Ids, the noun 'Admins' should not appear after the underscore. Note: If you have already shipped an SDK on top of this spec, fixing this warning may introduce a breaking change.",
+    "path": [
+      "paths",
+      "/admins",
+      "get",
+      "operationId"
+    ],
+    "severity": 0
+  }
+]

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/noun-in-verb/tsp-diagnostics.json
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/noun-in-verb/tsp-diagnostics.json
@@ -2,7 +2,7 @@
   {
     "code": "tsp-lintdiff-local-linter/operation-id-noun-verb",
     "severity": "warning",
-    "message": "Per the Noun_Verb convention for Operation Ids, the noun 'Paths' should not appear after the underscore."
+    "message": "Per the Noun_Verb convention for Operation Ids, the noun 'Paths' should not appear after the underscore. Note: If you have already shipped an SDK on top of this spec, fixing this warning may introduce a breaking change."
   },
   {
     "code": "tsp-lintdiff-local-linter/xms-examples-required",

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/rule.md
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/rule.md
@@ -48,7 +48,7 @@ names that emit the same `Noun_Verb` shapes the upstream Spectral rule inspects:
 - `Paths_List` => valid
 - `GetWidget` (no underscore) => valid and ignored
 - explicit `@operationId("Certificates_GetCertificate")` => invalid
-- namespace fallback `Admins_listAdmins` => invalid
+- namespace fallback `Admins_ListAdmins` => invalid
 
 That evidence supports a native local lint that inspects the resolved emitted
 operationId and reproduces the upstream noun-repetition check directly. The

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/rule.md
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/rule.md
@@ -4,6 +4,8 @@ engine: spectral
 tspLints:
   - tsp-lintdiff-local-linter/operation-id-noun-verb
 tspRuleset: none
+coverageKind: lint
+projectionScope: http-reachable
 ---
 
 # OperationIdNounVerb
@@ -45,6 +47,8 @@ names that emit the same `Noun_Verb` shapes the upstream Spectral rule inspects:
 - `Paths_ListPath` => invalid
 - `Paths_List` => valid
 - `GetWidget` (no underscore) => valid and ignored
+- explicit `@operationId("Certificates_GetCertificate")` => invalid
+- namespace fallback `Admins_listAdmins` => invalid
 
 That evidence supports a native local lint that inspects the resolved emitted
 operationId and reproduces the upstream noun-repetition check directly. The
@@ -59,6 +63,8 @@ The local suite now covers the authorable branches that matter for migration:
 - singularized form of a plural noun in the verb => invalid
 - `Noun_Verb` without noun repetition => valid
 - no underscore => ignored / valid
+- explicit `@operationId` values => checked exactly like emitted operation IDs
+- namespace fallback operation IDs => checked like interface operation IDs
 
 The remaining upstream ignored branches are not especially useful as local
 TypeSpec fixtures: `@operationId` already requires a string literal, and the
@@ -66,9 +72,11 @@ no-underscore path overlaps separate operationId-format rules.
 
 ## Test Cases
 
-| ID                          | Violation | Description |
-| --------------------------- | --------- | ----------- |
-| `noun-in-verb`              | true      | OperationId repeats the full plural noun after the underscore |
-| `singularized-noun-in-verb` | true      | OperationId repeats the noun in singularized form after the underscore |
+| ID                          | Violation | Description                                                                  |
+| --------------------------- | --------- | ---------------------------------------------------------------------------- |
+| `noun-in-verb`              | true      | OperationId repeats the full plural noun after the underscore                |
+| `singularized-noun-in-verb` | true      | OperationId repeats the noun in singularized form after the underscore       |
 | `noun-not-in-verb`          | false     | Emitted `Noun_Verb` operationId stays compliant when the verb omits the noun |
-| `no-underscore`             | false     | OperationId without an underscore is ignored, matching upstream behavior |
+| `no-underscore`             | false     | OperationId without an underscore is ignored, matching upstream behavior     |
+| `explicit-operation-id`     | true      | Explicit `@operationId` repeats the noun in the verb                         |
+| `namespace-operation`       | true      | Namespace-derived operationId repeats the namespace noun in the verb         |

--- a/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/singularized-noun-in-verb/tsp-diagnostics.json
+++ b/packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/singularized-noun-in-verb/tsp-diagnostics.json
@@ -2,7 +2,7 @@
   {
     "code": "tsp-lintdiff-local-linter/operation-id-noun-verb",
     "severity": "warning",
-    "message": "Per the Noun_Verb convention for Operation Ids, the noun 'Paths' should not appear after the underscore."
+    "message": "Per the Noun_Verb convention for Operation Ids, the noun 'Paths' should not appear after the underscore. Note: If you have already shipped an SDK on top of this spec, fixing this warning may introduce a breaking change."
   },
   {
     "code": "tsp-lintdiff-local-linter/xms-examples-required",


### PR DESCRIPTION
## Original Swagger linter

- linter code: [OperationIdNounVerb](https://github.com/Azure/azure-openapi-validator/blob/1198225afecbb818c3050d4d2a91da92e14e56ce/packages/rulesets/src/spectral/functions/operation-id-noun-verb.ts)
- linter doc: [operation-id-noun-verb.md](https://github.com/Azure/azure-openapi-validator/blob/1198225afecbb818c3050d4d2a91da92e14e56ce/docs/operation-id-noun-verb.md)

Specific Swagger checks:

- Ignore empty, non-string, and no-underscore `operationId` values.
- Split `operationId` at the first underscore.
- Treat the first segment as the noun and the second segment as the verb.
- Report when the verb contains the noun.
- If the noun ends with `s`, also report when the verb contains the singularized noun.

## How the Swagger linter works

The Spectral rule runs on emitted Swagger/OpenAPI operation `operationId` fields and reports at the `operationId` JSON path. It compares emitted strings only; it does not inspect TypeSpec declarations. Its plural handling is permissive (`Nouns?`) and the diagnostic warns that fixing shipped SDK operation IDs can be breaking.

## How the migrated TypeSpec linter works

The TypeSpec rule visits operations that TCGC includes in generated client/OpenAPI operation sets, skips template declarations and override customization operations omitted from OpenAPI, and resolves the AutoRest-style operation ID using TCGC client names/client locations plus explicit `@operationId`. It standardizes underscore-separated parts to match emitted AutoRest casing before applying the same noun and singularized-noun repetition check. Diagnostics target the TypeSpec operation declaration that emits the violating operation ID.

## Migration evidence

See [`packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/migration.md`](packages/typespec-lintdiff/test/fixtures/OperationIdNounVerb/migration.md) for focused fixture evidence, the final full-corpus comparison (`34/34` project overlap and `111/111` assessable diagnostics), eliminated TypeSpec-only/validator-only project sets, compile failures, and code-backed gap examples.
