### PR TITLE
Use standard Python CI setup actions and keep tool versions in sync

### DIFF
--- a/.github/actions/setup-python/action.yml
+++ b/.github/actions/setup-python/action.yml
@@ -1,11 +1,16 @@
 name: Setup Python
-description: Setup Python for typespec-python package development and CI
+description: Setup Python for typespec-python CI
 
 runs:
   using: composite
 
   steps:
-    - name: Setup mise
-      uses: jdx/mise-action@1648a7812b9aeae629881980618f079932869151 # v4.0.1
+    - name: Setup Python
+      uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
       with:
-        install_args: "python uv"
+        python-version: "3.12"
+
+    - name: Setup uv
+      uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+      with:
+        version: "0.11.30"

--- a/.github/workflows/consistency.yml
+++ b/.github/workflows/consistency.yml
@@ -137,7 +137,7 @@ jobs:
         with:
           args: -color -verbose
 
-  # Check catalog is in sync with core
+  # Check dependency and CI tool versions are in sync
   version-consistency:
     name: Versions consistency
     runs-on: ubuntu-latest
@@ -152,7 +152,7 @@ jobs:
         name: Install dependencies
 
       - run: pnpm deps check
-        name: Check catalog is in sync
+        name: Check dependency and CI tool versions are in sync
 
       - run: pnpm run check-lockfile
         name: Check lockfile has no tarball URLs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,6 +24,11 @@ mise is recommended but not required; if you use another version manager,
 install the versions declared in `mise.toml` and the pnpm version declared by
 the `packageManager` field in `package.json`.
 
+The Python CI setup action uses the Python and uv versions declared in
+`mise.toml`. After updating either version, run `pnpm deps fix` to sync the
+action. `pnpm deps check` reports version drift as part of the CI consistency
+checks.
+
 # Testing a change in repo azure-rest-api-specs
 
 If you are proposing a change that is likely to impact existing specs, it's

