### PR TITLE
Sync TypeSpec Java dependencies for September

### DIFF
--- a/.chronus/changes/sync-typespec-java-september-2026-09-11.md
+++ b/.chronus/changes/sync-typespec-java-september-2026-09-11.md
@@ -4,4 +4,4 @@ packages:
   - "@azure-tools/typespec-java"
 ---
 
-Update TypeSpec dependencies to their September minor versions and sync Java generation behavior, including responses that return either a model body or no content ([microsoft/typespec#11936](https://github.com/microsoft/typespec/pull/11936)).
+Update TypeSpec dependencies to their September minor versions. Includes behavior changes from upstream libraries such as TCGC ([microsoft/typespec#11936](https://github.com/microsoft/typespec/pull/11936)).

--- a/.chronus/changes/sync-typespec-java-september-2026-09-11.md
+++ b/.chronus/changes/sync-typespec-java-september-2026-09-11.md
@@ -1,0 +1,7 @@
+---
+changeKind: feature
+packages:
+  - "@azure-tools/typespec-java"
+---
+
+Update TypeSpec dependencies to their September minor versions and sync Java generation behavior, including responses that return either a model body or no content ([microsoft/typespec#11936](https://github.com/microsoft/typespec/pull/11936)).

--- a/packages/typespec-java/core-commit.json
+++ b/packages/typespec-java/core-commit.json
@@ -1,1 +1,1 @@
-{ "sha": "f16f4d44efe4f48d9dbfd82ffdb47609457e2659" }
+{ "sha": "e5ed49457d888c5fc37f616779ddb502b78cfa15" }

--- a/packages/typespec-java/emitter-tests/spector.config.yaml
+++ b/packages/typespec-java/emitter-tests/spector.config.yaml
@@ -90,6 +90,7 @@ specs:
   payload/xml: true
   resiliency/srv-driven/main.tsp: { options: { advanced-versioning: true } }
   resiliency/srv-driven/old.tsp: { options: { namespace: resiliency.servicedriven.v1, advanced-versioning: true } }
+  response/body-or-no-content: true
   response/status-code-range: true
   routes: true
   serialization/encoded-name/json: true

--- a/packages/typespec-java/emitter-tests/src/test/java/response/bodyornocontent/BodyOrNoContentTests.java
+++ b/packages/typespec-java/emitter-tests/src/test/java/response/bodyornocontent/BodyOrNoContentTests.java
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+package response.bodyornocontent;
+
+import com.azure.core.http.HttpHeaderName;
+import com.azure.core.http.rest.RequestOptions;
+import com.azure.core.http.rest.Response;
+import com.azure.core.util.BinaryData;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import response.bodyornocontent.models.BlobLayout;
+
+public class BodyOrNoContentTests {
+
+    private static final HttpHeaderName REQUEST_ID = HttpHeaderName.fromString("x-ms-request-id");
+
+    private final BodyOrNoContentClient client = new BodyOrNoContentClientBuilder().buildClient();
+
+    @Test
+    public void testGetBody() {
+        Response<BinaryData> response = client.getBodyWithResponse(new RequestOptions());
+
+        Assertions.assertEquals(200, response.getStatusCode());
+        Assertions.assertEquals("body-request", response.getHeaders().getValue(REQUEST_ID));
+        Assertions.assertEquals("hello", response.getValue().toObject(BlobLayout.class).getContent());
+    }
+
+    @Test
+    public void testGetNoContent() {
+        Response<BinaryData> response = client.getNoContentWithResponse(new RequestOptions());
+
+        Assertions.assertEquals(204, response.getStatusCode());
+        Assertions.assertEquals("no-content-request", response.getHeaders().getValue(REQUEST_ID));
+        Assertions.assertArrayEquals(new byte[0], response.getValue().toBytes());
+        Assertions.assertNull(response.getValue().toObject(BlobLayout.class));
+    }
+}

--- a/packages/typespec-java/emitter-tests/tsp/enum.tsp
+++ b/packages/typespec-java/emitter-tests/tsp/enum.tsp
@@ -8,6 +8,7 @@ using Azure.ClientGenerator.Core;
 @service(#{ title: "EnumService" })
 namespace TspTest.EnumService;
 
+#suppress "@azure-tools/typespec-azure-core/use-extensible-enum" "For testing"
 enum Color {
   Red,
   Blue,
@@ -44,17 +45,20 @@ union OlympicRecordModel {
   Olympic_200_Meters: 19.30,
 }
 
+#suppress "@azure-tools/typespec-azure-core/use-extensible-enum" "For testing"
 enum Priority {
   High: 100,
   Low: 0,
 }
 
+#suppress "@azure-tools/typespec-azure-core/use-extensible-enum" "For testing"
 enum Unit {
   Grams: 1,
   KiloGrams: 0.001,
   Milligram: 1000,
 }
 
+#suppress "@azure-tools/typespec-azure-core/use-extensible-enum" "For testing"
 enum OperationStateValues {
   Running,
   Completed,

--- a/packages/typespec-java/emitter-tests/tsp/internal.tsp
+++ b/packages/typespec-java/emitter-tests/tsp/internal.tsp
@@ -55,6 +55,7 @@ model StandAloneUnion {
 }
 
 // Color and ColorModel will be generated in implementation.models package
+#suppress "@azure-tools/typespec-azure-core/use-extensible-enum" "For testing"
 @access(Access.internal)
 @usage(Usage.input | Usage.output)
 enum Color {

--- a/packages/typespec-java/emitter-tests/tsp/naming-javaparser.tsp
+++ b/packages/typespec-java/emitter-tests/tsp/naming-javaparser.tsp
@@ -75,6 +75,7 @@ model BytesData extends Data {
   data: bytes;
 }
 
+#suppress "@azure-tools/typespec-azure-core/use-extensible-enum" "For testing"
 @summary("summary of Types")
 @doc("description of Types")
 enum TypesModel {

--- a/packages/typespec-java/emitter-tests/tsp/naming.tsp
+++ b/packages/typespec-java/emitter-tests/tsp/naming.tsp
@@ -78,6 +78,7 @@ model BytesData extends Data {
   data: bytes;
 }
 
+#suppress "@azure-tools/typespec-azure-core/use-extensible-enum" "For testing"
 @summary("summary of Types")
 @doc("description of Types")
 enum TypesModel {


### PR DESCRIPTION
## Summary

- update the TypeSpec Java core pin to microsoft/typespec#11936
- sync Java test fixtures for the September TypeSpec dependency versions
- enable and test responses that return either a model body or no content

## Validation

- `pnpm format`
- `pnpm lint`
- `pnpm -r --filter "@azure-tools/typespec-java..." build`
- `pnpm regenerate -- --parallelization 4 --skip-build`
- `pnpm test`
- `pnpm test:java:e2e`
