### PR TITLE
Fix promotion generated-doc formatting and skill PR targeting guidance

### DIFF
--- a/.github/skills/lintdiff-rule-promote/SKILL.md
+++ b/.github/skills/lintdiff-rule-promote/SKILL.md
@@ -390,7 +390,10 @@ reference entries as a substitute for regeneration. After docs regeneration,
 inspect the generated target-package README and website linter/rule references
 for the official rule name, page path, links, and table entry. Format the changed
 Markdown files and check them with Prettier so generated tables use the expected
-layout.
+layout. Use the scoped empty-ignore override in step 9: ordinary Prettier
+commands silently skip website references covered by `.prettierignore` and
+generated rule pages covered by `.gitignore`. Leave both ignore files untouched
+and do not force-add ignored generated rule pages.
 
 ### 7. Update rulesets
 
@@ -471,7 +474,8 @@ Optimized validation order:
 5. inspect the generated package README and website linter/rule references for
    the official rule name, page path, links, and table entry
 6. format changed Markdown and run a Prettier check over the generated package
-   README, rule documentation, and website linter/rule references
+   README, rule documentation, and website linter/rule references, using an
+   empty-ignore override and explicit filenames as shown below
 7. `@azure-tools/typespec-azure-rulesets` build and test when rulesets changed
 8. affected package test
 9. if broad local validation is warranted, run the repo build or
@@ -484,7 +488,9 @@ dedicated Website job runs without the skip and is the authoritative Astro check
 and build for generated website content.
 
 For ARM rule promotion, use this command set as the default targeted validation
-loop, replacing `<rule-name>` with the promoted rule file stem:
+loop, setting `RULE_NAME` to the exact official TypeSpec rule name/file stem
+(for example, `use-create-for-put`, not the validator slug
+`put-in-operation-name`):
 
 ```bash
 RULE_NAME="replace-with-rule-name"
@@ -493,8 +499,8 @@ pnpm --filter @azure-tools/typespec-azure-resource-manager exec vitest run "test
 pnpm --filter @azure-tools/typespec-azure-resource-manager build
 pnpm --filter @azure-tools/typespec-azure-resource-manager lint
 pnpm --filter @azure-tools/typespec-azure-resource-manager regen-docs
-pnpm exec prettier --write packages/typespec-azure-resource-manager/README.md "packages/typespec-azure-resource-manager/src/rules/${RULE_NAME}.md" website/src/content/docs/docs/libraries/azure-resource-manager/reference/linter.md
-pnpm exec prettier --check packages/typespec-azure-resource-manager/README.md "packages/typespec-azure-resource-manager/src/rules/${RULE_NAME}.md" website/src/content/docs/docs/libraries/azure-resource-manager/reference/linter.md
+pnpm exec prettier --ignore-path /dev/null --write packages/typespec-azure-resource-manager/README.md "packages/typespec-azure-resource-manager/src/rules/${RULE_NAME}.md" website/src/content/docs/docs/libraries/azure-resource-manager/reference/linter.md "website/src/content/docs/docs/libraries/azure-resource-manager/rules/${RULE_NAME}.md"
+pnpm exec prettier --ignore-path /dev/null --check packages/typespec-azure-resource-manager/README.md "packages/typespec-azure-resource-manager/src/rules/${RULE_NAME}.md" website/src/content/docs/docs/libraries/azure-resource-manager/reference/linter.md "website/src/content/docs/docs/libraries/azure-resource-manager/rules/${RULE_NAME}.md"
 pnpm --filter @azure-tools/typespec-azure-rulesets build
 pnpm --filter @azure-tools/typespec-azure-rulesets test
 pnpm --filter @azure-tools/typespec-azure-resource-manager test
@@ -511,14 +517,41 @@ pnpm --filter @azure-tools/typespec-azure-core exec vitest run "test/rules/${RUL
 pnpm --filter @azure-tools/typespec-azure-core build
 pnpm --filter @azure-tools/typespec-azure-core lint
 pnpm --filter @azure-tools/typespec-azure-core regen-docs
-pnpm exec prettier --write packages/typespec-azure-core/README.md "packages/typespec-azure-core/src/rules/${RULE_NAME}.md" website/src/content/docs/docs/libraries/azure-core/reference/linter.md
-pnpm exec prettier --check packages/typespec-azure-core/README.md "packages/typespec-azure-core/src/rules/${RULE_NAME}.md" website/src/content/docs/docs/libraries/azure-core/reference/linter.md
+pnpm exec prettier --ignore-path /dev/null --write packages/typespec-azure-core/README.md "packages/typespec-azure-core/src/rules/${RULE_NAME}.md" website/src/content/docs/docs/libraries/azure-core/reference/linter.md "website/src/content/docs/docs/libraries/azure-core/rules/${RULE_NAME}.md"
+pnpm exec prettier --ignore-path /dev/null --check packages/typespec-azure-core/README.md "packages/typespec-azure-core/src/rules/${RULE_NAME}.md" website/src/content/docs/docs/libraries/azure-core/reference/linter.md "website/src/content/docs/docs/libraries/azure-core/rules/${RULE_NAME}.md"
 pnpm --filter @azure-tools/typespec-azure-rulesets build
 pnpm --filter @azure-tools/typespec-azure-rulesets test
 pnpm --filter @azure-tools/typespec-azure-core test
 pnpm exec cross-env TYPESPEC_SKIP_WEBSITE_BUILD=true pnpm validate:pr
 git diff --check
 ```