--- a/eng/scripts/sync-ci-tool-versions.test.ts
+++ b/eng/scripts/sync-ci-tool-versions.test.ts
@@ -1,0 +1,130 @@
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { syncCiToolVersions } from "./sync-ci-tool-versions.ts";
+
+const mise = `[tools]
+python = "3.12"
+uv = "0.11.30"
+
+[settings]
+python = "not-a-tool-version"
+`;
+
+const action = `name: Setup Python
+runs:
+  using: composite
+  steps:
+    - name: Setup Python
+      uses: actions/setup-python@python-sha # v7.0.0
+      with:
+        python-version: "3.12"
+    - name: Setup uv
+      uses: astral-sh/setup-uv@uv-sha # v10.0.1
+      with:
+        version: "0.11.30" # Keep this comment
+    - uses: example/other@other-sha
+      with:
+        version: "1.0.0"
+`;
+
+describe("syncCiToolVersions", () => {
+  let root: string;
+  let misePath: string;
+  let actionPath: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "sync-ci-tool-versions-"));
+    misePath = join(root, "mise.toml");
+    actionPath = join(root, ".github/actions/setup-python/action.yml");
+    mkdirSync(join(root, ".github/actions/setup-python"), { recursive: true });
+    writeFileSync(misePath, mise);
+    writeFileSync(actionPath, action);
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it.each(["check", "fix"] as const)("leaves matching versions unchanged in %s mode", (mode) => {
+    expect(syncCiToolVersions(root, mode)).toEqual([]);
+    expect(readFileSync(actionPath, "utf8")).toBe(action);
+  });
+
+  it("reports both mismatches without changing either file in check mode", () => {
+    const updatedMise = mise.replace("3.12", "3.13").replace("0.11.30", "0.12.0");
+    writeFileSync(misePath, updatedMise);
+
+    expect(syncCiToolVersions(root, "check")).toEqual([
+      { tool: "python", currentVersion: "3.12", expectedVersion: "3.13" },
+      { tool: "uv", currentVersion: "0.11.30", expectedVersion: "0.12.0" },
+    ]);
+    expect(readFileSync(actionPath, "utf8")).toBe(action);
+    expect(readFileSync(misePath, "utf8")).toBe(updatedMise);
+  });
+
+  it("fixes only the tool inputs and is idempotent", () => {
+    const updatedMise = mise.replace("3.12", "3.13").replace("0.11.30", "0.12.0");
+    writeFileSync(misePath, updatedMise);
+
+    expect(syncCiToolVersions(root, "fix")).toHaveLength(2);
+    expect(readFileSync(actionPath, "utf8")).toBe(
+      action
+        .replace('python-version: "3.12"', 'python-version: "3.13"')
+        .replace('version: "0.11.30"', 'version: "0.12.0"'),
+    );
+    expect(readFileSync(misePath, "utf8")).toBe(updatedMise);
+    expect(syncCiToolVersions(root, "fix")).toEqual([]);
+    expect(syncCiToolVersions(root, "check")).toEqual([]);
+  });
+
+  it("accepts quoted TOML versions with comments and quoted or plain YAML versions", () => {
+    writeFileSync(misePath, mise.replace('uv = "0.11.30"', "uv = '0.11.30' # Pin uv"));
+    writeFileSync(actionPath, action.replace('"3.12"', "'3.12'").replace('"0.11.30"', "0.11.30"));
+    expect(syncCiToolVersions(root, "check")).toEqual([]);
+  });
+
+  it("preserves CRLF line endings when fixing", () => {
+    writeFileSync(misePath, mise.replace("0.11.30", "0.12.0").replaceAll("\n", "\r\n"));
+    writeFileSync(actionPath, action.replaceAll("\n", "\r\n"));
+
+    expect(syncCiToolVersions(root, "fix")).toHaveLength(1);
+    expect(readFileSync(actionPath, "utf8")).toBe(
+      action.replace("0.11.30", "0.12.0").replaceAll("\n", "\r\n"),
+    );
+  });
+
+  it.each([
+    ["missing tools section", mise.replace("[tools]", "[other]"), "Missing [tools] section"],
+    ["missing tool", mise.replace('uv = "0.11.30"\n', ""), "Expected a quoted uv version"],
+    ["unsupported tool value", mise.replace('"0.11.30"', "{}"), "Expected a quoted uv version"],
+  ])("rejects %s without writing", (_, invalidMise, message) => {
+    writeFileSync(misePath, invalidMise);
+    expect(() => syncCiToolVersions(root, "fix")).toThrow(message);
+    expect(readFileSync(actionPath, "utf8")).toBe(action);
+  });
+
+  it.each([
+    [
+      "missing action",
+      action.replace("astral-sh/setup-uv@", "example/setup-uv@"),
+      "Expected exactly one astral-sh/setup-uv step",
+    ],
+    [
+      "duplicate action",
+      action + "    - uses: astral-sh/setup-uv@another-sha\n",
+      "Expected exactly one astral-sh/setup-uv step",
+    ],
+    [
+      "missing input",
+      action.replace('        version: "0.11.30" # Keep this comment\n', ""),
+      "Missing or unsupported version input",
+    ],
+  ])("rejects %s without partially fixing earlier steps", (_, invalidAction, message) => {
+    writeFileSync(misePath, mise.replace("3.12", "3.13"));
+    writeFileSync(actionPath, invalidAction);
+    expect(() => syncCiToolVersions(root, "fix")).toThrow(message);
+    expect(readFileSync(actionPath, "utf8")).toBe(invalidAction);
+  });
+});

