### PR TITLE
Run Spector coverage only on main

### DIFF
--- a/eng/pipelines/publish.yml
+++ b/eng/pipelines/publish.yml
@@ -34,6 +34,7 @@ extends:
       - stage: spector_coverage
         displayName: Spector Coverage
         dependsOn: build
+        condition: and(succeeded(), eq(variables['Build.SourceBranch'], 'refs/heads/main'))
         pool:
           name: $(LINUXPOOL)
           image: $(LINUXVMIMAGE)


### PR DESCRIPTION
## Summary

- run the Spector Coverage stage only on `main`
- prevent `release/*` pipeline runs from overwriting the coverage index with an older package version

## Validation

- `pnpm format`
- `pnpm lint`
