### PR TITLE
Register custom Azure resources for resolution

### DIFF
--- a/.chronus/changes/fix-custom-azure-resource-registration-2026-09-07.md
+++ b/.chronus/changes/fix-custom-azure-resource-registration-2026-09-07.md
@@ -1,0 +1,7 @@
+---
+changeKind: fix
+packages:
+  - "@azure-tools/typespec-azure-resource-manager"
+---
+
+Register custom Azure resource models for `resolveArmResources` when `@customAzureResource` marks them as Azure resources.

--- a/packages/typespec-azure-resource-manager/generated-defs/Azure.ResourceManager.Private.ts
+++ b/packages/typespec-azure-resource-manager/generated-defs/Azure.ResourceManager.Private.ts
@@ -239,7 +239,13 @@ export type LegacyResourceOperationDecorator = (
   target: Operation,
   resourceType: Model,
   operationType:
-    "read" | "createOrUpdate" | "update" | "delete" | "list" | "action" | "checkExistence",
+    | "read"
+    | "createOrUpdate"
+    | "update"
+    | "delete"
+    | "list"
+    | "action"
+    | "checkExistence",
   resourceName?: string,
 ) => DecoratorValidatorCallbacks | void;
 
@@ -258,7 +264,13 @@ export type ExtensionResourceOperationDecorator = (
   targetResourceType: Model,
   extensionResourceType: Model,
   operationType:
-    "read" | "createOrUpdate" | "update" | "delete" | "list" | "action" | "checkExistence",
+    | "read"
+    | "createOrUpdate"
+    | "update"
+    | "delete"
+    | "list"
+    | "action"
+    | "checkExistence",
   resourceName?: string,
 ) => DecoratorValidatorCallbacks | void;
 
@@ -277,7 +289,13 @@ export type BuiltInResourceOperationDecorator = (
   parentResourceType: Model,
   builtInResourceType: Model,
   operationType:
-    "read" | "createOrUpdate" | "update" | "delete" | "list" | "action" | "checkExistence",
+    | "read"
+    | "createOrUpdate"
+    | "update"
+    | "delete"
+    | "list"
+    | "action"
+    | "checkExistence",
   resourceName?: string,
 ) => DecoratorValidatorCallbacks | void;
 
@@ -294,7 +312,13 @@ export type LegacyExtensionResourceOperationDecorator = (
   target: Operation,
   resourceType: Model,
   operationType:
-    "read" | "createOrUpdate" | "update" | "delete" | "list" | "action" | "checkExistence",
+    | "read"
+    | "createOrUpdate"
+    | "update"
+    | "delete"
+    | "list"
+    | "action"
+    | "checkExistence",
   resourceName?: string,
 ) => DecoratorValidatorCallbacks | void;
 

