### PR TITLE
docs: lead migration notes with concise gap explanations

### DIFF
--- a/.github/skills/develop-lintdiff-rule/SKILL.md
+++ b/.github/skills/develop-lintdiff-rule/SKILL.md
@@ -597,7 +597,42 @@ the newly generated results. This step is required for every rule that proceeds
 through the Development workflow, including runs that started with an empty
 diff or required no production rule change.
 
-Record:
+#### Lead with the result and gap explanation
+
+Immediately after the document title, start with `## Result and gap summary`.
+This is the migration note's primary reader-facing information, not an audit-log
+introduction. In roughly 150 words or fewer, answer:
+
+- **Results:** What are the latest validator versus migrated TypeSpec diagnostic
+  counts and affected-project counts? Name the compared scope, including staging
+  versus production or selected API version when material. Label partial or
+  non-comparable results explicitly.
+- **Why they differ:** Explain the concrete cause of each material discrepancy
+  in plain language and quantify its contribution when established. Distinguish
+  a real missed check from validator false positives, emitted duplicates,
+  version/population differences, or exclusions. Say what each engine checks
+  differently; labels such as "different methodologies" are not an explanation.
+- **Decision:** State whether a TypeSpec rule update is required, was completed,
+  or is unnecessary for the explained gap, and why. State the functional
+  equivalence conclusion separately from raw-count equality.
+- **Uncertainty:** Surface any unexplained remainder or material evidence
+  limitation here, not only deep in the document. Do not present an unresolved
+  gap as intentional or call findings false positives without supporting evidence.
+
+Use a short paragraph or compact bullets; when several causes contribute, a
+small cause/count/disposition table can follow. Link to the detailed evidence
+sections below rather than repeating their full tables. If counts match, say
+there is no observed count gap without treating equality as proof of equivalence.
+If comparison is blocked, lead with that blocker instead of implying parity.
+
+A reader should understand the mismatch and its migration impact from this
+opening alone. Do not lead with commit hashes, tool versions, commands, report
+reconciliation history, or repair chronology.
+
+#### Keep the supporting evidence below the summary
+
+Retain the complete evidence required by `/analyze-swagger-typespec-lint-gap`;
+the concise opening supplements it, not replaces it. Record:
 
 - the specs commit and whether the run was full or partial
 - latest validator and TypeSpec project and diagnostic counts
@@ -674,6 +709,9 @@ The reviewer must:
   `refs/remotes/origin/<target-branch>`, not a same-named local branch
 - inspect the production rule, fixtures, snapshots, `rule.md`, and
   `migration.md`
+- verify that `migration.md` opens with an accurate result and gap summary:
+  counts, concrete causes, rule-change decision, and material uncertainty must
+  agree with the detailed evidence without requiring readers to reconstruct them
 - check for semantic misses, false positives, incorrect TypeSpec compiler API
   usage, version/projection mistakes, unstable diagnostic targets, ineffective
   deduplication, and misleading diagnostics


### PR DESCRIPTION
## Why

The reader of the ConsistentResponseSchemaForPut migration note in #5424 could not quickly understand the most important result: why the validator reported 13 diagnostics while the migrated TypeSpec rule reported 1. The note opened with revisions and report reconciliation, leaving the concrete gap explanation buried in the evidence.

The development skill required explanations, but did not require putting them first. This is a documentation-structure correction, not a change to migration semantics or validation requirements.

## Change

Require `migration.md` to open immediately after its title with a short **Result and gap summary** that states:

- Latest diagnostic and affected-project counts, with the comparison scope.
- The concrete reason for every material discrepancy, quantified when established.
- Whether a TypeSpec rule change is required, completed, or unnecessary, separately from count equality.
- Any unexplained remainder or material evidence limitation.

Keep detailed provenance, reconciliation, code-backed examples, and complete evidence below that summary. Add an independent-review check that the opening agrees with the evidence. Matching counts must not be presented as proof of equivalence, and unresolved differences must not be called intentional.

## Scope and validation

- Only `.github/skills/develop-lintdiff-rule/SKILL.md` changes.
- Based on freshly fetched `feature/lintdiff-migration-new` at `39a989f5a7c2d0116774970af1feb26249ffa39e`.
- Existing Prettier run and check on the changed skill only; complete diff and `git diff --check` inspected.
- No rule code, migration notes, generated data, dependencies, or submodule changes.
- No builds, corpus runs, or CI polling; normal CI is left to run without bypassing checks.
