### PR TITLE
Bump typespec-java to 0.46.4 for hotfix

### DIFF
--- a/.chronus/changes/fix-java-duplicate-inherited-discriminators-2026-09-02.md
+++ b/.chronus/changes/fix-java-duplicate-inherited-discriminators-2026-09-02.md
@@ -1,7 +1,0 @@
----
-changeKind: fix
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Avoid duplicate inherited discriminator fields in generated Java models.

--- a/.chronus/changes/java-request-header-collection-prefix-2026-09-09.md
+++ b/.chronus/changes/java-request-header-collection-prefix-2026-09-09.md
@@ -1,7 +1,0 @@
----
-changeKind: feature
-packages:
-  - "@azure-tools/typespec-java"
----
-
-Support collection prefixes for request headers in generated Java clients.

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @azure-tools/typespec-java
 
+## 0.46.4
+
+### Bug Fixes
+
+- [#5381](https://github.com/Azure/typespec-azure/pull/5381) Avoid duplicate inherited discriminator fields in generated Java models.
+
+
 ## 0.46.3
 
 ### Bug Fixes

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Support collection prefixes for request headers in generated Java clients.
+- [#5436](https://github.com/Azure/typespec-azure/pull/5436) Support collection prefixes for request headers in generated Java clients.
 
 ### Bug Fixes
 
@@ -12,8 +12,6 @@
 
 
 ## 0.46.3
-
-### Bug Fixes
 
 ### Features
 

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## 0.46.4
 
+### Features
+
+- Support collection prefixes for request headers in generated Java clients.
+
 ### Bug Fixes
 
 - [#5381](https://github.com/Azure/typespec-azure/pull/5381) Avoid duplicate inherited discriminator fields in generated Java models.

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -4,11 +4,11 @@
 
 ### Features
 
-- [#5436](https://github.com/Azure/typespec-azure/pull/5436) Support collection prefixes for request headers in generated Java clients.
+- Support collection prefixes for request headers in generated Java clients.
 
 ### Bug Fixes
 
-- [#5381](https://github.com/Azure/typespec-azure/pull/5381) Avoid duplicate inherited discriminator fields in generated Java models.
+- Avoid duplicate inherited discriminator fields in generated Java models.
 
 
 ## 0.46.3

--- a/packages/typespec-java/CHANGELOG.md
+++ b/packages/typespec-java/CHANGELOG.md
@@ -11,7 +11,9 @@
 
 ### Bug Fixes
 
-- [#5394](https://github.com/Azure/typespec-azure/pull/5394) Sync core to microsoft/typespec commit `890cad64c`. Support collection header prefixes for
+### Features
+
+- Sync core to microsoft/typespec commit `890cad64c`. Support collection header prefixes for
   map-valued response headers and document the Java emitter and client options (core,
   [microsoft/typespec#11860](https://github.com/microsoft/typespec/pull/11860)).
 

--- a/packages/typespec-java/package.json
+++ b/packages/typespec-java/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@azure-tools/typespec-java",
-  "version": "0.46.3",
+  "version": "0.46.4",
   "description": "TypeSpec library for emitting Java client from the TypeSpec REST protocol binding",
   "keywords": [
     "TypeSpec"


### PR DESCRIPTION
## Summary

- bump `@azure-tools/typespec-java` from `0.46.3` to `0.46.4`
- avoid duplicate inherited discriminator fields in generated Java models
- support collection prefixes for request headers in generated Java clients
- consume both change entries in the `0.46.4` changelog