--- a/eng/scripts/sync-ci-tool-versions.ts
+++ b/eng/scripts/sync-ci-tool-versions.ts
@@ -1,0 +1,71 @@
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const actionPath = ".github/actions/setup-python/action.yml";
+const tools = [
+  { tool: "python", action: "actions/setup-python", input: "python-version" },
+  { tool: "uv", action: "astral-sh/setup-uv", input: "version" },
+];
+
+interface ToolVersionMismatch {
+  tool: string;
+  currentVersion: string;
+  expectedVersion: string;
+}
+
+export function syncCiToolVersions(root: string, mode: "check" | "fix"): ToolVersionMismatch[] {
+  const mise = readFileSync(resolve(root, "mise.toml"), "utf8");
+  const toolsSection = mise.match(
+    /^\[tools\][ \t]*(?:#.*)?\r?\n([\s\S]*?)(?=^\[|(?![\s\S]))/m,
+  )?.[1];
+  if (toolsSection === undefined) {
+    throw new Error("Missing [tools] section in mise.toml.");
+  }
+
+  const file = resolve(root, actionPath);
+  const content = readFileSync(file, "utf8");
+  // Edit only the matching step's input, preserving action SHAs, comments and formatting.
+  const steps = content.split(/(?=^ *- )/m);
+  const mismatches: ToolVersionMismatch[] = [];
+
+  for (const { tool, action, input } of tools) {
+    const expectedVersion = toolsSection.match(
+      new RegExp(`^${tool}[ \\t]*=[ \\t]*(["'])([^"'\\r\\n]+)\\1[ \\t]*(?:#.*)?\\r?$`, "m"),
+    )?.[2];
+    if (expectedVersion === undefined) {
+      throw new Error(`Expected a quoted ${tool} version in mise.toml [tools].`);
+    }
+
+    const matchingSteps = steps
+      .map((step, index) => ({ step, index }))
+      .filter(({ step }) =>
+        new RegExp(`^[ \\t]*(?:- )?uses:[ \\t]*["']?${action}@`, "m").test(step),
+      );
+    if (matchingSteps.length !== 1) {
+      throw new Error(`Expected exactly one ${action} step in ${actionPath}.`);
+    }
+
+    const { step, index } = matchingSteps[0];
+    const versionPattern = new RegExp(
+      `^([ \\t]+${input}:[ \\t]*)(?:"([^"\\r\\n]+)"|'([^'\\r\\n]+)'|([^\\s#]+))([ \\t]*(?:#.*)?\\r?)$`,
+      "m",
+    );
+    const match = step.match(versionPattern);
+    if (!match) {
+      throw new Error(`Missing or unsupported ${input} input for ${action} in ${actionPath}.`);
+    }
+    const currentVersion = match[2] ?? match[3] ?? match[4];
+    if (currentVersion !== expectedVersion) {
+      mismatches.push({ tool, currentVersion, expectedVersion });
+      steps[index] = step.replace(
+        versionPattern,
+        () => `${match[1]}"${expectedVersion}"${match[5]}`,
+      );
+    }
+  }
+
+  if (mode === "fix" && mismatches.length > 0) {
+    writeFileSync(file, steps.join(""));
+  }
+  return mismatches;
+}

--- a/eng/scripts/sync-deps.ts
+++ b/eng/scripts/sync-deps.ts
@@ -3,6 +3,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { join, relative, resolve } from "path";
 import pc from "picocolors";
 import { coreRepoRoot, repoRoot } from "./helpers.js";
+import { syncCiToolVersions } from "./sync-ci-tool-versions.ts";
 
 const WorkspaceYamlFile = "pnpm-workspace.yaml";
 
@@ -321,12 +322,27 @@ function main() {
   if (mode !== "check" && mode !== "fix") {
     console.error("Usage: pnpm deps <check|fix>");
     console.error(
-      "  check  - Verify catalog & overrides sync with core and enforce catalog: usage (exits non-zero if any issues)",
+      "  check  - Verify catalog & overrides sync with core, catalog: usage, and CI tool versions against mise.toml",
     );
     console.error(
-      "  fix    - Sync catalog & overrides from core, align packageManager, and remove unused entries",
+      "  fix    - Sync catalog & overrides from core, align packageManager and CI tool versions, and remove unused entries",
     );
     process.exit(1);
+  }
+
+  const toolMismatches = syncCiToolVersions(repoRoot, mode);
+  if (toolMismatches.length > 0) {
+    console.log("CI tool version mismatch(es) with mise.toml:");
+    for (const { tool, currentVersion, expectedVersion } of toolMismatches) {
+      console.log(`  ${pc.cyan(tool)}: ${pc.red(currentVersion)} → ${pc.green(expectedVersion)}`);
+    }
+    if (mode === "check") {
+      console.log(`\nRun ${pc.cyan("pnpm deps fix")} to sync CI tool versions.`);
+      process.exit(1);
+    }
+    console.log(pc.green("✓") + " Updated CI tool versions from mise.toml.");
+  } else {
+    console.log(pc.green("✓") + " CI tool versions are in sync with mise.toml.");
   }
 
   const repoWorkspaceYaml = resolve(repoRoot, WorkspaceYamlFile);

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,6 @@
 [tools]
 python = "3.12"
-uv = "latest"
+uv = "0.11.30"
 go = "1.26.1"
 java = "microsoft-11"
 maven = "3.9.16"


### PR DESCRIPTION
Python CI can fail before building when mise advertises a release that is not yet available on GitHub, as in [this failed job](https://github.com/Azure/typespec-azure/actions/runs/34230440325/job/102075208936). Use `actions/setup-python` and `astral-sh/setup-uv` directly in CI, while keeping mise for local development.

`mise.toml` remains the source of truth for Python and uv versions, with uv now explicitly pinned. `pnpm deps check` rejects drift in the CI action, and `pnpm deps fix` synchronizes its inputs without changing action SHAs or comments.

This is independent of https://github.com/Azure/typespec-azure/pull/5418 and does not include its core submodule update.