### PR TITLE
docs: summarize ConsistentResponseSchemaForPut migration gap

### DIFF
--- a/packages/typespec-lintdiff/test/fixtures/ConsistentResponseSchemaForPut/migration.md
+++ b/packages/typespec-lintdiff/test/fixtures/ConsistentResponseSchemaForPut/migration.md
@@ -1,5 +1,24 @@
 # ConsistentResponseSchemaForPut migration evidence
 
+## Result and gap summary
+
+- **Results:** In the recorded staging/latest-version comparison, Swagger reports
+  **13 diagnostics across 8 projects**; TypeSpec reports **1 in 1 project**.
+  The assessed population is 462 of 468 projects; six compile failures are excluded.
+- **Why 13 versus 1:** Both catch the same genuine Reservations/Quota mismatch.
+  The other **12 findings across 7 projects** have identical `200`/`201` schema
+  references. The validator compares JavaScript object identity (`!==`), so
+  separate objects representing the same schema trigger false positives.
+  TypeSpec compares schema types instead and intentionally avoids these findings.
+  See the [reference-pair evidence](#gap-example-resolved-external-reference-identity).
+- **Decision:** No further rule change is needed for this gap. The repaired rule
+  matches the tested PUT schema-consistency contract, not the validator's defects;
+  raw counts need not match.
+- **Limits:** External-reference resolution was not independently verified, and
+  the source's nested-namespace limitation remains. See the
+  [evidence limitations](#repair-findings-and-regression-evidence) and
+  [qualified conclusion](#official-coverage-and-conclusion).
+
 ## Sources and scope
 
 - azure-rest-api-specs commit:


### PR DESCRIPTION
## Summary

Apply the reader-first migration-note guidance merged in #5426 to ConsistentResponseSchemaForPut.

Add a concise opening that explains the recorded 13-versus-1 diagnostic gap immediately: both engines find the genuine Reservations/Quota mismatch; the other 12 findings across seven projects have identical schema references but trigger the validator's JavaScript object-identity comparison. The TypeSpec rule intentionally avoids those findings, so no further rule change is required for this gap.

The opening also states the comparison scope, affected-project counts, excluded compile failures, qualified equivalence conclusion, and reference-resolution/nested-namespace limitations. It links to the existing detailed evidence, which remains unchanged.

## Scope

Only [migration.md](https://github.com/Azure/typespec-azure/blob/docs/lintdiff-consistent-response-schema-for-put-gap-summary/packages/typespec-lintdiff/test/fixtures/ConsistentResponseSchemaForPut/migration.md) changes. No production code, fixtures, snapshots, skills, dependencies, or generated corpus data.

This summarizes the already-recorded run; it does not claim a new validation run. Existing Prettier, diff hygiene, summary length/link checks, and an independent documentation review cover this documentation-only update. No builds, corpus reruns, or CI waiting.
