### PR TITLE
Clarify ARM applicability guards in lintdiff development and promotion

### DIFF
--- a/.github/skills/develop-lintdiff-rule/SKILL.md
+++ b/.github/skills/develop-lintdiff-rule/SKILL.md
@@ -480,6 +480,31 @@ When evidence requires a rule update:
 
 Do not change Swagger validator code, emitters, or unrelated TypeSpec rules.
 
+#### ARM applicability without redundant namespace guards
+
+ARM-only catalog eligibility selects the rule's audience; it does not imply that
+every visited operation must carry provider namespace metadata. Before adding an
+ARM applicability check, inspect the actual ruleset/runner selection and
+neighboring rules in the intended official destination.
+
+- When an ARM-only execution context already supplies the applicability boundary,
+  do not add a provider-namespace presence check merely because the rule is ARM
+  specific. Keep checks for provider metadata only when that metadata is part of
+  the rule's contract.
+- Lintdiff can enable ARM and data-plane rules together. Do not assume that the
+  compiler filters declarations by package or catalog applicability. If the mixed
+  runner requires an isolation guard, record it as lintdiff-only infrastructure,
+  keep it separate from the rule's semantic checks, and cover applicable nested
+  namespaces and inapplicable services.
+- Verify helper traversal direction before using a namespace resolver as an
+  applicability predicate. `resolveProviderNamespace(program, namespace)` searches
+  that namespace and its descendants, not its ancestors; it does not establish
+  whether an operation is inside an ARM provider.
+- Document the intended promotion adaptation in `rule.md`. Native ARM tests should
+  cover ordinary and nested namespaces without an unnecessary provider decorator
+  when the selected official ruleset is the applicability boundary. Filtering
+  library declarations and non-endpoint templates is a separate concern.
+
 ### 3. Run focused validation
 
 Build the lintdiff package before any fixture validation or snapshot update

--- a/.github/skills/lintdiff-rule-promote/SKILL.md
+++ b/.github/skills/lintdiff-rule-promote/SKILL.md
@@ -173,6 +173,11 @@ Use these signals:
   package and official ruleset already provide the same applicability boundary,
   and compare neighboring destination rules before deciding whether the guard
   belongs in the promoted implementation.
+- Do not require provider namespace metadata merely because a rule is ARM-only.
+  Separate the selected ruleset's audience from semantic requirements on each
+  declaration. Package ownership alone does not make the compiler filter
+  namespaces; establish the intended boundary from the actual execution context
+  and neighboring rules.
 
 The recommendation should include:
 
@@ -244,13 +249,24 @@ Then adapt it to the destination package:
   - remove a guard when it exists only to isolate an ARM-only rule from
     data-plane programs (or the reverse) in lintdiff's combined rulesets, and
     the selected official package and ruleset already guarantee that boundary
+  - for an ARM-only destination, do not retain a provider-namespace presence
+    check unless provider metadata or per-service filtering is genuinely part
+    of the rule's contract. Removing redundant lintdiff isolation is a promotion
+    adaptation, not a source-semantic repair; it does not require changing the
+    immutable source rule
   - preserve a guard when the rule must still distinguish applicable and
     inapplicable services, namespaces, or declarations within the destination
     ruleset, or when provider metadata is part of the rule's semantics
   - use neighboring destination rules and ruleset registration as evidence,
     document the deliberate adaptation in the PR, and add a native test that
     would fail if the destination unnecessarily retained the lintdiff-only
-    guard
+    guard. Cover both ordinary and nested namespaces without a provider
+    decorator when the official ruleset supplies the applicability boundary;
+    keep library-declaration and template filtering as separate concerns
+  - do not use `resolveProviderNamespace(program, operationNamespace)` as an
+    ancestor-membership check: it searches the supplied namespace and its
+    descendants. If a semantic membership check is required, verify the helper's
+    traversal direction and test nested providers and unrelated services
   - do not remove a guard when destination ownership is ambiguous; return to
     destination analysis rather than broadening the rule speculatively
 - update exported rule variable names to match neighboring rules


### PR DESCRIPTION
## Summary

Clarify ARM applicability guidance in `develop-lintdiff-rule` and `lintdiff-rule-promote` only. This independent, explicitly requested skill update is based on `feature/lintdiff-migration-new` at `621a95d92706844c6d1ebbf3d207788490cabb08`; it contains no rule implementation, tests, generated documentation, dependency, or submodule changes.

## Observed evidence

During ConsistentResponseSchemaForPut repair/promotion, using `resolveProviderNamespace(program, operationNamespace)` as a provider-membership guard missed endpoints in nested namespaces. The helper in `packages/typespec-azure-resource-manager/src/namespace.ts` searches the supplied namespace and its descendants, not ancestors. Neighboring native ARM rules `no-response-body` and `arm-resource-operation` do not require provider namespace metadata to visit operations. The user accepted removal of the redundant native guard and requested guidance in both skills to prevent recurrence.

## Intended boundary

An ARM-only execution context generally does not need an additional provider-presence guard unless provider metadata or per-service discrimination is actually part of the rule contract. Package ownership and catalog metadata do not make the compiler filter declarations. Mixed lintdiff rulesets still require deliberate applicability isolation where needed; record that isolation separately from semantic checks.

Require ordinary and nested namespace regression coverage without unnecessary provider decorators when the official ruleset supplies the boundary. Keep library-declaration and non-endpoint template filtering separate. Removing redundant lintdiff isolation during promotion is a documented destination adaptation, not a source-semantic repair or permission to modify the immutable source rule.

## Validation

- Reviewed the complete diff against fetched `origin/feature/lintdiff-migration-new` and confirmed exactly the two skill documents changed.
- Existing Prettier `--check` passed for both absolute document paths using the prepared source checkout and its existing configuration; no dependencies or submodules were installed.
- `git diff --check` and staged diff hygiene passed.

No source build, test suites, documentation generation, or CI/review polling was run for this Markdown-only change.