### PR TITLE
Uptake linter reporting on user-supplied template arguments

### DIFF
--- a/packages/samples/specs/resource-manager/operations/operation-provider/main.tsp
+++ b/packages/samples/specs/resource-manager/operations/operation-provider/main.tsp
@@ -41,6 +41,8 @@ model VmSizeCollection is Page<VmSize>;
 /** LogAnalytics collection of operation status response */
 model LogAnalyticsCollection is Page<LogAnalyticsOperationResult>;
 
+@@identifiers(LogAnalyticsCollection.value, #[]);
+
 @armResourceOperations
 interface ProviderOperations {
   /** Operation to get virtual machines for subscription (/subscriptions/{subscriptionId}/providers/Microsoft.ContosoProviderHub/getVmSizes) */

--- a/packages/samples/specs/resource-manager/operations/operation-provider/main.tsp
+++ b/packages/samples/specs/resource-manager/operations/operation-provider/main.tsp
@@ -41,8 +41,6 @@ model VmSizeCollection is Page<VmSize>;
 /** LogAnalytics collection of operation status response */
 model LogAnalyticsCollection is Page<LogAnalyticsOperationResult>;
 
-@@identifiers(LogAnalyticsCollection.value, #[]);
-
 @armResourceOperations
 interface ProviderOperations {
   /** Operation to get virtual machines for subscription (/subscriptions/{subscriptionId}/providers/Microsoft.ContosoProviderHub/getVmSizes) */

--- a/packages/samples/test/output/azure/resource-manager/operations/operation-provider/@azure-tools/typespec-autorest/2022-11-01-preview/openapi.json
+++ b/packages/samples/test/output/azure/resource-manager/operations/operation-provider/@azure-tools/typespec-autorest/2022-11-01-preview/openapi.json
@@ -761,8 +761,7 @@
           "description": "The LogAnalyticsOperationResult items on this page",
           "items": {
             "$ref": "#/definitions/LogAnalyticsOperationResult"
-          },
-          "x-ms-identifiers": []
+          }
         },
         "nextLink": {
           "type": "string",

--- a/packages/samples/test/output/azure/resource-manager/operations/operation-provider/@azure-tools/typespec-autorest/2022-11-01-preview/openapi.json
+++ b/packages/samples/test/output/azure/resource-manager/operations/operation-provider/@azure-tools/typespec-autorest/2022-11-01-preview/openapi.json
@@ -761,7 +761,8 @@
           "description": "The LogAnalyticsOperationResult items on this page",
           "items": {
             "$ref": "#/definitions/LogAnalyticsOperationResult"
-          }
+          },
+          "x-ms-identifiers": []
         },
         "nextLink": {
           "type": "string",


### PR DESCRIPTION
Uptake of https://github.com/microsoft/typespec/pull/11862, which lets a linter rule report on a member a library template declared when the user picked the type it has — ARM's `ResourceNameParameter<..., Type = Azure.Core.uuid>` being the case that prompted it.

No suppressions or spec changes are needed. The compiler change attributes a member only when the user supplied its type *and* passed something they cannot edit, so rules keep quiet about members whose problem lies in a model the author already owns. Validated against `azure-rest-api-specs`: the previously hidden findings that surface are the ones the rules were written to catch (`ArmResponse<unknown>`, `ArmResponse<NetworkTrace[]>`), while `Page<T>` and blanked-documentation members no longer produce noise.
