### PR TITLE
Improve lintdiff migration orchestration

### DIFF
--- a/.github/skills/develop-lintdiff-rule/SKILL.md
+++ b/.github/skills/develop-lintdiff-rule/SKILL.md
@@ -26,6 +26,9 @@ Before dispatcher mode creates branches or worktrees, and before worker mode
 prepares dependencies or starts the Development workflow, check every requested
 Swagger validator rule ID against
 `packages/typespec-lintdiff/catalog/validator-rule-metadata.json`.
+Parse this file as a JSON array and select the entry whose rule-ID field matches
+the requested ID case-insensitively. Do not use object-property lookup by rule
+name; that can falsely report an existing rule as missing.
 
 Continue only when the rule exists and its catalog `applicability` is `ARM` or
 `Both`. If any requested rule is missing or `DataPlane`, stop immediately and
@@ -52,7 +55,11 @@ mandatory semantic check, not an exact-name search.
 Fetch the user-supplied target branch from `origin` and use
 `refs/remotes/origin/<target-branch>` as the source of truth. Do not use or
 update a same-named local branch; it may be stale or checked out in another
-worktree. Inspect all of the following:
+worktree. Before deeper investigation, use GitHub's exact head/base and PR-title
+evidence to detect whether this rule's migration PR already merged. Also compare
+the rule branch with the remote target. If a merged PR already supplied the
+migration or the diff is empty, stop before dependency setup and report the
+existing PR or empty-diff evidence. Inspect all of the following:
 
 1. Search the rule documentation under
    `packages/typespec-azure-core/src/rules` and
@@ -363,11 +370,13 @@ its supplied worktrees:
 <isolated-specs-worktree>` to build the linter and create the direct link in the
      specs worktree
    - separately provide the focused fixture source inputs immediately before
-     focused validation: either set and verify `LINTDIFF_VALIDATOR_ROOT` and
-     `LINTDIFF_COMMON_TYPES` against existing local sources, or create the two
-     documented temporary links. `compare:setup` does not populate these
-     sources. Do not assume a fresh rule worktree already contains
-     `test/azure-openapi-validator` or `test/common-types`
+     focused validation. On Windows, prefer the two documented temporary
+     junctions because they preserve stable snapshot references. Use
+     `LINTDIFF_VALIDATOR_ROOT` and `LINTDIFF_COMMON_TYPES` only when both paths
+     are verified and the resulting snapshots remain repository-relative.
+     `compare:setup` does not populate these sources. Do not assume a fresh rule
+     worktree already contains `test/azure-openapi-validator` or
+     `test/common-types`
 6. Verify that the specs worktree's local
    `node_modules/tsp-lintdiff-local-linter` resolves directly to the supplied
    typespec-azure worktree. `compare:setup` creates a direct per-worktree link
@@ -451,6 +460,12 @@ for shapes present in the selected projects and versions. Even complete
 same-project overlap cannot replace the emission matrix or establish universal
 semantic coverage.
 
+When the validator resolves external example files or another configured
+artifact directory, mirror its documented path, API-version, and
+`examples-directory` resolution exactly. Do not recursively scan a guessed
+project-root directory as a fallback. If TypeSpec cannot safely observe the
+same external files, document that limit instead of adding a broader heuristic.
+
 ### 2. Implement the focused rule change
 
 When evidence requires a rule update:
@@ -482,6 +497,10 @@ pnpm --dir packages/typespec-lintdiff specs:typespec `
   --specs-repo <isolated-azure-rest-api-specs-worktree> `
   --concurrency 6
 ```
+
+Pass the runner options directly as shown. Do not insert an additional `--`
+after `specs:typespec`; in this repository that separator is forwarded to the
+runner and rejected as an unknown argument.
 
 The command runs all local rules and rewrites canonical TypeSpec results and
 coverage files in this development worktree. Use the refreshed rule row and
@@ -662,6 +681,11 @@ creating a draft PR.
    rule branch as head and the user-supplied target branch as base. Do not mark
    it ready for review; the user decides when the migration evidence and rule
    behavior are ready for formal review.
+   If the preferred PR-creation tool returns an ambiguous transport error or
+   claims a conflicting PR, query GitHub for the exact head/base first. When no
+   PR exists, retry once with an explicit `gh pr create` command that supplies
+   `--head <rule-branch>`, `--base <target-branch>`, and `--draft`; when one
+   exists, return its canonical URL instead of creating a duplicate.
 6. Set the PR title to the exact stable pattern
    `[Swagger Linter Migration] <ValidatorRuleId> (origin)`, replacing
    `<ValidatorRuleId>` with the original Swagger validator rule ID.

--- a/.github/skills/do-linter-development-task-one-by-one/SKILL.md
+++ b/.github/skills/do-linter-development-task-one-by-one/SKILL.md
@@ -38,6 +38,14 @@ rule ID, TypeSpec worktree, or specs worktree may remain valid; mark every later
 queue entry that reuses any of them as failed. Do not ask the user to repair
 malformed input during the run.
 
+As part of complete-queue validation, read
+`packages/typespec-lintdiff/catalog/validator-rule-metadata.json` as a JSON array
+and match each rule by its rule-ID field case-insensitively. Mark a missing or
+`DataPlane`-only rule as failed before launching a worker; only `ARM` and `Both`
+are eligible for `/develop-lintdiff-rule`. Record the observed applicability as
+the blocker. This is a read-only eligibility check, not target synchronization
+or worktree verification.
+
 ## Queue state
 
 Keep an ordered ledger with one entry per input command:

--- a/.github/skills/loop-for-fix-and-review/SKILL.md
+++ b/.github/skills/loop-for-fix-and-review/SKILL.md
@@ -219,6 +219,12 @@ ledger. It owns these steps:
    the round unless the result is `new-verified` or
    `already-pending-active`.
 
+   Before polling, define one reusable collector for the whole round that
+   always normalizes API results to arrays with `@(...)`, handles zero and one
+   candidate without null/scalar ambiguity, parses timestamps in one place,
+   and returns structured evidence. Reuse it for ordinary polls and the final
+   refetch instead of rebuilding inline PowerShell expressions in each loop.
+
 5. Poll the paginated REST pull-reviews endpoint,
    `GET /repos/{owner}/{repo}/pulls/{number}/reviews`, at a moderate interval
    rather than repeatedly requesting reviews. Treat its raw response as the
@@ -273,9 +279,9 @@ ledger. It owns these steps:
      review, or the refetch itself fails any request, pagination, parsing,
      required-field, or timestamp check, report an indeterminate collector
      failure rather than a Copilot timeout.
-   These are operational evidence requirements. Report observed failures
-   without asserting which internal cache, pagination, parsing, or state bug
-   caused them.
+     These are operational evidence requirements. Report observed failures
+     without asserting which internal cache, pagination, parsing, or state bug
+     caused them.
 6. Confirm the completed review applies to the round's head SHA. If the PR head
    changed while review was pending, stop the round as stale.
 7. Fetch all inline comments from the review-specific numeric REST endpoint,


### PR DESCRIPTION
## Summary

- reject ineligible DataPlane rules before launching queue workers
- detect already-merged or empty rule migrations before expensive setup
- codify stable fixture, corpus argument, PR fallback, metadata, external-example, and review-polling behavior

## Evidence

These safeguards come directly from the four-rule sequential development run: one DataPlane eligibility blocker, one already-merged migration, corpus and PR invocation retries, metadata lookup and external-example corrections, and PowerShell review polling failures.