### PR TITLE
Bump typespec-java to 0.46.4 for hotfix

### DIFF
--- a/.chronus/changes/fix-java-duplicate-inherited-discriminators-2026-09-02.md
+++ b/.chronus/changes/fix-java-duplicate-inherited-discriminators-2026-09-02.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Avoid duplicate inherited discriminator fields in generated Java models.

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-java
 
+## 0.46.4
+
+### Bug Fixes
+
+- [#5381](https://github.com/Azure/typespec-azure/pull/5381) Avoid duplicate inherited discriminator fields in generated Java models.
+
+
 ## 0.46.3
 
 ### Bug Fixes

--- a/packages/typespec-java/package.json
+++ b/packages/typespec-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.46.3",
+  "version": "0.46.4",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
## Summary

- bump `@azure-tools/typespec-java` from `0.46.3` to `0.46.4`
- consume the duplicate inherited discriminator fix entry
- update the package changelog