### PR TITLE
Sync Java request header collection prefixes

### DIFF
--- a/.chronus/changes/java-request-header-collection-prefix-2026-09-09.md
+++ b/.chronus/changes/java-request-header-collection-prefix-2026-09-09.md
@@ -1,5 +1,5 @@
 ---
-changeKind: feature
+changeKind: fix
 packages:
   - "@azure-tools/typespec-java"
 ---

--- a/.chronus/changes/java-request-header-collection-prefix-2026-09-09.md
+++ b/.chronus/changes/java-request-header-collection-prefix-2026-09-09.md
@@ -1,5 +1,5 @@
 ---
-changeKind: fix
+changeKind: feature
 packages:
   - "@azure-tools/typespec-java"
 ---

--- a/.chronus/changes/java-request-header-collection-prefix-2026-09-09.md
+++ b/.chronus/changes/java-request-header-collection-prefix-2026-09-09.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-java"
+---
+
+Support collection prefixes for request headers in generated Java clients.

--- a/packages/typespec-java/core-commit.json
+++ b/packages/typespec-java/core-commit.json
@@ -1,1 +1,1 @@
-{ "sha": "a61e90890abb32806dba1efa87f6d4f0aae8bf29" }
+{ "sha": "f16f4d44efe4f48d9dbfd82ffdb47609457e2659" }

--- a/packages/typespec-java/emitter-tests/src/test/java/tsptest/requestheaders/RequestHeadersTests.java
+++ b/packages/typespec-java/emitter-tests/src/test/java/tsptest/requestheaders/RequestHeadersTests.java
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package tsptest.requestheaders;
+
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.rest.RequestOptions;
+import com.azure.core.http.rest.Response;
+import com.azure.core.test.http.MockHttpResponse;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+import tsptest.requestheaders.models.MetadataValue;
+
+public class RequestHeadersTests {
+
+    @Test
+    public void testRequestHeaderCollection() {
+        RequestHeadersClient client
+            = new RequestHeadersClientBuilder().endpoint("http://localhost:3000").httpClient(request -> {
+                Assertions.assertEquals("value1",
+                    request.getHeaders().getValue(HttpHeaderName.fromString("x-ms-meta-key1")));
+                Assertions.assertEquals("value2",
+                    request.getHeaders().getValue(HttpHeaderName.fromString("x-ms-meta-key2")));
+                Assertions.assertNull(request.getHeaders().getValue(HttpHeaderName.fromString("x-ms-meta")));
+                Assertions.assertNull(request.getHeaders().getValue(HttpHeaderName.fromString("x-ms-meta-null")));
+                Assertions.assertNull(request.getHeaders().getValue(HttpHeaderName.fromString("x-ms-meta-key3")));
+                Assertions.assertEquals("100",
+                    request.getHeaders().getValue(HttpHeaderName.fromString("x-ms-priority-level")));
+                return Mono.just(new MockHttpResponse(request, 204));
+            }).buildClient();
+
+        Map<String, String> metadata = new LinkedHashMap<>();
+        metadata.put("key1", "value1");
+        metadata.put("key2", "value2");
+        metadata.put(null, "ignored");
+        metadata.put("key3", null);
+        Response<Void> response
+            = client.sendWithResponse(metadata, Map.of("level", MetadataValue.HIGH), new RequestOptions());
+        Assertions.assertEquals(204, response.getStatusCode());
+    }
+}

--- a/packages/typespec-java/emitter-tests/tsp/request-headers.tsp
+++ b/packages/typespec-java/emitter-tests/tsp/request-headers.tsp
@@ -1,0 +1,29 @@
+import "@typespec/rest";
+import "@azure-tools/typespec-client-generator-core";
+
+using TypeSpec.Http;
+using Azure.ClientGenerator.Core;
+
+@service(#{ title: "RequestHeaders" })
+namespace TspTest.RequestHeaders;
+
+enum MetadataValue {
+  High: 100,
+  Low: 0,
+}
+
+model MetadataHeaders {
+  @header("x-ms-meta") metadata?: string;
+  @header("x-ms-priority") priorities?: int32;
+}
+
+@route("/request-headers")
+interface RequestHeaderOps {
+  @post
+  send(...MetadataHeaders): void;
+}
+
+@@alternateType(MetadataHeaders.metadata, Record<string>, "java");
+@@clientOption(MetadataHeaders.metadata, "collectionHeaderPrefix", "x-ms-meta-", "java");
+@@alternateType(MetadataHeaders.priorities, Record<MetadataValue>, "java");
+@@clientOption(MetadataHeaders.priorities, "collectionHeaderPrefix", "x-ms-priority-", "java");

--- a/packages/typespec-java/eng/scripts/generate.ts
+++ b/packages/typespec-java/eng/scripts/generate.ts
@@ -83,8 +83,11 @@ function getGenerationOptions(typeSpecFile: string): string[] {
     );
   } else if (/tsp\/protocol-api-sync-over-async\.tsp$/.test(normalized)) {
     options.push(`${emitterName}.enable-sync-stack=false`);
-  } else if (/tsp\/max-overload-model\.tsp$/.test(normalized)) {
-    options.push(`${emitterName}.max-overload=model`, `${emitterName}.advanced-versioning=true`);
+  } else if (/tsp\/(max-overload-model|request-headers)\.tsp$/.test(normalized)) {
+    options.push(`${emitterName}.max-overload=model`);
+    if (/tsp\/max-overload-model\.tsp$/.test(normalized)) {
+      options.push(`${emitterName}.advanced-versioning=true`);
+    }
   } else if (/tsp\/subclient\.tsp$/.test(normalized)) {
     options.push(
       `${emitterName}.enable-subclient=true`,


### PR DESCRIPTION
## Summary

- pin the Java emitter to microsoft/typespec merge commit `f16f4d44efe4f48d9dbfd82ffdb47609457e2659`
- sync the request-header collection-prefix TypeSpec fixture and focused JUnit coverage
- configure the request-header fixture to generate model overloads
- add a `feature` Chronus entry for `@azure-tools/typespec-java`

Upstream: microsoft/typespec#11887

## Validation

- `pnpm --filter @azure-tools/typespec-java sync-tests`
- targeted Prettier and Node syntax checks for `eng/scripts/generate.ts`
- CI `Java / Build & Test`
- CI `Java / Regen & Spector Tests`
- all required checks
- reviewed the substantive fixture delta: prefixed string and enum-valued request headers, null key/value filtering, and absence of the unprefixed header
- repository `core` gitlink remains `f30cd352f93997e04c75d48c7ace6947a1d5d07a`
- `pnpm-lock.yaml` remains unchanged