+
+The Bash examples use the POSIX empty ignore path `/dev/null`. In Windows
+PowerShell, use `NUL` instead; the equivalent four-file formatting commands are
+below. Set `$Library` to `azure-resource-manager` or `azure-core` and `$RuleName`
+to the exact official rule name:
+
+```powershell
+$Library = "azure-resource-manager"
+$RuleName = "use-create-for-put"
+$DocFiles = @(
+  "packages\typespec-$Library\README.md"
+  "packages\typespec-$Library\src\rules\$RuleName.md"
+  "website\src\content\docs\docs\libraries\$Library\reference\linter.md"
+  "website\src\content\docs\docs\libraries\$Library\rules\$RuleName.md"
+)
+pnpm exec prettier --ignore-path NUL --write @DocFiles
+pnpm exec prettier --ignore-path NUL --check @DocFiles
+```
+
+An explicit empty ignore file is also valid in place of the platform null path.
+Apply this override only to these explicit filenames, never a directory, glob,
+or repo-wide formatting command. Confirm the `--write` output actually lists all
+four files, including `reference/linter.md` and `rules/<official-rule-name>.md`;
+a successful `--check` summary alone does not prove ignored files were checked.
+If needed, use `prettier --ignore-path <empty-ignore-path> --file-info <filename>`
+for each generated file and confirm `"ignored": false`, then rerun the scoped
+write/check commands.
 
 Run a focused code review after steps 1-2 pass and before steps 3-6 when the
 rule logic is non-trivial. This catches semantic gaps before expensive full

--- a/.github/skills/shared/post-run-process-review.md
+++ b/.github/skills/shared/post-run-process-review.md
@@ -61,9 +61,10 @@ For qualifying improvements:
    or release/change entries.
 5. Push the dedicated branch to the personal fork and open an independent PR
    against `Azure/typespec-azure` with base
-   `feature/lintdiff-migration-new` explicitly selected. Describe the observed
-   evidence, rationale, affected skills, and narrow validation in the PR body.
-   Do not add skill changes to the primary task's PR.
+   `feature/lintdiff-migration-new` explicitly selected, following the
+   publication targeting guidance below. Describe the observed evidence,
+   rationale, affected skills, and narrow validation in the PR body. Do not
+   add skill changes to the primary task's PR.
 6. Verify the created PR's base, head, and complete file list. All changes must
    be skill instructions or supporting skill documentation. Do not report
    successful completion if the PR target or scope is wrong.