--- a/packages/typespec-azure-resource-manager/src/private.decorators.ts
+++ b/packages/typespec-azure-resource-manager/src/private.decorators.ts
@@ -529,7 +529,25 @@ export function registerArmResource(
   type?: string,
   nameParameter?: string,
 ): void {
-  const { program } = context;
+  registerArmResourceCore(context.program, context, resourceType, type, nameParameter);
+}
+
+export function registerArmResourceFromModel(
+  program: Program,
+  resourceType: Model,
+  type?: string,
+  nameParameter?: string,
+): void {
+  registerArmResourceCore(program, undefined, resourceType, type, nameParameter);
+}
+
+function registerArmResourceCore(
+  program: Program,
+  context: DecoratorContext | undefined,
+  resourceType: Model,
+  type?: string,
+  nameParameter?: string,
+): void {
   const namespaceName = resourceType.namespace ? getTypeName(resourceType.namespace) : undefined;
   if (
     namespaceName === undefined ||
@@ -583,7 +601,7 @@ export function registerArmResource(
     }
 
     // Set the name property to be read only
-    if (primaryKeyProperty.name === "name") {
+    if (context && primaryKeyProperty.name === "name") {
       const Lifecycle = getLifecycleVisibilityEnum(program);
       // Decorators may be re-applied to copies of the resource (e.g. by versioning
       // projections or emitters using the mutator framework), and such copies share the
@@ -646,7 +664,7 @@ export function registerArmResource(
     },
   };
 
-  setArmResource(context.program, resourceType, armResourceDetails);
+  setArmResource(program, resourceType, armResourceDetails);
 }
 
 export function listArmResources(program: Program): ArmResourceDetails[] {

--- a/packages/typespec-azure-resource-manager/src/resource.ts
+++ b/packages/typespec-azure-resource-manager/src/resource.ts
@@ -71,11 +71,22 @@ import {
   getResourceNameForOperation,
   resolveResourceOperations,
 } from "./operations.js";
-import { getArmResource, listArmResources, registerArmResource } from "./private.decorators.js";
+import {
+  getArmResource,
+  listArmResources,
+  registerArmResource,
+  registerArmResourceFromModel,
+} from "./private.decorators.js";
 import { ArmStateKeys } from "./state.js";
 
 export type ArmResourceKind =
-  "Tracked" | "Proxy" | "Extension" | "Virtual" | "Custom" | "BuiltIn" | "Generic";
+  | "Tracked"
+  | "Proxy"
+  | "Extension"
+  | "Virtual"
+  | "Custom"
+  | "BuiltIn"
+  | "Generic";
 
 /**
  * The base details for all kinds of resources
@@ -356,6 +367,22 @@ export function isCustomAzureResource(program: Program, target: Model): boolean 
   return false;
 }
 
+export function isCustomAzureResourceMarkedAzure(program: Program, target: Model): boolean {
+  const resourceOptions = getCustomResourceOptions(program, target);
+  if (resourceOptions) return resourceOptions.isAzureResource === true;
+  if (target.baseModel) return isCustomAzureResourceMarkedAzure(program, target.baseModel);
+  return false;
+}
+
+function registerCustomAzureResourceOperationModels(program: Program): void {
+  for (const resourceType of program.stateMap(ArmStateKeys.resourceOperationList).keys()) {
+    if (resourceType.kind !== "Model") continue;
+    if (!isCustomAzureResourceMarkedAzure(program, resourceType)) continue;
+    if (getArmResource(program, resourceType)) continue;
+    registerArmResourceFromModel(program, resourceType);
+  }
+}
+
 function getArmResourceItemPath(operations: ArmResourceOperations): string | undefined {
   const returnPath =
     operations.lifecycle.read?.path ||
@@ -506,6 +533,7 @@ export function resolveArmResources(program: Program): Provider {
     // Return the cached resource details
     return resolvedResources;
   }
+  registerCustomAzureResourceOperationModels(program);
 
   // We haven't generated the full resource details yet
   const resources: ResolvedResource[] = [];

--- a/packages/typespec-azure-resource-manager/test/resource-resolution.test.ts
+++ b/packages/typespec-azure-resource-manager/test/resource-resolution.test.ts
@@ -4411,6 +4411,149 @@ namespace Microsoft.Resources {
     },
   );
 
+  it("collects operation information for customAzureResource-based converted resources", async () => {
+    const { program } = await Tester.compile(`
+
+using Azure.Core;
+
+@armProviderNamespace
+@service(#{ title: "NetworkManagementClient" })
+@versioned(Versions)
+namespace Microsoft.Network;
+
+enum Versions {
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
+  v2024_01_01: "2024-01-01",
+}
+
+@Azure.ResourceManager.Legacy.customAzureResource(#{ isAzureResource: true })
+model CustomResourceBase {}
+
+model ApplicationGateway extends CustomResourceBase {
+  @visibility(Lifecycle.Read)
+  @path
+  @key("applicationGatewayName")
+  @segment("applicationGateways")
+  name: string;
+
+  properties?: ApplicationGatewayProperties;
+}
+
+model ApplicationGatewayProperties {}
+
+interface Operations extends Azure.ResourceManager.Operations {}
+
+alias ApplicationGatewayOps = Azure.ResourceManager.Legacy.LegacyOperations<
+  {
+    ...ApiVersionParameter;
+    ...SubscriptionIdParameter;
+    ...ResourceGroupParameter;
+    ...Azure.ResourceManager.Legacy.Provider;
+  },
+  {
+    @path
+    @key("applicationGatewayName")
+    @segment("applicationGateways")
+    applicationGatewayName: string;
+  }
+>;
+
+@armResourceOperations(#{ omitTags: true })
+interface ApplicationGateways {
+  get is ApplicationGatewayOps.Read<ApplicationGateway>;
+  createOrUpdate is ApplicationGatewayOps.CreateOrUpdateSync<ApplicationGateway>;
+  update is ApplicationGatewayOps.CustomPatchSync<ApplicationGateway, ApplicationGateway>;
+  delete is ApplicationGatewayOps.DeleteSync<ApplicationGateway>;
+  listByResourceGroup is ApplicationGatewayOps.List<ApplicationGateway>;
+}
+`);
+    const provider = resolveArmResources(program);
+    expect(provider).toBeDefined();
+    expect(provider.resources).toBeDefined();
+    ok(provider.resources);
+    expect(provider.resources).toHaveLength(1);
+
+    const resource = provider.resources[0];
+    ok(resource);
+    expect(resource).toMatchObject({
+      kind: "Other",
+      providerNamespace: "Microsoft.Network",
+      type: expect.anything(),
+    });
+
+    checkResolvedOperations(resource, {
+      operations: {
+        lifecycle: {
+          createOrUpdate: [
+            {
+              operationGroup: "ApplicationGateways",
+              name: "createOrUpdate",
+              kind: "createOrUpdate",
+            },
+          ],
+          delete: [{ operationGroup: "ApplicationGateways", name: "delete", kind: "delete" }],
+          read: [{ operationGroup: "ApplicationGateways", name: "get", kind: "read" }],
+          update: [{ operationGroup: "ApplicationGateways", name: "update", kind: "update" }],
+        },
+        lists: [
+          {
+            operationGroup: "ApplicationGateways",
+            name: "listByResourceGroup",
+            kind: "list",
+          },
+        ],
+      },
+      resourceType: {
+        provider: "Microsoft.Network",
+        types: ["applicationGateways"],
+      },
+      resourceInstancePath:
+        "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Network/applicationGateways/{applicationGatewayName}",
+      resourceName: "ApplicationGateways",
+    });
+  }, 30_000);
+
+  it("does not collect resources for customAzureResource when isAzureResource is false", async () => {
+    const { program } = await Tester.compile(`
+
+using Azure.Core;
+
+@armProviderNamespace
+@service(#{ title: "NetworkManagementClient" })
+@versioned(Versions)
+namespace Microsoft.Network;
+
+enum Versions {
+  @armCommonTypesVersion(Azure.ResourceManager.CommonTypes.Versions.v5)
+  v2024_01_01: "2024-01-01",
+}
+
+@Azure.ResourceManager.Legacy.customAzureResource(#{ isAzureResource: false })
+model CustomResourceBase {}
+
+model ApplicationGateway extends CustomResourceBase {
+  @visibility(Lifecycle.Read)
+  @path
+  @key("applicationGatewayName")
+  @segment("applicationGateways")
+  name: string;
+
+  properties?: ApplicationGatewayProperties;
+}
+
+model ApplicationGatewayProperties {}
+
+interface Operations extends Azure.ResourceManager.Operations {}
+
+@armResourceOperations(#{ omitTags: true })
+interface ApplicationGateways {
+  get is ArmResourceRead<ApplicationGateway>;
+}
+`);
+    const provider = resolveArmResources(program);
+    expect(provider.resources).toHaveLength(0);
+  });
+
   it.each(["default", "current"])(
     "provides singleton information for @singleton('%s') decorated resources",
     async (singletonKey) => {


### PR DESCRIPTION
## Summary

Fixes #4798 by registering `@customAzureResource(#{ isAzureResource: true })` models for `resolveArmResources` when ARM resource operations target them.

This keeps resource discovery based on registered ARM resources while allowing converted specs that use custom-resource-marked bases to participate in `resolveArmResources`.

## Changes

- Adds a resolution-time registration pass for operation-targeted custom Azure resource models.
- Refactors ARM resource registration so it can run after decorator evaluation without requiring a `DecoratorContext`.
- Adds regression coverage for a Network-style converted resource that extends a `@customAzureResource(#{ isAzureResource: true })` base.
- Verifies `isAzureResource: false` does not register a resource.

## Validation

- `pnpm exec vitest run test/resource-resolution.test.ts -t "customAzureResource"`
- `pnpm exec vitest run test/resource-resolution.test.ts`
- `pnpm --filter @azure-tools/typespec-azure-resource-manager build`
- `pnpm --filter @azure-tools/typespec-azure-resource-manager lint`