### PR TITLE
Bump typespec-java to 0.46.3 for hotfix

### DIFF
--- a/.chronus/changes/typespec-java-collection-header-prefix-2026-09-04.md
+++ b/.chronus/changes/typespec-java-collection-header-prefix-2026-09-04.md
@@ -1,9 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Sync core to microsoft/typespec commit `890cad64c`. Support collection header prefixes for
-map-valued response headers and document the Java emitter and client options (core
-[microsoft/typespec#11860](https://github.com/microsoft/typespec/pull/11860)).

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log - @azure-tools/typespec-java
 
+## 0.46.3
+
+### Bug Fixes
+
+- [#5394](https://github.com/Azure/typespec-azure/pull/5394) Sync core to microsoft/typespec commit `890cad64c`. Support collection header prefixes for
+  map-valued response headers and document the Java emitter and client options (core,
+  [microsoft/typespec#11860](https://github.com/microsoft/typespec/pull/11860)).
+
+
 ## 0.46.2
 
 ### Bug Fixes

--- a/packages/typespec-java/package.json
+++ b/packages/typespec-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.46.2",
+  "version": "0.46.3",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
## Summary

- bump `@azure-tools/typespec-java` from `0.46.2` to `0.46.3`
- consume the collection-header hotfix change entry
- update the package changelog