@@ -72,6 +73,36 @@ If the base is unavailable, the correction is unsafe, or publishing fails,
 stop the skill-update attempt without asking the user or modifying the primary
 workflow's result. Report a concrete operational blocker briefly when a
 qualifying update could not be published. Never merge the PR automatically.
+
+### Publication targeting
+
+- Record the intended base repository and branch, personal-fork owner, and
+  pushed head branch before choosing the publication tool. Git upstream
+  tracking, `branch.<name>.gh-merge-base`, and an app session's comparison base
+  are separate settings; changing one does not prove the others changed.
+- When creating an app-native worktree session for this PR, explicitly pass
+  `base_branch: "feature/lintdiff-migration-new"` rather than accepting the
+  project's default branch. Confirm the resulting session's base before
+  preparing changes. Do not assume registering an existing worktree as a
+  project or branch session preserves its intended PR base.
+- Where the environment permits GitHub CLI PR creation, select both branches
+  explicitly: use `gh pr create --repo Azure/typespec-azure --base
+feature/lintdiff-migration-new --head <fork-owner>:<skill-branch>` with the
+  reviewed title and body. Do not rely on inferred defaults.
+- Honor the environment's PR-creation tool requirements. If an integrated
+  tool is required, inspect its available targeting controls and supported
+  fallback before proceeding; this skill does not authorize bypassing those
+  requirements. A skill change cannot add a missing tool parameter.
+- A mismatched app change overview is a warning, not evidence that GitHub
+  rejected a PR or that the creation tool necessarily uses that same base.
+  Inspect the actual skill-only diff against the fetched base. Resolve the
+  publication target through supported controls; do not knowingly publish
+  against `main`, or report a creation failure when no attempt was made.
+- After creation, query the PR's actual base repository/branch, head
+  repository/branch, and complete file list. If explicit targeting cannot be
+  established, preserve the pushed branch and report the missing control,
+  whether creation was attempted, and the exact intended base/head separately
+  from the primary workflow's outcome.
 
 ## Lightweight validation and CI
 


### PR DESCRIPTION
## Observed evidence

During the PutInOperationName promotion in #5457, ordinary `pnpm exec prettier --write/--check` silently skipped explicitly named generated website references because `.prettierignore` contains `**/docs/**/reference/`; generated per-rule pages are also gitignored. The promotion worker confirmed that an empty-ignore override processed the README, source rule documentation, generated linter reference, and generated `rules/use-create-for-put.md` page.

The subsequent skill-only publication attempt exposed confusion between Git upstream tracking, `gh-merge-base`, and the app session comparison base. A mismatched overview alone does not establish an actual PR-creation failure; actual PR metadata must be inspected.

## Changes

- Update ARM and Core promotion examples to use scoped empty-ignore overrides with four explicit filenames, including the exact official generated rule page. Provide POSIX `/dev/null`, Windows PowerShell `NUL`, and explicit empty-file guidance; require output/file-info evidence that generated files are not skipped.
- Preserve repository ignore files and prohibit broad override globs or force-adding ignored generated pages.
- Clarify independent skill PR base/head selection, app-session base distinctions, explicit GitHub CLI targeting where permitted, mandatory integrated-tool/fallback constraints, and verification of actual PR metadata and complete file scope.

## Intended publication target and scope

Base: `Azure/typespec-azure:feature/lintdiff-migration-new`.
Head: `msyyc:fix-promotion-generated-doc-formatting`.

Only `.github/skills/lintdiff-rule-promote/SKILL.md` and `.github/skills/shared/post-run-process-review.md` change. No package code, generated output, ignore files, lockfiles, submodule changes, or change entries. Primary promotion #5457 and its terminated review loop remain untouched.

## Lightweight validation

Existing prepared-worktree Prettier checked both explicit skill files with the prepared configuration. Complete skill-only diff, shared-policy link, PowerShell example syntax, and `git diff --check` passed. No dependency installation, builds, docs regeneration, monorepo lint/tests, new review loop, or CI polling.